### PR TITLE
Export CANASTA_CONFIG_DIR before invoking ansible-playbook (closes #368)

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -689,6 +689,14 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
         "-o UserKnownHostsFile=~/.ssh/known_hosts",
     )
 
+    # Hand the platform-correct config dir to Ansible. get_config_dir()
+    # picks the macOS / Linux / root location; without exporting it,
+    # YAML-side env lookups (e.g. roles/install/tasks/k3s_worker.yml)
+    # fall through to a Linux-only fallback and miss hosts.yml on
+    # macOS. setdefault preserves any pre-set value (canasta-docker
+    # sets it explicitly, and tests use it for isolation).
+    os.environ.setdefault("CANASTA_CONFIG_DIR", get_config_dir())
+
     return ansible_args
 
 


### PR DESCRIPTION
Closes #368.

## Summary

`canasta install k8s-worker` failed on macOS with `File not found: /Users/<u>/.config/canasta/hosts.yml` even after the user had correctly registered the cp-host with `canasta host add`. The file was at the right macOS location (`~/Library/Application Support/canasta/hosts.yml`); the Ansible task was just looking somewhere else.

`canasta.py:get_config_dir()` is platform-aware, but `canasta.py` never exported `CANASTA_CONFIG_DIR` into the env when it invoked `ansible-playbook`. The YAML-side env lookup at `roles/install/tasks/k3s_worker.yml:18-28` then fell through to a hardcoded Linux fallback (`HOME ~ '/.config/canasta'`).

This PR exports the resolved path before invoking `ansible-playbook` so Ansible sees the same location Python uses. `setdefault` preserves any pre-set value, so `canasta-docker`'s explicit export and the test harness's `CANASTA_CONFIG_DIR` isolation override both still win.

## Why only `k8s-worker` is affected today

`canasta install k8s-cp` doesn't read `hosts.yml` from inside Ansible — `--host cp` resolution happens entirely on the Python side (`canasta.py:670` calls `get_config_dir()`, finds `hosts.yml`, and passes it as `-i hosts.yml` to `ansible-playbook`). Inventory machinery + SSH config aliases handle the rest. The cp install task itself never touches the file directly.

`canasta install k8s-worker` is the only command that *slurps* `hosts.yml` from inside YAML — it has to, because the controller needs to discover the cp host's SSH target while running on `worker1` so it can delegate back to cp and fetch the join token. That's the path that does its own (Linux-only) resolution and trips on macOS. Same root cause; only one task exposes it today. The fix is preventative for any future task that does the same lookup.

## Test plan

- [x] `make validate` — 61 commands / 53 playbooks
- [x] `make test-unit` — 564 passed
- [ ] End-to-end retest on macOS: `canasta install k8s-worker --host worker1 --cp-host cp` against a registered cp host, where `hosts.yml` lives at `~/Library/Application Support/canasta/hosts.yml`.
