### PR TITLE
_ssh_run: resolve canasta short names via hosts.yml before ssh (closes #411)

### DIFF
--- a/direct_commands.py
+++ b/direct_commands.py
@@ -408,7 +408,16 @@ def _ssh_args():
 
 
 def _ssh_run(host, cmd):
-    full_cmd = ["ssh"] + _ssh_args() + [host, cmd]
+    # `host` may be a canasta short name registered via `canasta host
+    # add` rather than something ~/.ssh/config or DNS knows about.
+    # _resolve_ssh_target maps short names to their actual SSH target
+    # (user@hostname) via hosts.yml; if there's no match it returns
+    # `host` unchanged, so real hostnames/IPs/user@host strings keep
+    # working. Without this, `canasta argocd password --host node1`
+    # ends up running `ssh node1 …` which fails with "Could not
+    # resolve hostname node1" even though canasta knows the mapping.
+    target = _resolve_ssh_target(host)
+    full_cmd = ["ssh"] + _ssh_args() + [target, cmd]
     try:
         result = subprocess.run(
             full_cmd, capture_output=True, text=True, timeout=30,

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -199,6 +199,62 @@ class TestShellQuote:
         assert direct_commands._shell_quote("hello world") == "'hello world'"
 
 
+class TestSshRunResolvesCanastaHostName:
+    """_ssh_run must translate canasta short names from hosts.yml into
+    their actual SSH targets before invoking ssh, so commands like
+    `canasta argocd password --host node1` don't hit `ssh: Could not
+    resolve hostname node1`."""
+
+    def test_short_name_resolved_via_hosts_yml(self, monkeypatch):
+        captured = {}
+
+        monkeypatch.setattr(
+            direct_commands, "_read_hosts_yml",
+            lambda: {"all": {"hosts": {"node1": {
+                "ansible_host": "cp.example.com",
+                "ansible_user": "admin",
+            }}}},
+        )
+
+        def fake_run(full_cmd, **kwargs):
+            captured["cmd"] = full_cmd
+            return type("R", (), {"returncode": 0, "stdout": "ok", "stderr": ""})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        rc, _ = direct_commands._ssh_run("node1", "echo hi")
+        assert rc == 0
+        # ssh target must be admin@cp.example.com, not the bare 'node1'.
+        ssh_target = captured["cmd"][-2]
+        assert ssh_target == "admin@cp.example.com"
+
+    def test_unregistered_host_passes_through(self, monkeypatch):
+        captured = {}
+
+        monkeypatch.setattr(direct_commands, "_read_hosts_yml", lambda: None)
+
+        def fake_run(full_cmd, **kwargs):
+            captured["cmd"] = full_cmd
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        direct_commands._ssh_run("cp.example.com", "echo hi")
+        assert captured["cmd"][-2] == "cp.example.com"
+
+    def test_user_at_host_passes_through(self, monkeypatch):
+        """When hosts.yml has no entry but the input is already a
+        user@host string, leave it alone."""
+        captured = {}
+        monkeypatch.setattr(direct_commands, "_read_hosts_yml", lambda: None)
+
+        def fake_run(full_cmd, **kwargs):
+            captured["cmd"] = full_cmd
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        direct_commands._ssh_run("admin@cp.example.com", "echo hi")
+        assert captured["cmd"][-2] == "admin@cp.example.com"
+
+
 class TestCheckDirExists:
     def test_local_exists(self, tmp_path):
         d = tmp_path / "exists"


### PR DESCRIPTION
Closes #411.

## Summary

Direct commands that took `--host` from argparse and routed through `_ssh_run` failed with `ssh: Could not resolve hostname node1` whenever the user passed a canasta short name registered via `canasta host add`. Most visibly today:

```
$ canasta argocd password --host node1
ssh: Could not resolve hostname node1: nodename nor servname provided, or not known
Argo CD initial-admin secret not found on node1. …
```

Other direct commands (`canasta list`, `canasta delete`) work because their `host` value comes from the registry — where `canasta create` stored the resolved FQDN at create time, not the canasta short name.

## Fix

Move the existing `_resolve_ssh_target` lookup one level down: have `_ssh_run` itself resolve the input before constructing the ssh command. Real hostnames, IPs, and `user@host` strings don't match a `hosts.yml` entry and pass through unchanged, so existing direct commands keep working.

Now `canasta argocd password --host node1` works the same as `canasta argocd password --host admin@cp.example.com` does today.

## Test plan

- [x] `make test-unit` — 594 passed (3 new in `TestSshRunResolvesCanastaHostName`: short-name-resolved, unregistered-passes-through, user@host-passes-through). The 2 pre-existing direct-commands version-test failures on main are unrelated.
- [x] `make validate` — clean.
- [ ] End-to-end on the multi-node EC2 cluster: `canasta argocd password --host node1` should print the password instead of failing with `Could not resolve hostname`.