### PR TITLE
canasta create: retry cert-manager.yaml apply through transient GitHub 5xx (closes #413)

### DIFF
--- a/roles/orchestrator/tasks/k8s_certmanager.yml
+++ b/roles/orchestrator/tasks/k8s_certmanager.yml
@@ -15,12 +15,21 @@
 - name: Install cert-manager
   when: _cm_check.resources | default([]) | length == 0
   block:
+    # GitHub occasionally returns 5xx for releases asset URLs, which
+    # would otherwise abort canasta create after the validate-inputs
+    # step. Retry a few times before giving up — kubectl apply is
+    # idempotent against the cluster, so re-running on a partial
+    # success is safe.
     - name: Apply cert-manager CRDs and deployment
       ansible.builtin.command:
         cmd: >-
           kubectl apply -f
           https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+      register: _cm_apply
       changed_when: true
+      until: _cm_apply.rc == 0
+      retries: 4
+      delay: 5
 
     # Wait on the Deployments, not on their Pods. `kubectl wait
     # --for=condition=Ready pod -l ...` runs the moment kubectl apply


### PR DESCRIPTION
Wrap the kubectl apply in until/retries so a single GitHub 502 doesn't abort the whole create.