### PR TITLE
Redesign canasta version: drop --all, add --cli-only, default to listing all instances outside an instance dir

### DIFF
--- a/direct_commands.py
+++ b/direct_commands.py
@@ -857,35 +857,21 @@ def cmd_version(args):
     print("Canasta CLI v%s (%s, commit %s, built %s)" % (version, mode, commit, date))
     print("Target Canasta version: %s" % target_canasta_version)
 
-    # Per-instance image reports (on demand)
-    inst_id = getattr(args, "id", None)
-    want_all = getattr(args, "all", False)
-
-    if want_all:
-        # Report every instance on the current host.
-        config_dir = _get_config_dir()
-        conf_path = os.path.join(config_dir, "conf.json")
-        instances = _read_registry(conf_path)
-        host_filter = getattr(args, "host", None)
-        instances = _filter_by_host(instances, host_filter)
-        if not instances:
-            print("No instances registered.")
-            return 0
-        for iid in sorted(instances.keys()):
-            image, running = _read_instance_image(iid, instances[iid])
-            print("Instance '%s': %s (running: %s)" % (iid, image, running))
+    # --cli-only: stop after the two-line header; no instance reads.
+    if getattr(args, "cli_only", False):
         return 0
 
+    inst_id = getattr(args, "id", None)
+
     if inst_id:
-        # Explicit -i: resolve and report.
+        # Explicit -i: full-fidelity report (image tag + running runtime).
         inst_id, inst = _resolve_instance(args)
         image, running = _read_instance_image(inst_id, inst)
         print("Instance '%s': %s (running: %s)" % (inst_id, image, running))
         return 0
 
-    # No -i / --all: try to auto-resolve from PWD, report if we find
-    # a match. Outside any instance directory is the common case and
-    # not an error — just stop at the two-line CLI/target report.
+    # No -i: try cwd resolution. If inside an instance directory,
+    # give the same full-fidelity report as -i.
     config_dir = _get_config_dir()
     conf_path = os.path.join(config_dir, "conf.json")
     instances = _read_registry(conf_path)
@@ -900,6 +886,22 @@ def cmd_version(args):
         if parent == cwd:
             break
         cwd = parent
+
+    # Outside any instance directory: list every registered instance
+    # with its pinned CANASTA_IMAGE tag only (no docker-compose-exec
+    # query for the running version). Keeps the default fast even with
+    # many registered instances across remote hosts.
+    host_filter = getattr(args, "host", None)
+    instances = _filter_by_host(instances, host_filter)
+    if not instances:
+        print("No instances registered.")
+        return 0
+    for iid in sorted(instances.keys()):
+        host = instances[iid].get("host") or "localhost"
+        path = instances[iid].get("path", "")
+        env_vars = _read_env_file(path, host)
+        image = env_vars.get("CANASTA_IMAGE", "(unset)")
+        print("Instance '%s': %s" % (iid, image))
     return 0
 
 

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -269,24 +269,37 @@ commands:
   - name: version
     description: "Display version information"
     long_description: |
-      Show Canasta-Ansible CLI version. With --id, also report the
-      image version (CANASTA_IMAGE tag and runtime Canasta version)
-      for the named instance. With --all, report image versions for
-      every registered instance.
+      Always prints the Canasta-Ansible CLI version and the target
+      Canasta version (the image tag this CLI release is built to
+      deploy).
+
+      Additional output depends on context:
+
+      - Inside an instance directory: also reports that instance's
+        pinned CANASTA_IMAGE tag and running runtime version.
+      - Outside any instance directory: lists every registered
+        instance with its pinned CANASTA_IMAGE tag (no runtime query;
+        fast).
+      - With --id: reports full image + running version for the
+        named instance (same as inside that instance's directory).
+      - With --cli-only: prints only the CLI header; skips all
+        instance reads. Intended for scripts that just want the CLI
+        version deterministically.
     examples:
       - "canasta version"
       - "canasta version -i mysite"
-      - "canasta version --all"
+      - "canasta version --cli-only"
     direct_only: true
     parameters:
       - name: id
         short: i
         type: string
         description: "Report image version for this instance"
-      - name: all
+      - name: cli_only
+        short: c
         type: bool
         default: false
-        description: "Report image version for every registered instance"
+        description: "Print only the CLI version; skip instance queries"
 
   - name: doctor
     description: "Check target host dependencies"

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -42,17 +42,22 @@ class TestBuildParser:
     def test_version_bare(self, parser):
         args = parser.parse_args(["version"])
         assert args.id is None
-        assert args.all is False
+        assert args.cli_only is False
 
     def test_version_with_id(self, parser):
         args = parser.parse_args(["version", "-i", "mysite"])
         assert args.id == "mysite"
-        assert args.all is False
+        assert args.cli_only is False
 
-    def test_version_with_all_flag(self, parser):
-        args = parser.parse_args(["version", "--all"])
+    def test_version_with_cli_only_flag(self, parser):
+        args = parser.parse_args(["version", "--cli-only"])
         assert args.id is None
-        assert args.all is True
+        assert args.cli_only is True
+
+    def test_version_with_cli_only_short_flag(self, parser):
+        args = parser.parse_args(["version", "-c"])
+        assert args.id is None
+        assert args.cli_only is True
 
     def test_list_cleanup_flags(self, parser):
         args = parser.parse_args(["list", "--cleanup"])

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -756,7 +756,7 @@ class TestCmdVersion:
 
     def test_target_canasta_version_line(self, tmp_path, monkeypatch, capsys):
         """When CANASTA_VERSION file is present, the target version line
-        is always printed, even without -i/--all."""
+        is always printed, even without -i."""
         (tmp_path / "VERSION").write_text("4.0.0\n")
         (tmp_path / "CANASTA_VERSION").write_text("3.5.7\n")
         (tmp_path / "BUILD_COMMIT").write_text("abc1234\n")
@@ -765,7 +765,7 @@ class TestCmdVersion:
         monkeypatch.setattr(direct_commands, "_get_script_dir", lambda: str(tmp_path))
         # No instances registered — PWD auto-resolve should be a no-op.
         monkeypatch.setenv("CANASTA_CONFIG_DIR", str(tmp_path))
-        args = type("Args", (), {"id": None, "all": False, "host": None})()
+        args = type("Args", (), {"id": None, "cli_only": False, "host": None})()
         rc = direct_commands.cmd_version(args)
         assert rc == 0
         out = capsys.readouterr().out
@@ -780,7 +780,7 @@ class TestCmdVersion:
         monkeypatch.setenv("CANASTA_RUN_MODE", "docker")
         monkeypatch.setattr(direct_commands, "_get_script_dir", lambda: str(tmp_path))
         monkeypatch.setenv("CANASTA_CONFIG_DIR", str(tmp_path))
-        args = type("Args", (), {"id": None, "all": False, "host": None})()
+        args = type("Args", (), {"id": None, "cli_only": False, "host": None})()
         rc = direct_commands.cmd_version(args)
         assert rc == 0
         out = capsys.readouterr().out
@@ -825,6 +825,120 @@ class TestCmdVersion:
         out = capsys.readouterr().out
         assert "v4.0.0" in out
         assert "unknown" in out
+
+
+class TestCmdVersionInstanceModes:
+    """Behavioral coverage for the three instance-reporting modes added
+    in the version redesign: --cli-only, cwd-resolve-inside, and
+    list-all-outside. Uses a fake script_dir + registry so the header
+    and instance lookups can be exercised end-to-end without real
+    Canasta installs."""
+
+    def _setup(self, tmp_path, monkeypatch, instances):
+        """Build a script_dir + registry under tmp_path and wire
+        direct_commands at it. Returns (script_dir, config_dir)."""
+        script_dir = tmp_path / "script"
+        script_dir.mkdir()
+        (script_dir / "VERSION").write_text("4.0.0\n")
+        (script_dir / "CANASTA_VERSION").write_text("3.6.3\n")
+        (script_dir / "BUILD_COMMIT").write_text("abc1234\n")
+        (script_dir / "BUILD_DATE").write_text("2026-04-23 00:00:00\n")
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "conf.json").write_text(json.dumps({"Instances": instances}))
+        monkeypatch.setenv("CANASTA_RUN_MODE", "docker")
+        monkeypatch.setattr(direct_commands, "_get_script_dir", lambda: str(script_dir))
+        monkeypatch.setenv("CANASTA_CONFIG_DIR", str(config_dir))
+        return script_dir, config_dir
+
+    def test_cli_only_skips_instance_reads(self, tmp_path, monkeypatch, capsys):
+        """--cli-only short-circuits after the two header lines, even
+        when instances are registered and cwd would match one."""
+        site = tmp_path / "site"
+        site.mkdir()
+        (site / ".env").write_text("CANASTA_IMAGE=canasta:3.6.3\n")
+        self._setup(tmp_path, monkeypatch, {
+            "site": {"path": str(site), "host": "localhost"},
+        })
+        monkeypatch.chdir(site)  # inside the instance dir
+        args = type("Args", (), {"id": None, "cli_only": True, "host": None})()
+        rc = direct_commands.cmd_version(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Canasta CLI v4.0.0" in out
+        assert "Target Canasta version: 3.6.3" in out
+        # No instance line — cli_only must short-circuit.
+        assert "Instance '" not in out
+
+    def test_outside_instance_lists_all_without_running_query(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Outside any instance directory, the default lists every
+        registered instance's pinned CANASTA_IMAGE tag but skips the
+        docker-compose-exec runtime query (keeps the default fast)."""
+        s1 = tmp_path / "site1"
+        s1.mkdir()
+        (s1 / ".env").write_text("CANASTA_IMAGE=canasta:3.6.0\n")
+        s2 = tmp_path / "site2"
+        s2.mkdir()
+        (s2 / ".env").write_text("CANASTA_IMAGE=canasta:3.6.3\n")
+        self._setup(tmp_path, monkeypatch, {
+            "site1": {"path": str(s1), "host": "localhost"},
+            "site2": {"path": str(s2), "host": "localhost"},
+        })
+        # Sit somewhere that is not inside either instance dir.
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        monkeypatch.chdir(outside)
+        args = type("Args", (), {"id": None, "cli_only": False, "host": None})()
+        rc = direct_commands.cmd_version(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Instance 'site1': canasta:3.6.0" in out
+        assert "Instance 'site2': canasta:3.6.3" in out
+        # List-all must NOT include '(running: ...)' — that suffix
+        # comes from _read_instance_image's runtime query, which
+        # is intentionally skipped for the fast default.
+        assert "running:" not in out
+
+    def test_inside_instance_dir_shows_current_full(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Inside an instance directory with no -i, should print the
+        full (image + running) line for that instance only."""
+        site = tmp_path / "site"
+        site.mkdir()
+        (site / ".env").write_text("CANASTA_IMAGE=canasta:3.6.3\n")
+        self._setup(tmp_path, monkeypatch, {
+            "site": {"path": str(site), "host": "localhost"},
+            "other": {"path": str(tmp_path / "other"), "host": "localhost"},
+        })
+        monkeypatch.chdir(site)
+        # Stub the runtime-version query to return a known string so
+        # the test doesn't depend on docker being available.
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: type("R", (), {
+                "returncode": 0, "stdout": "3.6.3-running\n",
+            })(),
+        )
+        args = type("Args", (), {"id": None, "cli_only": False, "host": None})()
+        rc = direct_commands.cmd_version(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Instance 'site': canasta:3.6.3 (running: 3.6.3-running)" in out
+        # The sibling instance must not appear — cwd resolution wins
+        # and suppresses the list-all fallback.
+        assert "'other'" not in out
+
+    def test_all_flag_rejected(self, tmp_path, monkeypatch, capsys):
+        """--all was removed; argparse should reject it so anyone who
+        still uses it gets a loud error instead of silently falling
+        through to the default."""
+        import canasta
+        parser = canasta.build_parser(canasta.load_definitions())
+        with pytest.raises(SystemExit):
+            parser.parse_args(["version", "--all"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Redesigns `canasta version` so it follows the cwd-resolution convention the rest of the CLI uses, removing the `--all` flag and adding `--cli-only` (`-c`) as a scripting escape hatch.

| Invocation | Output |
|---|---|
| `canasta version` outside instance dir | CLI header + list of all instances (pinned image tags only) |
| `canasta version` inside instance dir | CLI header + that instance (full: image + running) |
| `canasta version -i X` | CLI header + X (full: image + running) |
| `canasta version --cli-only` / `-c` | CLI header only |

Breaking change: `canasta version --all` is no longer recognized. The default outside an instance directory replaces it. Scripts that relied on the old two-line-only output can add `--cli-only` / `-c`.

The list-all default reads only each instance's `.env` (no docker-compose-exec runtime query), so `canasta version` outside an instance dir stays fast even across many remote hosts.

Closes #323. After merge, #322 can be rebased to drop the hardcoded `version` exception from the flag-table footnote logic.

## Test plan
- [x] `make test-unit` — 551 passed (4 new behavioral tests in `TestCmdVersionInstanceModes`, 1 new parser test, updated existing tests for the new flag shape)
- [x] `make validate` — passed
- [x] `canasta version --help` — help text and flag list render correctly
- [x] `canasta version --all` — rejected with `error: unrecognized arguments: --all`
- [x] `make docs` — regenerated `docs/commands/version.md` reflects the new behavior (file is gitignored)
- [ ] After merge: manually verify against dev.amethyst-ck.com — inside an instance, outside any, and with `-i`/`-c`
