### PR TITLE
canasta storage list (closes #395)

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -41,7 +41,7 @@ SUBCOMMAND_GROUPS = {
         "init", "join", "add", "rm", "push", "pull",
         "status", "diff", "fix-submodules", "sync",
     ],
-    "storage": ["setup"],
+    "storage": ["setup", "list"],
     "host": ["add", "remove", "list"],
 }
 

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1882,7 +1882,7 @@ commands:
         type: string
         description: "Target host (default: localhost)"
 
-- name: status
+  - name: status
     description: "Show pod/PVC/ingress/cert state for a single instance"
     long_description: |
       Show runtime state for a single Canasta instance: containers /

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1860,3 +1860,24 @@ commands:
         type: string
         default: efs
         description: "Name for the Kubernetes StorageClass"
+
+  - name: storage_list
+    description: "List StorageClasses on the cluster"
+    long_description: |
+      List the StorageClasses installed on the target Kubernetes
+      cluster, alongside the StorageClass canasta will use by default
+      when `canasta create --storage-class` isn't passed (set by the
+      most recent `canasta storage setup`).
+
+      For a laptop driving a remote cluster, pass `--host <name>` to
+      target a registered host that has a kubeconfig pointing at the
+      cluster — typically the control plane.
+    examples:
+      - "canasta storage list --host cp"
+      - "canasta storage list"
+    playbook: storage_list.yml
+    parameters:
+      - name: host
+        short: H
+        type: string
+        description: "Target host (default: localhost)"

--- a/playbooks/storage_list.yml
+++ b/playbooks/storage_list.yml
@@ -1,0 +1,29 @@
+---
+# canasta storage list — Show StorageClasses on the target cluster
+# alongside the canasta-configured default (set by `canasta storage
+# setup` and stored in conf.json on the controller).
+
+- name: Read canasta-configured default StorageClass
+  canasta_registry:
+    state: get_setting
+    setting_key: defaultStorageClass
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
+  register: _default_sc
+
+- name: Get StorageClass list from cluster
+  ansible.builtin.command:
+    cmd: kubectl get storageclass
+  register: _sc_raw
+  changed_when: false
+
+- name: Display StorageClasses
+  ansible.builtin.debug:
+    msg: |-
+      Canasta default StorageClass: {{ _default_sc.value
+        if _default_sc.value | default('') | length > 0
+        else '(none — pass --storage-class on canasta create)' }}
+
+      {{ _sc_raw.stdout }}


### PR DESCRIPTION
Closes #395.

## Summary

New small subcommand under the existing storage group. Reads the canasta-configured default StorageClass from `conf.json` on the controller (set by `canasta storage setup`), runs `kubectl get storageclass` on the target host, and prints both. With `--host`, the kubectl call dispatches via SSH to the host that has a working kubeconfig — same pattern the rest of the storage-aware commands use.

## Output

```
Canasta default StorageClass: nfs

NAME        PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE   …
local-path  rancher.io/local-path   Delete          WaitForFirstConsumer
nfs         nfs.csi.k8s.io          Retain          Immediate
```

Replaces the `ssh node1 'sudo k3s kubectl get storageclass'` reach the multi-node walkthrough on canasta.wiki currently leans on.

## Test plan

- [x] `make validate` — 62 commands / 54 playbooks (one new of each)
- [x] `make test-unit` — 584 passed
- [x] Smoke: argparse routes `canasta storage list --host cp` to `storage_list` with `target_host: "cp"` in extra-vars.
- [ ] End-to-end: `canasta storage list --host node1` against the existing multi-node test cluster.