### PR TITLE
canasta_registry: document drifted parameters and state choices (closes #427)

### DIFF
--- a/roles/common/library/canasta_registry.py
+++ b/roles/common/library/canasta_registry.py
@@ -17,12 +17,20 @@ module: canasta_registry
 short_description: Manage the Canasta instance registry
 description:
   - Read, add, update, and remove Canasta instances from the local registry (conf.json).
+  - Also manages registry-level settings (key/value) via set_setting / get_setting states.
   - Compatible with the Go CLI's registry format.
 options:
   state:
     description: Desired state of the instance in the registry.
     type: str
-    choices: [present, absent, query, query_all, query_by_path]
+    choices:
+      - present
+      - absent
+      - query
+      - query_all
+      - query_by_path
+      - set_setting
+      - get_setting
     default: query
   id:
     description: Canasta instance ID.
@@ -50,6 +58,20 @@ options:
     type: str
   build_from:
     description: Local source directory for image builds.
+    type: str
+  host:
+    description: SSH host (user@host or host) for instances on a remote machine.
+    type: str
+  filter_host:
+    description: With state=query_all, return only instances whose host matches this value.
+    type: str
+  setting_key:
+    description: Settings key to read or write (with state=get_setting or state=set_setting).
+    type: str
+  setting_value:
+    description: >-
+      Value to write for setting_key (with state=set_setting). Omit or pass null
+      to delete the setting.
     type: str
   config_dir:
     description: Override the config directory (instead of auto-detection).


### PR DESCRIPTION
## Summary

Update `canasta_registry`'s `DOCUMENTATION` block to match what the module actually accepts.

## Context

The DOCUMENTATION block listed 5 `state` choices: `present, absent, query, query_all, query_by_path`. The module's `argument_spec` actually accepted 7 — `set_setting` and `get_setting` were undocumented. Several other parameters that exist in `argument_spec` (`setting_key`, `setting_value`, `host`, `filter_host`) were also missing from the docs.

Tools that read the YAML docstring (e.g. `ansible-doc canasta_registry`) only saw a partial surface, and contributors who needed the missing functionality had to read the source to discover it.

## Changes

- `roles/common/library/canasta_registry.py`: extend the `state` choices list to all 7 supported values; add `host`, `filter_host`, `setting_key`, `setting_value` parameter blocks with descriptions; clarify the short description to mention registry-level settings.

## Test plan

- [x] `make validate` passes
- [x] `make test-unit` — 601 tests pass
- [ ] Manual: `ansible-doc canasta_registry` shows all 7 state choices and the previously-missing parameters

Closes #427.
