### PR TITLE
Replace ansible_connection dance with delegate_to: localhost (closes #426)

### DIFF
--- a/roles/common/tasks/resolve_instance.yml
+++ b/roles/common/tasks/resolve_instance.yml
@@ -10,23 +10,17 @@
 # Input: id (optional)
 # Output: instance_id, instance_path, instance_orchestrator,
 #   instance_devmode, instance_managed_cluster
+#
+# Note: registry queries below all carry delegate_to: localhost so they
+# run against the controller's registry regardless of the inbound
+# connection state. We capture the inbound host/conn purely to drive the
+# resolution-path branching (remote vs localhost) — we do not switch
+# ansible_connection itself, which would have to be undone afterwards.
 
-# Save current connection state so we can restore after registry queries.
-# This is needed because resolve_instance may be called after
-# switch_connection.yml has set ansible_connection to ssh.
-- name: Save connection state before registry queries
+- name: Capture inbound connection state for resolution branching
   ansible.builtin.set_fact:
-    _ri_saved_host: "{{ ansible_host | default('localhost') }}"
-    _ri_saved_conn: "{{ ansible_connection | default('local') }}"
-    _ri_saved_user: "{{ ansible_user | default('') }}"
-    _ri_saved_python: "{{ ansible_python_interpreter | default(ansible_playbook_python) }}"
-
-- name: Switch to local for registry queries
-  ansible.builtin.set_fact:
-    ansible_host: "localhost"
-    ansible_connection: "local"
-    ansible_user: ""
-    ansible_python_interpreter: "{{ ansible_playbook_python }}"
+    _ri_orig_host: "{{ ansible_host | default('localhost') }}"
+    _ri_orig_conn: "{{ ansible_connection | default('local') }}"
 
 # Step 1: Determine which ID to look up
 - name: Use provided ID
@@ -37,25 +31,29 @@
 - name: Resolve ID from host (remote, no ID)
   when:
     - id is not defined or id == ''
-    - _ri_saved_host != 'localhost' or _ri_saved_conn == 'ssh'
+    - _ri_orig_host != 'localhost' or _ri_orig_conn == 'ssh'
   block:
     - name: Query instances on this host
       canasta_registry:
         state: query_all
-        filter_host: "{{ _ri_saved_host }}"
+        filter_host: "{{ _ri_orig_host }}"
+      delegate_to: localhost
+      vars:
+        ansible_connection: local
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
       register: _host_instances
 
     - name: Fail if no instances on this host
       ansible.builtin.fail:
         msg: >-
           No Canasta instances registered on
-          '{{ _ri_saved_host }}'.
+          '{{ _ri_orig_host }}'.
       when: _host_instances.instances | length == 0
 
     - name: Fail if multiple instances on this host
       ansible.builtin.fail:
         msg: >-
-          Multiple instances on '{{ _ri_saved_host }}'.
+          Multiple instances on '{{ _ri_orig_host }}'.
           Specify --id:
           {{ _host_instances.instances.keys()
              | list | join(', ') }}
@@ -69,12 +67,16 @@
 - name: Resolve ID from working directory (localhost)
   when:
     - id is not defined or id == ''
-    - _ri_saved_host == 'localhost' and _ri_saved_conn != 'ssh'
+    - _ri_orig_host == 'localhost' and _ri_orig_conn != 'ssh'
   block:
     - name: Look up by PWD
       canasta_registry:
         path: "{{ lookup('env', 'CANASTA_HOST_PWD') | default(lookup('env', 'PWD'), true) }}"
         state: query_by_path
+      delegate_to: localhost
+      vars:
+        ansible_connection: local
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
       register: _pwd_lookup
 
     - name: Set PWD-resolved ID
@@ -86,14 +88,11 @@
   canasta_registry:
     id: "{{ _resolved_id }}"
     state: query
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
   register: _instance_result
-
-- name: Restore connection state after registry queries
-  ansible.builtin.set_fact:
-    ansible_host: "{{ _ri_saved_host }}"
-    ansible_connection: "{{ _ri_saved_conn }}"
-    ansible_user: "{{ _ri_saved_user }}"
-    ansible_python_interpreter: "{{ _ri_saved_python }}"
 
 - name: Set instance facts
   ansible.builtin.set_fact:

--- a/roles/delete/tasks/main.yml
+++ b/roles/delete/tasks/main.yml
@@ -223,28 +223,14 @@
     - not (_inst_dir.stat.exists | default(false))
     - _instance_registered | default(false) | bool
   block:
-    - name: Switch to local for controller deregistration
-      ansible.builtin.set_fact:
-        _saved_host: "{{ ansible_host | default('localhost') }}"
-        _saved_conn: "{{ ansible_connection | default('local') }}"
-        _saved_user: "{{ ansible_user | default('') }}"
-        _saved_python: "{{ ansible_python_interpreter | default('auto') }}"
-        ansible_host: "localhost"
-        ansible_connection: "local"
-        ansible_user: ""
-        ansible_python_interpreter: "{{ ansible_playbook_python }}"
-
     - name: Deregister already-removed instance from controller
       canasta_registry:
         id: "{{ instance_id }}"
         state: absent
-
-    - name: Restore connection for target deregistration
-      ansible.builtin.set_fact:
-        ansible_host: "{{ _saved_host }}"
-        ansible_connection: "{{ _saved_conn }}"
-        ansible_user: "{{ _saved_user }}"
-        ansible_python_interpreter: "{{ _saved_python }}"
+      delegate_to: localhost
+      vars:
+        ansible_connection: local
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
     - name: Deregister already-removed instance from target host
       canasta_registry:
@@ -263,28 +249,14 @@
 # if subsequent cleanup steps fail (e.g., directory already gone from
 # a previous partial delete). Better to have an orphaned directory
 # than an orphaned registry entry.
-- name: Temporarily switch to local for controller deregistration
-  ansible.builtin.set_fact:
-    _saved_ansible_host: "{{ ansible_host | default('localhost') }}"
-    _saved_ansible_connection: "{{ ansible_connection | default('local') }}"
-    _saved_ansible_user: "{{ ansible_user | default('') }}"
-    _saved_ansible_python: "{{ ansible_python_interpreter | default('auto') }}"
-    ansible_host: "localhost"
-    ansible_connection: "local"
-    ansible_user: ""
-    ansible_python_interpreter: "{{ ansible_playbook_python }}"
-
 - name: Deregister instance from controller
   canasta_registry:
     id: "{{ instance_id }}"
     state: absent
-
-- name: Restore connection after controller deregistration
-  ansible.builtin.set_fact:
-    ansible_host: "{{ _saved_ansible_host }}"
-    ansible_connection: "{{ _saved_ansible_connection }}"
-    ansible_user: "{{ _saved_ansible_user }}"
-    ansible_python_interpreter: "{{ _saved_ansible_python }}"
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Deregister instance from target host
   canasta_registry:


### PR DESCRIPTION
## Summary

Replace the brittle `ansible_connection` save/switch/restore dance in `resolve_instance.yml` and `delete/main.yml` with `delegate_to: localhost` on the few canasta_registry calls that need it.

## Background (from #426)

Both files had this pattern wrapping their canasta_registry calls:

```yaml
- name: Switch to local for registry queries
  ansible.builtin.set_fact:
    _saved_host: "{{ ansible_host | default('localhost') }}"
    _saved_conn: "{{ ansible_connection | default('local') }}"
    _saved_user: "{{ ansible_user | default('') }}"
    _saved_python: "{{ ansible_python_interpreter | default(...) }}"
    ansible_host: "localhost"
    ansible_connection: "local"
    ...
- name: Run the registry call
  canasta_registry: { ... }
- name: Restore connection
  ansible.builtin.set_fact:
    ansible_host: "{{ _saved_host }}"
    ...
```

Two flaws:

1. **Failure between save and restore leaves the play in a "switched" state.** Any task that fails (or aborts via `meta: end_play` etc.) between the save and restore strands the playbook with `ansible_connection=local` for downstream tasks that should have continued running against the original target.
2. **Save and restore drift.** The two lists must stay in sync (currently four fields each in two different blocks); a new field added to one but not the other silently breaks restoration. The audit caught one such drift (`_saved_python: ... default('auto')` vs `_ri_saved_python: ... default(ansible_playbook_python)`).

The same effect — running just the registry call against the controller, regardless of inbound connection — is already what most of the codebase does, with a single-task `delegate_to: localhost` plus a `vars` block. `roles/create/tasks/main.yml`'s "Check instance does not already exist" is the canonical example.

## Changes

- **`roles/common/tasks/resolve_instance.yml`**: drop the save/switch/restore. Still capture the inbound `ansible_host`/`ansible_connection` into `_ri_orig_*` because the resolution-path branching (remote vs localhost) needs to know which the operator targeted. Drop `_ri_saved_user` and `_ri_saved_python` (no longer needed since nothing's switching). Add `delegate_to: localhost` + `vars` to the three `canasta_registry` calls (`query_all`, `query_by_path`, `query`).
- **`roles/delete/tasks/main.yml`**: drop both dance instances (the "Handle already-removed instance" block at lines 226-247, and the standalone "Deregister instance from controller" block at lines 266-287). Each collapses to a single `canasta_registry` call with `delegate_to: localhost`.

Net: −29 lines, identical behavior.

## Test plan

- [x] `make validate` passes
- [x] `make test-unit` — 604 tests pass
- [ ] Manual: `canasta delete -i <id>` with the instance on a remote host (registry on controller, files on remote) still cleans up both registries.
- [ ] Manual: `canasta start/stop/restart -i <id>` (which depends on `resolve_instance`) for both local and remote-host instances still resolves correctly.

Closes #426.
