### PR TITLE
canasta storage setup {nfs,efs}: add --host flag (closes #377)

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1587,11 +1587,23 @@ commands:
       Install the NFS CSI driver and create a StorageClass for shared storage
       on Kubernetes clusters. Optionally install an NFS server on the target host.
       After setup, set persistence.*.storageClass in values.yaml to use it.
+
+      When canasta runs on a different machine than the Kubernetes cluster
+      (e.g. a laptop driving an EC2 cluster), pass `--host <name>` to target
+      a registered host that already has kubectl/helm and a kubeconfig
+      pointing at the cluster — typically the control plane. `--install-server`
+      then installs NFS on that same host, and the StorageClass points back
+      at it.
     examples:
-      - "canasta storage setup nfs --server 192.168.1.10 --share /srv/nfs/canasta"
+      - "canasta storage setup nfs --host cp --install-server --share /srv/nfs/canasta"
+      - "canasta storage setup nfs --host cp --server 192.168.1.10 --share /srv/nfs/canasta"
       - "canasta storage setup nfs --install-server --share /srv/nfs/canasta"
     playbook: storage_setup_nfs.yml
     parameters:
+      - name: host
+        short: H
+        type: string
+        description: "Target host (default: localhost)"
       - name: server
         type: string
         description: "NFS server IP or hostname"
@@ -1677,10 +1689,20 @@ commands:
       Install the EFS CSI driver and create a StorageClass for shared storage
       on AWS Kubernetes clusters. The EFS filesystem must be created separately
       via AWS console or CLI.
+
+      When canasta runs on a different machine than the Kubernetes cluster
+      (e.g. a laptop driving an EC2 cluster), pass `--host <name>` to target
+      a registered host that already has kubectl/helm and a kubeconfig
+      pointing at the cluster — typically the control plane.
     examples:
+      - "canasta storage setup efs --host cp --filesystem-id fs-0123456789abcdef0"
       - "canasta storage setup efs --filesystem-id fs-0123456789abcdef0"
     playbook: storage_setup_efs.yml
     parameters:
+      - name: host
+        short: H
+        type: string
+        description: "Target host (default: localhost)"
       - name: filesystem_id
         type: string
         required: true


### PR DESCRIPTION
Closes #377.

## Summary

`canasta storage setup nfs` and `canasta storage setup efs` had no `--host` parameter, so both always ran on `localhost`. That breaks the laptop-drives-remote-cluster model surfaced during multi-node testing of #349/#350: `--install-server` tries to apt-install on macOS, and the `kubernetes.core.helm`/`k8s` steps target the laptop's kubeconfig (typically Docker Desktop) rather than the remote EC2 cluster.

Add `-H, --host` to both commands, matching `install`'s shape. The Ansible dispatcher (`canasta.yml: hosts: "{{ target_host | default('localhost') }}"`) already routes `target_host` correctly, so no playbook changes are needed — only the parameter declaration.

For the multi-node case, `--host cp` is the natural target: cp already has kubectl/helm and a working kubeconfig from `canasta install k8s-cp`, and with `--install-server` the NFS server lands on cp itself.

## Docs

`make docs` regenerates `docs/commands/storage_setup_nfs.md` and `storage_setup_efs.md` from the updated YAML. (Those generated files are gitignored — `wiki_publish.py` is the publishing path for canasta.wiki.) `long_description` and examples on both commands now spell out when `--host` matters and show both `--install-server` and `--server <addr>` modes pointed at cp. A no-host example is kept for the single-node co-located case.

## Test plan

- [x] `make validate` — 61 commands / 53 playbooks
- [x] `make test-unit` — 564 passed
- [x] `make docs` — regenerates cleanly; new flag and examples render correctly
- [x] Smoke test: `canasta storage setup nfs --host cp --install-server --share /srv/nfs/canasta` produces `target_host: "cp"` in the extra-vars JSON
- [ ] End-to-end: `canasta storage setup nfs --host cp --install-server --share /srv/nfs/canasta` against the existing 3-node EC2 cluster — should install NFS on cp, install the CSI driver, and create the `nfs` StorageClass.
