### PR TITLE
canasta install k8s-worker: join workers via --cp-host with auto-discovery (closes #350)

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -362,27 +362,37 @@ commands:
     description: "Install dependencies on the target host"
     long_description: |
       Install one or more dependencies on the target host. Supported
-      packages: docker, k8s-cp, git-crypt.
+      packages: docker, k8s-cp, k8s-worker, git-crypt.
 
       `k8s-cp` installs k3s as a control-plane node — the cluster's
       API server, scheduler, etc., plus kubectl + helm on the same
       machine. The right install for single-node K8s deployments and
       for the first node of a multi-node cluster.
 
-      Pass `--public-ip <addr>` whenever the canasta CLI runs on a
-      different machine than the control plane — i.e. for any
-      multi-node cluster, and for single-node setups where canasta is
-      installed on a separate host (laptop / VPS / etc.). The address
-      is added to the k3s API server's TLS certificate so kubectl can
-      verify the cert when reaching the cluster over that address.
-      Repeat `--public-ip` to add more than one (e.g. an IP and a
-      hostname).
+      `k8s-worker` joins the target host to an existing k3s cluster as
+      a worker (agent) node — runs only the kubelet + container
+      runtime, no kubectl/helm. Use `--cp-host <name>` to point at a
+      registered host where the control plane lives; canasta will SSH
+      to the control plane to fetch the join token and the cluster's
+      internal API URL automatically.
+
+      Pass `--public-ip <addr>` (k8s-cp only) whenever the canasta CLI
+      runs on a different machine than the control plane — i.e. for
+      any multi-node cluster, and for single-node setups where canasta
+      is installed on a separate host (laptop / VPS / etc.). The
+      address is added to the k3s API server's TLS certificate so
+      kubectl can verify the cert when reaching the cluster over that
+      address. Repeat to add more than one (e.g. an IP and a hostname).
+
+      Multiple packages can be combined in a single command, except
+      that `k8s-cp` and `k8s-worker` are mutually exclusive on a given
+      host.
     examples:
       - "canasta install docker"
       - "canasta install k8s-cp"
       - "canasta install k8s-cp --public-ip 203.0.113.10"
+      - "canasta install --host node2 k8s-worker --cp-host node1"
       - "canasta install docker git-crypt"
-      - "canasta install docker --host prod1.example.com"
     playbook: install.yml
     parameters:
       - name: host
@@ -394,7 +404,9 @@ commands:
         positional: true
         multi: true
         required: true
-        description: "Dependencies to install (docker, k8s-cp, git-crypt)"
+        description: >-
+          Dependencies to install (docker, k8s-cp, k8s-worker,
+          git-crypt)
       - name: public_ip
         type: string
         multi: true
@@ -405,6 +417,13 @@ commands:
           multi-node cluster, plus single-node setups where canasta is
           on a separate host. Repeat the flag to add multiple
           addresses.
+      - name: cp_host
+        type: string
+        description: >-
+          Name of the registered control-plane host (k8s-worker only).
+          Canasta SSHs to this host to fetch the join token and the
+          cluster's internal API URL. The host must already be
+          registered via 'canasta host add'.
 
   - name: uninstall
     description: "Uninstall dependencies from the target host"

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -369,13 +369,14 @@ commands:
       machine. The right install for single-node K8s deployments and
       for the first node of a multi-node cluster.
 
-      For multi-node deployments where the controller (the machine
-      running canasta) is a separate machine from the cluster nodes,
-      pass `--public-ip <addr>` to add that address to the k3s API
-      server's TLS certificate. Without it, the controller's `kubectl`
-      fails TLS verification when talking to the cluster over the
-      public IP. Repeat `--public-ip` to add more than one (e.g. an IP
-      and a hostname).
+      Pass `--public-ip <addr>` whenever the canasta CLI runs on a
+      different machine than the control plane — i.e. for any
+      multi-node cluster, and for single-node setups where canasta is
+      installed on a separate host (laptop / VPS / etc.). The address
+      is added to the k3s API server's TLS certificate so kubectl can
+      verify the cert when reaching the cluster over that address.
+      Repeat `--public-ip` to add more than one (e.g. an IP and a
+      hostname).
     examples:
       - "canasta install docker"
       - "canasta install k8s-cp"
@@ -399,11 +400,11 @@ commands:
         multi: true
         description: >-
           Public IP or hostname of the cluster node, added to the k3s
-          API server's TLS cert (k8s-cp only). Repeat to add multiple.
-          Required when the controller talks to k3s over a non-private
-          address — without it, kubectl from the controller fails TLS
-          verification because the cert defaults only cover the node's
-          internal IP and 127.0.0.1.
+          API server's TLS cert (k8s-cp only). Required when canasta
+          runs on a different machine than the control plane — any
+          multi-node cluster, plus single-node setups where canasta is
+          on a separate host. Repeat the flag to add multiple
+          addresses.
 
   - name: uninstall
     description: "Uninstall dependencies from the target host"

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -364,9 +364,18 @@ commands:
       Install one or more dependencies on the target host. Supported
       packages: docker, k8s, git-crypt. k8s installs kubectl, helm,
       and k3s. Multiple packages can be specified in a single command.
+
+      For multi-node Kubernetes clusters where the controller (the
+      machine running canasta) is a separate machine from the cluster
+      nodes, pass `--public-ip <addr>` on the k8s install. The address
+      is added to the k3s API server's TLS certificate, so the
+      controller's `kubectl` can verify the cert when talking to the
+      cluster over the public IP. Repeat `--public-ip` to add more
+      than one (e.g. an IP and a hostname).
     examples:
       - "canasta install docker"
       - "canasta install k8s"
+      - "canasta install k8s --public-ip 203.0.113.10"
       - "canasta install docker git-crypt"
       - "canasta install docker --host prod1.example.com"
     playbook: install.yml
@@ -381,6 +390,16 @@ commands:
         multi: true
         required: true
         description: "Dependencies to install (docker, k8s, git-crypt)"
+      - name: public_ip
+        type: string
+        multi: true
+        description: >-
+          Public IP or hostname of the cluster node, added to the k3s
+          API server's TLS cert (k8s only). Repeat to add multiple.
+          Required when the controller talks to k3s over a non-private
+          address — without it, kubectl from the controller fails TLS
+          verification because the cert defaults only cover the node's
+          internal IP and 127.0.0.1.
 
   - name: uninstall
     description: "Uninstall dependencies from the target host"

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -362,20 +362,24 @@ commands:
     description: "Install dependencies on the target host"
     long_description: |
       Install one or more dependencies on the target host. Supported
-      packages: docker, k8s, git-crypt. k8s installs kubectl, helm,
-      and k3s. Multiple packages can be specified in a single command.
+      packages: docker, k8s-cp, git-crypt.
 
-      For multi-node Kubernetes clusters where the controller (the
-      machine running canasta) is a separate machine from the cluster
-      nodes, pass `--public-ip <addr>` on the k8s install. The address
-      is added to the k3s API server's TLS certificate, so the
-      controller's `kubectl` can verify the cert when talking to the
-      cluster over the public IP. Repeat `--public-ip` to add more
-      than one (e.g. an IP and a hostname).
+      `k8s-cp` installs k3s as a control-plane node — the cluster's
+      API server, scheduler, etc., plus kubectl + helm on the same
+      machine. The right install for single-node K8s deployments and
+      for the first node of a multi-node cluster.
+
+      For multi-node deployments where the controller (the machine
+      running canasta) is a separate machine from the cluster nodes,
+      pass `--public-ip <addr>` to add that address to the k3s API
+      server's TLS certificate. Without it, the controller's `kubectl`
+      fails TLS verification when talking to the cluster over the
+      public IP. Repeat `--public-ip` to add more than one (e.g. an IP
+      and a hostname).
     examples:
       - "canasta install docker"
-      - "canasta install k8s"
-      - "canasta install k8s --public-ip 203.0.113.10"
+      - "canasta install k8s-cp"
+      - "canasta install k8s-cp --public-ip 203.0.113.10"
       - "canasta install docker git-crypt"
       - "canasta install docker --host prod1.example.com"
     playbook: install.yml
@@ -389,13 +393,13 @@ commands:
         positional: true
         multi: true
         required: true
-        description: "Dependencies to install (docker, k8s, git-crypt)"
+        description: "Dependencies to install (docker, k8s-cp, git-crypt)"
       - name: public_ip
         type: string
         multi: true
         description: >-
           Public IP or hostname of the cluster node, added to the k3s
-          API server's TLS cert (k8s only). Repeat to add multiple.
+          API server's TLS cert (k8s-cp only). Repeat to add multiple.
           Required when the controller talks to k3s over a non-private
           address — without it, kubectl from the controller fails TLS
           verification because the cert defaults only cover the node's

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -40,4 +40,3 @@
     name: install
     tasks_from: canasta.yml
   when: "'canasta' in _install_packages"
-

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -6,13 +6,14 @@
   ansible.builtin.set_fact:
     _install_packages: >-
       {{ packages.split()
-         | map('regex_replace', '^(k8s|kubernetes)$', 'k3s')
+         | map('regex_replace', '^k8s-cp$', 'k3s')
          | list }}
 
 - name: Validate packages
   ansible.builtin.fail:
     msg: >-
-      Unknown package '{{ item }}'. Supported: docker, k8s, git-crypt, canasta.
+      Unknown package '{{ item }}'. Supported: docker, k8s-cp,
+      git-crypt, canasta.
   when: item not in ['docker', 'k3s', 'git-crypt', 'canasta']
   loop: "{{ _install_packages }}"
 

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -1,21 +1,43 @@
 ---
 # canasta install - Install dependencies on the target host.
-# Accepts one or more package names: docker, k3s, git-crypt, canasta.
+# Accepts one or more package names: docker, k8s-cp, k8s-worker,
+# git-crypt, canasta.
 
 - name: Normalize package names
   ansible.builtin.set_fact:
     _install_packages: >-
       {{ packages.split()
          | map('regex_replace', '^k8s-cp$', 'k3s')
+         | map('regex_replace', '^k8s-worker$', 'k3s-worker')
          | list }}
 
 - name: Validate packages
   ansible.builtin.fail:
     msg: >-
       Unknown package '{{ item }}'. Supported: docker, k8s-cp,
-      git-crypt, canasta.
-  when: item not in ['docker', 'k3s', 'git-crypt', 'canasta']
+      k8s-worker, git-crypt, canasta.
+  when: item not in ['docker', 'k3s', 'k3s-worker', 'git-crypt', 'canasta']
   loop: "{{ _install_packages }}"
+
+- name: Validate k8s-cp + k8s-worker not requested together
+  ansible.builtin.fail:
+    msg: >-
+      k8s-cp and k8s-worker are mutually exclusive on a single host.
+      A node is either the cluster's control plane or a worker, not
+      both.
+  when:
+    - "'k3s' in _install_packages"
+    - "'k3s-worker' in _install_packages"
+
+- name: Validate --cp-host is provided for k8s-worker
+  ansible.builtin.fail:
+    msg: >-
+      Joining a worker requires --cp-host <name>, where <name> is the
+      control plane host registered via 'canasta host add'. Canasta
+      SSHs to that host to fetch the join token and cluster API URL.
+  when:
+    - "'k3s-worker' in _install_packages"
+    - not (cp_host is defined and (cp_host | length > 0))
 
 - name: Install Docker
   ansible.builtin.include_role:
@@ -23,11 +45,17 @@
     tasks_from: docker.yml
   when: "'docker' in _install_packages"
 
-- name: Install Kubernetes (k3s, kubectl, helm)
+- name: Install Kubernetes control plane (k3s server, kubectl, helm)
   ansible.builtin.include_role:
     name: install
     tasks_from: k3s.yml
   when: "'k3s' in _install_packages"
+
+- name: Install Kubernetes worker (k3s agent joined to control plane)
+  ansible.builtin.include_role:
+    name: install
+    tasks_from: k3s_worker.yml
+  when: "'k3s-worker' in _install_packages"
 
 - name: Install git-crypt
   ansible.builtin.include_role:

--- a/roles/install/tasks/k3s_worker.yml
+++ b/roles/install/tasks/k3s_worker.yml
@@ -1,0 +1,124 @@
+---
+# Install k3s on the target host as a worker (agent) joined to an
+# existing control plane.
+#
+# Resolves --cp-host (a registered Canasta host name) to its SSH
+# target by reading the controller's hosts.yml, then SSHs to the
+# control plane to fetch:
+#   - the k3s join token (/var/lib/rancher/k3s/server/node-token)
+#   - the cluster-internal API IP (k3s kubectl get node ...)
+# and finally invokes k8s_install_k3s_agent.yml on this host with
+# those values to actually do the join.
+
+# --- Read controller's hosts.yml to resolve cp-host SSH details ---
+
+# CANASTA_CONFIG_DIR drives where hosts.yml lives. Resolve from the
+# controller's environment, with the same precedence canasta.py uses
+# (env override → /etc/canasta if root → ~/.config/canasta otherwise).
+- name: Determine controller config dir
+  ansible.builtin.set_fact:
+    _canasta_config_dir: >-
+      {{ lookup('ansible.builtin.env', 'CANASTA_CONFIG_DIR')
+         or (
+             (lookup('ansible.builtin.env', 'USER') == 'root')
+             | ternary(
+                 '/etc/canasta',
+                 lookup('ansible.builtin.env', 'HOME') ~ '/.config/canasta'
+               )
+            ) }}
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+
+- name: Read controller's hosts.yml
+  ansible.builtin.slurp:
+    src: "{{ _canasta_config_dir }}/hosts.yml"
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  register: _cp_hosts_yml_raw
+
+- name: Parse hosts.yml and resolve cp-host SSH target
+  ansible.builtin.set_fact:
+    _cp_host_entry: >-
+      {{ ((_cp_hosts_yml_raw.content | b64decode | from_yaml)
+          .all.hosts[cp_host]) | default({}) }}
+
+- name: Fail if cp-host is not registered
+  ansible.builtin.fail:
+    msg: >-
+      Host '{{ cp_host }}' is not registered. Run
+      'canasta host add --name {{ cp_host }} --ssh user@host' first.
+  when: not _cp_host_entry
+
+- name: Compose cp-host SSH target string
+  ansible.builtin.set_fact:
+    _cp_ssh_target: >-
+      {{ (_cp_host_entry.ansible_user | default('') | length > 0)
+         | ternary(
+             _cp_host_entry.ansible_user ~ '@' ~ _cp_host_entry.ansible_host,
+             _cp_host_entry.ansible_host
+           ) }}
+
+# --- SSH to cp-host, fetch token + cluster-internal IP ---
+
+- name: Fetch k3s join token from cp-host
+  ansible.builtin.command:
+    argv:
+      - ssh
+      - -o
+      - StrictHostKeyChecking=accept-new
+      - "{{ _cp_ssh_target }}"
+      - sudo cat /var/lib/rancher/k3s/server/node-token
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  register: _cp_token_raw
+  changed_when: false
+  no_log: true  # token is sensitive
+
+- name: Fetch cluster-internal IP of cp-host (via k3s kubectl)
+  ansible.builtin.command:
+    argv:
+      - ssh
+      - -o
+      - StrictHostKeyChecking=accept-new
+      - "{{ _cp_ssh_target }}"
+      - >-
+        k3s kubectl get nodes
+        -o jsonpath='{.items[?(@.metadata.labels.node-role\.kubernetes\.io/control-plane=="true")].status.addresses[?(@.type=="InternalIP")].address}'
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  register: _cp_internal_ip_raw
+  changed_when: false
+
+- name: Set k3s join parameters
+  ansible.builtin.set_fact:
+    _k3s_server_url: "https://{{ _cp_internal_ip_raw.stdout | trim }}:6443"
+    _k3s_join_token: "{{ _cp_token_raw.stdout | trim }}"
+  no_log: true
+
+- name: Validate fetched values
+  ansible.builtin.fail:
+    msg: >-
+      Failed to discover cluster info from cp-host '{{ cp_host }}'.
+      Check that k3s is installed and running there
+      ('canasta --host {{ cp_host }} install k8s-cp').
+  when:
+    - (_cp_internal_ip_raw.stdout | trim | length == 0)
+      or (_cp_token_raw.stdout | trim | length == 0)
+
+- name: Report join target
+  ansible.builtin.debug:
+    msg: "Joining k3s cluster at {{ _k3s_server_url }} as a worker..."
+
+# --- Run the agent install with the resolved values ---
+
+- name: Install k3s agent
+  ansible.builtin.include_role:
+    name: orchestrator
+    tasks_from: k8s_install_k3s_agent.yml
+  vars:
+    server: "{{ _k3s_server_url }}"
+    token: "{{ _k3s_join_token }}"

--- a/roles/install/tasks/k3s_worker.yml
+++ b/roles/install/tasks/k3s_worker.yml
@@ -86,7 +86,8 @@
       - "{{ _cp_ssh_target }}"
       - >-
         k3s kubectl get nodes
-        -o jsonpath='{.items[?(@.metadata.labels.node-role\.kubernetes\.io/control-plane=="true")].status.addresses[?(@.type=="InternalIP")].address}'
+        -l node-role.kubernetes.io/control-plane=true
+        -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'
   delegate_to: localhost
   vars:
     ansible_connection: local

--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -28,9 +28,27 @@
       ansible.builtin.debug:
         msg: "Installing Kubernetes (k3s)..."
 
+    # When --public-ip is provided, each address is appended to the
+    # k3s API server's cert via INSTALL_K3S_EXEC="--tls-san <addr>".
+    # Empty string when not provided (k3s uses its default cert SANs:
+    # 127.0.0.1, the node's internal IP, kubernetes.default.*).
+    - name: Build k3s install exec args
+      ansible.builtin.set_fact:
+        _k3s_install_exec: >-
+          {{ (public_ip | default([]))
+             | map('regex_replace', '^(.*)$', '--tls-san \1')
+             | join(' ') }}
+
+    - name: Report public IPs being added to API server cert
+      ansible.builtin.debug:
+        msg: "Adding to k3s API server TLS cert: {{ public_ip | join(', ') }}"
+      when: (public_ip | default([])) | length > 0
+
     - name: Download and install k3s
       ansible.builtin.shell:
-        cmd: "curl -sfL https://get.k3s.io | sh -"
+        cmd: >-
+          curl -sfL https://get.k3s.io |
+          INSTALL_K3S_EXEC={{ _k3s_install_exec | quote }} sh -
       changed_when: true
 
     - name: Make k3s kubeconfig readable (before verification)

--- a/roles/orchestrator/tasks/k8s_install_k3s_agent.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s_agent.yml
@@ -1,0 +1,60 @@
+---
+# Install k3s as an agent (worker) on the target host.
+# Input vars:
+#   server - k3s server URL (e.g. https://10.0.0.1:6443)
+#   token  - k3s join token (read from
+#            /var/lib/rancher/k3s/server/node-token on the cp host)
+# Idempotent — checks if k3s is already running.
+#
+# Agents run only the kubelet + container runtime; they don't need
+# kubectl, helm, or a kubeconfig (those live on the control plane /
+# on the controller that talks to the cluster's API). So this is
+# much shorter than k8s_install_k3s.yml.
+
+- name: Check if k3s is already running
+  ansible.builtin.command:
+    cmd: k3s --version
+  register: _k3s_agent_running
+  changed_when: false
+  ignore_errors: true  # OK if k3s not installed yet
+
+- name: Skip if k3s already running
+  ansible.builtin.debug:
+    msg: "k3s is already installed."
+  when: _k3s_agent_running.rc == 0
+
+- name: Install k3s agent
+  when: _k3s_agent_running.rc != 0
+  block:
+    - name: Report joining cluster
+      ansible.builtin.debug:
+        msg: "Joining k3s cluster at {{ server }} as a worker..."
+
+    # K3S_URL pre-set on the install command flips the upstream
+    # installer into agent mode (vs the default server install).
+    # Both env vars are required.
+    - name: Download and install k3s agent
+      ansible.builtin.shell:
+        cmd: >-
+          curl -sfL https://get.k3s.io |
+          K3S_URL={{ server | quote }}
+          K3S_TOKEN={{ token | quote }}
+          sh -
+      changed_when: true
+      no_log: true  # token is sensitive
+
+    - name: Wait for k3s-agent service to be active
+      ansible.builtin.command:
+        cmd: systemctl is-active k3s-agent
+      register: _k3s_agent_ready
+      until: _k3s_agent_ready.rc == 0
+      retries: 30
+      delay: 5
+      changed_when: false
+
+- name: Report status
+  ansible.builtin.debug:
+    msg: >-
+      k3s agent is running and joined to {{ server }}. Verify from
+      the controller with 'kubectl get nodes' — this host should
+      appear within ~30 seconds.


### PR DESCRIPTION
## Summary

Closes #350.

Adds a `k8s-worker` install package and a `--cp-host <name>` parameter that together let a host join an existing k3s cluster as a worker (agent) node. Auto-discovers the join token and cluster-internal API URL from the registered control-plane host — no manual env-var juggling.

Builds on #363 (which adds `k8s-cp` and `--public-ip`). Merge order: #363 first, then this. With both merged, the multi-node bootstrap becomes:

```bash
# Register both nodes
canasta host add --name node1 --ssh ubuntu@<NODE1_PUBLIC_IP>
canasta host add --name node2 --ssh ubuntu@<NODE2_PUBLIC_IP>

# Install control plane on node 1, with public IP in the cert SANs
canasta --host node1 install k8s-cp --public-ip <NODE1_PUBLIC_IP>

# Join node 2 as a worker — canasta SSHs to node1 to fetch token + IP
canasta --host node2 install k8s-worker --cp-host node1
```

That's the entire multi-node setup, no manual `curl … | sh` steps anywhere.

## How --cp-host works

When `--cp-host <name>` is given (and `<name>` is a registered Canasta host):

1. The install playbook running on the worker reads the controller's `hosts.yml` (via `delegate_to: localhost`, slurp + parse) to resolve `<name>` → its SSH target (`ansible_user@ansible_host`).
2. It SSHs from the controller to the cp host to fetch:
   - Join token from `/var/lib/rancher/k3s/server/node-token`.
   - Cluster-internal IP via `k3s kubectl get nodes -o jsonpath='…InternalIP'` (k3s itself decides which interface is the cluster-internal one — authoritative, beats `hostname -I` guessing).
3. Composes `K3S_URL=https://<internal-ip>:6443` and `K3S_TOKEN=<token>`, then runs the agent install (`k8s_install_k3s_agent.yml`) on the worker with those values.

The SSH from controller → cp uses the same SSH config the user already has set up for canasta-registered hosts (StrictHostKeyChecking=accept-new for first connection, matching the rest of canasta).

Token + IP are read live at install time (not cached). The join token persists across restarts on the cp host but does change on a fresh cp install; this design always uses the current value.

## Implementation

- **`meta/command_definitions.yml`** — add `cp_host` parameter to install. Updates long_description with k8s-cp / k8s-worker semantics. Adds `k8s-worker` examples.
- **`playbooks/install.yml`** — extend package normalization to recognize `k8s-worker → k3s-worker`. Add validation that `k8s-cp` and `k8s-worker` are mutually exclusive on a single host, and that `--cp-host` is required when `k8s-worker` is requested.
- **`roles/install/tasks/k3s_worker.yml`** (new) — cp-host lookup + SSH-fetch + dispatch to agent install. Reads hosts.yml from `CANASTA_CONFIG_DIR` (with the same precedence rules canasta.py uses).
- **`roles/orchestrator/tasks/k8s_install_k3s_agent.yml`** (new) — minimal k3s agent install. Skips kubectl / helm / kubeconfig / python-kubernetes (none of which agents need; those live on the cp / on the controller). Idempotent.

## Externally managed clusters

This package is for self-managed k3s only. For EKS / GKE / AKS / BYO k3s clusters, the controller doesn't need to know about cp/worker nodes individually — the kubeconfig abstracts the cluster, and `canasta create -o kubernetes …` works against whatever cluster the kubeconfig points at. `Help:Multi-node Kubernetes` already documents that path under "Managed Kubernetes (EKS, GKE, AKS)".

## Test plan

- [x] `make validate` passes (61 commands).
- [x] `make test-unit` passes (564 tests).
- [x] `make docs` regenerates `docs/commands/install.md`.
- [x] `canasta install --help` shows the new package list and `--cp-host CP_HOST`.
- [x] Validation: `canasta install k8s-worker` without `--cp-host` fails with a clear error message.
- [x] Validation: `canasta install k8s-cp k8s-worker` (both at once) fails with a clear message about mutual exclusivity.
- [ ] Manual end-to-end on a real two-node setup (post-merge):
  ```bash
  # Assume cp already installed via #363's example
  canasta host add --name node2 --ssh ubuntu@<NODE2_IP>
  canasta --host node2 install k8s-worker --cp-host node1
  kubectl get nodes  # node2 should appear within ~30s
  ```

## Follow-up

- Wiki update (`Help:Multi-node Kubernetes` Step 1) staged locally at `/tmp/update_help_multinode_post_merge.py` — replaces the manual `curl | sh` server + worker blocks with the new `canasta install k8s-cp --public-ip` and `canasta install k8s-worker --cp-host` forms. Run after both #363 and #364 are merged.
- `canasta uninstall k8s` could similarly split into `uninstall k8s-cp` / `uninstall k8s-worker` for symmetry. Not in scope; uninstall path currently handles either install via the same `uninstall_k3s.yml`.
