### PR TITLE
canasta create --path: stop leaking laptop paths to remote hosts (closes #384)

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -611,17 +611,53 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
             if value:
                 extra_vars[name] = "true"
         elif ptype == "path":
-            # Resolve against the invoking shell's CWD (and expand ~).
-            # Ansible otherwise resolves relative paths against
-            # playbook_dir, which is the canasta.py install directory
-            # — not what users expect when they pass `-p .`.
-            # For remote hosts, absolute paths are already correct
-            # (they refer to the remote filesystem, not local).
-            expanded = os.path.expanduser(str(value))
-            if host_value and os.path.isabs(expanded):
-                extra_vars[name] = expanded
+            # path_kind: remote means the value is a path on the
+            # target host (e.g. `create --path` is the new instance
+            # dir on the remote). With --host set, we must NOT
+            # rewrite it against the laptop's filesystem — that's how
+            # `--path .` ended up as `/Users/<u>/...` on a Linux cp
+            # host (#384).
+            #
+            # path_kind: local (the default) is for paths that name a
+            # file on the laptop the user wants uploaded to the
+            # remote (--envfile, --database, --global-settings, etc.)
+            # or for the no-host case. Those still resolve against
+            # the laptop cwd as before.
+            path_kind = param.get("path_kind", "local")
+            if host_value and path_kind == "remote":
+                # Default "." (or empty) becomes the canonical
+                # remote default. Ansible expands ~ on the target.
+                if str(value) in (".", ""):
+                    extra_vars[name] = "~/canasta"
+                elif os.path.isabs(str(value)) or str(value).startswith("~"):
+                    extra_vars[name] = str(value)
+                else:
+                    print(
+                        "Error: --%s is relative ('%s') but --host is "
+                        "set. With --host, --%s must be an absolute "
+                        "path on the remote host (or a path starting "
+                        "with '~'). Omit --%s to use the default "
+                        "'~/canasta'."
+                        % (
+                            name.replace("_", "-"),
+                            value,
+                            name.replace("_", "-"),
+                            name.replace("_", "-"),
+                        ),
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
             else:
-                extra_vars[name] = os.path.abspath(expanded)
+                # Local resolution: expand ~ and resolve relatives
+                # against the laptop cwd. Ansible otherwise resolves
+                # relative paths against playbook_dir, which is the
+                # canasta.py install directory — not what users
+                # expect when they pass `-p .`.
+                expanded = os.path.expanduser(str(value))
+                if host_value and os.path.isabs(expanded):
+                    extra_vars[name] = expanded
+                else:
+                    extra_vars[name] = os.path.abspath(expanded)
         else:
             extra_vars[name] = str(value)
 

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -15,6 +15,10 @@
 #   sensitive         - Value is a secret (auto-generated if omitted, no_log in Ansible)
 #   mutual_exclusion  - Cannot be combined with the named parameter
 #   positional        - Accepted as positional argument(s), not a flag
+#   validator         - Name of a regex in canasta.py:_VALIDATORS (e.g. 'hostname')
+#   path_kind         - For type:path. 'remote' = remote target dir (default with
+#                       --host is '~/canasta'; relative paths rejected with --host).
+#                       Omit or 'local' = path on the laptop, resolved against cwd.
 
 global_flags:
   # --help/-h is provided automatically by argparse on every parser;
@@ -52,8 +56,14 @@ commands:
       - name: path
         short: p
         type: path
+        path_kind: remote
         default: "."
-        description: "Canasta installation directory"
+        description: >-
+          Canasta installation directory. Default is '.' for local
+          installs; with --host, default is '~/canasta' on the remote
+          and the value must be absolute (or '~'-prefixed) — relative
+          paths are rejected because they'd otherwise be resolved
+          against the laptop's filesystem.
       - name: orchestrator
         short: o
         type: choice

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -775,6 +775,78 @@ class TestPathResolution:
         assert not extra["path"].startswith("~")
 
 
+class TestPathKindRemote:
+    """With --host, `create --path` is path_kind: remote — default '.'
+    becomes the canonical remote default '~/canasta', absolute paths
+    pass through, and relative paths are rejected up front instead of
+    being silently abspath'd against the laptop (#384)."""
+
+    def _get_vars(self, result):
+        import json
+        for i, arg in enumerate(result):
+            if arg == "-e" and i + 1 < len(result) and result[i + 1].startswith("@"):
+                with open(result[i + 1][1:]) as f:
+                    return json.load(f)
+        return {}
+
+    def test_path_dot_with_host_becomes_remote_canasta(self, data):
+        from argparse import Namespace
+        args = Namespace(
+            command="create", host="cp", verbose=False, id="mysite",
+            wiki="main", domain_name=None, site_name=None,
+            database=None, path=".", orchestrator=None,
+            admin_password=None, wiki_db_password=None,
+            root_db_password=None,
+        )
+        result = canasta_cli.build_ansible_args("ap", "create", args, data)
+        extra = self._get_vars(result)
+        assert extra["path"] == "~/canasta"
+
+    def test_path_absolute_with_host_passthrough(self, data):
+        from argparse import Namespace
+        args = Namespace(
+            command="create", host="cp", verbose=False, id="mysite",
+            wiki="main", domain_name=None, site_name=None,
+            database=None, path="/home/admin/canasta", orchestrator=None,
+            admin_password=None, wiki_db_password=None,
+            root_db_password=None,
+        )
+        result = canasta_cli.build_ansible_args("ap", "create", args, data)
+        extra = self._get_vars(result)
+        assert extra["path"] == "/home/admin/canasta"
+
+    def test_path_tilde_with_host_passthrough_unexpanded(self, data):
+        """Don't expanduser against the laptop when targeting a remote
+        host — Ansible expands ~ on the remote user's home."""
+        from argparse import Namespace
+        args = Namespace(
+            command="create", host="cp", verbose=False, id="mysite",
+            wiki="main", domain_name=None, site_name=None,
+            database=None, path="~/instances", orchestrator=None,
+            admin_password=None, wiki_db_password=None,
+            root_db_password=None,
+        )
+        result = canasta_cli.build_ansible_args("ap", "create", args, data)
+        extra = self._get_vars(result)
+        assert extra["path"] == "~/instances"
+
+    def test_path_relative_with_host_errors(self, data, capsys):
+        from argparse import Namespace
+        args = Namespace(
+            command="create", host="cp", verbose=False, id="mysite",
+            wiki="main", domain_name=None, site_name=None,
+            database=None, path="instances/site", orchestrator=None,
+            admin_password=None, wiki_db_password=None,
+            root_db_password=None,
+        )
+        with pytest.raises(SystemExit) as exc:
+            canasta_cli.build_ansible_args("ap", "create", args, data)
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "instances/site" in err
+        assert "absolute" in err.lower()
+
+
 class TestSubcommandGroupHelp:
     """Invoking a subcommand group with no subcommand should list
     subcommands, not error with 'Unknown command'."""


### PR DESCRIPTION
Closes #384.

## Summary

`canasta create --host cp` (without `--path`) defaulted to `.`, which `canasta.py:build_ansible_args` resolved against the laptop's cwd to `/Users/<u>/...` and handed to cp. cp tried to `mkdir /Users` and got EACCES. Same shape as the `CANASTA_CONFIG_DIR` leak fixed in #369.

## Fix

Add a `path_kind` field to `type: path` parameters in `meta/command_definitions.yml`. `path_kind: remote` means the value names a directory on the target host; with `--host` set:

- default `.` (or empty) → `~/canasta` (Ansible expands `~` on the remote user's home)
- absolute (`/srv/canasta`) or `~`-prefixed (`~/instances`) → pass through unmodified — no laptop-side `expanduser`, since `~` refers to the remote user's home
- relative otherwise (`instances/site`) → fail up front with a clear error

`path_kind: local` (the default when the field is omitted) is unchanged: laptop-side cwd resolution and `~`-expansion still apply to upload-style params (`--envfile`, `--database`, `--global-settings`, `--wiki-settings`, `--composer`, `--build-from`, `--yamlfile`).

`create --path` is the only param tagged `remote` today; that's the only place affected. Update its description to mention the `~/canasta` default and the absolute-only requirement when `--host` is set.

## Test plan

- [x] `make validate` — 61 commands / 53 playbooks
- [x] `make test-unit` — 568 passed (4 new in `TestPathKindRemote`)
- [ ] End-to-end: `canasta create --host cp -i site -w main --orchestrator k8s --storage-class nfs --access-mode ReadWriteMany` (no `--path`) should land at `~/canasta/site/` on cp.
- [ ] End-to-end: `canasta create --host cp --path instances/site …` should fail in milliseconds with the absolute-required error.
- [ ] End-to-end: `canasta create --host cp --path /home/admin/canasta-instances …` should still work (the workaround the user used in #384).
