### PR TITLE
Render global flags (--help, --verbose) on every command page

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -17,6 +17,14 @@
 #   positional        - Accepted as positional argument(s), not a flag
 
 global_flags:
+  # --help/-h is provided automatically by argparse on every parser;
+  # listed here so wiki_publish.py renders it in the Global Flags
+  # section of every command page. No argparse wiring reads this entry.
+  - name: help
+    short: h
+    type: bool
+    default: false
+    description: "Show help message and exit"
   - name: verbose
     short: v
     type: bool

--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -115,8 +115,13 @@ def cmd_page_title(internal_name):
     return PAGE_PREFIX + "canasta " + cmd_display_name(internal_name)
 
 
-def gen_wikitext(cmd):
-    """Generate wikitext for a single command page."""
+def gen_wikitext(cmd, global_flags=None):
+    """Generate wikitext for a single command page.
+
+    If global_flags is provided, a 'Global Flags' section is emitted
+    after the command's own flag table, listing flags inherited by
+    every command (e.g. --help, --verbose).
+    """
     name = cmd["name"]
     display = "canasta " + cmd_display_name(name)
     lines = []
@@ -235,6 +240,35 @@ def gen_wikitext(cmd):
             )
         lines.append("")
 
+    if global_flags:
+        lines.append("=== Global Flags ===")
+        lines.append("")
+        lines.append('{| class="wikitable"')
+        lines.append(
+            "! Flag !! Shorthand !! Description "
+            "!! Default !! style=\"text-align:center\" | Required"
+        )
+        for p in sorted(global_flags, key=lambda x: x["name"]):
+            flag = "<code>--" + p["name"].replace("_", "-") + "</code>"
+            short = ""
+            if p.get("short"):
+                short = "<code>-%s</code>" % p["short"]
+            desc = p.get("description", "")
+            default = ""
+            if p.get("default") not in (None, "", False, 0):
+                default = "<code>%s</code>" % p["default"]
+            required = ""
+            if p.get("required"):
+                required = "✓"
+            lines.append("|-")
+            lines.append(
+                "| %s || %s || %s || %s "
+                '|| style="text-align:center" | %s'
+                % (flag, short, desc, default, required)
+            )
+        lines.append("|}")
+        lines.append("")
+
     lines.append("{{Reference Manual}}")
     return "\n".join(lines)
 
@@ -291,9 +325,13 @@ def generate_all_pages(data):
     # Per-command pages — parent_path arg retained for back-compat,
     # but gen_wikitext now derives the breadcrumb chain itself via
     # _ancestors() so nested subcommands render correctly.
+    global_flags = data.get("global_flags", [])
     for cmd in data["commands"]:
         name = cmd["name"]
-        pages.append((cmd_page_title(name), gen_wikitext(cmd)))
+        pages.append((
+            cmd_page_title(name),
+            gen_wikitext(cmd, global_flags=global_flags),
+        ))
 
     # Menu page
     menu_lines = ["* # | Canasta CLI Reference"]

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -187,3 +187,55 @@ class TestCwdResolutionFootnote:
         # footnote via some bug unrelated to the -i param.
         page = self._page_for("doctor")
         assert "matching the current directory" not in page
+
+
+class TestGlobalFlagsSection:
+    """Every command page should carry a 'Global Flags' section listing
+    flags inherited by all commands (currently --help and --verbose).
+    The section is rendered from data['global_flags'] in the YAML so
+    there's a single source of truth for what readers see."""
+
+    def _pages(self):
+        data = wp.load_definitions()
+        return dict(wp.generate_all_pages(data))
+
+    def test_every_command_page_has_global_flags_section(self):
+        pages = self._pages()
+        missing = []
+        for title, content in pages.items():
+            if not title.startswith(wp.PAGE_PREFIX + "canasta"):
+                continue
+            if title == wp.PAGE_PREFIX + "canasta":
+                continue  # root page has no flag table
+            if "=== Global Flags ===" not in content:
+                missing.append(title)
+        assert not missing, (
+            "pages missing Global Flags section:\n  "
+            + "\n  ".join(missing)
+        )
+
+    def test_global_flags_section_lists_help_and_verbose(self):
+        """The two globals today are --help (inherited from argparse)
+        and --verbose. If either is missing from the rendered section
+        the reader loses documentation of a real flag."""
+        page = wp.gen_wikitext(
+            {"name": "start", "description": "Start",
+             "parameters": [{"name": "id", "short": "i",
+                             "type": "string",
+                             "description": "Canasta instance ID"}]},
+            global_flags=wp.load_definitions()["global_flags"],
+        )
+        assert "=== Global Flags ===" in page
+        assert "--help" in page
+        assert "--verbose" in page
+
+    def test_global_flags_omitted_when_not_supplied(self):
+        """gen_wikitext called without global_flags (e.g. from tests)
+        emits the page without the Global Flags section — back-compat."""
+        page = wp.gen_wikitext(
+            {"name": "start", "description": "Start",
+             "parameters": [{"name": "id", "short": "i",
+                             "type": "string",
+                             "description": "Canasta instance ID"}]}
+        )
+        assert "=== Global Flags ===" not in page


### PR DESCRIPTION
## Summary
- Adds a `help` entry to `global_flags` in `command_definitions.yml` so the wiki publisher can render `-h/--help` alongside `-v/--verbose` on every command reference page. (Argparse wires `--help` automatically; the YAML entry is for the publisher only.)
- In `scripts/wiki_publish.py`, `gen_wikitext(cmd, global_flags=...)` now emits a `=== Global Flags ===` wikitable after the per-command flag table when `global_flags` is supplied. `generate_all_pages` passes the globals through; direct callers that don't (e.g. older tests) continue to work.
- Adds three tests in `TestGlobalFlagsSection`: every command page carries the section, `--help`+`--verbose` appear in it, and the section is omitted when `global_flags` isn't passed.

Closes #329.

## Test plan
- [x] `make test-unit` — 550 passed (3 new)
- [x] `make validate` — passed
- [x] Dry-run spot check: `CLI:canasta start` now ends with a Global Flags table listing `--help` and `--verbose`
- [ ] After merge: re-run against dev.amethyst-ck.com, confirm the section renders under the Chameleon theme
