### PR TITLE
canasta create: validate --domain-name up front (closes #385)

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -9,6 +9,7 @@ the bash wrapper script with Cobra-equivalent argument handling.
 import argparse
 import json
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -52,6 +53,29 @@ NESTED_SUBCOMMAND_GROUPS = {
     "storage": {
         "setup": ["nfs", "efs"],
     },
+}
+
+# Named regex validators for parameters tagged with `validator: <name>`
+# in meta/command_definitions.yml. Each entry is (compiled_regex,
+# error_template). The error template is appended after the offending
+# value, e.g. "Error: --domain-name 'foo' is not a valid hostname …".
+#
+# Validation runs after argparse but before any Ansible invocation, so
+# bad values fail in milliseconds instead of after Argo CD/helm/image
+# pull steps have already done work.
+_VALIDATORS = {
+    # RFC 1123 subdomain. Same regex k8s uses to validate
+    # Ingress.spec.rules[].host. Lowercase letters/digits, '-' and '.'
+    # only; each label starts and ends with an alphanumeric character.
+    "hostname": (
+        re.compile(
+            r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+            r"(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+        ),
+        "is not a valid hostname. Expected lowercase letters, digits, "
+        "'-' and '.' only, with each label starting and ending with an "
+        "alphanumeric character (e.g. 'example.com').",
+    ),
 }
 
 
@@ -824,6 +848,40 @@ def main():
                     file=sys.stderr,
                 )
                 sys.exit(1)
+
+    # Validate parameters tagged with `validator: <name>` against a
+    # named regex. Catches typos (e.g. comma-vs-period in domain names)
+    # before any Ansible work is done — much cheaper than the same
+    # check failing at the end of the create pipeline.
+    for param in cmd_def.get("parameters", []):
+        validator_name = param.get("validator")
+        if not validator_name:
+            continue
+        value = getattr(args, param["name"], None)
+        if value is None or value == "":
+            continue
+        validator = _VALIDATORS.get(validator_name)
+        if validator is None:
+            # Unknown validator name in command_definitions.yml is a
+            # bug in the YAML, not a user error — surface loudly.
+            print(
+                "Internal error: parameter '%s' references unknown "
+                "validator '%s'" % (param["name"], validator_name),
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        regex, error_template = validator
+        if not regex.match(str(value)):
+            print(
+                "Error: --%s %r %s"
+                % (
+                    param["name"].replace("_", "-"),
+                    str(value),
+                    error_template,
+                ),
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     # Interactive exec: bypass Ansible for TTY support.
     if command_name == "maintenance_exec":

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -78,6 +78,7 @@ commands:
         short: n
         type: string
         default: localhost
+        validator: hostname
         description: "Domain name"
       - name: admin
         short: a


### PR DESCRIPTION
Closes #385.

## Summary

`canasta create --domain-name cp,acknowledge.wiki` (with a typo'd comma) used to fail only at the very end of the create pipeline, after Argo CD checks, file generation, image pull, and helm chart staging — all of which had to be torn back down. The error came from k8s validating `Ingress.spec.rules[].host` against RFC 1123. End-to-end testing of #349/#350 hit this twice tonight.

Adds a generic validator framework: parameters in `meta/command_definitions.yml` can declare `validator: <name>`, where `<name>` is a key in the `_VALIDATORS` registry in `canasta.py`. After argparse but before any Ansible invocation, every parameter with a validator is checked against its regex; a mismatch fails with a clear error in milliseconds.

First validator: `hostname`, using the same RFC 1123 subdomain regex k8s uses. `create --domain-name` is tagged with it.

## Why a registry rather than a one-off check

Other params will benefit from the same wiring: `--tls-email` (basic email shape), `--filesystem-id` (`fs-[0-9a-f]+`), `-i`/`--id` (the existing instance-ID regex moved here), and so on. The framework cost is small (≈30 lines of canasta.py); each new validator is one entry in `_VALIDATORS` and one `validator: <name>` in the YAML.

## Test plan

- [x] `make validate` — 61 commands / 53 playbooks
- [x] `make test-unit` — 564 passed
- [x] Smoke: `--domain-name cp,acknowledge.wiki` (comma) rejected; `--domain-name testsite.example.com` accepted; default `localhost` accepted.
- [ ] End-to-end: `canasta create --domain-name <bad>` should fail in milliseconds, before any SSH connection or Argo CD work.

## Out of scope

The "Argo CD is already running" check at `roles/create/tasks/main.yml:74-80` happens *before* the "Validating inputs" step at line 82. Even with the new up-front domain validation, that one network round-trip still survives (because Ansible only runs after canasta.py finishes parsing). Reordering so all input validation runs before the first network/SSH step is a separate small fix; not included here.
