### PR TITLE
Fix MYSQL_USER fallback when key is empty in .env (followup to #352)

### DIFF
--- a/playbooks/add.yml
+++ b/playbooks/add.yml
@@ -151,7 +151,7 @@
           --confpath=/tmp/canasta-install/
           --scriptpath=/w
           --server=https://{{ _add_domain }}
-          --installdbuser={{ _add_dbuser.value | default('root') | quote }}
+          --installdbuser={{ _add_dbuser.value | default('root', true) | quote }}
           --installdbpass={{ _add_dbpass.value | quote }}
           --dbuser={{ wikidbuser | default('root') | quote }}
           --dbpass={{ _add_dbpass.value | quote }}

--- a/roles/mediawiki/tasks/install_single_wiki.yml
+++ b/roles/mediawiki/tasks/install_single_wiki.yml
@@ -36,7 +36,7 @@
       --confpath=/tmp/canasta-install/
       --scriptpath=/w
       --server=https://{{ _install_domain }}
-      --installdbuser={{ _install_env.variables.MYSQL_USER | default('root') | quote }}
+      --installdbuser={{ _install_env.variables.MYSQL_USER | default('root', true) | quote }}
       --installdbpass={{ install_root_db_password | quote }}
       --dbuser={{ install_wiki_db_username | quote }}
       --dbpass={{ install_wiki_db_password | quote }}


### PR DESCRIPTION
## Summary

Fix integration test regression introduced by #441 (the #352 fix). `--installdbuser` was being passed as an empty string when the envfile had no `MYSQL_USER`, instead of falling back to `root`.

## Root cause

#441 changed `--installdbuser='root'` to:

```yaml
--installdbuser={{ _add_dbuser.value | default('root') | quote }}
```

But `canasta_env: state=read, key=MYSQL_USER` returns `value: ""` (empty string) when the key isn't in the envfile, not `undefined`. Jinja's `default()` only fires on undefined values — empty strings pass through unchanged. So `'' | default('root')` evaluates to `''`, and `install.php` was invoked with `--installdbuser=''`, failing with:

```
Cannot access the database: :real_connect(): (HY000/1045): Access denied for user @'172.18.0.4' (using password: YES)
```

(note the empty user before `@'...'`).

This blew up Integration: Features, Integration: Core Lifecycle, and Remote Host Integration Tests on `main` immediately after #441 merged.

## Fix

Use `default('root', true)` (the second-arg form) so empty / falsy values also fall back to `'root'`. Two call sites:

- `roles/mediawiki/tasks/install_single_wiki.yml` — `canasta create` path
- `playbooks/add.yml` — `canasta add` path

## Behavior preservation

- **Self-hosted deployments without `MYSQL_USER` in `.env`** (the integration test scenario, and a common pre-#441 case): now correctly defaults to `root` again. Pre-#441 behavior restored.
- **External-DB deployments with `MYSQL_USER=admin`** (the case #441 was fixing): unchanged. The truthy value passes through `default('root', true)` untouched.

## Test plan

- [x] `make validate` passes
- [x] `make test-unit` — 601 tests pass
- [ ] CI's failing integration jobs — Integration: Features, Integration: Core Lifecycle, Remote Host Integration Tests — should all go green again on this branch.

Followup to #352 (fix in #441).
