### PR TITLE
Flip --host to post-command position in tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ canasta list
 The simplest way to target a remote host is the `user@host` shorthand:
 
 ```bash
-canasta --host ubuntu@prod1.example.com create --id wiki-prod --wiki main
+canasta create --host ubuntu@prod1.example.com --id wiki-prod --wiki main
 ```
 
 This works without any inventory setup. SSH keys must be in place for
@@ -216,7 +216,7 @@ canasta host remove prod1
 After adding, use the short name:
 
 ```bash
-canasta --host prod1 create --id wiki-prod --wiki main
+canasta create --host prod1 --id wiki-prod --wiki main
 ```
 
 You can also edit `$CANASTA_CONFIG_DIR/hosts.yml` directly for
@@ -237,10 +237,10 @@ Manage instances across hosts:
 
 ```bash
 # Create on a remote host
-./canasta --host prod1.example.com create --id wiki-prod --wiki main
+./canasta create --host prod1.example.com --id wiki-prod --wiki main
 
 # Create on another host
-./canasta --host staging.example.com create --id wiki-staging --wiki main
+./canasta create --host staging.example.com --id wiki-staging --wiki main
 
 # List all instances across all hosts
 ./canasta list

--- a/canasta.yml
+++ b/canasta.yml
@@ -5,7 +5,7 @@
 #   ansible-playbook canasta.yml -e "command=create id=mysite wiki=mywiki"
 #   ansible-playbook canasta.yml -e "command=start id=mysite target_host=prod1.example.com" --limit prod1.example.com
 #   ./canasta create --id mysite --wiki mywiki
-#   ./canasta --host prod1.example.com start --id mysite
+#   ./canasta create --host prod1.example.com --id mysite --wiki mywiki
 #
 - name: Canasta
   hosts: "{{ target_host | default('localhost') }}"

--- a/tests/integration/REMOTE_TEST_DESIGN.md
+++ b/tests/integration/REMOTE_TEST_DESIGN.md
@@ -70,7 +70,7 @@ The entrypoint starts both `dockerd` (background) and `sshd` (foreground).
 ### 1. Create with -H
 
 ```bash
-./canasta -H canasta@127.0.0.1:2222 create -i remotesite -w main
+./canasta create -H canasta@127.0.0.1:2222 -i remotesite -w main
 ```
 
 Verify:
@@ -81,7 +81,7 @@ Verify:
 ### 2. List with -H
 
 ```bash
-./canasta -H 127.0.0.1:2222 list
+./canasta list -H 127.0.0.1:2222
 ```
 
 Verify:

--- a/tests/integration/remote/run_tests.sh
+++ b/tests/integration/remote/run_tests.sh
@@ -117,7 +117,7 @@ echo ""
 
 # --- Test 1: Create with -H ---
 echo "Test 1: canasta create with -H"
-if canasta -H "${REMOTE_HOST}" create -i "${INSTANCE_ID}" -w main -n localhost -p "${CANASTA_TEST_DATA}" 2>&1; then
+if canasta create -H "${REMOTE_HOST}" -i "${INSTANCE_ID}" -w main -n localhost -p "${CANASTA_TEST_DATA}" 2>&1; then
     pass "create with -H"
 else
     fail "create with -H"


### PR DESCRIPTION
## Summary
`#326` demoted `--host`/`-H` from global to per-command. The remote integration test script and several doc examples still used the old `canasta --host X <cmd>` syntax, which now errors. This PR flips them to the valid `canasta <cmd> --host X` form.

Files changed:
- `tests/integration/remote/run_tests.sh` — the one `canasta -H ... create` invocation that was causing the CI cascade (6 failures, all downstream of the create step)
- `tests/integration/REMOTE_TEST_DESIGN.md` — two example invocations
- `README.md` — four example invocations (three in "remote host" section + one prose example)
- `canasta.yml` — comment example (also changed from `start` to `create` since `start` no longer accepts `--host`)

Closes #333.

## Test plan
- [x] `make test-unit` — 550 passed
- [x] `grep -rn 'canasta -H\|canasta --host' --include='*.sh' --include='*.md' --include='*.py' --include='*.yml'` returns nothing
- [ ] After merge: the failing "Remote Host Integration Tests" CI job should pass

Noticed but not in scope: `README.md` has `canasta host add prod1 --ssh ...` using `prod1` as a positional, but the `host add` param is flag-only (`-n/--name`). That's a separate pre-existing bug; I'll file it as a follow-up.
