### PR TITLE
canasta install k8s-cp / k8s-worker: print kubectl get nodes from cp (closes #423)

### DIFF
--- a/roles/install/tasks/k3s.yml
+++ b/roles/install/tasks/k3s.yml
@@ -7,3 +7,17 @@
   ansible.builtin.include_role:
     name: orchestrator
     tasks_from: k8s_install_k3s.yml
+
+# --- Final visibility: show cluster nodes from the cp itself ---
+# The operator's first question after install is "did the cluster come
+# up?". Print the table as the final output so they don't have to ssh +
+# sudo + kubectl manually.
+- name: Get cluster nodes
+  ansible.builtin.command:
+    cmd: sudo k3s kubectl get nodes -o wide
+  register: _k3s_install_nodes
+  changed_when: false
+
+- name: Show cluster nodes
+  ansible.builtin.debug:
+    msg: "{{ _k3s_install_nodes.stdout_lines }}"

--- a/roles/install/tasks/k3s_worker.yml
+++ b/roles/install/tasks/k3s_worker.yml
@@ -78,3 +78,32 @@
   vars:
     server: "{{ _k3s_server_url }}"
     token: "{{ _k3s_join_token }}"
+
+# --- Final visibility: show cluster nodes from cp ---
+# After the agent installs, the new worker may take a few seconds to
+# appear in the cp's view (kubelet registration). Retry briefly so the
+# printed table reflects the new node when possible; surface whatever
+# state the cp sees if it hasn't shown up by the timeout.
+- name: Wait briefly for the new worker to register on cp
+  ansible.builtin.command:
+    argv:
+      - ssh
+      - -o
+      - StrictHostKeyChecking=accept-new
+      - "{{ _cp_ssh_target }}"
+      - sudo k3s kubectl get nodes -o wide
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  register: _cp_post_join_nodes
+  changed_when: false
+  retries: 6
+  delay: 5
+  until: >-
+    (_cp_post_join_nodes.stdout | regex_findall('Ready') | length)
+    >= ((_cp_post_join_nodes.stdout_lines | length) - 1)
+  failed_when: false  # Show whatever state we got, even if not all Ready
+
+- name: Show cluster nodes from cp
+  ansible.builtin.debug:
+    msg: "{{ _cp_post_join_nodes.stdout_lines }}"


### PR DESCRIPTION
## Summary

Print `kubectl get nodes -o wide` (run from the control-plane host) as the final output of `canasta install k8s-cp` and `canasta install k8s-worker`. Removes the manual SSH-and-sudo verify step the post-install hint currently asks for.

## Context

After `canasta install k8s-cp` or `canasta install k8s-worker` completes, the operator's first question is "did the cluster come up?". Today the install commands answer with a verify *hint* — `ssh <cp> sudo k3s kubectl get nodes` — that the operator has to run themselves. The install machinery already SSHes to the cp; printing the node table from there directly is a small ergonomic win.

## Changes

- `roles/install/tasks/k3s.yml`: after the cp install completes, run `sudo k3s kubectl get nodes -o wide` on the target (which is the cp) and print the table.
- `roles/install/tasks/k3s_worker.yml`: after the agent install completes, SSH to cp via the already-resolved `_cp_ssh_target` and run the same command. Wrap in a short `retries: 6, delay: 5` loop so the new worker has time to register (kubelet registration can take a few seconds), and use `failed_when: false` so the operator sees the actual cluster state even if the worker doesn't reach Ready by the timeout.

## Test plan

- [x] `make validate` passes
- [x] `make test-unit` — 601 tests pass
- [ ] Manual on a fresh cluster: `canasta install k8s-cp ...` prints a single-node table at the end
- [ ] Manual on a multi-node cluster: `canasta install k8s-worker ...` prints the table from cp showing the new worker (Ready or NotReady, with Ready preferred via the retry loop)

Closes #423.
