### PR TITLE
Tag Docker image + git ref on VERSION bump (release-tagging flow)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,19 @@
 ---
 # Build and push canasta-ansible Docker image.
 #
-# Builds on push to main and on version tag.
-# Pushes to ghcr.io/canastawiki/canasta-ansible.
+# Triggers:
+#   - push to main: builds image, tags it 'main' + 'latest'. If the
+#     pushed commit changed VERSION, additionally tags 'X.Y.Z' / 'X.Y'
+#     and pushes a 'vX.Y.Z' git tag (so 'git checkout vX.Y.Z' works).
+#   - push of a v* git tag: builds image, tags it 'X.Y.Z' / 'X.Y' via
+#     the metadata-action's semver patterns. Useful as a manual escape
+#     hatch; the auto-tag flow above is the normal path.
+#   - workflow_dispatch: manual rebuild without producing version tags.
+#
+# No GitHub Release is created here — the v3.7.0 release on this repo
+# (mirrored from Canasta-Go) needs to remain the API-latest so legacy
+# 'canasta upgrade' clients keep working. Creating a v4.x.y Release
+# would mark v4.x.y as latest and break that flow.
 
 name: Docker Image
 
@@ -13,8 +24,37 @@ on:
   workflow_dispatch:
 
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.read.outputs.version }}
+      major_minor: ${{ steps.read.outputs.major_minor }}
+      changed: ${{ steps.check.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+      - name: Read VERSION
+        id: read
+        run: |
+          V=$(cat VERSION | tr -d '[:space:]')
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "major_minor=${V%.*}" >> "$GITHUB_OUTPUT"
+      - name: Check if VERSION changed
+        id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "push" \
+             && "${{ github.ref }}" == "refs/heads/main" ]] \
+             && git diff HEAD~1 --name-only 2>/dev/null \
+                | grep -q '^VERSION$'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     runs-on: ubuntu-latest
+    needs: version
     permissions:
       contents: read
       packages: write
@@ -38,6 +78,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ needs.version.outputs.version }},enable=${{ needs.version.outputs.changed == 'true' }}
+            type=raw,value=${{ needs.version.outputs.major_minor }},enable=${{ needs.version.outputs.changed == 'true' }}
 
       - name: Set up QEMU for multi-platform builds
         uses: docker/setup-qemu-action@v3
@@ -62,3 +104,26 @@ jobs:
           build-args: |
             BUILD_COMMIT=${{ steps.buildmeta.outputs.commit }}
             BUILD_DATE=${{ steps.buildmeta.outputs.date }}
+
+  tag:
+    runs-on: ubuntu-latest
+    needs: [version, build]
+    if: needs.version.outputs.changed == 'true'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Push v${{ needs.version.outputs.version }} git tag
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Idempotent on re-run: skip if tag already exists upstream.
+          if git ls-remote --tags origin "v$VERSION" | grep -q "refs/tags/v$VERSION$"; then
+            echo "Tag v$VERSION already exists on origin; skipping push."
+            exit 0
+          fi
+          git tag "v$VERSION" "$GITHUB_SHA"
+          git push origin "v$VERSION"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,12 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
+# Default to read-only for the GITHUB_TOKEN; jobs that need to write
+# (build pushes images, tag pushes a git tag) declare their own
+# permissions blocks below.
+permissions:
+  contents: read
+
 jobs:
   version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds VERSION-bump-driven release tagging to `docker.yml`, modeled on the Go CLI's `release.yml` flow.

When a commit on `main` changes `VERSION`:
- The Docker image gets tagged `X.Y.Z`, `X.Y`, plus the existing `latest` and `main`.
- A `vX.Y.Z` git tag is pushed to origin so `git checkout vX.Y.Z` works.

When a commit on `main` *doesn't* change `VERSION` (the regular case): unchanged from today — image just gets `latest` + `main`.

## Why this design

- **Image-side tagging via `type=raw`** rather than relying on `type=semver` patterns. Semver patterns only fire from a `v*` git tag *event*; relying on them would require a two-step "push commit, then push tag" sequence. The `type=raw,enable=...` form lets us produce version tags from a single push when VERSION changes.
- **Git tag pushed by the workflow** (idempotent — skips if already on origin) so end users can `git checkout vX.Y.Z`. Tag pushes from a workflow don't trigger downstream workflow runs (default `GITHUB_TOKEN` behavior), so no double-build.
- **No GitHub Release created.** The `v3.7.0` Release on this repo is the cross-repo mirror that legacy `canasta upgrade` clients hit at `releases/latest`. Creating a `v4.x.y` Release would override it as latest and break that upgrade flow. End users get version-tagged Docker images and git tags; that's enough for normal use.
- **Manual `tags: ["v*"]` trigger preserved** as an escape hatch. If someone pushes a tag directly, the workflow still fires and `metadata-action`'s `type=semver` patterns produce the version-tagged image. The new VERSION-detection job sets `changed=false` in that case (it only fires for `push` events on `refs/heads/main`), so the new tag-push step skips.

## Mode-by-mode behavior

| Trigger | Image tags applied | Git tag pushed? |
|---|---|---|
| `push` to main, VERSION unchanged | `latest`, `main` | no |
| `push` to main, VERSION changed | `latest`, `main`, `X.Y.Z`, `X.Y` | `vX.Y.Z` |
| `push` of a `v*` tag (manual) | `X.Y.Z`, `X.Y` (via semver pattern) | n/a (already exists) |
| `workflow_dispatch` | `latest`, `main` | no |

## Test plan

- [ ] Merge this PR (no VERSION change): the workflow fires, image gets `latest` + `main`, no git tag pushed (unchanged behavior).
- [ ] Optional follow-up commit bumping VERSION (e.g., `4.0.0` → `4.0.1`): the workflow fires, image gets `latest` + `main` + `4.0.1` + `4.0`, and a `v4.0.1` git tag appears on origin.
- [ ] Verify the existing manual-tag-push path still works (e.g., push a one-off `v0.0.0-test` tag): image gets `0.0.0-test` from semver pattern, no double-build.

I haven't included a VERSION bump in this PR to keep the diff small and let you decide when to actually cut 4.0.1. If you'd rather exercise the new flow immediately, just amend the PR with a VERSION bump and merge — that'll exercise both behaviors back-to-back.

## Idempotency note

The `tag` job checks `git ls-remote --tags origin` before pushing, so re-running the workflow against an already-tagged commit is a no-op rather than a hard failure. Useful if a transient infra failure on the *first* run pushed the tag but the build half failed and you re-trigger.
