### PR TITLE
Add Orchestrator column to wiki flag tables

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -101,7 +101,8 @@ commands:
       - name: override
         short: r
         type: path
-        description: "File to copy to docker-compose.override.yml (Compose only)"
+        orchestrator_only: compose
+        description: "File to copy to docker-compose.override.yml"
       - name: rootdbpass
         type: string
         sensitive: true

--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -115,6 +115,25 @@ def cmd_page_title(internal_name):
     return PAGE_PREFIX + "canasta " + cmd_display_name(internal_name)
 
 
+# Orchestrator-column labels. Params without an `orchestrator_only`
+# field apply to both orchestrators; params with the field are scoped
+# to just one. The column is rendered on every flag table per the
+# docs-wiki audit so readers don't have to infer scope from the flag's
+# description.
+_ORCHESTRATOR_LABELS = {
+    "compose": "Compose",
+    "kubernetes": "Kubernetes",
+    "k8s": "Kubernetes",
+}
+
+
+def _orchestrator_label(value):
+    """Map a param's orchestrator_only value to a table label."""
+    if not value:
+        return "Both"
+    return _ORCHESTRATOR_LABELS.get(value, value)
+
+
 def gen_wikitext(cmd, global_flags=None):
     """Generate wikitext for a single command page.
 
@@ -205,7 +224,8 @@ def gen_wikitext(cmd, global_flags=None):
         lines.append(
             "! Flag !! Shorthand !! Description "
             "!! style=\"text-align:center\" | Default "
-            "!! style=\"text-align:center\" | Required"
+            "!! style=\"text-align:center\" | Required "
+            "!! style=\"text-align:center\" | Orchestrator"
         )
         # Non-required -i flags that simply select an instance get an
         # asterisk in the Default column pointing to a footnote about
@@ -226,12 +246,14 @@ def gen_wikitext(cmd, global_flags=None):
             if p.get("short") == "i" and not p.get("required"):
                 default = (default + "*") if default else "*"
                 show_cwd_note = True
+            orch = _orchestrator_label(p.get("orchestrator_only"))
             lines.append("|-")
             lines.append(
                 "| %s || %s || %s "
                 '|| style="text-align:center" | %s '
+                '|| style="text-align:center" | %s '
                 '|| style="text-align:center" | %s'
-                % (flag, short, desc, default, required)
+                % (flag, short, desc, default, required, orch)
             )
         lines.append("|}")
         if show_cwd_note:
@@ -249,7 +271,8 @@ def gen_wikitext(cmd, global_flags=None):
         lines.append(
             "! Flag !! Shorthand !! Description "
             "!! style=\"text-align:center\" | Default "
-            "!! style=\"text-align:center\" | Required"
+            "!! style=\"text-align:center\" | Required "
+            "!! style=\"text-align:center\" | Orchestrator"
         )
         for p in sorted(global_flags, key=lambda x: x["name"]):
             flag = "<code>--" + p["name"].replace("_", "-") + "</code>"
@@ -263,12 +286,14 @@ def gen_wikitext(cmd, global_flags=None):
             required = ""
             if p.get("required"):
                 required = "✓"
+            orch = _orchestrator_label(p.get("orchestrator_only"))
             lines.append("|-")
             lines.append(
                 "| %s || %s || %s "
                 '|| style="text-align:center" | %s '
+                '|| style="text-align:center" | %s '
                 '|| style="text-align:center" | %s'
-                % (flag, short, desc, default, required)
+                % (flag, short, desc, default, required, orch)
             )
         lines.append("|}")
         lines.append("")

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -239,3 +239,65 @@ class TestGlobalFlagsSection:
                              "description": "Canasta instance ID"}]}
         )
         assert "=== Global Flags ===" not in page
+
+
+class TestOrchestratorColumn:
+    """Flag tables carry an 'Orchestrator' column so readers can see at
+    a glance which orchestrator each flag applies to. Values come from
+    the YAML's optional `orchestrator_only` field: unset → 'Both',
+    'kubernetes' or 'k8s' → 'Kubernetes', 'compose' → 'Compose'."""
+
+    def _create_page(self):
+        data = wp.load_definitions()
+        cmd = next(c for c in data["commands"] if c["name"] == "create")
+        return wp.gen_wikitext(cmd, global_flags=data["global_flags"])
+
+    def test_column_header_present(self):
+        page = self._create_page()
+        assert "Orchestrator" in page
+
+    def test_kubernetes_only_param_labelled_kubernetes(self):
+        page = self._create_page()
+        # --storage-class has orchestrator_only: kubernetes. Its row
+        # must include the 'Kubernetes' label.
+        for line in page.splitlines():
+            if "<code>--storage-class</code>" in line:
+                assert "Kubernetes" in line
+                return
+        raise AssertionError("--storage-class row not found")
+
+    def test_compose_only_param_labelled_compose(self):
+        page = self._create_page()
+        for line in page.splitlines():
+            if "<code>--override</code>" in line:
+                assert "Compose" in line
+                return
+        raise AssertionError("--override row not found")
+
+    def test_orchestrator_neutral_param_labelled_both(self):
+        page = self._create_page()
+        # --id is the plain per-instance flag, applies to both.
+        for line in page.splitlines():
+            if "<code>--id</code>" in line:
+                assert "Both" in line
+                return
+        raise AssertionError("--id row not found")
+
+    def test_global_flags_section_also_has_column(self):
+        """Global flags apply to every command regardless of
+        orchestrator, so they show 'Both' in the column."""
+        page = self._create_page()
+        # The Global Flags section is the tail of the page after
+        # '=== Global Flags ==='.
+        gf = page.split("=== Global Flags ===", 1)[1]
+        assert "Orchestrator" in gf
+        for line in gf.splitlines():
+            if "<code>--help</code>" in line or "<code>--verbose</code>" in line:
+                assert "Both" in line
+
+    def test_label_helper_maps_values(self):
+        assert wp._orchestrator_label(None) == "Both"
+        assert wp._orchestrator_label("") == "Both"
+        assert wp._orchestrator_label("kubernetes") == "Kubernetes"
+        assert wp._orchestrator_label("k8s") == "Kubernetes"
+        assert wp._orchestrator_label("compose") == "Compose"


### PR DESCRIPTION
## Summary
- `scripts/wiki_publish.py` now renders an `Orchestrator` column (centered, like `Default` and `Required`) on both the per-command and Global Flags tables. Values: `Both` (default), `Compose`, or `Kubernetes`.
- Adds `orchestrator_only: compose` to `create.override` in `meta/command_definitions.yml` — closing the data gap where the description said "(Compose only)" but no field was set. The parenthetical is removed from the description since the column now conveys it.
- Six new tests in `TestOrchestratorColumn`: column header present, K8s-only param labelled Kubernetes, Compose-only param labelled Compose, orchestrator-neutral param labelled Both, globals table has the column with Both values, and a helper-function mapping test.

Closes #337.

## Test plan
- [x] `make test-unit` — 556 passed (6 new)
- [x] `make validate` — passed
- [x] Dry-run spot checks: `create.--storage-class` → Kubernetes, `create.--override` → Compose, `create.--id` → Both, `start.--id` → Both, Global Flags rows → Both
- [ ] After merge: re-publish to dev.amethyst-ck.com, confirm the column renders under the Chameleon theme
