### PR TITLE
Fix --public-ip serialization and uninstall prompt placeholder (closes #366)

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -586,7 +586,22 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
         value = getattr(args, name, None)
         if value is None:
             continue
-        # REMAINDER args come as a list, join into string
+        # Non-positional multi-valued flags (e.g. --public-ip) come
+        # from argparse as a list and must reach Ansible as a list,
+        # so playbook filters like `| join(', ')` operate over
+        # elements rather than iterating a joined string char-by-char.
+        if (
+            isinstance(value, list)
+            and param.get("multi")
+            and not param.get("positional")
+        ):
+            if not value:
+                continue
+            extra_vars[name] = value
+            continue
+        # Positional multi (packages) and REMAINDER args (exec_args/
+        # script_args) are consumed Ansible-side via .split(), so
+        # collapse them to a space-joined string.
         if isinstance(value, list):
             value = " ".join(value)
             if not value:
@@ -838,11 +853,18 @@ def main():
     )
     if has_yes_param and not getattr(args, "yes", False):
         description = cmd_def.get("description", command_name)
-        instance_id = getattr(args, "id", None) or "unknown"
+        instance_id = getattr(args, "id", None)
+        host = getattr(args, "host", None)
+        if instance_id:
+            target = " '%s'" % instance_id
+        elif host:
+            target = " '%s'" % host
+        else:
+            target = ""
         try:
             answer = input(
-                "%s '%s'. Continue? [y/N] "
-                % (description, instance_id)
+                "%s%s. Continue? [y/N] "
+                % (description, target)
             )
         except (EOFError, KeyboardInterrupt):
             print("\nOperation cancelled.")


### PR DESCRIPTION
Closes #366.

## Summary

- `canasta install k8s-cp --public-ip <addr>`: pass the value to Ansible as a list, not a space-joined string. PR #365 fixed argparse but `build_ansible_args` then collapsed `["cp.example.com"]` back to `"cp.example.com"`, so the playbook's `| join(', ')` iterated chars and the cert was built from one-letter SANs.
- Confirmation prompt: stop hardcoding `args.id or "unknown"`. Prefer `--id`, fall back to `--host`, drop the placeholder when neither applies. Fixes `canasta uninstall k8s --host cp` showing `'unknown'`.

## Scope

Only `public_ip` is affected by bug #1 — it's the lone non-positional `multi: true` param in `command_definitions.yml`. Positional multi (`packages`/`keys`/`key_value_pairs`) and REMAINDER args (`exec_args`/`script_args`) still collapse to a space-joined string because their playbooks consume them via `.split()`.

## Test plan

- [x] `make validate` — 61 commands / 53 playbooks
- [x] `make test-unit` — 564 passed
- [x] Smoke test serialization: `--public-ip a` and `--public-ip a --public-ip b` both produce JSON arrays in the temp extra-vars file; missing flag yields no entry; positional `packages` still serializes as `"k8s-cp"`.
- [x] Smoke test all three prompt branches: `delete -i mysite` → `Delete a Canasta instance 'mysite'. Continue?`; `uninstall k8s --host cp` → `Uninstall dependencies from the target host 'cp'. Continue?`; `uninstall k8s` → `Uninstall dependencies from the target host. Continue?`.
- [ ] End-to-end EC2 retest of `canasta install k8s-cp --public-ip ...` (depends on this merging).
