### PR TITLE
canasta install k8s-worker: handle cp-host registered without user@ prefix (closes #370)

### DIFF
--- a/roles/install/tasks/k3s_worker.yml
+++ b/roles/install/tasks/k3s_worker.yml
@@ -53,12 +53,15 @@
 
 - name: Compose cp-host SSH target string
   ansible.builtin.set_fact:
+    # Bracket notation + default() handles entries written by
+    # `canasta host add --ssh host` (no user@ prefix), which omit
+    # ansible_user. Dot notation on a dict missing the key raises
+    # AttributeError before default() can apply.
     _cp_ssh_target: >-
-      {{ (_cp_host_entry.ansible_user | default('') | length > 0)
-         | ternary(
-             _cp_host_entry.ansible_user ~ '@' ~ _cp_host_entry.ansible_host,
-             _cp_host_entry.ansible_host
-           ) }}
+      {{ (_cp_host_entry['ansible_user'] | default('')
+          ~ '@' ~ _cp_host_entry['ansible_host'])
+         if (_cp_host_entry['ansible_user'] | default('') | length > 0)
+         else _cp_host_entry['ansible_host'] }}
 
 # --- SSH to cp-host, fetch token + cluster-internal IP ---
 


### PR DESCRIPTION
Closes #370.

## Summary

`canasta install k8s-worker --host worker1 --cp-host cp` crashed with `object of type 'dict' has no attribute 'ansible_user'` whenever the cp-host was registered without an explicit user, e.g. `canasta host add --name cp --ssh host.example.com`. That form is documented as valid (`meta/command_definitions.yml:1633` says `--ssh` accepts "user@host or just host"), and `direct_commands.py` correctly writes the entry as `{ansible_host: ...}` with no `ansible_user` key.

The worker task's Jinja expression used dot-notation attribute access (`_cp_host_entry.ansible_user | default('')`). In Ansible's Jinja2 environment, `dict.missing_attr` raises `AttributeError` *before* `| default()` can apply — `default()` only catches `Undefined`. Bracket notation (`_cp_host_entry['ansible_user']`) returns `Undefined` for missing keys, which `default()` then handles cleanly.

## Result

- Host added with `--ssh user@host.example.com` → SSH target = `user@host.example.com` (unchanged).
- Host added with `--ssh host.example.com` → SSH target = `host.example.com`. SSH config / default-user behavior takes over from there.

## Test plan

- [x] `make validate` — 61 commands / 53 playbooks
- [x] `make test-unit` — 564 passed
- [x] `make lint` — no new warnings on `roles/install/tasks/k3s_worker.yml` (line 93 is pre-existing)
- [ ] End-to-end retest: `canasta install k8s-worker --host worker1 --cp-host cp` against a cp registered without `user@`.
