### PR TITLE
Center the Default column in flag tables

### DIFF
--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -204,7 +204,8 @@ def gen_wikitext(cmd, global_flags=None):
         lines.append('{| class="wikitable"')
         lines.append(
             "! Flag !! Shorthand !! Description "
-            "!! Default !! style=\"text-align:center\" | Required"
+            "!! style=\"text-align:center\" | Default "
+            "!! style=\"text-align:center\" | Required"
         )
         # Non-required -i flags that simply select an instance get an
         # asterisk in the Default column pointing to a footnote about
@@ -227,7 +228,8 @@ def gen_wikitext(cmd, global_flags=None):
                 show_cwd_note = True
             lines.append("|-")
             lines.append(
-                "| %s || %s || %s || %s "
+                "| %s || %s || %s "
+                '|| style="text-align:center" | %s '
                 '|| style="text-align:center" | %s'
                 % (flag, short, desc, default, required)
             )
@@ -246,7 +248,8 @@ def gen_wikitext(cmd, global_flags=None):
         lines.append('{| class="wikitable"')
         lines.append(
             "! Flag !! Shorthand !! Description "
-            "!! Default !! style=\"text-align:center\" | Required"
+            "!! style=\"text-align:center\" | Default "
+            "!! style=\"text-align:center\" | Required"
         )
         for p in sorted(global_flags, key=lambda x: x["name"]):
             flag = "<code>--" + p["name"].replace("_", "-") + "</code>"
@@ -262,7 +265,8 @@ def gen_wikitext(cmd, global_flags=None):
                 required = "✓"
             lines.append("|-")
             lines.append(
-                "| %s || %s || %s || %s "
+                "| %s || %s || %s "
+                '|| style="text-align:center" | %s '
                 '|| style="text-align:center" | %s'
                 % (flag, short, desc, default, required)
             )


### PR DESCRIPTION
## Summary
In both the per-command flags table and the Global Flags table, apply `style="text-align:center"` to the Default column header and cells — matches the Required column's styling.

Closes #331.

## Test plan
- [x] `make test-unit` — 550 passed (no test changes needed; existing tests don't assert on column alignment)
- [x] Dry-run spot check: `CLI:canasta start`'s flag table now has centered `*` in the Default cell for `-i`
- [ ] After merge: re-publish to dev.amethyst-ck.com, confirm centering renders in Chameleon
