### PR TITLE
Filter MW_SITE_FQDN cascade by old domain (closes #445)

### DIFF
--- a/roles/common/library/canasta_wikis_yaml.py
+++ b/roles/common/library/canasta_wikis_yaml.py
@@ -33,6 +33,12 @@ options:
   domain:
     description: Domain name for the wiki URL.
     type: str
+  old_domain:
+    description: >-
+      With state=update_domain, only update wikis whose current host matches
+      this value. Required for update_domain — prevents clobbering wikis that
+      live on other domains in multi-domain instances.
+    type: str
   wiki_path:
     description: URL path suffix (e.g. 'docs' for example.com/docs).
     type: str
@@ -142,6 +148,15 @@ def update_url_port(url, new_port, default_port="443"):
     return domain + path
 
 
+def url_host(url):
+    """Extract the bare host from a wiki URL, stripping port and path."""
+    server, _ = parse_url(url)
+    colon_idx = server.rfind(":")
+    if colon_idx != -1:
+        return server[:colon_idx]
+    return server
+
+
 def update_url_domain(url, new_domain):
     """Replace the domain in a wiki URL, preserving port and path."""
     old_domain = url
@@ -191,6 +206,7 @@ def run_module():
                             "update_port", "update_domain"]),
         wiki_id=dict(type="str", required=False),
         domain=dict(type="str", required=False),
+        old_domain=dict(type="str", required=False),
         wiki_path=dict(type="str", required=False),
         site_name=dict(type="str", required=False),
         port=dict(type="str", required=False),
@@ -310,15 +326,31 @@ def run_module():
         if not domain:
             module.fail_json(msg="domain is required for update_domain")
             return
+        old_domain = module.params.get("old_domain")
+        if not old_domain:
+            module.fail_json(
+                msg="old_domain is required for update_domain "
+                    "(filter prevents clobbering wikis on other domains)"
+            )
+            return
+        # Strip port from old_domain for host-only comparison.
+        old_colon = old_domain.rfind(":")
+        old_host = old_domain[:old_colon] if old_colon != -1 else old_domain
         wikis = read_wikis(instance_path)
         updated = []
+        changed = False
         for w in wikis:
             w = dict(w)
-            w["url"] = update_url_domain(w.get("url", ""), domain)
+            url = w.get("url", "")
+            if url_host(url) == old_host:
+                new_url = update_url_domain(url, domain)
+                if new_url != url:
+                    w["url"] = new_url
+                    changed = True
             updated.append(w)
-        if not module.check_mode:
+        if changed and not module.check_mode:
             write_wikis(instance_path, updated)
-        result["changed"] = True
+        result["changed"] = changed
         result["wikis"] = updated
 
     module.exit_json(**result)

--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -237,22 +237,37 @@
 - name: Apply MW_SITE_FQDN side effects
   when: _config_key == 'MW_SITE_FQDN'
   block:
-    - name: Update wikis.yaml URLs with new domain
-      canasta_wikis_yaml:
-        instance_path: "{{ instance_path }}"
-        state: update_domain
-        domain: "{{ _config_value }}"
-
-    - name: Read current MW_SITE_SERVER to preserve scheme
+    # MW_SITE_FQDN in .env has already been overwritten with the new value by
+    # the time this cascade fires, but MW_SITE_SERVER still holds the OLD
+    # domain (we only update it here, below). Read it to recover the old
+    # FQDN so update_domain can filter to wikis on that domain — without the
+    # filter, every wiki's URL gets clobbered to the new domain regardless
+    # of its original host (issue #445).
+    - name: Read current MW_SITE_SERVER to preserve scheme and old FQDN
       canasta_env:
         path: "{{ instance_path }}/.env"
         state: read
         key: MW_SITE_SERVER
       register: _current_server
 
-    - name: Determine scheme from current MW_SITE_SERVER
+    - name: Extract old FQDN and scheme from current MW_SITE_SERVER
       ansible.builtin.set_fact:
+        _old_fqdn: >-
+          {{ _current_server.value | default('')
+             | regex_replace('^https?://', '')
+             | regex_replace('/.*$', '')
+             | regex_replace(':.*$', '') }}
         _server_scheme: "{{ (_current_server.value | default('https://') | regex_search('^https?://')) or 'https://' }}"
+
+    - name: Update wikis.yaml URLs (only for wikis on the old FQDN)
+      canasta_wikis_yaml:
+        instance_path: "{{ instance_path }}"
+        state: update_domain
+        old_domain: "{{ _old_fqdn }}"
+        domain: "{{ _config_value }}"
+      when:
+        - _old_fqdn != ''
+        - _old_fqdn != _config_value
 
     - name: Update MW_SITE_SERVER to match new FQDN
       canasta_env:

--- a/tests/unit/test_canasta_wikis_yaml.py
+++ b/tests/unit/test_canasta_wikis_yaml.py
@@ -348,6 +348,7 @@ class TestRunModuleUpdateDomain:
         result, failed, _ = run_module_with_params(canasta_wikis_yaml, {
             "instance_path": tmp_dir, "state": "update_domain",
             "wiki_id": None, "domain": "new.example.com",
+            "old_domain": "old.example.com",
             "wiki_path": None, "site_name": None,
             "port": None,
         })
@@ -356,9 +357,11 @@ class TestRunModuleUpdateDomain:
         assert result["wikis"][0]["url"] == "new.example.com"
 
     def test_update_domain_multiple_wikis(self, sample_wikis_yaml):
+        # sample_wikis_yaml fixture: both wikis on example.com.
         result, failed, _ = run_module_with_params(canasta_wikis_yaml, {
             "instance_path": sample_wikis_yaml, "state": "update_domain",
             "wiki_id": None, "domain": "newsite.com",
+            "old_domain": "example.com",
             "wiki_path": None, "site_name": None,
             "port": None,
         })
@@ -376,6 +379,7 @@ class TestRunModuleUpdateDomain:
         result, failed, _ = run_module_with_params(canasta_wikis_yaml, {
             "instance_path": tmp_dir, "state": "update_domain",
             "wiki_id": None, "domain": "new.com",
+            "old_domain": "old.com",
             "wiki_path": None, "site_name": None,
             "port": None,
         })
@@ -387,8 +391,66 @@ class TestRunModuleUpdateDomain:
         result, failed, msg = run_module_with_params(canasta_wikis_yaml, {
             "instance_path": sample_wikis_yaml, "state": "update_domain",
             "wiki_id": None, "domain": None,
+            "old_domain": "example.com",
             "wiki_path": None, "site_name": None,
             "port": None,
         })
         assert failed
         assert "domain is required" in msg
+
+    def test_update_domain_requires_old_domain(self, sample_wikis_yaml):
+        # Without old_domain, the module must refuse — preventing the
+        # multi-domain clobber bug from #445.
+        result, failed, msg = run_module_with_params(canasta_wikis_yaml, {
+            "instance_path": sample_wikis_yaml, "state": "update_domain",
+            "wiki_id": None, "domain": "newsite.com",
+            "old_domain": None,
+            "wiki_path": None, "site_name": None,
+            "port": None,
+        })
+        assert failed
+        assert "old_domain is required" in msg
+
+    def test_update_domain_filters_other_domains(self, tmp_dir):
+        # Multi-domain instance: changing the FQDN of one wiki must not
+        # touch wikis on unrelated domains. Regression test for #445.
+        os.makedirs(os.path.join(tmp_dir, "config"), exist_ok=True)
+        canasta_wikis_yaml.write_wikis(tmp_dir, [
+            {"id": "main", "url": "a.example.com", "name": "Main"},
+            {"id": "docs", "url": "a.example.com/docs", "name": "Docs"},
+            {"id": "side", "url": "unrelated.org", "name": "Side"},
+            {"id": "other", "url": "b.example.com", "name": "Other"},
+        ])
+        result, failed, _ = run_module_with_params(canasta_wikis_yaml, {
+            "instance_path": tmp_dir, "state": "update_domain",
+            "wiki_id": None, "domain": "newhost.example.com",
+            "old_domain": "a.example.com",
+            "wiki_path": None, "site_name": None,
+            "port": None,
+        })
+        assert not failed
+        assert result["changed"]
+        urls = {w["id"]: w["url"] for w in result["wikis"]}
+        assert urls["main"] == "newhost.example.com"
+        assert urls["docs"] == "newhost.example.com/docs"
+        # Wikis on other domains untouched:
+        assert urls["side"] == "unrelated.org"
+        assert urls["other"] == "b.example.com"
+
+    def test_update_domain_no_match_is_noop(self, tmp_dir):
+        # If old_domain doesn't match any wiki, the module reports
+        # changed=False and the file is unchanged.
+        os.makedirs(os.path.join(tmp_dir, "config"), exist_ok=True)
+        canasta_wikis_yaml.write_wikis(tmp_dir, [
+            {"id": "main", "url": "a.example.com", "name": "Main"},
+        ])
+        result, failed, _ = run_module_with_params(canasta_wikis_yaml, {
+            "instance_path": tmp_dir, "state": "update_domain",
+            "wiki_id": None, "domain": "newhost.example.com",
+            "old_domain": "completely-different.com",
+            "wiki_path": None, "site_name": None,
+            "port": None,
+        })
+        assert not failed
+        assert not result["changed"]
+        assert result["wikis"][0]["url"] == "a.example.com"


### PR DESCRIPTION
## Summary

Fix the `MW_SITE_FQDN` cascade so it only updates wikis whose URL is on the old FQDN, instead of clobbering every wiki to the new domain. Adds a required `old_domain` parameter to `canasta_wikis_yaml`'s `update_domain` state — the implementation that produced the original bug.

## Background (from #445)

On a multi-domain instance, running `canasta config set MW_SITE_FQDN=<new>` would rewrite every wiki's URL to `<new>`, regardless of which domain that wiki was originally on. The matching `MW_SITE_SERVER` cascade did the right thing already (regex-replace targeted only the old FQDN), but the `MW_SITE_FQDN` cascade went through `canasta_wikis_yaml: state=update_domain`, which iterated every wiki unconditionally:

```python
elif state == "update_domain":
    ...
    for w in wikis:
        w["url"] = update_url_domain(w.get("url", ""), domain)
```

## Changes

- **`roles/common/library/canasta_wikis_yaml.py`**:
  - New required `old_domain` parameter on the `update_domain` state.
  - Loop filtered: only update wikis whose current host (port-stripped) matches `old_domain`.
  - Returns `changed=False` when no wiki matches, instead of always-true.
  - New helper `url_host(url)` to extract bare host (port + path stripped) for the comparison.
  - DOCUMENTATION updated.

- **`roles/config/tasks/_side_effects.yml`** (`MW_SITE_FQDN` cascade):
  - `MW_SITE_FQDN` in `.env` is already the new value when the cascade runs, but `MW_SITE_SERVER` still holds the old domain (we update it later in the same cascade). The cascade now reads it, extracts the old FQDN, and passes it through as `old_domain`.
  - The `update_domain` call is gated on `_old_fqdn` being non-empty and different from the new value.

- **`tests/unit/test_canasta_wikis_yaml.py`**:
  - Existing four `update_domain` tests updated to pass `old_domain` (necessary because the parameter is now required).
  - New `test_update_domain_requires_old_domain` — refuses without it.
  - New `test_update_domain_filters_other_domains` — direct regression test for the bug pattern from #445.
  - New `test_update_domain_no_match_is_noop` — no-op when `old_domain` doesn't match any wiki.

## Test plan

- [x] `make validate` passes
- [x] `make test-unit` — 604 tests pass (+3 new)
- [x] `make lint` — no new warnings
- [ ] Manual on a multi-domain instance: `canasta config set MW_SITE_FQDN=...` rewrites only wikis on the old FQDN; wikis on other domains are untouched.

Closes #445.
