### PR TITLE
Auto-publish CLI reference to wiki on push to main

### DIFF
--- a/.github/workflows/wiki-publish.yml
+++ b/.github/workflows/wiki-publish.yml
@@ -1,28 +1,25 @@
 ---
 # Publish Canasta CLI Reference to wiki
 #
-# DISABLED by default -- uses workflow_dispatch (manual trigger only).
-# To enable automatic publishing on push to main, uncomment the push
-# trigger below.
+# Fires on every push to main and on manual dispatch. Publishes the
+# CLI: namespace and MediaWiki:Menu-cli-reference to the wiki at
+# WIKI_API_URL.
 #
-# Page names match the Go CLI format (CLI:canasta_create, etc.)
-# so this can serve as a drop-in replacement when ready.
-#
-# Default target: test-docs.canasta.wiki
-# Change WIKI_API_URL secret to https://canasta.wiki/w/api.php
-# when ready for production.
-#
-# Required secrets:
-#   WIKI_API_URL      - default: https://test-docs.canasta.wiki/w/api.php
-#   WIKI_BOT_USER     - e.g., User@BotName
+# Required secrets (set at the repo or org level):
+#   WIKI_API_URL      - e.g. https://canasta.wiki/w/api.php
+#   WIKI_BOT_USER     - e.g. User@BotName
 #   WIKI_BOT_PASSWORD
 
 name: Publish CLI Reference to Wiki
 
 on:
-  # push:
-  #   branches:
-  #     - main
+  push:
+    branches:
+      - main
+    paths:
+      - 'meta/command_definitions.yml'
+      - 'scripts/wiki_publish.py'
+      - '.github/workflows/wiki-publish.yml'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary

Now that the wiki-publish workflow has been validated end-to-end against canasta.wiki — 71 CLI: pages and `MediaWiki:Menu-cli-reference` all published, content byte-identical to the dev staging wiki — enable the `push: branches: [main]` trigger so future changes to the canonical command list flow through automatically.

## Trigger scope

Path-filtered so unrelated commits don't fire a no-op publish:

- `meta/command_definitions.yml` — the canonical command spec
- `scripts/wiki_publish.py` — the publisher itself
- `.github/workflows/wiki-publish.yml` — this file (so changes to the workflow itself trigger validation)

`workflow_dispatch` stays available for manual one-off runs.

## Test plan

- [x] Manual `workflow_dispatch` against canasta.wiki has been verified to publish all pages cleanly (run completed earlier today).
- [ ] After merge: confirm a no-op push to main doesn't fire the workflow (path filter works).
- [ ] After merge + a meaningful `meta/command_definitions.yml` change: confirm the workflow auto-fires and updates pages on canasta.wiki.