### PR TITLE
Strip how-to hints from CLI success messages and wiki URL from values.yaml (closes #382)

### DIFF
--- a/playbooks/storage_setup_efs.yml
+++ b/playbooks/storage_setup_efs.yml
@@ -52,5 +52,3 @@
     msg: >-
       EFS storage configured. StorageClass
       '{{ storage_class_name | default('efs') }}' is ready.
-      To run a multi-replica web pod across nodes, also pass
-      --access-mode ReadWriteMany when creating the instance.

--- a/playbooks/storage_setup_nfs.yml
+++ b/playbooks/storage_setup_nfs.yml
@@ -106,5 +106,3 @@
     msg: >-
       NFS storage configured. StorageClass
       '{{ storage_class_name | default('nfs') }}' is ready.
-      To run a multi-replica web pod across nodes, also pass
-      --access-mode ReadWriteMany when creating the instance.

--- a/roles/install/tasks/k3s_worker.yml
+++ b/roles/install/tasks/k3s_worker.yml
@@ -126,4 +126,3 @@
   vars:
     server: "{{ _k3s_server_url }}"
     token: "{{ _k3s_join_token }}"
-    cp_host_name: "{{ cp_host }}"

--- a/roles/orchestrator/files/helm/canasta/values.yaml
+++ b/roles/orchestrator/files/helm/canasta/values.yaml
@@ -111,9 +111,8 @@ ingress:
 # ReadWriteMany provisioner (e.g. nfs, efs) AND set accessMode to
 # ReadWriteMany. The default ReadWriteOnce is correct for single-node
 # clusters and for multi-replica deployments where all pods can be
-# scheduled to the same node. See
-# https://canasta.wiki/wiki/Help:Multi-node_Kubernetes and
-# 'canasta storage setup' for help configuring shared storage.
+# scheduled to the same node. See `canasta storage setup --help` for
+# the available shared-storage commands.
 persistence:
   images:
     size: 10Gi

--- a/roles/orchestrator/tasks/k8s_install_k3s_agent.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s_agent.yml
@@ -54,9 +54,4 @@
 
 - name: Report status
   ansible.builtin.debug:
-    msg: >-
-      k3s agent is running and joined to {{ server }}. To verify, SSH
-      to the cp host and run 'sudo k3s kubectl get nodes'{{
-        " (e.g. 'ssh " ~ cp_host_name ~ "')" if cp_host_name | default('')
-        else ""
-      }} — this host should appear within ~30 seconds.
+    msg: "k3s agent is running and joined to {{ server }}."


### PR DESCRIPTION
Closes #382.

## Summary

CLI runtime output should report what was done. Usage guidance — "also pass X", "to verify run Y", "see <doc>" — belongs in the command reference, user guide, and the command's own `--help` / `long_description` output. PR #381 dropped wiki URLs from the same messages on the same principle; this PR extends it to inline how-to hints.

## Changes

**CLI success messages (drop the trailing hint, keep the report):**

- `playbooks/storage_setup_nfs.yml`: was "NFS storage configured. StorageClass 'nfs' is ready. To run a multi-replica web pod across nodes, also pass `--access-mode ReadWriteMany` when creating the instance." Now: "NFS storage configured. StorageClass 'nfs' is ready."
- `playbooks/storage_setup_efs.yml`: same trailer, same fix.
- `roles/orchestrator/tasks/k8s_install_k3s_agent.yml`: was "k3s agent is running and joined to {{ server }}. To verify, SSH to the cp host and run 'sudo k3s kubectl get nodes' (e.g. 'ssh …') — this host should appear within ~30 seconds." Now: "k3s agent is running and joined to {{ server }}." Drop the `cp_host_name` var passed in from `roles/install/tasks/k3s_worker.yml` — it existed only to interpolate into the verify hint.

**Embedded comment (different category, narrower change):**

- `roles/orchestrator/files/helm/canasta/values.yaml` lines 110-116: this is conceptual guidance in a config template the user edits — appropriate to keep. But its `https://canasta.wiki/...` URL has the same rot/circular-reference problem the CLI sites do. Strip the URL, keep the rest of the comment and the existing reference to `canasta storage setup --help`.

## Test plan

- [x] `make validate` — 61 commands / 53 playbooks
- [x] `make test-unit` — 564 passed
- [ ] End-to-end: `canasta storage setup nfs --host cp --install-server …` should print just the StorageClass-ready report.
- [ ] End-to-end: `canasta install k8s-worker --host worker3 --cp-host cp` should print just the joined-to report.
