### PR TITLE
canasta status --id: pod/PVC/ingress/cert state for one instance (closes #394)

### DIFF
--- a/direct_commands.py
+++ b/direct_commands.py
@@ -1653,3 +1653,127 @@ def cmd_doctor(args):
         return 1
 
     return 0
+
+
+# ---------------------------------------------------------------------------
+# canasta status
+# ---------------------------------------------------------------------------
+
+def _resolve_status_instance(args):
+    """Pick the instance the user wants status for.
+
+    Same dispatch as `canasta delete`: --id wins; if absent, look up
+    by current working directory against the registry's `path` field.
+    Returns (id, instance_dict) or (None, None) on no match.
+    """
+    inst_id = getattr(args, "id", None)
+    conf_path = os.path.join(_get_config_dir(), "conf.json")
+    instances = _read_registry(conf_path)
+    if inst_id:
+        return (inst_id, instances.get(inst_id))
+    cwd = os.environ.get("CANASTA_HOST_PWD") or os.getcwd()
+    for k, v in instances.items():
+        if v.get("path") == cwd:
+            return (k, v)
+    return (None, None)
+
+
+def _kubectl_section(host, ns, cmd_args, label):
+    """Run a kubectl get (locally or via SSH) and return formatted output.
+
+    Always runs against namespace `ns`. Returns a (label, body) tuple
+    suitable for printing.
+    """
+    cmd = "kubectl get %s -n %s" % (cmd_args, ns)
+    if _is_localhost(host):
+        try:
+            r = subprocess.run(
+                cmd.split(), capture_output=True, text=True, timeout=15,
+            )
+            rc, out = r.returncode, r.stdout
+        except (subprocess.TimeoutExpired, OSError):
+            return (label, "(query failed)")
+    else:
+        rc, out = _ssh_run(host, cmd)
+    if rc != 0:
+        if "not found" in out.lower() or "no resources found" in out.lower():
+            return (label, "(none)")
+        return (label, "(query failed)")
+    if not out.strip():
+        return (label, "(none)")
+    return (label, out.rstrip())
+
+
+@register("status")
+def cmd_status(args):
+    inst_id, inst = _resolve_status_instance(args)
+    if not inst:
+        if getattr(args, "id", None):
+            print(
+                "Error: instance '%s' not found in the registry."
+                % args.id, file=sys.stderr,
+            )
+        else:
+            print(
+                "Error: no instance found for the current directory; "
+                "pass --id explicitly.", file=sys.stderr,
+            )
+        return 1
+
+    orchestrator = inst.get("orchestrator", "compose")
+    host = inst.get("host", "localhost")
+    path = inst.get("path", "")
+
+    # Header
+    print("Instance:     %s" % inst_id)
+    print("Host:         %s" % host)
+    print("Orchestrator: %s" % orchestrator.upper())
+
+    if orchestrator in ("kubernetes", "k8s"):
+        running = _check_running_k8s(inst_id, host)
+        print("Status:       %s" % ("RUNNING" if running else "STOPPED"))
+        ns = "canasta-%s" % inst_id
+        sections = [
+            ("Pods", "pods -o wide"),
+            ("Volumes", "pvc"),
+            ("Services", "svc"),
+            ("Ingress", "ingress"),
+            ("Certificate", "certificate"),
+        ]
+        for label, cmd_args in sections:
+            tag, body = _kubectl_section(host, ns, cmd_args, label)
+            print()
+            print("%s:" % tag)
+            for line in body.splitlines():
+                print("  %s" % line)
+        return 0
+
+    # Compose
+    running = _check_running_compose(path, host)
+    print("Status:       %s" % ("RUNNING" if running else "STOPPED"))
+    if not path:
+        print("\n(no path on file — cannot inspect containers)")
+        return 0
+
+    ps_cmd = "docker compose ps"
+    if _is_localhost(host):
+        try:
+            r = subprocess.run(
+                ps_cmd.split(),
+                cwd=path, capture_output=True, text=True, timeout=15,
+            )
+            rc, out = r.returncode, r.stdout
+        except (subprocess.TimeoutExpired, OSError):
+            rc, out = 1, ""
+    else:
+        rc, out = _ssh_run(
+            host, "cd %s && %s" % (_shell_quote(path), ps_cmd),
+        )
+    print()
+    print("Containers:")
+    if rc != 0 or not out.strip():
+        print("  (query failed or no containers)")
+    else:
+        for line in out.rstrip().splitlines():
+            print("  %s" % line)
+    return 0

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1860,3 +1860,22 @@ commands:
         type: string
         default: efs
         description: "Name for the Kubernetes StorageClass"
+
+  - name: status
+    description: "Show pod/PVC/ingress/cert state for a single instance"
+    long_description: |
+      Show runtime state for a single Canasta instance: containers /
+      pods, volumes, ingress / domain, and (on Kubernetes) the TLS
+      certificate. Replaces the orchestrator-native incantations the
+      multi-node walkthrough currently spells out (`kubectl get pods,
+      pvc,ingress,certificate -n canasta-<id>` on K8s; `docker
+      compose ps` on Compose).
+    examples:
+      - "canasta status --id mysite"
+      - "cd /path/to/instance && canasta status"
+    direct_only: true
+    parameters:
+      - name: id
+        short: i
+        type: string
+        description: "Canasta instance ID"

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2251,3 +2251,121 @@ class TestDoctor:
         assert "Docker:          MISSING" in result
         assert "Docker daemon:   NOT RUNNING" in result
         assert "www-data group:  NOT A MEMBER" in result
+
+
+class TestCanastaStatus:
+    """canasta status --id X — direct_only command that gathers
+    pods/PVCs/ingress/certs (K8s) or `docker compose ps` (Compose)
+    for a single instance."""
+
+    def _args(self, **kw):
+        from argparse import Namespace
+        defaults = {"id": None, "verbose": False}
+        defaults.update(kw)
+        return Namespace(**defaults)
+
+    def test_unknown_id_errors(self, monkeypatch, capsys):
+        monkeypatch.setattr(direct_commands, "_read_registry", lambda p: {})
+        rc = direct_commands.cmd_status(self._args(id="ghost"))
+        assert rc == 1
+        assert "not found in the registry" in capsys.readouterr().err
+
+    def test_k8s_routes_through_ssh(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            direct_commands, "_read_registry",
+            lambda p: {
+                "mysite": {
+                    "id": "mysite", "orchestrator": "kubernetes",
+                    "host": "node1", "path": "/home/admin/canasta-instances/mysite",
+                },
+            },
+        )
+        monkeypatch.setattr(
+            direct_commands, "_check_running_k8s",
+            lambda inst, host: True,
+        )
+        ssh_calls = []
+
+        def fake_ssh(host, cmd):
+            ssh_calls.append((host, cmd))
+            return 0, "stub-output"
+
+        monkeypatch.setattr(direct_commands, "_ssh_run", fake_ssh)
+        # Make sure no local subprocess is called for K8s sections.
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **k: (_ for _ in ()).throw(
+                AssertionError("K8s sections must dispatch via SSH")
+            ),
+        )
+
+        rc = direct_commands.cmd_status(self._args(id="mysite"))
+        assert rc == 0
+        # Header sanity
+        out = capsys.readouterr().out
+        assert "Instance:     mysite" in out
+        assert "Host:         node1" in out
+        assert "KUBERNETES" in out
+        assert "RUNNING" in out
+        # Sections requested
+        cmds = [c for _, c in ssh_calls]
+        joined = " | ".join(cmds)
+        for piece in [
+            "kubectl get pods -o wide -n canasta-mysite",
+            "kubectl get pvc -n canasta-mysite",
+            "kubectl get ingress -n canasta-mysite",
+            "kubectl get certificate -n canasta-mysite",
+        ]:
+            assert piece in joined
+
+    def test_compose_uses_docker_compose_ps_locally(self, monkeypatch, capsys, tmp_path):
+        path = str(tmp_path)
+        monkeypatch.setattr(
+            direct_commands, "_read_registry",
+            lambda p: {
+                "mysite": {
+                    "id": "mysite", "orchestrator": "compose",
+                    "host": "localhost", "path": path,
+                },
+            },
+        )
+        monkeypatch.setattr(
+            direct_commands, "_check_running_compose",
+            lambda p, h: False,
+        )
+        captured = {}
+
+        def fake_run(cmd, cwd=None, **kw):
+            captured["cmd"] = cmd
+            captured["cwd"] = cwd
+            return type("R", (), {"returncode": 0, "stdout": "NAME STATUS\nweb_1 Up\n"})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        rc = direct_commands.cmd_status(self._args(id="mysite"))
+        assert rc == 0
+        assert captured["cmd"][:3] == ["docker", "compose", "ps"]
+        assert captured["cwd"] == path
+        out = capsys.readouterr().out
+        assert "STOPPED" in out
+        assert "web_1 Up" in out
+
+    def test_resolves_by_cwd_when_no_id(self, monkeypatch, tmp_path, capsys):
+        path = str(tmp_path)
+        monkeypatch.setattr(
+            direct_commands, "_read_registry",
+            lambda p: {
+                "by-cwd": {
+                    "id": "by-cwd", "orchestrator": "compose",
+                    "host": "localhost", "path": path,
+                },
+            },
+        )
+        monkeypatch.setattr(direct_commands, "_check_running_compose", lambda p, h: True)
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **k: type("R", (), {"returncode": 0, "stdout": ""})(),
+        )
+        monkeypatch.chdir(path)
+        rc = direct_commands.cmd_status(self._args(id=None))
+        assert rc == 0
+        assert "Instance:     by-cwd" in capsys.readouterr().out


### PR DESCRIPTION
Closes #394.

## Summary

New direct_only command that gathers a single instance's runtime state in one shot, replacing the kubectl-list-this/list-that incantations the multi-node walkthrough on canasta.wiki currently spells out.

```
$ canasta status --id mysite
Instance:     mysite
Host:         node1
Orchestrator: KUBERNETES
Status:       RUNNING

Pods:
  NAME                                       READY  STATUS   NODE
  canasta-mysite-caddy-...                   1/1    Running  ip-172-…
  canasta-mysite-db-0                        1/1    Running  ip-172-…
  …

Volumes:
  NAME                              STATUS  ACCESS  CLASS  …
  canasta-mysite-extensions         Bound   RWX     nfs

Services:
  NAME    TYPE       …

Ingress:
  HOSTS                ADDRESS

Certificate:
  NAME                 READY
```

Compose path runs `docker compose ps` (locally or via SSH) and prints the result. Both paths reuse the host-aware `_check_running_k8s` / `_check_running_compose` helpers from #400 so the RUNNING/STOPPED line is correct on remote hosts.

Instance resolution mirrors `canasta delete`: `--id` wins; without it, look up by current working directory against the registry.

## Why direct_only

Pure read-only orchestrator-native queries with no per-instance state to manage. Direct command keeps the latency low (~200 ms vs. ~3-5 s for an Ansible-playbook run).

## Test plan

- [x] `make validate` — 62 commands / 53 playbooks
- [x] `make test-unit` — 588 passed (4 new in `TestCanastaStatus`: unknown-id error, K8s-routes-via-SSH, Compose-uses-docker-compose-ps, cwd-resolution-when-no-id)
- [x] Smoke: argparse routes `canasta status --id mysite` to `status` direct command
- [ ] End-to-end: against the multi-node EC2 cluster, `canasta status --id testsite` prints the full runtime view in under a second.

## Out of scope

- `--watch` mode (live-refreshing) — useful but adds complexity; deferred.
- JSON output (`--json`) — useful for scripting; deferred.