### PR TITLE
Remove dead state: cleanup from canasta_registry

### DIFF
--- a/roles/common/library/canasta_registry.py
+++ b/roles/common/library/canasta_registry.py
@@ -22,7 +22,7 @@ options:
   state:
     description: Desired state of the instance in the registry.
     type: str
-    choices: [present, absent, query, query_all, query_by_path, cleanup]
+    choices: [present, absent, query, query_all, query_by_path]
     default: query
   id:
     description: Canasta instance ID.
@@ -173,7 +173,7 @@ def run_module():
     module_args = dict(
         state=dict(type="str", default="query",
                    choices=["present", "absent", "query", "query_all",
-                            "query_by_path", "cleanup",
+                            "query_by_path",
                             "set_setting", "get_setting"]),
         setting_key=dict(type="str", required=False),
         setting_value=dict(type="str", required=False),
@@ -295,32 +295,6 @@ def run_module():
                 data["Instances"] = instances
                 write_config(config_dir, data)
         result["changed"] = changed
-
-    elif state == "cleanup":
-        # Only auto-cleanup localhost entries. Remote entries can't be
-        # verified from the controller (the path belongs to a different
-        # filesystem) — the calling playbook is responsible for probing
-        # remote hosts over SSH and, when appropriate, calling this
-        # module with state=absent for each confirmed-missing entry.
-        to_remove = []
-        skipped_remote = []
-        for iid, inst in instances.items():
-            host = inst.get("host", "localhost")
-            if host != "localhost":
-                skipped_remote.append(iid)
-                continue
-            if not os.path.isdir(inst.get("path", "")):
-                to_remove.append(iid)
-        if to_remove:
-            changed = True
-            if not module.check_mode:
-                for iid in to_remove:
-                    del instances[iid]
-                data["Instances"] = instances
-                write_config(config_dir, data)
-        result["changed"] = changed
-        result["removed"] = to_remove
-        result["skipped_remote"] = skipped_remote
 
     elif state == "get_setting":
         setting_key = module.params.get("setting_key")

--- a/tests/unit/test_canasta_registry.py
+++ b/tests/unit/test_canasta_registry.py
@@ -336,66 +336,6 @@ class TestRunModuleAbsent:
         assert not result["changed"]
 
 
-class TestRunModuleCleanup:
-    def test_cleanup_removes_stale(self, tmp_dir):
-        data = {"Instances": {
-            "good": {"id": "good", "path": os.path.join(tmp_dir, "good"), "orchestrator": "compose"},
-            "stale": {"id": "stale", "path": "/nonexistent/path", "orchestrator": "compose"},
-        }}
-        os.makedirs(os.path.join(tmp_dir, "good"))
-        with open(os.path.join(tmp_dir, "conf.json"), "w") as f:
-            json.dump(data, f)
-        result, failed, _ = run_module_with_params(canasta_registry, {
-            "state": "cleanup", "id": None, "path": None,
-            "orchestrator": "compose", "dev_mode": False,
-            "managed_cluster": False, "registry": None,
-            "kind_cluster": None, "build_from": None,
-            "host": None, "filter_host": None,
-            "config_dir": tmp_dir,
-        })
-        assert not failed
-        assert result["changed"]
-        assert "stale" in result["removed"]
-
-    def test_cleanup_skips_remote_entries(self, tmp_dir):
-        """Remote entries can't be verified from the controller's local
-        filesystem, so the module must skip them and let the caller
-        handle SSH-based probing."""
-        data = {"Instances": {
-            "local_good": {"id": "local_good",
-                           "path": os.path.join(tmp_dir, "local_good"),
-                           "orchestrator": "compose", "host": "localhost"},
-            "local_stale": {"id": "local_stale", "path": "/nonexistent/local",
-                            "orchestrator": "compose", "host": "localhost"},
-            "remote_alive": {"id": "remote_alive", "path": "/srv/canasta/alive",
-                             "orchestrator": "compose",
-                             "host": "wikiworks@prod.example.com"},
-            "remote_unreachable": {"id": "remote_unreachable",
-                                   "path": "/srv/canasta/u",
-                                   "orchestrator": "compose",
-                                   "host": "wikiworks@offline.example.com"},
-        }}
-        os.makedirs(os.path.join(tmp_dir, "local_good"))
-        with open(os.path.join(tmp_dir, "conf.json"), "w") as f:
-            json.dump(data, f)
-        result, failed, _ = run_module_with_params(canasta_registry, {
-            "state": "cleanup", "id": None, "path": None,
-            "orchestrator": "compose", "dev_mode": False,
-            "managed_cluster": False, "registry": None,
-            "kind_cluster": None, "build_from": None,
-            "host": None, "filter_host": None,
-            "config_dir": tmp_dir,
-        })
-        assert not failed
-        # Only the local missing one should be removed
-        assert result["removed"] == ["local_stale"]
-        # Both remote entries should be reported as skipped (to be
-        # handled by the playbook's SSH-aware cleanup)
-        assert sorted(result["skipped_remote"]) == [
-            "remote_alive", "remote_unreachable",
-        ]
-
-
 class TestRunModuleQueryByPath:
     def test_query_by_path(self, sample_config):
         config_dir, data = sample_config


### PR DESCRIPTION
Closes #312. Follow-up to #311.

## Summary

With `list` converted to `direct_only` in #311, the only caller of `canasta_registry`'s `state: cleanup` action (`playbooks/list.yml`) no longer exists. This PR removes the dead module action and its tests.

## Changes

- `roles/common/library/canasta_registry.py`:
  - Drop `"cleanup"` from the DOCUMENTATION `state` choices list
  - Drop `"cleanup"` from the `argument_spec` `state` choices list
  - Remove the `elif state == "cleanup":` branch from `run_module()` (~25 lines)
- `tests/unit/test_canasta_registry.py`:
  - Remove `TestRunModuleCleanup` class and its two tests (`test_cleanup_removes_stale`, `test_cleanup_skips_remote_entries`)

No functional change to any other state action.

## Test plan

- [x] `make validate`: `Validation passed: 61 commands, 53 playbooks`
- [x] Full unit suite: **534 passed** (was 536; -2 removed tests, no new tests)
- [x] No remaining references to `cleanup` in the module or its tests (grep clean)
