### PR TITLE
Fix wiki_publish.py output to match canasta.wiki conventions

### DIFF
--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -47,23 +47,14 @@ def load_definitions():
 # --- Wikitext generation ---
 
 # Subcommand hierarchy for menu and page structure
-SUBCOMMAND_GROUPS = {
-    "config": ["get", "set", "unset"],
-    "extension": ["list", "enable", "disable"],
-    "skin": ["list", "enable", "disable"],
-    "maintenance": ["update", "script", "extension", "exec"],
-    "devmode": ["enable", "disable"],
-    "sitemap": ["generate", "remove"],
-    "backup": [
-        "init", "list", "create", "restore", "delete",
-        "unlock", "files", "check", "diff", "purge",
-        "schedule_set", "schedule_list", "schedule_remove",
-    ],
-    "gitops": [
-        "init", "join", "add", "rm", "push", "pull",
-        "status", "diff", "fix_submodules",
-    ],
-}
+# Import the live group definitions from canasta.py so this stays in
+# lockstep with the CLI itself — drifted local copies are how the
+# 'gitops fix-submodules' page-name bug crept in.
+sys.path.insert(0, REPO_ROOT)
+import canasta as _canasta  # noqa: E402
+
+SUBCOMMAND_GROUPS = _canasta.SUBCOMMAND_GROUPS
+NESTED_SUBCOMMAND_GROUPS = _canasta.NESTED_SUBCOMMAND_GROUPS
 
 CMD_GROUPS = [
     ("Instance Management", [
@@ -76,36 +67,82 @@ CMD_GROUPS = [
     ("Maintenance", ["maintenance", "sitemap"]),
     ("Data Protection", ["backup", "gitops"]),
     ("Development", ["devmode"]),
+    ("Multi-host", ["host"]),
+    ("Storage", ["storage"]),
+    ("System", ["install", "uninstall"]),
 ]
 
 
+def _build_display_name_map():
+    """Build internal_name -> display_name map preserving hyphenated subcommands.
+
+    The CLI uses hyphenated subcommand names like 'fix-submodules', but
+    command_definitions.yml stores them with underscores ('gitops_fix_submodules')
+    because YAML keys can't contain hyphens cleanly. The display name
+    in the wiki must match what the user types: 'gitops fix-submodules',
+    not 'gitops fix submodules'.
+    """
+    display_map = {}
+    for group, subs in SUBCOMMAND_GROUPS.items():
+        for sub in subs:
+            internal = "%s_%s" % (group, sub.replace("-", "_"))
+            display_map[internal] = "%s %s" % (group, sub)
+    for group, subgroups in NESTED_SUBCOMMAND_GROUPS.items():
+        for subgroup, subs in subgroups.items():
+            for sub in subs:
+                internal = "%s_%s_%s" % (
+                    group, subgroup, sub.replace("-", "_"),
+                )
+                display_map[internal] = "%s %s %s" % (group, subgroup, sub)
+    return display_map
+
+
+_DISPLAY_NAMES = _build_display_name_map()
+
+
 def cmd_display_name(internal_name):
-    """Convert internal name to display: config_get -> config get."""
+    """Convert internal name to display name (preserves hyphenated subcommands)."""
+    if internal_name in _DISPLAY_NAMES:
+        return _DISPLAY_NAMES[internal_name]
     return internal_name.replace("_", " ")
 
 
 def cmd_page_title(internal_name):
-    """Convert to wiki page title: config_get -> canasta_config_get."""
-    return PAGE_PREFIX + "canasta_" + internal_name
+    """Convert to wiki page title: 'config_get' -> 'CLI:canasta config get'.
+
+    Uses display_name semantics so hyphenated subcommands like
+    'fix-submodules' produce 'CLI:canasta gitops fix-submodules', not
+    'CLI:canasta gitops fix submodules' (which would be a different
+    MediaWiki page).
+    """
+    return PAGE_PREFIX + "canasta " + cmd_display_name(internal_name)
 
 
-def gen_wikitext(cmd, parent_path=None):
+def gen_wikitext(cmd):
     """Generate wikitext for a single command page."""
     name = cmd["name"]
     display = "canasta " + cmd_display_name(name)
     lines = []
 
-    # Breadcrumb
-    if parent_path:
-        parent_link = "[[%s|%s]]" % (
-            cmd_page_title(parent_path),
-            "canasta " + cmd_display_name(parent_path),
+    # Breadcrumb. The link chain walks ancestors from the root
+    # 'canasta' page down to the direct parent; the terminal segment
+    # is the leaf name (with parent prefix stripped, so e.g.
+    # 'fix-submodules' instead of 'gitops fix-submodules' on the
+    # gitops_fix_submodules page). Always shown except on the root.
+    crumbs = ["[[%s|canasta]]" % (PAGE_PREFIX + "canasta")]
+    ancestors = _ancestors(name)
+    for anc in ancestors:
+        crumbs.append(
+            "[[%s|%s]]" % (cmd_page_title(anc), cmd_display_name(anc))
         )
-        lines.append(
-            "[[%s|canasta]] > %s > %s"
-            % (PAGE_PREFIX + "canasta", parent_link, name.split("_")[-1])
-        )
-        lines.append("")
+    leaf = display[len("canasta "):]
+    if ancestors:
+        parent_disp = cmd_display_name(ancestors[-1])
+        if leaf.startswith(parent_disp + " "):
+            leaf = leaf[len(parent_disp) + 1:]
+    crumbs.append(leaf)
+    lines.append(" > ".join(crumbs))
+    lines.append("")
 
     lines.append("== %s ==" % display)
     lines.append("")
@@ -119,18 +156,14 @@ def gen_wikitext(cmd, parent_path=None):
         lines.append(long_desc.strip())
         lines.append("")
 
-    # Usage line
-    usage_parts = [display]
-    for p in cmd.get("parameters", []):
-        flag = "--" + p["name"].replace("_", "-")
-        if p.get("positional"):
-            usage_parts.append("[%s]" % p["name"].upper())
-        elif p.get("required"):
-            usage_parts.append("%s <%s>" % (flag, p["name"].upper()))
-        else:
-            usage_parts.append("[%s <%s>]" % (flag, p["name"].upper()))
+    # Usage line — match the live wiki's compact form ('canasta create
+    # [flags]') instead of an inline listing of every option. The
+    # detailed flag table below is the authoritative reference.
     lines.append("<syntaxhighlight lang=\"bash\">")
-    lines.append(" ".join(usage_parts))
+    if cmd.get("parameters"):
+        lines.append("%s [flags]" % display)
+    else:
+        lines.append(display)
     lines.append("</syntaxhighlight>")
     lines.append("")
 
@@ -139,26 +172,29 @@ def gen_wikitext(cmd, parent_path=None):
         lines.append("=== Subcommands ===")
         lines.append("")
         for sub in SUBCOMMAND_GROUPS[name]:
-            internal = "%s_%s" % (name, sub)
-            sub_display = sub.replace("_", " ")
+            # 'sub' is the user-facing name (may contain hyphens like
+            # 'fix-submodules'); convert to underscore form to find the
+            # internal command_definitions.yml entry.
+            internal = "%s_%s" % (name, sub.replace("-", "_"))
             link = cmd_page_title(internal)
-            lines.append(
-                "* [[%s|%s]] — see page" % (link, sub_display)
-            )
+            lines.append("* [[%s|%s]] — see page" % (link, sub))
         lines.append("")
 
-    # Examples
+    # Examples — copy=1 enables the per-block copy-to-clipboard button
+    # the live wiki uses on its example blocks.
     examples = cmd.get("examples", [])
     if examples:
         lines.append("=== Examples ===")
         lines.append("")
-        lines.append("<syntaxhighlight lang=\"bash\">")
+        lines.append("<syntaxhighlight lang=\"bash\" copy=1>")
         for ex in examples:
             lines.append(ex)
         lines.append("</syntaxhighlight>")
         lines.append("")
 
-    # Flags table
+    # Flags table — alphabetized by flag name so readers can scan
+    # quickly. Definition order in command_definitions.yml is convenient
+    # for authors but unhelpful when there are 30+ flags.
     params = cmd.get("parameters", [])
     if params:
         lines.append("=== Flags ===")
@@ -168,7 +204,7 @@ def gen_wikitext(cmd, parent_path=None):
             "! Flag !! Shorthand !! Description "
             "!! Default !! style=\"text-align:center\" | Required"
         )
-        for p in params:
+        for p in sorted(params, key=lambda x: x["name"]):
             flag = "<code>--" + p["name"].replace("_", "-") + "</code>"
             short = ""
             if p.get("short"):
@@ -191,6 +227,28 @@ def gen_wikitext(cmd, parent_path=None):
 
     lines.append("{{Reference Manual}}")
     return "\n".join(lines)
+
+
+def _ancestors(internal_name):
+    """Return list of ancestor internal names (outermost to direct parent).
+
+    Examples:
+      'create'                 -> []
+      'config_get'             -> ['config']
+      'gitops_fix_submodules'  -> ['gitops']
+      'backup_schedule_set'    -> ['backup', 'backup_schedule']
+      'storage_setup_nfs'      -> ['storage', 'storage_setup']
+    """
+    parts = internal_name.split("_")
+    if len(parts) < 2:
+        return []
+    if parts[0] in NESTED_SUBCOMMAND_GROUPS:
+        nested = NESTED_SUBCOMMAND_GROUPS[parts[0]]
+        if len(parts) >= 3 and parts[1] in nested:
+            return [parts[0], "%s_%s" % (parts[0], parts[1])]
+    if parts[0] in SUBCOMMAND_GROUPS:
+        return [parts[0]]
+    return []
 
 
 def generate_all_pages(data):
@@ -220,34 +278,42 @@ def generate_all_pages(data):
     root_lines.append("{{Reference Manual}}")
     pages.append((PAGE_PREFIX + "canasta", "\n".join(root_lines)))
 
-    # Per-command pages
+    # Per-command pages — parent_path arg retained for back-compat,
+    # but gen_wikitext now derives the breadcrumb chain itself via
+    # _ancestors() so nested subcommands render correctly.
     for cmd in data["commands"]:
         name = cmd["name"]
-        # Determine parent for breadcrumb
-        parent = None
-        if "_" in name:
-            parts = name.split("_")
-            if parts[0] in SUBCOMMAND_GROUPS:
-                parent = parts[0]
-        pages.append((cmd_page_title(name), gen_wikitext(cmd, parent)))
+        pages.append((cmd_page_title(name), gen_wikitext(cmd)))
 
     # Menu page
-    menu_lines = ["* # | Canasta-Ansible Reference"]
+    menu_lines = ["* # | Canasta CLI Reference"]
     for heading, names in CMD_GROUPS:
         menu_lines.append("** # | %s" % heading)
         for name in names:
-            if name not in cmd_index:
+            # CMD_GROUPS entries can be either leaf commands (in
+            # cmd_index) or subcommand-group keys (in SUBCOMMAND_GROUPS,
+            # but not standalone in command_definitions.yml). Render
+            # both: leaf commands as a single line, group keys as a
+            # parent header (linking the hand-curated CLI:canasta <group>
+            # page) followed by per-subcommand links.
+            if name in cmd_index:
+                link = cmd_page_title(name)
+                menu_lines.append("*** %s | canasta %s" % (link, name))
+            elif name in SUBCOMMAND_GROUPS:
+                # Synthetic group page (hand-curated, not auto-generated).
+                menu_lines.append(
+                    "*** %s | canasta %s"
+                    % (PAGE_PREFIX + "canasta " + name, name)
+                )
+            else:
                 continue
-            link = cmd_page_title(name)
-            menu_lines.append("*** %s | canasta %s" % (link, name))
             if name in SUBCOMMAND_GROUPS:
                 for sub in SUBCOMMAND_GROUPS[name]:
-                    internal = "%s_%s" % (name, sub)
-                    sub_display = sub.replace("_", " ")
+                    internal = "%s_%s" % (name, sub.replace("-", "_"))
                     sub_link = cmd_page_title(internal)
                     menu_lines.append(
                         "**** %s | canasta %s %s"
-                        % (sub_link, name, sub_display)
+                        % (sub_link, name, sub)
                     )
     pages.append((
         "MediaWiki:Menu-cli-reference",

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -1,0 +1,114 @@
+"""Tests for scripts/wiki_publish.py page-naming helpers.
+
+These guard against the class of bug where wiki page titles drift
+from the user-facing CLI command names — e.g. 'gitops fix-submodules'
+becoming 'gitops fix submodules' (spaces) and creating a duplicate
+page at the wrong title.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts"))
+import wiki_publish as wp
+
+
+class TestDisplayName:
+    def test_top_level_unchanged(self):
+        assert wp.cmd_display_name("create") == "create"
+        assert wp.cmd_display_name("version") == "version"
+
+    def test_simple_subcommand_uses_space(self):
+        assert wp.cmd_display_name("config_get") == "config get"
+        assert wp.cmd_display_name("backup_list") == "backup list"
+
+    def test_hyphenated_subcommand_preserves_hyphen(self):
+        # The bug we shipped in #303 was that 'gitops_fix_submodules'
+        # rendered as 'gitops fix submodules' (three words, all spaces),
+        # producing a wiki page title different from what the user
+        # types ('canasta gitops fix-submodules').
+        assert (
+            wp.cmd_display_name("gitops_fix_submodules")
+            == "gitops fix-submodules"
+        )
+
+    def test_nested_subcommand(self):
+        assert (
+            wp.cmd_display_name("backup_schedule_set")
+            == "backup schedule set"
+        )
+        assert (
+            wp.cmd_display_name("storage_setup_nfs")
+            == "storage setup nfs"
+        )
+
+
+class TestPageTitle:
+    def test_uses_display_name(self):
+        assert wp.cmd_page_title("create") == "CLI:canasta create"
+        assert (
+            wp.cmd_page_title("gitops_fix_submodules")
+            == "CLI:canasta gitops fix-submodules"
+        )
+        assert (
+            wp.cmd_page_title("backup_schedule_set")
+            == "CLI:canasta backup schedule set"
+        )
+
+
+class TestAncestors:
+    def test_top_level_has_no_ancestors(self):
+        assert wp._ancestors("create") == []
+        assert wp._ancestors("version") == []
+
+    def test_subcommand_has_group_ancestor(self):
+        assert wp._ancestors("config_get") == ["config"]
+        assert wp._ancestors("gitops_fix_submodules") == ["gitops"]
+
+    def test_nested_subcommand_has_full_chain(self):
+        assert wp._ancestors("backup_schedule_set") == [
+            "backup", "backup_schedule",
+        ]
+        assert wp._ancestors("storage_setup_nfs") == [
+            "storage", "storage_setup",
+        ]
+
+
+class TestEveryCommandHasMatchingDisplayName:
+    """The publisher's display-name map must cover every entry that
+    canasta.py knows about as a subcommand. Drift here is the same
+    class of bug as the original fix-submodules issue."""
+
+    def test_all_subcommands_covered(self):
+        missing = []
+        for group, subs in wp.SUBCOMMAND_GROUPS.items():
+            for sub in subs:
+                internal = "%s_%s" % (group, sub.replace("-", "_"))
+                expected = "%s %s" % (group, sub)
+                if wp.cmd_display_name(internal) != expected:
+                    missing.append("%s -> got %r, want %r" % (
+                        internal, wp.cmd_display_name(internal), expected,
+                    ))
+        assert not missing, (
+            "subcommand display-name drift:\n  " + "\n  ".join(missing)
+        )
+
+    def test_all_nested_subcommands_covered(self):
+        missing = []
+        for group, subgroups in wp.NESTED_SUBCOMMAND_GROUPS.items():
+            for subgroup, subs in subgroups.items():
+                for sub in subs:
+                    internal = "%s_%s_%s" % (
+                        group, subgroup, sub.replace("-", "_"),
+                    )
+                    expected = "%s %s %s" % (group, subgroup, sub)
+                    if wp.cmd_display_name(internal) != expected:
+                        missing.append("%s -> got %r, want %r" % (
+                            internal, wp.cmd_display_name(internal), expected,
+                        ))
+        assert not missing, (
+            "nested subcommand display-name drift:\n  " + "\n  ".join(missing)
+        )


### PR DESCRIPTION
Closes #314.

## Summary

Local-wiki test against the live canasta.wiki layout surfaced several output divergences in `scripts/wiki_publish.py`. Fix them all in one pass since they touch adjacent code.

## Bugs fixed

1. **Hyphenated subcommand names mis-titled.** `gitops_fix_submodules` rendered as `gitops fix submodules` (three space-separated words), making the wiki page title differ from what users type (`canasta gitops fix-submodules`). Root cause: a drifted local copy of `SUBCOMMAND_GROUPS` in `wiki_publish.py` had `"fix_submodules"` instead of `"fix-submodules"`.
2. **Verbose synopsis.** Switched to `canasta <cmd> [flags]`; the table below is the authoritative reference. Matches the live wiki.
3. **Definition-order flag table.** Now alphabetized.
4. **No `copy=1` on Examples block.** Added — enables the per-block copy-to-clipboard button the live wiki uses.
5. **No breadcrumbs.** Now emitted on every per-command page. Top-level: `canasta > create`. Nested: full chain like `canasta > backup > backup schedule > set`.
6. **Menu page missing entire group sections.** `"Extensions & Skins"` / `"Maintenance"` / `"Data Protection"` etc. rendered empty because their entries (`"extension"`, `"backup"`, ...) are `SUBCOMMAND_GROUPS` keys, not standalone `command_definitions.yml` entries — `if name in cmd_index` skipped them. Now rendered as parent header + per-subcommand links.
7. **`CMD_GROUPS` outdated** — added `Multi-host` (`host`), `Storage` (`storage`), `System` (`install`, `uninstall`).

## Architectural change

Replaced the local copy of `SUBCOMMAND_GROUPS` / `NESTED_SUBCOMMAND_GROUPS` with imports from `canasta.py`. The local copy had drifted, which is how bug #1 crept in — putting it on a single source of truth prevents recurrence.

## Test plan

- [x] Full unit suite: **544 passed** (was 534; +10 new tests in `tests/unit/test_wiki_publish.py`)
  - Display name correctness for top-level, simple-sub, hyphenated-sub, nested-sub
  - Page title round-trip
  - Ancestors helper for all four shapes
  - **Drift guard**: every `SUBCOMMAND_GROUPS` / `NESTED_SUBCOMMAND_GROUPS` entry must round-trip cleanly through the display-name map. Catches the recurrence of bug #1 for any future command.
- [x] Spot-checked generated output for `create`, `gitops_fix_submodules`, `backup_schedule_set` — all correct.
- [ ] Re-publish to local wiki + visual check before pushing to staging wiki.

## Out of scope

Bot password API auth issue (`action=login` returns `wrongpassword` on Canasta default config despite internal `BotPassword::login()` succeeding) — separate issue, will retest against a real-host wiki.
