### PR TITLE
canasta install: rename k8s → k8s-cp, add --public-ip (closes #349)

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -369,13 +369,14 @@ commands:
       machine. The right install for single-node K8s deployments and
       for the first node of a multi-node cluster.
 
-      For multi-node deployments where the controller (the machine
-      running canasta) is a separate machine from the cluster nodes,
-      pass `--public-ip <addr>` to add that address to the k3s API
-      server's TLS certificate. Without it, the controller's `kubectl`
-      fails TLS verification when talking to the cluster over the
-      public IP. Repeat `--public-ip` to add more than one (e.g. an IP
-      and a hostname).
+      Pass `--public-ip <addr>` whenever the canasta CLI runs on a
+      different machine than the control plane — i.e. for any
+      multi-node cluster, and for single-node setups where canasta is
+      installed on a separate host (laptop / VPS / etc.). The address
+      is added to the k3s API server's TLS certificate so kubectl can
+      verify the cert when reaching the cluster over that address.
+      Repeat `--public-ip` to add more than one (e.g. an IP and a
+      hostname).
     examples:
       - "canasta install docker"
       - "canasta install k8s-cp"
@@ -399,11 +400,11 @@ commands:
         multi: true
         description: >-
           Public IP or hostname of the cluster node, added to the k3s
-          API server's TLS cert (k8s-cp only). Repeat to add multiple.
-          Required when the controller talks to k3s over a non-private
-          address — without it, kubectl from the controller fails TLS
-          verification because the cert defaults only cover the node's
-          internal IP and 127.0.0.1.
+          API server's TLS cert (k8s-cp only). Required when canasta
+          runs on a different machine than the control plane — any
+          multi-node cluster, plus single-node setups where canasta is
+          on a separate host. Repeat the flag to add multiple
+          addresses.
 
   - name: uninstall
     description: "Uninstall dependencies from the target host"

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -364,9 +364,18 @@ commands:
       Install one or more dependencies on the target host. Supported
       packages: docker, k8s, git-crypt. k8s installs kubectl, helm,
       and k3s. Multiple packages can be specified in a single command.
+
+      For multi-node Kubernetes clusters where the controller (the
+      machine running canasta) is a separate machine from the cluster
+      nodes, pass `--public-ip <addr>` on the k8s install. The address
+      is added to the k3s API server's TLS certificate, so the
+      controller's `kubectl` can verify the cert when talking to the
+      cluster over the public IP. Repeat `--public-ip` to add more
+      than one (e.g. an IP and a hostname).
     examples:
       - "canasta install docker"
       - "canasta install k8s"
+      - "canasta install k8s --public-ip 203.0.113.10"
       - "canasta install docker git-crypt"
       - "canasta install docker --host prod1.example.com"
     playbook: install.yml
@@ -381,6 +390,16 @@ commands:
         multi: true
         required: true
         description: "Dependencies to install (docker, k8s, git-crypt)"
+      - name: public_ip
+        type: string
+        multi: true
+        description: >-
+          Public IP or hostname of the cluster node, added to the k3s
+          API server's TLS cert (k8s only). Repeat to add multiple.
+          Required when the controller talks to k3s over a non-private
+          address — without it, kubectl from the controller fails TLS
+          verification because the cert defaults only cover the node's
+          internal IP and 127.0.0.1.
 
   - name: uninstall
     description: "Uninstall dependencies from the target host"

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -362,20 +362,24 @@ commands:
     description: "Install dependencies on the target host"
     long_description: |
       Install one or more dependencies on the target host. Supported
-      packages: docker, k8s, git-crypt. k8s installs kubectl, helm,
-      and k3s. Multiple packages can be specified in a single command.
+      packages: docker, k8s-cp, git-crypt.
 
-      For multi-node Kubernetes clusters where the controller (the
-      machine running canasta) is a separate machine from the cluster
-      nodes, pass `--public-ip <addr>` on the k8s install. The address
-      is added to the k3s API server's TLS certificate, so the
-      controller's `kubectl` can verify the cert when talking to the
-      cluster over the public IP. Repeat `--public-ip` to add more
-      than one (e.g. an IP and a hostname).
+      `k8s-cp` installs k3s as a control-plane node — the cluster's
+      API server, scheduler, etc., plus kubectl + helm on the same
+      machine. The right install for single-node K8s deployments and
+      for the first node of a multi-node cluster.
+
+      For multi-node deployments where the controller (the machine
+      running canasta) is a separate machine from the cluster nodes,
+      pass `--public-ip <addr>` to add that address to the k3s API
+      server's TLS certificate. Without it, the controller's `kubectl`
+      fails TLS verification when talking to the cluster over the
+      public IP. Repeat `--public-ip` to add more than one (e.g. an IP
+      and a hostname).
     examples:
       - "canasta install docker"
-      - "canasta install k8s"
-      - "canasta install k8s --public-ip 203.0.113.10"
+      - "canasta install k8s-cp"
+      - "canasta install k8s-cp --public-ip 203.0.113.10"
       - "canasta install docker git-crypt"
       - "canasta install docker --host prod1.example.com"
     playbook: install.yml
@@ -389,13 +393,13 @@ commands:
         positional: true
         multi: true
         required: true
-        description: "Dependencies to install (docker, k8s, git-crypt)"
+        description: "Dependencies to install (docker, k8s-cp, git-crypt)"
       - name: public_ip
         type: string
         multi: true
         description: >-
           Public IP or hostname of the cluster node, added to the k3s
-          API server's TLS cert (k8s only). Repeat to add multiple.
+          API server's TLS cert (k8s-cp only). Repeat to add multiple.
           Required when the controller talks to k3s over a non-private
           address — without it, kubectl from the controller fails TLS
           verification because the cert defaults only cover the node's

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -40,4 +40,3 @@
     name: install
     tasks_from: canasta.yml
   when: "'canasta' in _install_packages"
-

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -6,13 +6,14 @@
   ansible.builtin.set_fact:
     _install_packages: >-
       {{ packages.split()
-         | map('regex_replace', '^(k8s|kubernetes)$', 'k3s')
+         | map('regex_replace', '^k8s-cp$', 'k3s')
          | list }}
 
 - name: Validate packages
   ansible.builtin.fail:
     msg: >-
-      Unknown package '{{ item }}'. Supported: docker, k8s, git-crypt, canasta.
+      Unknown package '{{ item }}'. Supported: docker, k8s-cp,
+      git-crypt, canasta.
   when: item not in ['docker', 'k3s', 'git-crypt', 'canasta']
   loop: "{{ _install_packages }}"
 

--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -28,9 +28,27 @@
       ansible.builtin.debug:
         msg: "Installing Kubernetes (k3s)..."
 
+    # When --public-ip is provided, each address is appended to the
+    # k3s API server's cert via INSTALL_K3S_EXEC="--tls-san <addr>".
+    # Empty string when not provided (k3s uses its default cert SANs:
+    # 127.0.0.1, the node's internal IP, kubernetes.default.*).
+    - name: Build k3s install exec args
+      ansible.builtin.set_fact:
+        _k3s_install_exec: >-
+          {{ (public_ip | default([]))
+             | map('regex_replace', '^(.*)$', '--tls-san \1')
+             | join(' ') }}
+
+    - name: Report public IPs being added to API server cert
+      ansible.builtin.debug:
+        msg: "Adding to k3s API server TLS cert: {{ public_ip | join(', ') }}"
+      when: (public_ip | default([])) | length > 0
+
     - name: Download and install k3s
       ansible.builtin.shell:
-        cmd: "curl -sfL https://get.k3s.io | sh -"
+        cmd: >-
+          curl -sfL https://get.k3s.io |
+          INSTALL_K3S_EXEC={{ _k3s_install_exec | quote }} sh -
       changed_when: true
 
     - name: Make k3s kubeconfig readable (before verification)


### PR DESCRIPTION
## Summary

Closes #349.

Two changes that fit naturally together:

1. Rename the install package `k8s` → `k8s-cp` (no backwards-compat alias kept; v4.0.0 just released, no deployed install base depends on the old name). The new naming makes room for the matching `k8s-worker` in #364.
2. Add `--public-ip <addr>` to `canasta install` (k8s-cp only), repeatable. Each value is added to the k3s API server's TLS certificate.

The motivating scenario is multi-node Kubernetes deployments where the controller is a separate machine from the cluster nodes — its `kubectl` talks to the API over a public IP/hostname. Without `--public-ip`, the cert defaults only cover `127.0.0.1`, the node's internal IP, and `kubernetes.default.*`; a remote controller hitting `https://<public-ip>:6443` fails TLS verification.

## Naming choice

Earlier draft used `--tls-san`, the literal k3s/x509 term. Renamed to `--public-ip` because most users will pass a public IP — that's the entire reason they reach for the flag. "TLS SAN" is jargon. The flag still accepts hostnames if needed (k3s `--tls-san` accepts either) — `--public-ip` is the common-case framing.

## Implementation

- **`meta/command_definitions.yml`** — rename `k8s` to `k8s-cp` in package list. Add `public_ip` parameter (multi-valued, optional). Update long_description and examples.
- **`playbooks/install.yml`** — drop `k8s` and `kubernetes` aliases; only `k8s-cp` maps to the existing k3s server install path.
- **`roles/orchestrator/tasks/k8s_install_k3s.yml`** — build `INSTALL_K3S_EXEC` from the `public_ip` list and pass to `curl … | sh -`. Empty when no addresses given (default behavior preserved).

## Test plan

- [x] `make validate` passes (61 commands).
- [x] `make test-unit` passes (564 tests).
- [x] `make docs` regenerates `docs/commands/install.md`.
- [x] `canasta install --help` shows the new package list and `--public-ip PUBLIC_IP`.
- [x] `canasta install k8s-cp --help` (well, `canasta install --help`; subcommand has no per-package help) reflects the renamed package.
- [ ] Manual end-to-end on a real cp node (post-merge):
  ```bash
  canasta host add --name node1 --ssh ubuntu@<NODE1_PUBLIC_IP>
  canasta --host node1 install k8s-cp --public-ip <NODE1_PUBLIC_IP>
  ssh ubuntu@<NODE1_PUBLIC_IP> "sudo k3s kubectl config view --raw" > ~/.kube/config
  sed -i "s/127.0.0.1/<NODE1_PUBLIC_IP>/" ~/.kube/config
  kubectl get nodes  # should succeed; no --insecure-skip-tls-verify
  ```

## Idempotency

The k3s install is idempotent — if k3s is already running on the target, the install step is skipped. So `--public-ip` only takes effect on the first install. Adding SANs to an already-running k3s server requires editing `/etc/rancher/k3s/config.yaml` and restarting k3s; not in scope here.

## Adjacent / follow-up

- **`canasta uninstall k8s`** still uses the old name. Will rename to `canasta uninstall k8s-cp` (and add `k8s-worker`) as a small follow-up after #364 lands. Not blocking.
- **Wiki update** for `Help:Multi-node Kubernetes` to use `canasta install k8s-cp --public-ip` is staged at `/tmp/update_help_multinode_post_merge.py`. Will run after both #363 and #364 land.
