### PR TITLE
canasta delete: skip K8s cluster-side cleanup when the cluster API is dead (closes #405)

### DIFF
--- a/roles/delete/tasks/main.yml
+++ b/roles/delete/tasks/main.yml
@@ -115,6 +115,42 @@
     - name: End play for unreachable host
       ansible.builtin.meta: end_play
 
+# For registered K8s instances, the host can be reachable via SSH but
+# the cluster API behind it can be gone (operator ran `canasta uninstall
+# k8s` while instances were still registered, or k3s crashed). Without
+# this probe, the play falls through to helm/kubectl cleanup tasks that
+# emit ugly `Connection refused` errors for every cluster-side step.
+# We probe up front and gate the K8s cleanup on the result.
+- name: Probe K8s API reachability
+  ansible.builtin.command:
+    cmd: kubectl version --request-timeout=5s
+  register: _k8s_reachable
+  changed_when: false
+  ignore_errors: true
+  when:
+    - _delete_query is succeeded
+    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+
+- name: Set K8s reachability fact
+  ansible.builtin.set_fact:
+    _k8s_api_reachable: >-
+      {{ (_k8s_reachable.rc | default(1)) == 0 }}
+  when:
+    - _delete_query is succeeded
+    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+
+- name: Warn when K8s API is unreachable
+  ansible.builtin.debug:
+    msg: >-
+      K8s API unreachable on host '{{ _instance_host }}' — the cluster
+      appears to be uninstalled or down. Deregistering
+      '{{ instance_id }}' from the registry; skipping cluster-side
+      cleanup (Argo CD Application, helm release, namespace).
+  when:
+    - _delete_query is succeeded
+    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+    - not _k8s_api_reachable
+
 - name: Discover unregistered instance
   when: _delete_query is failed
   block:
@@ -271,7 +307,9 @@
   ignore_errors: true  # OK if containers already removed
 
 - name: Clean up container-owned files (Kubernetes)
-  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+  when:
+    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+    - _k8s_api_reachable | default(true)
   block:
     - name: Check if K8s pods are running
       ansible.builtin.include_role:
@@ -302,13 +340,18 @@
     name: "canasta-{{ instance_id }}"
     namespace: "{{ argocd_namespace | default('argocd') }}"
   ignore_errors: true  # OK if Argo CD not installed
-  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+  when:
+    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+    - _k8s_api_reachable | default(true)
 
 - name: Destroy containers and volumes
   ansible.builtin.include_role:
     name: orchestrator
     tasks_from: destroy.yml
   ignore_errors: true  # OK if already destroyed
+  when: >-
+    instance_orchestrator | default('compose') == 'compose'
+    or _k8s_api_reachable | default(true)
 
 - name: Remove instance directory contents
   ansible.builtin.command:


### PR DESCRIPTION
Closes #405.

## Summary

Sequence that triggers it (a forgivable operator mistake — running uninstall before delete):

```
$ canasta uninstall k8s --host node3 --cp-host node1
$ canasta uninstall k8s --host node2 --cp-host node1
$ canasta uninstall k8s --host node1
$ canasta delete --id testsite --yes
Error: Task failed: Module failed: ... HTTPSConnection ...:
  Failed to establish a new connection: [Errno 111] Connection refused
… (×7) …
```

The instance's host (cp) is reachable via SSH, but k3s is gone — the K8s API server isn't answering. The play deregisters from the controller registry first (good), then runs cluster-side cleanup tasks against a dead API and emits `Connection refused` for each. Errors are caught by `ignore_errors`, the play completes, registry does get cleaned up — but the operator sees 7+ stack traces and reasonably wonders whether anything worked.

There's already a `Test remote host reachability` check that handles the SSH-side unreachable case (VM destroyed) by deregistering and exiting. There was no symmetric check for "host is up but K8s API is gone".

## Fix

Add a `kubectl version --request-timeout=5s` probe up front, only for K8s instances and only on the target host, to set `_k8s_api_reachable`. Gate the three cluster-side cleanup steps on that fact:

- `Clean up container-owned files (Kubernetes)` block
- `Remove Argo CD Application if present`
- `Destroy containers and volumes` (only the K8s branch — Compose stays unconditional)

Plus a one-line debug message when the API is unreachable, so the operator knows registry deregistration happened but cluster-side cleanup was skipped.

## Test plan

- [x] `make validate` — 61 commands / 53 playbooks
- [x] `make test-unit` — 584 passed
- [ ] Reproduce the original symptom: register an instance, uninstall k8s on its hosts, then `canasta delete --id <id> --yes`. Should print one warn line, deregister, and exit clean — no `Connection refused` stacks.
- [ ] Sanity: `canasta delete` against a healthy K8s instance still does full cleanup (no behavior change when `_k8s_api_reachable` is true).

## Workaround until merged

Drop the orphaned registry entry by hand:

```bash
python3 -c "
import json, os
p = os.path.expanduser('~/Library/Application Support/canasta/conf.json')
d = json.load(open(p))
d.get('Instances', {}).pop('<id>', None)
json.dump(d, open(p, 'w'), indent=2)
"
```
