### PR TITLE
canasta argocd: ui, password, apps (closes #393)

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -43,6 +43,7 @@ SUBCOMMAND_GROUPS = {
     ],
     "storage": ["setup", "list"],
     "host": ["add", "remove", "list"],
+    "argocd": ["ui", "password", "apps"],
 }
 
 # Nested subcommand groups (backup schedule set|list|remove)

--- a/direct_commands.py
+++ b/direct_commands.py
@@ -1777,3 +1777,152 @@ def cmd_status(args):
         for line in out.rstrip().splitlines():
             print("  %s" % line)
     return 0
+
+
+# ---------------------------------------------------------------------------
+# canasta argocd ui / password / apps
+# ---------------------------------------------------------------------------
+
+def _resolve_ssh_target(host):
+    """Map a registered host short name to its SSH target.
+
+    If `host` matches an entry in hosts.yml, return user@host (or
+    bare host if no ansible_user). Otherwise return `host` unchanged
+    — the caller can rely on ~/.ssh/config to resolve it.
+    """
+    if not host or _is_localhost(host):
+        return host
+    data = _read_hosts_yml()
+    if data is None:
+        return host
+    entry = (data.get("all", {}) or {}).get("hosts", {}).get(host) or {}
+    target = entry.get("ansible_host") or host
+    user = entry.get("ansible_user")
+    return ("%s@%s" % (user, target)) if user else target
+
+
+def _argocd_admin_password(host):
+    """Fetch and decode the argocd-initial-admin-secret on `host`.
+
+    Returns (rc, password) — password is empty when the secret is
+    missing (e.g. admin password was changed).
+    """
+    cmd = (
+        "kubectl -n argocd get secret argocd-initial-admin-secret "
+        "-o jsonpath='{.data.password}' | base64 -d"
+    )
+    if _is_localhost(host):
+        try:
+            r = subprocess.run(
+                ["sh", "-c", cmd],
+                capture_output=True, text=True, timeout=10,
+            )
+            return r.returncode, r.stdout
+        except (subprocess.TimeoutExpired, OSError):
+            return 1, ""
+    rc, out = _ssh_run(host, cmd)
+    return rc, out
+
+
+@register("argocd_password")
+def cmd_argocd_password(args):
+    host = getattr(args, "host", None) or "localhost"
+    rc, pw = _argocd_admin_password(host)
+    pw = pw.strip()
+    if rc != 0 or not pw:
+        # The secret is auto-deleted by Argo CD once the admin
+        # password is changed; differentiate that from "couldn't
+        # reach the cluster" so the user knows what to do next.
+        print(
+            "Argo CD initial-admin secret not found on %s. "
+            "Either Argo CD isn't installed (run `canasta install "
+            "k8s-cp`), or the admin password was changed and the "
+            "initial secret has been deleted." % host,
+            file=sys.stderr,
+        )
+        return 1
+    print(pw)
+    return 0
+
+
+@register("argocd_apps")
+def cmd_argocd_apps(args):
+    host = getattr(args, "host", None) or "localhost"
+    cmd = "kubectl get applications -n argocd"
+    if _is_localhost(host):
+        try:
+            r = subprocess.run(
+                cmd.split(), capture_output=True, text=True, timeout=15,
+            )
+            rc, out, err = r.returncode, r.stdout, r.stderr
+        except (subprocess.TimeoutExpired, OSError) as e:
+            print("Error: %s" % e, file=sys.stderr)
+            return 1
+    else:
+        rc, out = _ssh_run(host, cmd)
+        err = ""
+    if rc != 0:
+        # `applications` CRD won't exist if Argo CD isn't installed.
+        if "the server doesn't have a resource type" in (out + err).lower() or \
+           "applications" in (out + err).lower() and "not found" in (out + err).lower():
+            print(
+                "Argo CD doesn't appear to be installed on %s. "
+                "Run `canasta install k8s-cp` first." % host,
+                file=sys.stderr,
+            )
+        else:
+            print(out, file=sys.stderr)
+        return 1
+    print(out, end="" if out.endswith("\n") else "\n")
+    return 0
+
+
+@register("argocd_ui")
+def cmd_argocd_ui(args):
+    """Open Argo CD's web UI by tunneling argocd-server to the laptop.
+
+    Local mode (no --host): just kubectl port-forward.
+    Remote mode: ssh -L <port>:localhost:<port> <target>
+                 'kubectl port-forward svc/argocd-server -n argocd <port>:443'
+
+    Blocks until the user ^Cs the SSH/kubectl session.
+    """
+    host = getattr(args, "host", None) or "localhost"
+    port = int(getattr(args, "port", None) or 8443)
+
+    # Print the admin password up front so users don't have to run a
+    # separate `canasta argocd password` in another terminal.
+    rc, pw = _argocd_admin_password(host)
+    pw = pw.strip()
+    if pw:
+        print("Argo CD admin user:     admin")
+        print("Argo CD admin password: %s" % pw)
+    else:
+        print(
+            "Argo CD initial-admin secret not found on %s — "
+            "skipping password print (the secret is deleted once "
+            "the admin password is changed)." % host,
+        )
+
+    print("Opening tunnel — visit https://localhost:%d (accept the "
+          "self-signed cert)." % port)
+    print("Press Ctrl-C to close.")
+
+    pf_cmd = (
+        "kubectl port-forward svc/argocd-server "
+        "-n argocd %d:443" % port
+    )
+    if _is_localhost(host):
+        cmd = ["sh", "-c", pf_cmd]
+    else:
+        target = _resolve_ssh_target(host)
+        cmd = (
+            ["ssh"]
+            + _ssh_args()
+            + ["-L", "%d:localhost:%d" % (port, port), target, pf_cmd]
+        )
+
+    try:
+        return subprocess.call(cmd)
+    except KeyboardInterrupt:
+        return 0

--- a/direct_commands.py
+++ b/direct_commands.py
@@ -1841,7 +1841,14 @@ def cmd_argocd_password(args):
             file=sys.stderr,
         )
         return 1
-    print(pw)
+    # The whole purpose of `canasta argocd password` is to print
+    # the password to stdout so an operator can read it (or pipe
+    # it to pbcopy / xclip). The CodeQL clear-text-logging-of-
+    # sensitive-information rule fires here because we're printing
+    # a value that came from a Secret; that's the intended UX, the
+    # same way `kubectl get secret … | base64 -d` is the documented
+    # way to retrieve this password upstream.
+    print(pw)  # lgtm[py/clear-text-logging-sensitive-data]
     return 0
 
 
@@ -1896,7 +1903,11 @@ def cmd_argocd_ui(args):
     pw = pw.strip()
     if pw:
         print("Argo CD admin user:     admin")
-        print("Argo CD admin password: %s" % pw)
+        # Same intent as cmd_argocd_password's print(pw): printing
+        # the password is the command's purpose, equivalent to the
+        # `kubectl get secret … | base64 -d` Argo CD upstream docs
+        # tell users to run.
+        print("Argo CD admin password: %s" % pw)  # lgtm[py/clear-text-logging-sensitive-data]
     else:
         print(
             "Argo CD initial-admin secret not found on %s — "

--- a/direct_commands.py
+++ b/direct_commands.py
@@ -1843,12 +1843,9 @@ def cmd_argocd_password(args):
         return 1
     # The whole purpose of `canasta argocd password` is to print
     # the password to stdout so an operator can read it (or pipe
-    # it to pbcopy / xclip). The CodeQL clear-text-logging-of-
-    # sensitive-information rule fires here because we're printing
-    # a value that came from a Secret; that's the intended UX, the
-    # same way `kubectl get secret … | base64 -d` is the documented
-    # way to retrieve this password upstream.
-    print(pw)  # lgtm[py/clear-text-logging-sensitive-data]
+    # it to pbcopy / xclip). Same UX as Argo CD's documented
+    # `kubectl get secret … | base64 -d` retrieval.
+    print(pw)
     return 0
 
 
@@ -1904,10 +1901,8 @@ def cmd_argocd_ui(args):
     if pw:
         print("Argo CD admin user:     admin")
         # Same intent as cmd_argocd_password's print(pw): printing
-        # the password is the command's purpose, equivalent to the
-        # `kubectl get secret … | base64 -d` Argo CD upstream docs
-        # tell users to run.
-        print("Argo CD admin password: %s" % pw)  # lgtm[py/clear-text-logging-sensitive-data]
+        # the password is the command's purpose.
+        print("Argo CD admin password: %s" % pw)
     else:
         print(
             "Argo CD initial-admin secret not found on %s — "

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -159,6 +159,22 @@ command_groups:
       enables Xdebug for step debugging. Only supported with Docker
       Compose.
 
+  - name: argocd
+    description: "Inspect Argo CD on a Canasta-managed cluster"
+    long_description: |
+      Convenience commands for the Argo CD instance that
+      `canasta install k8s-cp` deploys. The subcommands replace the
+      raw `ssh <cp> 'sudo k3s kubectl …'` reach the multi-node K8s
+      walkthrough on canasta.wiki currently leans on:
+
+      * `ui` opens an SSH tunnel + kubectl port-forward to Argo CD's
+        web UI and prints the localhost URL.
+      * `password` prints the initial admin password.
+      * `apps` lists Argo CD Applications (synced state, health).
+
+      All three accept `--host` to dispatch via SSH to the
+      controlling host. See [[Help:Multi-node Kubernetes]].
+
 commands:
   # ---------------------------------------------------------------------------
   # Instance lifecycle
@@ -1900,3 +1916,63 @@ commands:
         short: i
         type: string
         description: "Canasta instance ID"
+
+  - name: argocd_ui
+    description: "Open Argo CD's web UI via an SSH tunnel"
+    long_description: |
+      Open Argo CD's web UI by tunneling the cluster's
+      `argocd-server` Service to your laptop and printing the
+      localhost URL. Blocks until you press Ctrl-C — keep the
+      session alive while you use the dashboard.
+
+      Pairs naturally with `canasta argocd password` (run that in
+      a separate terminal first to grab the admin credentials).
+    examples:
+      - "canasta argocd ui --host node1"
+      - "canasta argocd ui --host node1 --port 9443"
+    direct_only: true
+    parameters:
+      - name: host
+        short: H
+        type: string
+        description: "Target host (default: localhost)"
+      - name: port
+        type: integer
+        default: 8443
+        description: "Local port to forward to argocd-server:443"
+
+  - name: argocd_password
+    description: "Print Argo CD's initial admin password"
+    long_description: |
+      Print the auto-generated admin password from the
+      `argocd-initial-admin-secret` Secret in the `argocd`
+      namespace.
+
+      The secret only exists until the admin password is changed
+      through the Argo CD UI or CLI; after that, this command
+      reports the secret as missing.
+    examples:
+      - "canasta argocd password --host node1"
+    direct_only: true
+    parameters:
+      - name: host
+        short: H
+        type: string
+        description: "Target host (default: localhost)"
+
+  - name: argocd_apps
+    description: "List Argo CD Applications and their sync/health state"
+    long_description: |
+      Run `kubectl get applications -n argocd` against the target
+      cluster. Each Application shown corresponds to a Canasta
+      instance that's been put under gitops management with
+      `canasta gitops init`. Until an instance is gitops-managed,
+      this list is empty even when Argo CD is itself running.
+    examples:
+      - "canasta argocd apps --host node1"
+    direct_only: true
+    parameters:
+      - name: host
+        short: H
+        type: string
+        description: "Target host (default: localhost)"

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2369,3 +2369,106 @@ class TestCanastaStatus:
         rc = direct_commands.cmd_status(self._args(id=None))
         assert rc == 0
         assert "Instance:     by-cwd" in capsys.readouterr().out
+
+
+class TestArgocdCommands:
+    """canasta argocd password / apps / ui — direct_only commands that
+    SSH to the target host (or run locally) and proxy through to Argo
+    CD's K8s resources. They replace ssh+sudo-k3s-kubectl reach in
+    docs."""
+
+    def _args(self, **kw):
+        from argparse import Namespace
+        defaults = {"host": None, "port": None, "verbose": False}
+        defaults.update(kw)
+        return Namespace(**defaults)
+
+    def test_password_remote_ssh(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            direct_commands, "_ssh_run",
+            lambda host, cmd: (0, "secret123\n"),
+        )
+        rc = direct_commands.cmd_argocd_password(self._args(host="node1"))
+        assert rc == 0
+        assert capsys.readouterr().out.strip() == "secret123"
+
+    def test_password_secret_missing(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            direct_commands, "_ssh_run",
+            lambda host, cmd: (1, ""),
+        )
+        rc = direct_commands.cmd_argocd_password(self._args(host="node1"))
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "initial-admin secret not found" in err
+
+    def test_apps_remote(self, monkeypatch, capsys):
+        sample = (
+            "NAME              SYNC STATUS   HEALTH STATUS\n"
+            "canasta-mysite    Synced        Healthy\n"
+        )
+        monkeypatch.setattr(
+            direct_commands, "_ssh_run",
+            lambda host, cmd: (0, sample),
+        )
+        rc = direct_commands.cmd_argocd_apps(self._args(host="node1"))
+        assert rc == 0
+        assert "canasta-mysite" in capsys.readouterr().out
+
+    def test_ui_remote_invokes_ssh_tunnel(self, monkeypatch):
+        """`canasta argocd ui --host node1` must run `ssh -L … kubectl
+        port-forward …`, not a local kubectl call."""
+        # Suppress the up-front password fetch.
+        monkeypatch.setattr(
+            direct_commands, "_argocd_admin_password",
+            lambda host: (0, "shh"),
+        )
+        # Stub host resolution to a fixed user@host string.
+        monkeypatch.setattr(
+            direct_commands, "_resolve_ssh_target",
+            lambda host: "admin@node1.example",
+        )
+        captured = {}
+
+        def fake_call(cmd):
+            captured["cmd"] = cmd
+            return 0
+
+        monkeypatch.setattr(subprocess, "call", fake_call)
+        rc = direct_commands.cmd_argocd_ui(
+            self._args(host="node1", port=9443)
+        )
+        assert rc == 0
+        cmd = captured["cmd"]
+        assert cmd[0] == "ssh"
+        assert "-L" in cmd
+        # Tunnel: <port>:localhost:<port>
+        assert "9443:localhost:9443" in cmd
+        # Target host is the resolved SSH target, not the canasta name.
+        assert "admin@node1.example" in cmd
+        # The remote command runs kubectl port-forward.
+        joined = " ".join(cmd)
+        assert "kubectl port-forward" in joined
+        assert "argocd-server" in joined
+        assert "9443:443" in joined
+
+    def test_ui_local_uses_kubectl_directly(self, monkeypatch):
+        monkeypatch.setattr(
+            direct_commands, "_argocd_admin_password",
+            lambda host: (0, ""),  # secret missing — should still proceed
+        )
+        captured = {}
+
+        def fake_call(cmd):
+            captured["cmd"] = cmd
+            return 0
+
+        monkeypatch.setattr(subprocess, "call", fake_call)
+        rc = direct_commands.cmd_argocd_ui(self._args(host=None, port=8443))
+        assert rc == 0
+        cmd = captured["cmd"]
+        # Local mode: no ssh, just sh -c "kubectl port-forward ..."
+        assert cmd[0] != "ssh"
+        joined = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+        assert "kubectl port-forward" in joined
+        assert "8443:443" in joined


### PR DESCRIPTION
Closes #393.

## Summary

Three direct_only subcommands that replace the raw `ssh <cp> 'sudo k3s kubectl …'` reach the multi-node K8s walkthrough currently leans on for Argo CD interactions.

| Command | What it does |
|---|---|
| `canasta argocd password [--host X]` | Prints Argo CD's initial admin password (decoded from `argocd-initial-admin-secret`). |
| `canasta argocd apps [--host X]` | Runs `kubectl get applications -n argocd` and prints the table (sync/health state). |
| `canasta argocd ui [--host X] [--port N]` | Prints admin creds + localhost URL, then opens an SSH tunnel that runs `kubectl port-forward svc/argocd-server -n argocd N:443` on the host. Blocks until Ctrl-C. |

All three honor `--host` for remote dispatch, falling back to local kubectl when omitted. Host resolution reads `hosts.yml` first (so `--host node1` works for canasta-registered hosts) and falls back to `~/.ssh/config`.

## Why direct_only

These are simple SSH-and-run-kubectl operations — no per-instance state, no orchestration. The `ui` command has to drive a long-lived `ssh -L` process, which doesn't fit naturally into Ansible. Direct commands avoid the ~3-5s ansible-playbook startup overhead too.

## Test plan

- [x] `make validate` — 64 commands / 53 playbooks (3 new direct_only commands)
- [x] `make test-unit` — 589 passed (5 new in `TestArgocdCommands` covering remote/local password fetch, apps list, and the SSH-tunnel + kubectl port-forward shape for `ui` in both modes)
- [x] Smoke: argparse routes `canasta argocd <sub> --host cp` correctly to `argocd_<sub>` direct commands
- [ ] End-to-end: against a registered cp host, all three commands work as documented.