### PR TITLE
Fix --public-ip iterating chars + refresh apt cache before k3s install

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -202,6 +202,20 @@ def add_params_to_parser(parser, params):
                 help=desc,
                 dest=name,
             )
+        elif param.get("multi"):
+            # Repeatable flag: --foo X --foo Y collects into a list.
+            # Use action='append' so each occurrence appends to the
+            # named dest, rather than the default which would store
+            # only the last value (and Ansible-side filters that
+            # expect a list would iterate over the string's chars).
+            parser.add_argument(
+                *flags,
+                action="append",
+                default=default if default is not None else [],
+                required=required,
+                help=desc,
+                dest=name,
+            )
         else:
             parser.add_argument(
                 *flags,

--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -104,6 +104,8 @@
   ansible.builtin.apt:
     name: python3-kubernetes
     state: present
+    update_cache: true
+    cache_valid_time: 3600
   become: true
   when: _k8s_python.rc != 0
 


### PR DESCRIPTION
Two bugs caught in the first end-to-end multi-node K8s test on a fresh Debian EC2:

## Bug 1: \`--public-ip\` iterates over characters

\`\`\`
$ canasta install k8s-cp --host cp --public-ip cp.acknowledge.wiki
Installing Kubernetes (k3s)...
Adding to k3s API server TLS cert: c, p, ., a, c, k, n, o, w, l, e, d, g, e, ., w, i, k, i
\`\`\`

\`canasta.py\`'s \`add_params_to_parser\` only handled \`multi: true\` for **positional** parameters (\`packages\`). Non-positional multi:true flags fell through to the default \`add_argument\` call (single string value). \`--public-ip cp.acknowledge.wiki\` stored the literal string, and the Ansible \`map(...)\` filter iterated over the string's characters.

Fix: explicit branch in \`add_params_to_parser\` for non-positional \`multi: true\` using \`action='append'\` and default \`[]\`. Each \`--flag X\` invocation now appends to a list, dest is always a list, and Ansible's \`map\` iterates over values as expected.

## Bug 2: \`python3-kubernetes\` apt failure on fresh VM

\`\`\`
Error: No package matching 'python3-kubernetes' is available
\`\`\`

The \`apt: name: python3-kubernetes\` task had no \`update_cache\`, so on a brand-new VM with the AMI's stale apt cache the package was reported missing — even though it's in Debian/Ubuntu's main/universe repos. Fix: \`update_cache: true\` with \`cache_valid_time: 3600\` so apt refreshes once per hour at most.

## Test plan

- [x] \`make validate\` passes.
- [x] Live argparse test confirms \`--public-ip X\` → \`['X']\`, \`--public-ip X --public-ip Y\` → \`['X', 'Y']\`, \`--public-ip\` omitted → \`[]\`.
- [ ] Cindy retries \`canasta install k8s-cp --host cp --public-ip cp.acknowledge.wiki\` after merge — should report \`Adding to k3s API server TLS cert: cp.acknowledge.wiki\` (single value), and the Python kubernetes lib install should succeed.

## Note on bug 1's blast radius

The new \`--public-ip\` is the only non-positional \`multi: true\` parameter currently in \`command_definitions.yml\`. So this bug doesn't affect any other commands today. Worth fixing the wrapper anyway since the schema says \`multi: true\` and users will reasonably expect repeatable flags to behave like \`-l label=foo -l label=bar\` does in kubectl/docker/etc.