### PR TITLE
canasta storage setup {nfs,efs}: drop wiki URL from success message (closes #380)

### DIFF
--- a/playbooks/storage_setup_efs.yml
+++ b/playbooks/storage_setup_efs.yml
@@ -54,5 +54,3 @@
       '{{ storage_class_name | default('efs') }}' is ready.
       To run a multi-replica web pod across nodes, also pass
       --access-mode ReadWriteMany when creating the instance.
-      See https://canasta.wiki/wiki/Help:Multi-node_Kubernetes for
-      the full walkthrough.

--- a/playbooks/storage_setup_nfs.yml
+++ b/playbooks/storage_setup_nfs.yml
@@ -108,5 +108,3 @@
       '{{ storage_class_name | default('nfs') }}' is ready.
       To run a multi-replica web pod across nodes, also pass
       --access-mode ReadWriteMany when creating the instance.
-      See https://canasta.wiki/wiki/Help:Multi-node_Kubernetes for
-      the full walkthrough.


### PR DESCRIPTION
Closes #380.

## Summary

Drop the trailing "See https://canasta.wiki/..." sentence from the success messages of `canasta storage setup nfs` and `canasta storage setup efs`. The CLI is the source of truth for the tool, and the wiki page in question is published from `meta/command_definitions.yml` via `wiki_publish.py` — so a CLI message pointing at the wiki is circular for any single-command help. URLs in CLI output also rot independently of the code.

The actionable next step (`--access-mode ReadWriteMany` when creating the instance) is already inline; the URL added no information the user could act on right now.

## Out of scope

`roles/orchestrator/files/helm/canasta/values.yaml:114-115` has a similar wiki URL inside a comment block. That's documentation embedded in a config template the user edits, not CLI output — different category. Left alone in this PR pending a separate decision.

## Test plan

- [x] `make validate` — 61 commands / 53 playbooks
- [x] `make test-unit` — 564 passed
- [ ] End-to-end: `canasta storage setup nfs --host cp --install-server …` should print the success message without the wiki URL.
