### PR TITLE
Pin workflow GITHUB_TOKEN to read-only by default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,11 @@ on:
   # code. See #67.
   workflow_dispatch:
 
+# All jobs in this workflow only read the checkout to run tests and
+# linters; none push images, write back to the repo, or post comments.
+permissions:
+  contents: read
+
 jobs:
   unit:
     name: Unit Tests

--- a/.github/workflows/wiki-publish.yml
+++ b/.github/workflows/wiki-publish.yml
@@ -22,6 +22,11 @@ on:
       - '.github/workflows/wiki-publish.yml'
   workflow_dispatch:
 
+# Publishing happens against an external MediaWiki via API; the
+# workflow doesn't need to write to this repo.
+permissions:
+  contents: read
+
 env:
   WIKI_API_URL: >-
     ${{ secrets.WIKI_API_URL


### PR DESCRIPTION
## Summary

Adds top-level \`permissions: contents: read\` to \`tests.yml\` and \`wiki-publish.yml\` to address CodeQL's "Workflow does not contain permissions" warning.

Both workflows are read-only at the repo level — \`tests.yml\` only runs lint/test jobs against the checkout, \`wiki-publish.yml\` posts to an external MediaWiki via API — so neither has any job that needs to escalate beyond the read-only default.

Same pattern as #359 applies to \`docker.yml\` (where the \`build\` and \`tag\` jobs do need to escalate, and have job-level permissions blocks for it).

## Test plan

- [x] YAML valid (parsed via PyYAML).
- [ ] CodeQL re-run on this PR no longer flags either of the two files for the missing-permissions warning.
- [ ] After merge: confirm tests.yml and wiki-publish.yml workflows still run successfully on the next push to main (no functional change expected — these are pure restrictions, and no job needs more than read).