### PR TITLE
Include 3-level nested subcommands in wiki_publish menu

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -291,9 +291,10 @@ commands:
   - name: doctor
     description: "Check target host dependencies"
     long_description: |
-      Verify that all required tools (Docker, Docker Compose, etc.)
-      are installed on the target host. Reports status of optional
-      tools (kubectl, kind, git, git-crypt, rsync) and system
+      Verify that the target host has the tools required for its
+      orchestrator: Docker + Docker Compose for Compose installs,
+      or kubectl + Helm for Kubernetes installs. Also reports
+      status of optional tools (git, git-crypt, rsync) and system
       resources (memory, disk space).
     examples:
       - "canasta doctor"

--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -57,9 +57,9 @@ SUBCOMMAND_GROUPS = _canasta.SUBCOMMAND_GROUPS
 NESTED_SUBCOMMAND_GROUPS = _canasta.NESTED_SUBCOMMAND_GROUPS
 
 CMD_GROUPS = [
+    ("System", ["install", "doctor", "host", "storage", "uninstall"]),
     ("Instance Management", [
-        "create", "delete", "list", "upgrade", "version",
-        "doctor", "config",
+        "create", "delete", "list", "upgrade", "version", "config",
     ]),
     ("Wiki Management", ["add", "remove", "import", "export"]),
     ("Container Lifecycle", ["start", "stop", "restart"]),
@@ -67,9 +67,6 @@ CMD_GROUPS = [
     ("Maintenance", ["maintenance", "sitemap"]),
     ("Data Protection", ["backup", "gitops"]),
     ("Development", ["devmode"]),
-    ("Multi-host", ["host"]),
-    ("Storage", ["storage"]),
-    ("System", ["install", "uninstall"]),
 ]
 
 

--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -308,13 +308,34 @@ def generate_all_pages(data):
             else:
                 continue
             if name in SUBCOMMAND_GROUPS:
-                for sub in SUBCOMMAND_GROUPS[name]:
-                    internal = "%s_%s" % (name, sub.replace("-", "_"))
+                nested = NESTED_SUBCOMMAND_GROUPS.get(name, {})
+                # Walk direct subcommands plus any nested-group parent
+                # that isn't already in SUBCOMMAND_GROUPS — e.g.
+                # 'backup schedule' lives only in NESTED_SUBCOMMAND_GROUPS,
+                # so iterating SUBCOMMAND_GROUPS alone skips it and
+                # its leaves ('backup schedule set', etc.).
+                direct = list(SUBCOMMAND_GROUPS[name])
+                for extra in nested:
+                    if extra not in direct:
+                        direct.append(extra)
+                for sub in direct:
+                    sub_us = sub.replace("-", "_")
+                    internal = "%s_%s" % (name, sub_us)
                     sub_link = cmd_page_title(internal)
                     menu_lines.append(
                         "**** %s | canasta %s %s"
                         % (sub_link, name, sub)
                     )
+                    if sub in nested:
+                        for leaf in nested[sub]:
+                            leaf_internal = "%s_%s_%s" % (
+                                name, sub_us, leaf.replace("-", "_"),
+                            )
+                            leaf_link = cmd_page_title(leaf_internal)
+                            menu_lines.append(
+                                "***** %s | canasta %s %s %s"
+                                % (leaf_link, name, sub, leaf)
+                            )
     pages.append((
         "MediaWiki:Menu-cli-reference",
         "\n".join(menu_lines),

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -112,3 +112,42 @@ class TestEveryCommandHasMatchingDisplayName:
         assert not missing, (
             "nested subcommand display-name drift:\n  " + "\n  ".join(missing)
         )
+
+
+class TestMenuCoverage:
+    """The MediaWiki:Menu-cli-reference page must link to every command,
+    including 3-level nested leaves. The earlier bug was that the menu
+    generator stopped at 2-level subcommands, so entries like
+    'backup schedule set' and 'storage setup nfs' never appeared."""
+
+    def _menu_content(self):
+        data = wp.load_definitions()
+        pages = wp.generate_all_pages(data)
+        for title, content in pages:
+            if title == "MediaWiki:Menu-cli-reference":
+                return content
+        raise AssertionError("menu page not emitted")
+
+    def test_menu_includes_nested_leaves(self):
+        menu = self._menu_content()
+        expected = []
+        for group, subgroups in wp.NESTED_SUBCOMMAND_GROUPS.items():
+            for subgroup, subs in subgroups.items():
+                for sub in subs:
+                    expected.append("canasta %s %s %s" % (group, subgroup, sub))
+        missing = [e for e in expected if e not in menu]
+        assert not missing, (
+            "menu missing nested leaves:\n  " + "\n  ".join(missing)
+        )
+
+    def test_menu_uses_five_asterisks_for_nested_leaves(self):
+        menu = self._menu_content()
+        # A 3-level leaf like 'backup schedule set' lives under the
+        # 4-asterisk 'backup schedule' entry, so its depth marker must
+        # be five asterisks — four loses the hierarchy, six orphans it.
+        assert "***** " in menu
+        for line in menu.splitlines():
+            if line.startswith("***** "):
+                assert " | canasta " in line, (
+                    "malformed nested leaf line: %r" % line
+                )


### PR DESCRIPTION
## Summary
- Menu generator in `scripts/wiki_publish.py` now descends into `NESTED_SUBCOMMAND_GROUPS`, emitting 5-asterisk menu entries for leaves like `backup schedule set` and `storage setup nfs`.
- Also emits the nested-group parent (`backup schedule`) when it isn't already a direct subcommand, without duplicating it when it is (e.g. `storage setup`).
- Reorganizes `CMD_GROUPS` so `System` is first and absorbs the single-entry `Multi-host` and `Storage` groups plus `doctor`. New System order follows the setup flow: `install`, `doctor`, `host`, `storage`, `uninstall`.
- Rewrites `doctor`'s `long_description` to treat Docker Compose and Kubernetes as peer orchestrator options instead of framing Docker as required and K8s as optional.

Closes #316. Closes #318.

## Test plan
- [x] `make test-unit` — 546 passed
- [x] `make validate` — passed
- [x] Two new test cases in `tests/unit/test_wiki_publish.py` (presence of nested leaves, correct 5-asterisk depth)
- [x] Dry-run output for `backup` and `storage` sections eyeballed — correct hierarchy, no duplicates
- [x] Dry-run of regrouped menu eyeballed — `System` heads the list with `install → doctor → host → storage → uninstall`
- [ ] After merge: re-run `scripts/wiki_publish.py` against dev.amethyst-ck.com, confirm menu now lists all 63 leaves with correct nesting and new groupings
