### PR TITLE
canasta create on fresh K8s: wait on cert-manager Deployments, not Pods (closes #401)

### DIFF
--- a/roles/orchestrator/tasks/k8s_certmanager.yml
+++ b/roles/orchestrator/tasks/k8s_certmanager.yml
@@ -22,18 +22,21 @@
           https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
       changed_when: true
 
-    - name: Wait for cert-manager to be ready
+    # Wait on the Deployments, not on their Pods. `kubectl wait
+    # --for=condition=Ready pod -l ...` runs the moment kubectl apply
+    # returns — but the Deployment controller hasn't created the Pods
+    # yet, so the label selector matches zero pods and kubectl wait
+    # exits non-zero with "error: no matching resources found".
+    # Deployments themselves are created synchronously by kubectl
+    # apply, so waiting on `condition=Available` for the Deployment
+    # tolerates the brief gap between apply and pod creation, then
+    # blocks until the rollout has minimum replicas Ready.
+    - name: Wait for cert-manager Deployments to become Available
       ansible.builtin.command:
         cmd: >-
-          kubectl wait --for=condition=Ready pod
-          -l app=cert-manager -n cert-manager --timeout=120s
-      changed_when: false
-
-    - name: Wait for cert-manager webhook to be ready
-      ansible.builtin.command:
-        cmd: >-
-          kubectl wait --for=condition=Ready pod
-          -l app=webhook -n cert-manager --timeout=120s
+          kubectl wait --for=condition=Available
+          deployment -l app.kubernetes.io/instance=cert-manager
+          -n cert-manager --timeout=180s
       changed_when: false
 
     - name: Wait for webhook to register


### PR DESCRIPTION
Closes #401.

## Summary

`canasta create --orchestrator k8s` failed deterministically the first time it ran against a cluster without cert-manager:

```
Kubernetes configuration managed via Helm values.yaml
Error: non-zero return code
error: no matching resources found
Error: Instance creation failed. Files cleaned up.
```

`kubectl apply` returns as soon as the cert-manager Deployments are created. The Deployment controller then asynchronously creates Pods. The next task — `kubectl wait --for=condition=Ready pod -l app=cert-manager` — runs in between, with the label selector matching zero pods. `kubectl wait` does not retry on missing resources; it exits non-zero with `error: no matching resources found`.

Tonight's earlier multi-node testing (during #349/#350) didn't catch this because cert-manager was already installed on the cluster from prior runs, so the `_cm_check` block skipped the install branch entirely. The fresh-EC2 walkthrough is what surfaced it.

## Fix

Replace the two pod-based waits (cert-manager + webhook) with a single Deployment-based wait. Deployments are created synchronously by `kubectl apply`, so the label selector always matches at least one resource by the time `kubectl wait` runs. `condition=Available` becomes true once the Deployment has its minimum replicas Ready — same end state, no race.

```yaml
- name: Wait for cert-manager Deployments to become Available
  ansible.builtin.command:
    cmd: >-
      kubectl wait --for=condition=Available
      deployment -l app.kubernetes.io/instance=cert-manager
      -n cert-manager --timeout=180s
  changed_when: false
```

The label `app.kubernetes.io/instance=cert-manager` covers all three Deployments cert-manager.yaml installs (cert-manager, cert-manager-cainjector, cert-manager-webhook), so one wait task replaces both pod-based waits.

## Test plan

- [x] `make validate` — 61 commands / 53 playbooks
- [x] `make test-unit` — 584 passed
- [x] `make lint` — no new warnings
- [ ] After merge, fresh-cluster `canasta create --orchestrator k8s --domain-name <real-name> --staging-certs` succeeds without a retry.

## Workaround until merged

Retry `canasta create`. The first failure leaves cert-manager applied, so the retry's `_cm_check` skips the install block entirely and proceeds with ClusterIssuer creation + helm install.
