### PR TITLE
Auto-create hosts/hosts.yaml when upgrading Go-CLI gitops instances (closes #361)

### DIFF
--- a/get-canasta.sh
+++ b/get-canasta.sh
@@ -402,6 +402,36 @@ main() {
             esac
             ;;
     esac
+
+    post_install_upgrade
+}
+
+# When upgrading from the legacy Go CLI, the registered Canasta
+# instances need their config-file migrations applied (e.g.
+# hosts/hosts.yaml backfill for gitops) and their container images
+# pulled to current. Both happen as part of `canasta upgrade`. Run
+# it automatically here so users coming from `curl ... | bash` end
+# up in a fully-migrated state without an extra manual step.
+#
+# Best-effort: if upgrade hits a transient issue (network, locked
+# instance, etc.) we report a warning but don't fail the install —
+# the CLI itself is in place and the user can re-run `canasta upgrade`
+# after addressing the underlying problem.
+post_install_upgrade() {
+    if [[ "$EXISTING_INSTALL" != "go-cli" ]]; then
+        return
+    fi
+    info ""
+    info "========================================"
+    info "Running 'canasta upgrade' to apply config migrations and"
+    info "pull current container images for registered instances..."
+    info "========================================"
+    if ! "${BIN_DIR}/canasta" upgrade; then
+        warn ""
+        warn "'canasta upgrade' reported issues; review the output above."
+        warn "The Canasta CLI itself is installed and ready. Re-run"
+        warn "'canasta upgrade' after addressing the errors."
+    fi
 }
 
 main "$@"

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -39,6 +39,7 @@
     - remove_skip_binary_as_hex.yml
     - backfill_canasta_image.yml
     - backfill_compose_profiles.yml
+    - backfill_hosts_yaml.yml
   loop_control:
     loop_var: _migration
 

--- a/roles/upgrade/tasks/migrations/backfill_hosts_yaml.yml
+++ b/roles/upgrade/tasks/migrations/backfill_hosts_yaml.yml
@@ -1,0 +1,75 @@
+---
+# Migration: Create hosts/hosts.yaml when missing on Go-CLI gitops instances.
+#
+# Canasta CLI 3.x (Go) created hosts/<name>/vars.yaml during gitops init
+# but never wrote a top-level hosts/hosts.yaml host registry. The 4.x
+# Ansible CLI's gitops push reads hosts.yaml to determine each host's
+# role; without it, push fails with "File not found: .../hosts/hosts.yaml".
+#
+# This migration runs on instances that have gitops set up
+# (.gitops-host exists) but no hosts.yaml, generating one from the
+# existing hosts/<name>/ directory layout. Roles default to 'both' —
+# edit hosts.yaml manually if any host should be source-only or
+# sink-only.
+
+- name: Display a progress message
+  ansible.builtin.debug:
+    msg: "Checking hosts/hosts.yaml..."
+
+- name: Check for .gitops-host (instance has gitops set up)
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/.gitops-host"
+  register: _hosts_yaml_gitops_marker
+
+- name: Check for existing hosts.yaml
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/hosts/hosts.yaml"
+  register: _hosts_yaml_existing
+  when: _hosts_yaml_gitops_marker.stat.exists
+
+- name: Find per-host directories under hosts/
+  ansible.builtin.find:
+    paths: "{{ instance_path }}/hosts"
+    file_type: directory
+    excludes:
+      - "_shared"
+    recurse: false
+  register: _hosts_yaml_host_dirs
+  when:
+    - _hosts_yaml_gitops_marker.stat.exists
+    - not (_hosts_yaml_existing.stat.exists | default(false))
+
+- name: Backfill hosts.yaml from existing per-host directories
+  when:
+    - _hosts_yaml_gitops_marker.stat.exists
+    - not (_hosts_yaml_existing.stat.exists | default(false))
+    - (_hosts_yaml_host_dirs.files | default([]) | length) > 0
+  block:
+    - name: Collect host names from directory listing
+      ansible.builtin.set_fact:
+        _hosts_yaml_entries: >-
+          {{ _hosts_yaml_host_dirs.files
+             | map(attribute='path')
+             | map('basename')
+             | sort | list }}
+
+    - name: Write hosts.yaml
+      ansible.builtin.copy:
+        content: |
+          hosts:
+          {% for _h in _hosts_yaml_entries %}
+            - name: {{ _h }}
+              role: both
+              pull_requests: false
+          {% endfor %}
+        dest: "{{ instance_path }}/hosts/hosts.yaml"
+        mode: "0644"
+
+    - name: Report backfill
+      ansible.builtin.debug:
+        msg: >-
+          Backfilled hosts/hosts.yaml with
+          {{ _hosts_yaml_entries | length }} host(s):
+          {{ _hosts_yaml_entries | join(', ') }}.
+          Roles default to 'both'; edit hosts.yaml if any host should
+          be source-only or sink-only.

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -316,6 +316,75 @@ def test_upgrade(inst):
     wait_for_wiki(inst.http_port)
 
 
+def test_upgrade_backfill_hosts_yaml(inst):
+    """Initialize gitops, simulate Go-CLI layout (no hosts.yaml),
+    run upgrade, verify the backfill_hosts_yaml migration recreates
+    hosts/hosts.yaml from the existing per-host directories."""
+    if shutil.which("git-crypt") is None:
+        raise SkipTest("git-crypt not installed")
+
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir,
+        "-e", inst.env_file,
+    )
+    wait_for_wiki(inst.http_port)
+
+    print("Bootstrapping gitops to create the canonical layout...")
+    bare_repo = os.path.join(inst.work_dir, "gitops-remote.git")
+    subprocess.run(
+        ["git", "init", "--bare", bare_repo],
+        capture_output=True, check=True,
+    )
+    key_file = os.path.join(inst.work_dir, "gitops-test.key")
+    inst.run_ok(
+        "gitops", "init", "-i", inst.id,
+        "-n", "testhost",
+        "--repo", bare_repo,
+        "--key", key_file,
+    )
+
+    inst_path = inst.instance_path()
+    hosts_yaml = os.path.join(inst_path, "hosts", "hosts.yaml")
+    assert os.path.isfile(hosts_yaml), (
+        "hosts.yaml should have been created by gitops init"
+    )
+
+    print("Simulating Go-CLI gitops layout (delete hosts.yaml)...")
+    os.remove(hosts_yaml)
+    # Verify the directory structure that the migration keys off of
+    # is still present.
+    assert os.path.isdir(os.path.join(inst_path, "hosts", "testhost")), (
+        "per-host directory should still exist"
+    )
+    assert os.path.isfile(os.path.join(inst_path, ".gitops-host")), (
+        ".gitops-host marker should still exist"
+    )
+
+    print("Running upgrade...")
+    inst.run_ok("upgrade")
+
+    print("Verifying hosts.yaml was backfilled...")
+    assert os.path.isfile(hosts_yaml), (
+        "hosts.yaml not recreated by backfill_hosts_yaml migration"
+    )
+    with open(hosts_yaml) as f:
+        content = f.read()
+    assert "name: testhost" in content, (
+        "hosts.yaml missing entry for testhost: %s" % content
+    )
+    assert "role: both" in content, (
+        "hosts.yaml missing default role 'both': %s" % content
+    )
+    assert "pull_requests: false" in content, (
+        "hosts.yaml missing pull_requests default: %s" % content
+    )
+
+    print("Verifying wiki still accessible...")
+    wait_for_wiki(inst.http_port)
+
+
 def test_backup(inst):
     """Init repo, create snapshot, drop DB, restore, verify."""
     print("Creating instance...")
@@ -1669,6 +1738,7 @@ ALL_TESTS = {
     "lifecycle": test_lifecycle,
     "import": test_import_export,
     "upgrade": test_upgrade,
+    "upgrade-backfill-hosts-yaml": test_upgrade_backfill_hosts_yaml,
     "backup": test_backup,
     "backup-advanced": test_backup_advanced,
     "gitops": test_gitops,


### PR DESCRIPTION
## Summary

Closes #361.

Two layers of fix for the case where a Go-CLI gitops instance is upgraded to the Ansible CLI:

### 1. New upgrade migration: `backfill_hosts_yaml.yml`

When an instance has gitops set up (`.gitops-host` exists) but no top-level `hosts/hosts.yaml`, the migration walks `hosts/<name>/` per-host directories and generates the missing manifest. Roles default to `both` (the right answer for single-host setups; multi-host can be edited manually). Wired into `roles/upgrade/tasks/main.yml`'s migration loop, same pattern as `backfill_compose_profiles.yml` and friends.

### 2. `get-canasta.sh` runs `canasta upgrade` after an upgrade-from-Go install

Migrations live in `canasta upgrade`, but the 3.7.0 → 4.x transition happens via the install script, not via upgrade. Without this change, a user running `curl ... | bash` on a Go-CLI host ends up on the 4.x CLI but with no migrations applied and old container images still running — manifesting as confusing first-use errors (the gitops-push `hosts.yaml-not-found` failure that motivated #361 is the canonical example).

The auto-upgrade only fires when `EXISTING_INSTALL=='go-cli'` (i.e. specifically the upgrade scenario). Fresh installs and Ansible-CLI re-installs don't get an unexpected upgrade.

Best-effort: if `canasta upgrade` hits a transient issue (network, lock contention, etc.) the install script warns but doesn't fail — the CLI itself is in place and the user has a clean reproducible next step.

## Test plan

- [x] `make test-unit` clean (564 tests).
- [x] `make validate` clean.
- [x] `bash -n get-canasta.sh` clean.
- [ ] Integration test on a 3.6.x VM with gitops initialized: run the install script, confirm `canasta upgrade` fires automatically, `hosts/hosts.yaml` is created, and `canasta gitops push` then works without manual intervention.
- [ ] Integration test on a fresh VM (no Go CLI installed): install script does NOT fire `canasta upgrade` afterward (`EXISTING_INSTALL=='none'`).

## What this does NOT cover

- Existing 4.x installations that already came through the install script before this fix lands (e.g. canasta.wiki itself). They still need either the manual workaround (create hosts/hosts.yaml by hand) or a `canasta upgrade` invocation after this PR is merged. The migration would apply on that upgrade.
- Multi-host gitops setups where some hosts should be `source` or `sink` only. The migration defaults all to `both`; the user edits afterward.
