### PR TITLE
canasta install k8s-worker: drop duplicate join message and reword verify hint (closes #373)

### DIFF
--- a/roles/install/tasks/k3s_worker.yml
+++ b/roles/install/tasks/k3s_worker.yml
@@ -113,9 +113,9 @@
     - (_cp_internal_ip_raw.stdout | trim | length == 0)
       or (_cp_token_raw.stdout | trim | length == 0)
 
-- name: Report join target
-  ansible.builtin.debug:
-    msg: "Joining k3s cluster at {{ _k3s_server_url }} as a worker..."
+# The agent task itself prints "Joining k3s cluster at ..." inside
+# its install block (gated on a real install), so we don't duplicate
+# that message here.
 
 # --- Run the agent install with the resolved values ---
 
@@ -126,3 +126,4 @@
   vars:
     server: "{{ _k3s_server_url }}"
     token: "{{ _k3s_join_token }}"
+    cp_host_name: "{{ cp_host }}"

--- a/roles/orchestrator/tasks/k8s_install_k3s_agent.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s_agent.yml
@@ -55,6 +55,8 @@
 - name: Report status
   ansible.builtin.debug:
     msg: >-
-      k3s agent is running and joined to {{ server }}. Verify from
-      the controller with 'kubectl get nodes' — this host should
-      appear within ~30 seconds.
+      k3s agent is running and joined to {{ server }}. To verify, SSH
+      to the cp host and run 'sudo k3s kubectl get nodes'{{
+        " (e.g. 'ssh " ~ cp_host_name ~ "')" if cp_host_name | default('')
+        else ""
+      }} — this host should appear within ~30 seconds.


### PR DESCRIPTION
Closes #373.

## Summary

Two cosmetic fixes to the worker join, surfaced by end-to-end multi-node testing:

1. **Drop the duplicate "Joining k3s cluster at … as a worker…" line.** It came from both `roles/install/tasks/k3s_worker.yml` and the inner `roles/orchestrator/tasks/k8s_install_k3s_agent.yml` it includes. The agent task is the right owner — its message is gated on an actual install (`when: _k3s_agent_running.rc != 0`), so it stays quiet on no-op re-runs.

2. **Reword the post-join verification message.** Previously: "Verify from the controller with 'kubectl get nodes'". User report: ran that on their laptop and got Docker Desktop's local cluster, not the new EC2 cluster — because the laptop had no kubeconfig pointing at the EC2 cp host. The only verification path that works today is SSH to the cp host and `sudo k3s kubectl get nodes`. The new wording says exactly that, and when the wrapper passes the cp host's short name, it includes an inline `ssh <name>` hint.

The longer-term fix — a `canasta kubeconfig install --host cp` command that pulls cp's kubeconfig down to the laptop and rewrites the server URL to the public name (which is what `--public-ip` was added for) — is tracked separately in #372.

## Test plan

- [x] `make validate` — 61 commands / 53 playbooks
- [x] `make test-unit` — 564 passed
- [x] `make lint` — no new warnings on the edited files
- [ ] End-to-end: `canasta install k8s-worker --host worker3 --cp-host cp` should print one "Joining…" line and a verify message that points at SSH-to-cp.
