### PR TITLE
canasta create: probe cert-manager webhook instead of fixed-sleeping (closes #403)

### DIFF
--- a/roles/orchestrator/tasks/k8s_certmanager.yml
+++ b/roles/orchestrator/tasks/k8s_certmanager.yml
@@ -39,9 +39,36 @@
           -n cert-manager --timeout=180s
       changed_when: false
 
-    - name: Wait for webhook to register
-      ansible.builtin.pause:
-        seconds: 10
+    # Even after the webhook Deployment is Available, there's a brief
+    # window where the cert-manager admission webhook hasn't fully
+    # registered with the API server. ClusterIssuers created during
+    # that window get rejected with `failed calling webhook
+    # "webhook.cert-manager.io"`. Probe with a server-side dry-run
+    # of a benign SelfSigned ClusterIssuer — that traverses the
+    # admission webhook but doesn't persist anything — and retry
+    # until it succeeds. Replaces the prior fixed 10-second sleep,
+    # which both took longer than necessary in the common case and
+    # wasn't long enough on slower clusters.
+    - name: Wait for cert-manager admission webhook to register
+      ansible.builtin.command:
+        argv:
+          - kubectl
+          - apply
+          - --dry-run=server
+          - -f
+          - "-"
+        stdin: |
+          apiVersion: cert-manager.io/v1
+          kind: ClusterIssuer
+          metadata:
+            name: canasta-webhook-probe
+          spec:
+            selfSigned: {}
+      register: _webhook_probe
+      until: _webhook_probe.rc == 0
+      retries: 30
+      delay: 2
+      changed_when: false
 
 # Always create BOTH the production and staging ClusterIssuers
 # (idempotent). That way switching CANASTA_STAGING_CERTS later is


### PR DESCRIPTION
Closes #403.

## Summary

#402 fixed the `kubectl wait` race against pod creation but kept a trailing 10-second `ansible.builtin.pause` to cover the gap between "webhook pod Ready" and "admission webhook registered with the API server". Without that pause, the next tasks (creating `letsencrypt-prod` and `letsencrypt-staging` ClusterIssuers) can fail with `failed calling webhook "webhook.cert-manager.io"`.

Fixed sleep is fragile: 10 s is more than enough on small fast clusters and sometimes not enough on slow ones, and it adds 10 s of dead time on every fresh-cluster install regardless of the actual webhook state.

## Fix

Probe the webhook by doing a server-side dry-run of a benign `SelfSigned` ClusterIssuer, retried until `rc == 0`. Server-side dry-run traverses the admission webhook chain but doesn't persist anything, so it's safe to retry. The moment the webhook is reachable, the loop exits and the playbook proceeds.

```yaml
- name: Wait for cert-manager admission webhook to register
  ansible.builtin.command:
    argv:
      - kubectl
      - apply
      - --dry-run=server
      - -f
      - "-"
    stdin: |
      apiVersion: cert-manager.io/v1
      kind: ClusterIssuer
      metadata:
        name: canasta-webhook-probe
      spec:
        selfSigned: {}
  register: _webhook_probe
  until: _webhook_probe.rc == 0
  retries: 30
  delay: 2
  changed_when: false
```

Loop tops out at ~60 s (same total headroom as the existing Deployment-Available wait), but exits in milliseconds in the common case where the webhook is already reachable.

## Test plan

- [x] `make validate` — 61 commands / 53 playbooks
- [x] `make test-unit` — 582 passed (the 2 pre-existing direct_commands version-tests flake are unrelated to this PR)
- [x] `make lint` — no warnings on the edited file
- [ ] Fresh-cluster `canasta create --orchestrator k8s --domain-name <real> --staging-certs` succeeds without the trailing 10-second pause and without webhook errors on ClusterIssuer creation.

## Related

The probe-and-retry pattern could replace other "wait for K8s thing to settle" sleeps elsewhere in the playbooks (e.g. Argo CD post-install) if/when they become problematic.
