### PR TITLE
canasta create: require --domain-name (closes #435)

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -187,7 +187,7 @@ commands:
     examples:
       - "canasta create -i mysite -w main -n example.com"
       - "canasta create -i mysite -w main -n example.com -d /path/to/dump.sql"
-      - "canasta create -i mysite -w main -n localhost --skip-tls"
+      - "canasta create -i mysite -w main -n localhost"
     playbook: create.yml
     parameters:
       - name: host

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -186,7 +186,7 @@ commands:
       starts the containers, and runs the MediaWiki installer.
     examples:
       - "canasta create -i mysite -w main -n example.com"
-      - "canasta create -i mysite -w main -d /path/to/dump.sql"
+      - "canasta create -i mysite -w main -n example.com -d /path/to/dump.sql"
     playbook: create.yml
     parameters:
       - name: host
@@ -227,7 +227,7 @@ commands:
       - name: domain_name
         short: n
         type: string
-        default: localhost
+        required: true
         validator: hostname
         description: "Domain name"
       - name: admin

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -187,6 +187,7 @@ commands:
     examples:
       - "canasta create -i mysite -w main -n example.com"
       - "canasta create -i mysite -w main -n example.com -d /path/to/dump.sql"
+      - "canasta create -i mysite -w main -n localhost --skip-tls"
     playbook: create.yml
     parameters:
       - name: host

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -104,13 +104,15 @@ class TestBuildParser:
         assert args.yes is False
 
     def test_string_flag_with_value(self, parser):
-        args = parser.parse_args(["create", "-i", "mysite", "-w", "main"])
+        args = parser.parse_args([
+            "create", "-i", "mysite", "-w", "main", "-n", "example.com"
+        ])
         assert args.id == "mysite"
         assert args.wiki == "main"
 
     def test_choice_flag(self, parser):
         args = parser.parse_args([
-            "create", "-i", "mysite", "-w", "main",
+            "create", "-i", "mysite", "-w", "main", "-n", "example.com",
             "-o", "kubernetes"
         ])
         assert args.orchestrator == "kubernetes"
@@ -643,13 +645,14 @@ class TestCreateFlags:
 
     def test_skip_tls_accepted_with_compose(self, parser):
         args = parser.parse_args([
-            "create", "-i", "mysite", "-w", "main", "--skip-tls"
+            "create", "-i", "mysite", "-w", "main", "-n", "example.com",
+            "--skip-tls"
         ])
         assert args.skip_tls is True
 
     def test_skip_tls_accepted_with_kubernetes(self, parser):
         args = parser.parse_args([
-            "create", "-i", "mysite", "-w", "main",
+            "create", "-i", "mysite", "-w", "main", "-n", "example.com",
             "-o", "kubernetes", "--skip-tls"
         ])
         assert args.skip_tls is True
@@ -657,14 +660,14 @@ class TestCreateFlags:
 
     def test_storage_class_accepted_with_kubernetes(self, parser):
         args = parser.parse_args([
-            "create", "-i", "mysite", "-w", "main",
+            "create", "-i", "mysite", "-w", "main", "-n", "example.com",
             "-o", "kubernetes", "--storage-class", "nfs"
         ])
         assert args.storage_class == "nfs"
 
     def test_tls_email_accepted_with_kubernetes(self, parser):
         args = parser.parse_args([
-            "create", "-i", "mysite", "-w", "main",
+            "create", "-i", "mysite", "-w", "main", "-n", "example.com",
             "-o", "kubernetes", "--tls-email", "test@example.com"
         ])
         assert args.tls_email == "test@example.com"

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -166,10 +166,13 @@ class TestBuildParser:
         assert args.keep_config is True
 
     def test_domain_name_localhost_accepted(self, parser):
-        """Local-dev case: -n localhost is a valid value (no implicit default)."""
+        """Local-dev case: -n localhost is a valid value (no implicit default).
+
+        Caddy handles localhost via its internal CA (no ACME), so no extra
+        flags are needed.
+        """
         args = parser.parse_args([
-            "create", "-i", "mysite", "-w", "main",
-            "-n", "localhost", "--skip-tls"
+            "create", "-i", "mysite", "-w", "main", "-n", "localhost"
         ])
         assert args.domain_name == "localhost"
 

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -165,6 +165,14 @@ class TestBuildParser:
         assert args.domain_name == "example.com"
         assert args.keep_config is True
 
+    def test_domain_name_localhost_accepted(self, parser):
+        """Local-dev case: -n localhost is a valid value (no implicit default)."""
+        args = parser.parse_args([
+            "create", "-i", "mysite", "-w", "main",
+            "-n", "localhost", "--skip-tls"
+        ])
+        assert args.domain_name == "localhost"
+
     def test_gitops_fix_submodules(self, parser):
         args = parser.parse_args([
             "gitops", "fix-submodules", "-i", "mysite"


### PR DESCRIPTION
## Summary

Make `--domain-name` (`-n`) on `canasta create` required, replacing the previous `default: localhost`. Forgetting the flag now produces an immediate validation error instead of a silently broken wiki.

## Context

`localhost` is wrong for ~all real-world `canasta create` invocations — it produces a Caddyfile bound to `localhost`, ACME cert issuance fails, MW's `$wgServer` is wrong, and the wiki is unreachable at the actual hostname. The operator typically only discovers this after the wiki appears not to work.

Operators who actually do want a localhost-only setup (local development) pass `-n localhost` explicitly. Five extra characters; clear safety win.

## Changes

- `meta/command_definitions.yml`: `required: true` replaces `default: localhost` on `domain_name`; second example updated to include `-n`.
- `tests/unit/test_canasta_cli.py`: six tests that previously parsed `canasta create -i ... -w ...` without `-n` updated to pass `-n example.com`.

## Test plan

- [x] `make validate` passes
- [x] `make test-unit` — 600 tests pass
- [x] `make lint` — no new warnings (existing line-length warnings are unrelated)
- [ ] Manual sanity check: `canasta create -i x -w main` (no `-n`) errors with "the following arguments are required: -n/--domain-name"

Closes #435.
