### PR TITLE
Skip wiki usage line for commands with no parameters

### DIFF
--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -180,13 +180,14 @@ def gen_wikitext(cmd, global_flags=None):
     # Usage line — match the live wiki's compact form ('canasta create
     # [flags]') instead of an inline listing of every option. The
     # detailed flag table below is the authoritative reference.
-    lines.append("<syntaxhighlight lang=\"bash\">")
+    # Skip entirely when the command has no parameters: the line would
+    # read just 'canasta host list' and duplicate the bare-command
+    # example below.
     if cmd.get("parameters"):
+        lines.append("<syntaxhighlight lang=\"bash\">")
         lines.append("%s [flags]" % display)
-    else:
-        lines.append(display)
-    lines.append("</syntaxhighlight>")
-    lines.append("")
+        lines.append("</syntaxhighlight>")
+        lines.append("")
 
     # Subcommands
     if name in SUBCOMMAND_GROUPS:

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -301,3 +301,39 @@ class TestOrchestratorColumn:
         assert wp._orchestrator_label("kubernetes") == "Kubernetes"
         assert wp._orchestrator_label("k8s") == "Kubernetes"
         assert wp._orchestrator_label("compose") == "Compose"
+
+
+class TestUsageLineSkipsWhenNoParams:
+    """A command with no parameters has no flags to document in the
+    usage line. Emitting 'canasta host list' as a synoptic block
+    duplicates the bare-command example below. Skip the block entirely
+    in that case."""
+
+    def test_command_with_no_params_omits_usage_block(self):
+        page = wp.gen_wikitext({
+            "name": "host_list",
+            "description": "List hosts",
+            "long_description": "List every saved host definition.",
+            "examples": ["canasta host list"],
+        })
+        # The '[flags]' placeholder must not appear at all when there
+        # are no flags.
+        assert "[flags]" not in page
+        # There should be exactly one occurrence of a syntaxhighlight
+        # block (the Examples block), not two.
+        assert page.count('<syntaxhighlight lang="bash"') == 1
+
+    def test_command_with_params_keeps_usage_block(self):
+        page = wp.gen_wikitext({
+            "name": "start",
+            "description": "Start",
+            "long_description": "Start the instance.",
+            "examples": ["canasta start"],
+            "parameters": [{"name": "id", "short": "i",
+                            "type": "string",
+                            "description": "Canasta instance ID"}],
+        })
+        # With parameters, '[flags]' must appear in the usage block.
+        assert "canasta start [flags]" in page
+        # Two syntaxhighlight blocks: one for usage, one for examples.
+        assert page.count('<syntaxhighlight lang="bash"') == 2


### PR DESCRIPTION
## Summary
In `scripts/wiki_publish.py` `gen_wikitext`, the Synopsis-adjacent usage block is now skipped when the command has no parameters. Previously it emitted a bare `canasta <cmd>` that duplicated the Example below. With parameters, the block still renders `canasta <cmd> [flags]` as before.

Only one command is currently affected: `host list`. Every other command has at least one parameter.

Two new tests in `TestUsageLineSkipsWhenNoParams`.

Closes #341.

## Test plan
- [x] `make test-unit` — 558 passed (2 new)
- [x] `make validate` — passed
- [x] Dry-run spot check: `CLI:canasta host list` no longer carries the redundant usage block; `CLI:canasta start` still does

Note: this PR and #340 touch different regions of `wiki_publish.py` (this skips the usage block; #340 adds backtick-to-`<code>` transform). Merging this first means the final republish after #340 shows the clean `host list` page in one step. Merging #340 first works too; needs one extra intermediate republish to get there.
