### PR TITLE
canasta list: SSH to the instance's host for K8s status check (closes #399)

### DIFF
--- a/direct_commands.py
+++ b/direct_commands.py
@@ -460,7 +460,7 @@ def _read_wikis(path, host):
 
 def _check_running(instance_id, path, orchestrator, host):
     if orchestrator in ("kubernetes", "k8s"):
-        return _check_running_k8s(instance_id)
+        return _check_running_k8s(instance_id, host)
     return _check_running_compose(path, host)
 
 
@@ -482,23 +482,41 @@ def _check_running_compose(path, host):
         return rc == 0 and stdout.strip() != ""
 
 
-def _check_running_k8s(instance_id):
-    try:
-        result = subprocess.run(
-            [
-                "kubectl", "get",
-                "deployment/canasta-%s-web" % instance_id,
-                "-n", "canasta-%s" % instance_id,
-                "-o", "jsonpath={.status.readyReplicas}",
-            ],
-            capture_output=True, text=True, timeout=10,
-        )
-        return (
-            result.returncode == 0
-            and result.stdout.strip() not in ("", "0")
-        )
-    except (subprocess.TimeoutExpired, OSError):
-        return False
+def _check_running_k8s(instance_id, host):
+    """True if the instance's web deployment has ≥1 ready replica.
+
+    For remote hosts, SSH and run kubectl on the host — its kubeconfig
+    points at the cluster it's part of. Running kubectl on the laptop
+    (the previous behavior) only worked when the laptop happened to
+    have a kubeconfig for that cluster, otherwise the call hit
+    whatever the laptop's KUBECONFIG pointed at (Docker Desktop, an
+    unrelated cluster, ...) and reported STOPPED for instances that
+    were running fine.
+    """
+    if _is_localhost(host):
+        try:
+            result = subprocess.run(
+                [
+                    "kubectl", "get",
+                    "deployment/canasta-%s-web" % instance_id,
+                    "-n", "canasta-%s" % instance_id,
+                    "-o", "jsonpath={.status.readyReplicas}",
+                ],
+                capture_output=True, text=True, timeout=10,
+            )
+            return (
+                result.returncode == 0
+                and result.stdout.strip() not in ("", "0")
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            return False
+    cmd = (
+        "kubectl get deployment/canasta-%s-web "
+        "-n canasta-%s -o jsonpath='{.status.readyReplicas}'"
+        % (instance_id, instance_id)
+    )
+    rc, stdout = _ssh_run(host, cmd)
+    return rc == 0 and stdout.strip() not in ("", "0")
 
 
 _SENTINEL = "---CANASTA_DELIM---"
@@ -576,7 +594,7 @@ def _gather_k8s(inst_id, path, host):
 
     if not dir_exists:
         status = "NOT FOUND"
-    elif _check_running_k8s(inst_id):
+    elif _check_running_k8s(inst_id, host):
         status = "RUNNING"
     else:
         status = "STOPPED"

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -209,6 +209,66 @@ class TestCheckDirExists:
         assert not direct_commands._check_dir_exists(str(tmp_path / "nope"), "localhost")
 
 
+class TestCheckRunningK8s:
+    """canasta list's K8s status check must SSH to the instance's host
+    (where the kubeconfig pointing at the cluster lives) instead of
+    running kubectl locally against whatever the laptop's kubeconfig
+    happens to be (Docker Desktop in the worst case)."""
+
+    def test_local_running(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "1"})(),
+        )
+        assert direct_commands._check_running_k8s("mywiki", "localhost")
+
+    def test_local_zero_replicas_is_not_running(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "0"})(),
+        )
+        assert not direct_commands._check_running_k8s("mywiki", "localhost")
+
+    def test_remote_uses_ssh(self, monkeypatch):
+        """Remote hosts must dispatch via _ssh_run, not subprocess.run.
+        Guards against the original bug where a remote K8s instance
+        was reported STOPPED because the local kubectl had no idea
+        about the remote cluster."""
+        called = {}
+
+        def fake_ssh(host, cmd):
+            called["host"] = host
+            called["cmd"] = cmd
+            return 0, "1\n"
+
+        def fail_subprocess(*args, **kwargs):
+            raise AssertionError(
+                "remote check must not invoke subprocess.run directly"
+            )
+
+        monkeypatch.setattr(direct_commands, "_ssh_run", fake_ssh)
+        monkeypatch.setattr(subprocess, "run", fail_subprocess)
+        assert direct_commands._check_running_k8s("mywiki", "node1")
+        assert called["host"] == "node1"
+        assert "kubectl" in called["cmd"]
+        assert "canasta-mywiki-web" in called["cmd"]
+        assert "canasta-mywiki" in called["cmd"]  # namespace
+
+    def test_remote_not_running(self, monkeypatch):
+        monkeypatch.setattr(
+            direct_commands, "_ssh_run",
+            lambda host, cmd: (0, ""),
+        )
+        assert not direct_commands._check_running_k8s("mywiki", "node1")
+
+    def test_remote_ssh_failure_treated_as_stopped(self, monkeypatch):
+        monkeypatch.setattr(
+            direct_commands, "_ssh_run",
+            lambda host, cmd: (255, ""),  # SSH could not connect
+        )
+        assert not direct_commands._check_running_k8s("mywiki", "node1")
+
+
 class TestCheckRunningCompose:
     def test_running(self, monkeypatch, tmp_path):
         monkeypatch.setattr(


### PR DESCRIPTION
Closes #399.

## Summary

`canasta list` reported `STOPPED` for K8s instances on remote hosts even when they were running fine. `direct_commands.py:_check_running_k8s` shelled out to local `kubectl`, ignoring the instance's `host` field. The companion check `_check_dir_exists` already SSHes to the remote host; the running-state check didn't.

On a typical laptop where `kubectl` points at Docker Desktop, the namespace `canasta-<id>` doesn't exist on the local cluster, the deployment query returns empty, and the instance is marked `STOPPED` — despite serving traffic on the actual remote cluster. End-to-end testing tonight reproduced this on a healthy multi-node K8s install.

## Fix

Add a `host` arg to `_check_running_k8s`; SSH and run `kubectl` on the instance's host when it isn't local, mirroring `_check_dir_exists`. Remote hosts have their own kubeconfig pointing at the cluster they're part of (k3s writes one to `~/.kube/config` for the SSH user during `canasta install k8s-cp`; managed clusters need kubectl on the controller anyway). Update `_check_running`'s dispatcher to thread `host` through.

## Test plan

- [x] `make test-unit` — 584 passed, including 5 new in `TestCheckRunningK8s` covering local Running, local zero-replicas, remote-uses-SSH, remote-not-running, and SSH-failure.
- [x] `make validate` — clean.
- [ ] End-to-end on the next fresh-EC2 test: `canasta list` against a running multi-node K8s instance should report `RUNNING`, not `STOPPED`.

## Related

This is #372 (`canasta kubeconfig install`) showing through a different surface. After #372 lands, the laptop has a working kubeconfig and the original local-kubectl call would also work — but the host-aware fix is correct regardless: not every operator will run `canasta kubeconfig install`, and "list shows wrong status" is a confusing failure mode that's worth eliminating without depending on a separate feature.
