### PR TITLE
Annotate cwd-resolvable -i flags with asterisk and footnote

### DIFF
--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -201,6 +201,13 @@ def gen_wikitext(cmd):
             "! Flag !! Shorthand !! Description "
             "!! Default !! style=\"text-align:center\" | Required"
         )
+        # Non-required -i flags that simply select an instance get an
+        # asterisk in the Default column pointing to a footnote about
+        # cwd resolution. 'version' is excluded: its -i flag activates
+        # a different output mode rather than selecting a target, so
+        # the footnote would mislead readers into thinking plain
+        # 'canasta version' reports on the cwd instance.
+        show_cwd_note = False
         for p in sorted(params, key=lambda x: x["name"]):
             flag = "<code>--" + p["name"].replace("_", "-") + "</code>"
             short = ""
@@ -213,6 +220,13 @@ def gen_wikitext(cmd):
             required = ""
             if p.get("required"):
                 required = "\u2713"
+            if (
+                p.get("short") == "i"
+                and not p.get("required")
+                and cmd["name"] != "version"
+            ):
+                default = (default + "*") if default else "*"
+                show_cwd_note = True
             lines.append("|-")
             lines.append(
                 "| %s || %s || %s || %s "
@@ -220,6 +234,12 @@ def gen_wikitext(cmd):
                 % (flag, short, desc, default, required)
             )
         lines.append("|}")
+        if show_cwd_note:
+            lines.append("")
+            lines.append(
+                "<small>* Defaults to the Canasta instance matching "
+                "the current directory, if any.</small>"
+            )
         lines.append("")
 
     lines.append("{{Reference Manual}}")

--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -203,10 +203,7 @@ def gen_wikitext(cmd):
         )
         # Non-required -i flags that simply select an instance get an
         # asterisk in the Default column pointing to a footnote about
-        # cwd resolution. 'version' is excluded: its -i flag activates
-        # a different output mode rather than selecting a target, so
-        # the footnote would mislead readers into thinking plain
-        # 'canasta version' reports on the cwd instance.
+        # cwd resolution.
         show_cwd_note = False
         for p in sorted(params, key=lambda x: x["name"]):
             flag = "<code>--" + p["name"].replace("_", "-") + "</code>"
@@ -220,11 +217,7 @@ def gen_wikitext(cmd):
             required = ""
             if p.get("required"):
                 required = "\u2713"
-            if (
-                p.get("short") == "i"
-                and not p.get("required")
-                and cmd["name"] != "version"
-            ):
+            if p.get("short") == "i" and not p.get("required"):
                 default = (default + "*") if default else "*"
                 show_cwd_note = True
             lines.append("|-")

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -151,3 +151,40 @@ class TestMenuCoverage:
                 assert " | canasta " in line, (
                     "malformed nested leaf line: %r" % line
                 )
+
+
+class TestCwdResolutionFootnote:
+    """Non-required -i flags get a cwd-resolution footnote in the
+    flags table. Required -i (create) and semantics-changing -i
+    (version) must not, because the footnote would be wrong or
+    misleading for those."""
+
+    def _page_for(self, name):
+        data = wp.load_definitions()
+        cmd = next(c for c in data["commands"] if c["name"] == name)
+        return wp.gen_wikitext(cmd)
+
+    def test_cwd_resolvable_command_has_footnote(self):
+        page = self._page_for("start")
+        assert "matching the current directory" in page
+        # Asterisk appears in the Default column for the -i row.
+        assert "| * " in page or "|*" in page or " * |" in page
+
+    def test_required_id_command_has_no_footnote(self):
+        # create requires -i — there's no cwd resolution path, so no
+        # footnote should be emitted.
+        page = self._page_for("create")
+        assert "matching the current directory" not in page
+
+    def test_version_has_no_footnote(self):
+        # version's -i activates image-version mode; the footnote
+        # would wrongly imply plain 'canasta version' reports on the
+        # cwd instance.
+        page = self._page_for("version")
+        assert "matching the current directory" not in page
+
+    def test_command_without_id_param_has_no_footnote(self):
+        # doctor has no -i at all; don't accidentally emit the
+        # footnote via some bug unrelated to the -i param.
+        page = self._page_for("doctor")
+        assert "matching the current directory" not in page

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -155,9 +155,8 @@ class TestMenuCoverage:
 
 class TestCwdResolutionFootnote:
     """Non-required -i flags get a cwd-resolution footnote in the
-    flags table. Required -i (create) and semantics-changing -i
-    (version) must not, because the footnote would be wrong or
-    misleading for those."""
+    flags table. Required -i (create) does not, because there's no
+    cwd resolution path when -i is required."""
 
     def _page_for(self, name):
         data = wp.load_definitions()
@@ -176,12 +175,12 @@ class TestCwdResolutionFootnote:
         page = self._page_for("create")
         assert "matching the current directory" not in page
 
-    def test_version_has_no_footnote(self):
-        # version's -i activates image-version mode; the footnote
-        # would wrongly imply plain 'canasta version' reports on the
-        # cwd instance.
+    def test_version_has_footnote(self):
+        # After the version redesign (#324), 'canasta version'
+        # cwd-resolves an instance just like every other per-instance
+        # command, so the footnote is accurate for it too.
         page = self._page_for("version")
-        assert "matching the current directory" not in page
+        assert "matching the current directory" in page
 
     def test_command_without_id_param_has_no_footnote(self):
         # doctor has no -i at all; don't accidentally emit the


### PR DESCRIPTION
## Summary
- In `scripts/wiki_publish.py`, the flag table now marks non-required `-i` rows with `*` in the Default column and emits a footnote below the table: `* Defaults to the Canasta instance matching the current directory, if any.`
- `canasta create` is excluded because `-i` is declared required, so there's no cwd-resolution path.
- After #324, `canasta version` cwd-resolves like every other per-instance command, so it's no longer excluded — the footnote now appears on its flag table too.

Closes #321.

## Test plan
- [x] `make test-unit` — 555 passed (4 cwd-footnote test cases: footnote present on `start` and `version`, absent on `create` and `doctor`)
- [x] `make validate` — passed
- [x] Dry-run of regenerated pages spot-checked: `start` and `version` show the asterisk + footnote; `create` and `doctor` do not
- [ ] After merge: re-run `scripts/wiki_publish.py` against dev.amethyst-ck.com, confirm the footnote renders correctly in the Chameleon theme
