### PR TITLE
canasta storage setup nfs --install-server: gather IP fact instead of falling back to SSH alias (closes #389)

### DIFF
--- a/playbooks/storage_setup_nfs.yml
+++ b/playbooks/storage_setup_nfs.yml
@@ -47,9 +47,23 @@
         enabled: true
       become: true
 
+    # canasta.yml runs all plays with gather_facts: false, so we have
+    # to explicitly populate ansible_default_ipv4 here. Without it,
+    # the StorageClass would silently get the inventory hostname (the
+    # SSH alias) baked in as `server:`, and cluster nodes — which
+    # don't share the laptop's SSH config — couldn't resolve it.
+    - name: Gather network facts for NFS server IP
+      ansible.builtin.setup:
+        gather_subset: network
+        filter: ansible_default_ipv4
+
     - name: Set NFS server address to target host
       ansible.builtin.set_fact:
-        _nfs_server: "{{ ansible_default_ipv4.address | default(inventory_hostname) }}"
+        # No `default(inventory_hostname)` fallback: that's what
+        # produced the SSH-alias-as-StorageClass-server bug. If
+        # ansible_default_ipv4.address is missing after the setup
+        # task above, fail loudly.
+        _nfs_server: "{{ ansible_default_ipv4.address }}"
 
 - name: Set NFS server from parameter
   ansible.builtin.set_fact:


### PR DESCRIPTION
Closes #389.

## Summary

`canasta storage setup nfs --host cp --install-server` baked the SSH alias `cp` into `StorageClass.parameters.server`, breaking every NFS mount from cluster nodes that don't share the laptop's SSH config. End-to-end testing of #349/#350 surfaced this when the canasta-testsite web/jobrunner pods sat Pending forever; PVCs reported `mount.nfs: Failed to resolve server cp: Name or service not known`.

`playbooks/storage_setup_nfs.yml:50-52` resolved the StorageClass server as:

```yaml
_nfs_server: "{{ ansible_default_ipv4.address | default(inventory_hostname) }}"
```

But `canasta.yml:12` runs every play with `gather_facts: false` for speed, so `ansible_default_ipv4` was undefined. The `default()` fallback then wrote `inventory_hostname` — which is whatever `canasta.py:665` set as the inline inventory entry, i.e. the user's SSH alias.

Fix: explicitly gather the network fact set inside the `--install-server` block, and drop the `default(inventory_hostname)` fallback so a missing IP fails loudly instead of silently writing a broken value.

## Why single-node testing didn't catch it

When `target_host: localhost` (the default), `inventory_hostname` is `localhost`, which is resolvable from the cluster (same host). The bug only appears when the canasta CLI runs on a different machine than the cluster — exactly the multi-node scenario the rest of #349/#350 enables.

## Test plan

- [x] `make validate` — 61 commands / 53 playbooks
- [x] `make test-unit` — 568 passed
- [x] `make lint` — no new warnings
- [ ] End-to-end: from a laptop, `canasta storage setup nfs --host cp --install-server --share /srv/nfs/canasta` and confirm `kubectl get sc nfs -o jsonpath='{.parameters.server}'` returns cp's primary IP, not its SSH alias. Then `canasta create … --storage-class nfs --access-mode ReadWriteMany` should bind PVCs and bring the web pod Ready.
