### PR TITLE
canasta create: detect stale orchestrator state from prior failed runs (closes #391)

### DIFF
--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -98,13 +98,82 @@
       Run 'canasta delete --id {{ id }} --yes' to remove it first.
   when: _existing is succeeded
 
-- name: Kubernetes setup (validate + Argo CD)
+# --- Stale-state check (issue #391) ---
+# Even when the registry has no entry for this instance, a prior
+# 'canasta create' that failed mid-flight may have left orchestrator
+# state behind (Docker volumes for Compose, a namespace + PVCs for K8s).
+# Re-running create would generate fresh DB passwords that do not match
+# the existing volume contents, producing an unrecoverable auth mismatch.
+# Refuse upfront with a clear recovery hint.
+- name: Check for stale Compose volumes from prior failed create
+  when: (orchestrator | default('compose')) == 'compose'
+  block:
+    - name: Probe for existing docker volumes
+      ansible.builtin.command:
+        argv:
+          - docker
+          - volume
+          - ls
+          - --filter
+          - "name={{ id }}_"
+          - "-q"
+      register: _stale_volumes
+      changed_when: false
+      failed_when: false
+
+    - name: Fail if stale Compose volumes exist
+      ansible.builtin.fail:
+        msg: >-
+          Docker volumes for instance '{{ id }}' already exist
+          ({{ _stale_volumes.stdout_lines | join(', ') }}) but the
+          instance is not in the canasta registry. This usually means
+          a previous 'canasta create' failed mid-flight and left state
+          behind. Re-running would generate fresh DB passwords that
+          do not match the existing volumes, producing an unrecoverable
+          auth mismatch. To recover, list and remove the stale volumes
+          ('docker volume ls --filter name={{ id }}_' to list, then
+          'docker volume rm <name>' for each), then re-run.
+      when:
+        - _stale_volumes.stdout is defined
+        - _stale_volumes.stdout | trim | length > 0
+
+- name: Kubernetes setup (validate + stale-state check + Argo CD)
   when: (orchestrator | default('compose')) in ['kubernetes', 'k8s']
   block:
     - name: Validate Kubernetes prerequisites
       ansible.builtin.include_role:
         name: orchestrator
         tasks_from: k8s_preflight.yml
+
+    # Stale-state check must come AFTER preflight (which verifies
+    # kubectl is reachable) and BEFORE ArgoCD bootstrap (which is
+    # expensive). See block comment above for the full rationale.
+    - name: Probe for existing canasta-{{ id }} namespace
+      ansible.builtin.command:
+        argv:
+          - kubectl
+          - get
+          - namespace
+          - "canasta-{{ id }}"
+          - "-o"
+          - name
+      register: _stale_ns
+      changed_when: false
+      failed_when: false
+
+    - name: Fail if stale K8s namespace exists
+      ansible.builtin.fail:
+        msg: >-
+          Kubernetes namespace 'canasta-{{ id }}' already exists but
+          instance '{{ id }}' is not in the canasta registry. This
+          usually means a previous 'canasta create' failed mid-flight
+          and left state (PVCs, Secrets, helm release) behind.
+          Re-running would generate fresh DB passwords that do not
+          match the existing PVCs, producing an unrecoverable auth
+          mismatch. To recover, delete the stale namespace
+          ('kubectl delete namespace canasta-{{ id }}' — cascades
+          through the helm release, PVCs, and Secrets), then re-run.
+      when: _stale_ns.rc | default(1) == 0
 
     - name: Install Argo CD if not skipped
       ansible.builtin.include_role:


### PR DESCRIPTION
## Summary

Add a stale-state check to `canasta create` so a re-run after a failed mid-flight create fails fast with a clear recovery hint, instead of silently producing an unrecoverable DB auth mismatch.

## Background (from #391)

When `canasta create` fails partway through, the registry isn't updated — but orchestrator state may have already been created:

- **Compose**: Docker volumes named `<id>_*` (mysql-data-volume, mediawiki-logs, etc.) exist with the original DB grants baked in.
- **K8s**: namespace `canasta-<id>` exists with PVCs and Secrets.

A subsequent `canasta create` with the same instance ID generates fresh DB passwords. The web init container reads the new password, but the existing volumes/PVCs still hold the old root grant. MariaDB rejects the auth and the install fails with:

```
Cannot access the database: real_connect(): (HY000/1045):
Access denied for user 'root'@'10.42.0.12' (using password: YES).
```

There's no graceful recovery path from canasta — the operator has to drop down to `kubectl delete namespace` or `docker volume rm` manually, then retry.

## Changes

`roles/create/tasks/main.yml` — two new probes after the existing registry check:

- **Compose probe**: `docker volume ls --filter name=<id>_ -q`. If any output, fail with the volume names and a step-by-step removal recipe.
- **K8s probe**: `kubectl get namespace canasta-<id> -o name`. Positioned after K8s preflight (so kubectl reachability is already validated) but before Argo CD bootstrap (which is expensive). If the namespace exists, fail with `kubectl delete namespace` instructions.

Both error messages explicitly call out *why* re-running would fail (auth mismatch from regenerated passwords) so operators understand the cause, not just the recovery action.

## What this doesn't do

- **No `--force` flag yet.** The issue suggests adding one to nuke-and-recreate. Skipped here for scope; it's a clean follow-up if there's demand. The issue body's preferred shape was "loud, simple, no surprises" — refuse-and-instruct, which is what this implements.
- **Doesn't auto-recover.** Still requires the operator to run the cleanup command. The trade-off: opt-in destruction is safer than implicit, especially given the failure mode (lost DB data) is severe.

## Test plan

- [x] `make validate` passes
- [x] `make test-unit` — 604 tests pass
- [x] `make lint` — no new warnings
- [ ] Manual: K8s create that's interrupted, re-run produces the new error message (not the auth mismatch).
- [ ] Manual: Compose create that's interrupted (e.g., kill during install), re-run produces the new error message.
- [ ] Manual: Clean Compose / K8s host runs `canasta create` normally — neither probe triggers.

Closes #391.
