### PR TITLE
External DB: pass MYSQL_USER through to install.php (closes #352)

### DIFF
--- a/playbooks/add.yml
+++ b/playbooks/add.yml
@@ -63,6 +63,13 @@
   register: _add_dbpass
   no_log: true
 
+- name: Read .env for DB user (for install.php --installdbuser)
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read
+    key: MYSQL_USER
+  register: _add_dbuser
+
 - name: Generate admin password if not provided
   when: password is not defined or password == ''
   block:
@@ -144,7 +151,7 @@
           --confpath=/tmp/canasta-install/
           --scriptpath=/w
           --server=https://{{ _add_domain }}
-          --installdbuser='root'
+          --installdbuser={{ _add_dbuser.value | default('root') | quote }}
           --installdbpass={{ _add_dbpass.value | quote }}
           --dbuser={{ wikidbuser | default('root') | quote }}
           --dbpass={{ _add_dbpass.value | quote }}

--- a/roles/mediawiki/tasks/install_single_wiki.yml
+++ b/roles/mediawiki/tasks/install_single_wiki.yml
@@ -36,7 +36,7 @@
       --confpath=/tmp/canasta-install/
       --scriptpath=/w
       --server=https://{{ _install_domain }}
-      --installdbuser='root'
+      --installdbuser={{ _install_env.variables.MYSQL_USER | default('root') | quote }}
       --installdbpass={{ install_root_db_password | quote }}
       --dbuser={{ install_wiki_db_username | quote }}
       --dbpass={{ install_wiki_db_password | quote }}


### PR DESCRIPTION
## Summary

Pass `MYSQL_USER` from the instance's `.env` through to `install.php`'s `--installdbuser` flag at both call sites. Default to `root` when unset, preserving existing behavior for self-hosted MariaDB/MySQL. Makes `USE_EXTERNAL_DB=true` work against managed databases whose master user isn't named `root`.

## Context (from #352)

`MYSQL_USER` from the envfile flows through to:
- **Runtime**: web/jobrunner env vars, K8s `externalDatabase.user` ✓
- **Backup scripts**: `mariadb-dump -u "${MYSQL_USER:-root}"` ✓
- **`install.php`**: hardcoded `--installdbuser='root'` ✗

For RDS / Aurora / Cloud SQL / Azure Database for MySQL — where the master user is whatever the operator chose at provisioning time (commonly `admin`, never `root`) — `install.php` would fail with an authentication error. The documented workaround was "create a `root@'%'` user on the database with `WITH GRANT OPTION` and use its password as `MYSQL_PASSWORD`," which is an ugly extra step that shouldn't be needed.

## Changes

- `roles/mediawiki/tasks/install_single_wiki.yml`: change `--installdbuser='root'` → `--installdbuser={{ _install_env.variables.MYSQL_USER | default('root') | quote }}`. The task already reads the full env via `canasta_env: state=read_all` earlier; just use that value.
- `playbooks/add.yml`: add a small new read step for `MYSQL_USER` alongside the existing `MYSQL_PASSWORD` read, and use it on the `--installdbuser` line.

Both call sites default to `root` when `MYSQL_USER` is absent from `.env`, so existing self-hosted instances behave identically.

## Test plan

- [x] `make validate` passes
- [x] `make test-unit` — 601 tests pass
- [ ] Manual: `canasta create --use-external-db ...` against a managed DB whose master user is `admin` succeeds without creating a workaround `root@'%'` user
- [ ] Manual: `canasta create` against a self-hosted MariaDB without `MYSQL_USER` in the envfile still works (defaults to `root`)
- [ ] Doc: the "Caveats" section on `Help:External database` mentioning the root-user workaround can be removed once this lands

Closes #352.
