### PR TITLE
Add RELEASE_NOTES.md with v4.0.0 entry

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,6 @@
+Canasta CLI version history (Ansible-based, 4.0.0+):
+
+For earlier versions (0.1.0-alpha through 3.7.0, Go-based), see
+https://github.com/CanastaWiki/Canasta-Go/blob/main/RELEASE_NOTES.md
+
+- 4.0.0 - <release date>, 2026 - Complete rewrite from Go to Ansible; replaces Canasta-CLI 3.x (end-of-life as of 3.7.0). Existing `conf.json` registries and instance directories continue to work without modification; installer replaces the Go binary in place via `get-canasta.sh`. New capabilities: SSH-based multi-host management (`--host` flag, `canasta host add`/`remove`/`list`); multi-node Kubernetes with `ReadWriteMany` PVCs for multi-replica web pods; `canasta doctor`, `canasta install`/`uninstall`, `canasta storage setup nfs`/`efs`; auto-generated CLI reference on canasta.wiki. Feature parity otherwise with 3.6.3.


### PR DESCRIPTION
## Summary
Creates `RELEASE_NOTES.md` matching the Canasta-CLI convention (reverse-chronological, one-line-per-version dense prose). Adds the v4.0.0 entry. `<release date>` placeholder will be updated when we tag.

The top of the file points at Canasta-Go's `RELEASE_NOTES.md` for pre-4.0.0 history so the version trail stays followable.

Closes #345.

## Test plan
- [x] `make test-unit` — 564 passed
- [x] Visual review of the entry against the 3.3.1 "Major rewrite" style anchor
- [ ] On release day (Phase 5): replace `<release date>` with the actual tag date
