### PR TITLE
canasta uninstall k8s --host workerN: also delete the Node from cp (closes #379)

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -430,8 +430,15 @@ commands:
     long_description: |
       Uninstall dependencies from the target host. Supported packages:
       k8s (removes k3s, kubectl, helm, and cleans up iptables rules).
+
+      When uninstalling k8s from a worker, pass `--cp-host <name>` to
+      also delete the worker's Node entry from the control plane.
+      Without it, the Node lingers in `kubectl get nodes` until manually
+      removed (and a worker rejoining with the same hostname will
+      reclaim it, masking the uninstall).
     examples:
       - "canasta uninstall k8s"
+      - "canasta uninstall k8s --host worker1 --cp-host cp"
     playbook: uninstall.yml
     parameters:
       - name: host
@@ -444,6 +451,13 @@ commands:
         multi: true
         required: true
         description: "Dependencies to uninstall (k8s)"
+      - name: cp_host
+        type: string
+        description: >-
+          For k8s worker uninstalls, name of the registered control-plane
+          host. Canasta SSHs there after stopping the agent and runs
+          'kubectl delete node <hostname>' so the Node entry is cleaned
+          up. Ignored on control-plane uninstalls.
       - name: "yes"
         short: "y"
         type: bool

--- a/roles/common/tasks/resolve_cp_host_ssh.yml
+++ b/roles/common/tasks/resolve_cp_host_ssh.yml
@@ -1,0 +1,59 @@
+---
+# Resolve a registered cp-host short name to an SSH target string by
+# reading the controller's hosts.yml.
+#
+# Input: cp_host (string, the short name registered via 'canasta host add')
+# Output: sets fact _cp_ssh_target = "user@host" or just "host"
+#
+# Used by:
+#   - roles/install/tasks/k3s_worker.yml (fetch join token from cp)
+#   - roles/install/tasks/uninstall_k3s.yml (delete Node from cp on
+#     worker uninstall)
+
+- name: Determine controller config dir
+  ansible.builtin.set_fact:
+    _canasta_config_dir: >-
+      {{ lookup('ansible.builtin.env', 'CANASTA_CONFIG_DIR')
+         or (
+             (lookup('ansible.builtin.env', 'USER') == 'root')
+             | ternary(
+                 '/etc/canasta',
+                 lookup('ansible.builtin.env', 'HOME') ~ '/.config/canasta'
+               )
+            ) }}
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+
+- name: Read controller's hosts.yml
+  ansible.builtin.slurp:
+    src: "{{ _canasta_config_dir }}/hosts.yml"
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  register: _cp_hosts_yml_raw
+
+- name: Parse hosts.yml and resolve cp-host entry
+  ansible.builtin.set_fact:
+    _cp_host_entry: >-
+      {{ ((_cp_hosts_yml_raw.content | b64decode | from_yaml)
+          .all.hosts[cp_host]) | default({}) }}
+
+- name: Fail if cp-host is not registered
+  ansible.builtin.fail:
+    msg: >-
+      Host '{{ cp_host }}' is not registered. Run
+      'canasta host add --name {{ cp_host }} --ssh user@host' first.
+  when: not _cp_host_entry
+
+- name: Compose cp-host SSH target string
+  ansible.builtin.set_fact:
+    # Bracket notation + default() handles entries written by
+    # `canasta host add --ssh host` (no user@ prefix), which omit
+    # ansible_user. Dot notation on a dict missing the key raises
+    # AttributeError before default() can apply.
+    _cp_ssh_target: >-
+      {{ (_cp_host_entry['ansible_user'] | default('')
+          ~ '@' ~ _cp_host_entry['ansible_host'])
+         if (_cp_host_entry['ansible_user'] | default('') | length > 0)
+         else _cp_host_entry['ansible_host'] }}

--- a/roles/install/tasks/k3s_worker.yml
+++ b/roles/install/tasks/k3s_worker.yml
@@ -10,58 +10,10 @@
 # and finally invokes k8s_install_k3s_agent.yml on this host with
 # those values to actually do the join.
 
-# --- Read controller's hosts.yml to resolve cp-host SSH details ---
+# --- Resolve cp-host short name to SSH target ---
 
-# CANASTA_CONFIG_DIR drives where hosts.yml lives. Resolve from the
-# controller's environment, with the same precedence canasta.py uses
-# (env override → /etc/canasta if root → ~/.config/canasta otherwise).
-- name: Determine controller config dir
-  ansible.builtin.set_fact:
-    _canasta_config_dir: >-
-      {{ lookup('ansible.builtin.env', 'CANASTA_CONFIG_DIR')
-         or (
-             (lookup('ansible.builtin.env', 'USER') == 'root')
-             | ternary(
-                 '/etc/canasta',
-                 lookup('ansible.builtin.env', 'HOME') ~ '/.config/canasta'
-               )
-            ) }}
-  delegate_to: localhost
-  vars:
-    ansible_connection: local
-
-- name: Read controller's hosts.yml
-  ansible.builtin.slurp:
-    src: "{{ _canasta_config_dir }}/hosts.yml"
-  delegate_to: localhost
-  vars:
-    ansible_connection: local
-  register: _cp_hosts_yml_raw
-
-- name: Parse hosts.yml and resolve cp-host SSH target
-  ansible.builtin.set_fact:
-    _cp_host_entry: >-
-      {{ ((_cp_hosts_yml_raw.content | b64decode | from_yaml)
-          .all.hosts[cp_host]) | default({}) }}
-
-- name: Fail if cp-host is not registered
-  ansible.builtin.fail:
-    msg: >-
-      Host '{{ cp_host }}' is not registered. Run
-      'canasta host add --name {{ cp_host }} --ssh user@host' first.
-  when: not _cp_host_entry
-
-- name: Compose cp-host SSH target string
-  ansible.builtin.set_fact:
-    # Bracket notation + default() handles entries written by
-    # `canasta host add --ssh host` (no user@ prefix), which omit
-    # ansible_user. Dot notation on a dict missing the key raises
-    # AttributeError before default() can apply.
-    _cp_ssh_target: >-
-      {{ (_cp_host_entry['ansible_user'] | default('')
-          ~ '@' ~ _cp_host_entry['ansible_host'])
-         if (_cp_host_entry['ansible_user'] | default('') | length > 0)
-         else _cp_host_entry['ansible_host'] }}
+- name: Resolve cp-host SSH target from hosts.yml
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_cp_host_ssh.yml"
 
 # --- SSH to cp-host, fetch token + cluster-internal IP ---
 

--- a/roles/install/tasks/uninstall_k3s.yml
+++ b/roles/install/tasks/uninstall_k3s.yml
@@ -4,6 +4,13 @@
 # control-plane (k3s-uninstall.sh) and worker (k3s-agent-uninstall.sh)
 # install forms; the k3s installer creates a different script
 # depending on whether it set up a server or an agent.
+#
+# On a worker uninstall, if cp_host is provided, also SSH to the
+# control plane afterward and 'kubectl delete node <hostname>' so the
+# Node entry is removed from the cluster's view. Without that, the
+# Node lingers in 'kubectl get nodes' and a worker rejoining with the
+# same hostname reclaims it (preserving its AGE) — which masks the
+# uninstall.
 
 - name: Check for k3s server uninstall script
   ansible.builtin.stat:
@@ -32,6 +39,35 @@
   ansible.builtin.debug:
     msg: "k3s is not installed."
   when: not _k3s_uninstall_script
+
+# Worker uninstalls leave a Node entry on the control plane unless we
+# delete it. To keep cluster state coherent, require --cp-host so we
+# know where to send the delete. Control-plane uninstalls don't need
+# it; control plane is itself the registry, and tearing it down
+# discards the Node list along with everything else.
+- name: Require --cp-host for worker uninstalls
+  ansible.builtin.fail:
+    msg: >-
+      Uninstalling a k3s worker requires --cp-host <name>, where
+      <name> is the registered control-plane host. Canasta SSHs there
+      after stopping the agent and deletes this worker's Node entry
+      from the cluster. Without it, the Node lingers in 'kubectl get
+      nodes' and a worker rejoining with the same hostname reclaims
+      it.
+  when:
+    - _k3s_role_label == 'worker'
+    - not (cp_host is defined and (cp_host | length > 0))
+
+# Capture the worker's hostname *before* the uninstall script runs.
+# k8s Node names default to the OS hostname (the k3s installer doesn't
+# pass --node-name in this codebase), so this is what we'll ask cp to
+# delete from its Node registry below.
+- name: Capture worker hostname for Node cleanup
+  ansible.builtin.command:
+    cmd: hostname
+  register: _worker_hostname_raw
+  changed_when: false
+  when: _k3s_role_label == 'worker'
 
 - name: Uninstall k3s
   when: _k3s_uninstall_script | length > 0
@@ -73,3 +109,33 @@
     - name: Report uninstalled
       ansible.builtin.debug:
         msg: "Kubernetes ({{ _k3s_role_label }}) uninstalled."
+
+# --- Worker only: clean up the Node entry on the control plane ---
+
+- name: Delete worker Node from control plane
+  when: _k3s_role_label == 'worker'
+  block:
+    - name: Resolve cp-host SSH target from hosts.yml
+      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_cp_host_ssh.yml"
+
+    - name: Delete Node from control plane
+      ansible.builtin.command:
+        argv:
+          - ssh
+          - -o
+          - StrictHostKeyChecking=accept-new
+          - "{{ _cp_ssh_target }}"
+          - >-
+            sudo k3s kubectl delete node
+            {{ (_worker_hostname_raw.stdout | trim) | quote }}
+            --ignore-not-found
+      delegate_to: localhost
+      vars:
+        ansible_connection: local
+      register: _node_delete
+      changed_when: "'deleted' in (_node_delete.stdout | default(''))"
+
+    - name: Report Node cleanup
+      ansible.builtin.debug:
+        msg: "Removed Node '{{ _worker_hostname_raw.stdout | trim }}' from control plane."
+      when: "'deleted' in (_node_delete.stdout | default(''))"


### PR DESCRIPTION
Closes #379.

## Summary

Worker uninstalls left the Node entry on the control plane behind. `k3s-agent-uninstall.sh` stops the agent on the worker but doesn't talk to cp's API server, so `kubectl get nodes` still listed the host. A worker rejoining with the same hostname (typical on EC2 where the hostname is metadata-derived and stable) reclaimed the existing Node and preserved its AGE — making it look like the uninstall hadn't happened.

After the agent uninstall script runs, SSH to the cp host (resolved from `hosts.yml` using the same logic the install path uses) and run `kubectl delete node <hostname> --ignore-not-found`. The worker's hostname is captured *before* the uninstall script runs (k3s default Node names are the OS hostname).

## `--cp-host` is required for worker uninstalls

The alternative — leaving cp_host optional and printing a trailer like "the Node entry remains on cp; clean up with kubectl delete node …" — would have re-introduced the kind of how-to-hint-in-CLI-output we just removed in #382. A clear up-front error ("Uninstalling a k3s worker requires --cp-host …") is the right fail mode. Control-plane uninstalls don't need cp-host (tearing down the cp itself discards the Node list).

## Refactor

Extracted the cp-host SSH-target resolution from `roles/install/tasks/k3s_worker.yml` into `roles/common/tasks/resolve_cp_host_ssh.yml` so install and uninstall share it. The shared file reads `hosts.yml` from the controller, parses the cp-host entry, fails with a usable error if the host isn't registered, and composes the SSH target string (handling entries written without `user@` per #371).

## Test plan

- [x] `make validate` — 61 commands / 53 playbooks
- [x] `make test-unit` — 564 passed
- [x] `make lint` — no new warnings (lines 100-101 pre-existing on the iptables command)
- [ ] End-to-end: `canasta uninstall k8s --host worker2 --cp-host cp` should run `k3s-agent-uninstall.sh` AND remove the Node entry on cp, so `kubectl get nodes` shows the worker is gone. Reinstalling should produce a fresh Node with AGE=0.
- [ ] End-to-end: `canasta uninstall k8s --host worker2` (no --cp-host) should fail fast with the usability error.
- [ ] End-to-end: `canasta uninstall k8s --host cp` should still work as before (control-plane uninstall, cp-host ignored).
