### PR TITLE
Better UX when running canasta gitops before any instance exists (closes #450)

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -92,13 +92,15 @@ MOUNTS=(
     --user "$(id -u):$(id -g)"
 )
 
-# Set Ansible temp directories to /tmp when running as a non-root user in
-# rootless Docker. On rootless Docker, the UID/GID mapping causes directory
-# ownership to appear as root:root to the container process even though
+# Set Ansible temp + home directories to /tmp when running as a non-root user
+# in rootless Docker. On rootless Docker, the UID/GID mapping causes directory
+# ownership to appear as nobody:nogroup to the container process even though
 # the directory is owned by the host user. This causes Ansible to fail when
-# trying to create $HOME/.ansible/tmp. Using /tmp avoids the issue.
+# trying to create $HOME/.ansible (collections cache, retry files) and
+# $HOME/.ansible/tmp (per-task scratch). Using /tmp avoids the issue.
 if [[ "$(id -u)" != "0" ]]; then
     MOUNTS+=(
+        -e "ANSIBLE_HOME=/tmp/ansible-home"
         -e "ANSIBLE_LOCAL_TEMP=/tmp/ansible-local"
         -e "ANSIBLE_REMOTE_TEMP=/tmp/ansible-remote"
     )

--- a/roles/common/tasks/resolve_instance.yml
+++ b/roles/common/tasks/resolve_instance.yml
@@ -5,7 +5,14 @@
 # Resolution order:
 #   1. --id provided: look up by ID
 #   2. Remote host, no --id: auto-resolve if one instance on host
-#   3. Localhost, no --id: PWD-based resolution
+#   3. Localhost, no --id: match the current working directory against
+#      the registered `path` of each instance.
+#
+# "Current working directory" comes from CANASTA_HOST_PWD if set
+# (canasta-docker exports the host shell's $(pwd) under that name so
+# playbooks can resolve instances by host cwd, not the container cwd),
+# falling back to the standard POSIX $PWD env var. Despite the name,
+# CANASTA_HOST_PWD is a directory path, not a password.
 #
 # Input: id (optional)
 # Output: instance_id, instance_path, instance_orchestrator,
@@ -71,22 +78,22 @@
     - id is not defined or id == ''
     - _ri_saved_host == 'localhost' and _ri_saved_conn != 'ssh'
   block:
-    - name: Determine PWD for lookup
+    - name: Determine current working directory for lookup
       ansible.builtin.set_fact:
-        _ri_pwd: "{{ lookup('env', 'CANASTA_HOST_PWD') | default(lookup('env', 'PWD'), true) }}"
+        _ri_cwd: "{{ lookup('env', 'CANASTA_HOST_PWD') | default(lookup('env', 'PWD'), true) }}"
 
-    - name: Look up by PWD
+    - name: Look up by current working directory
       canasta_registry:
-        path: "{{ _ri_pwd }}"
+        path: "{{ _ri_cwd }}"
         state: query_by_path
-      register: _pwd_lookup
+      register: _cwd_lookup
       failed_when: false
 
-    - name: Check registry contents on PWD miss
+    - name: Check registry contents on cwd miss
       canasta_registry:
         state: query_all
       register: _ri_all_instances
-      when: _pwd_lookup.failed | default(false) or _pwd_lookup.instance is not defined
+      when: _cwd_lookup.failed | default(false) or _cwd_lookup.instance is not defined
 
     - name: Fail with helpful message if no instances are registered
       ansible.builtin.fail:
@@ -94,22 +101,22 @@
           No Canasta instances are registered yet. Create one first with:
             canasta create -i <id> -w <wiki>
       when:
-        - _pwd_lookup.failed | default(false) or _pwd_lookup.instance is not defined
+        - _cwd_lookup.failed | default(false) or _cwd_lookup.instance is not defined
         - (_ri_all_instances.instances | default({})) | length == 0
 
-    - name: Fail with helpful message if PWD does not match any instance
+    - name: Fail with helpful message if cwd does not match any instance
       ansible.builtin.fail:
         msg: |-
-          No Canasta instance is registered for this directory ({{ _ri_pwd }}).
+          No Canasta instance is registered for this directory ({{ _ri_cwd }}).
           Specify --id <id>, or cd into an instance directory.
           Registered instances: {{ (_ri_all_instances.instances | default({})).keys() | list | join(', ') }}
       when:
-        - _pwd_lookup.failed | default(false) or _pwd_lookup.instance is not defined
+        - _cwd_lookup.failed | default(false) or _cwd_lookup.instance is not defined
         - (_ri_all_instances.instances | default({})) | length > 0
 
-    - name: Set PWD-resolved ID
+    - name: Set cwd-resolved ID
       ansible.builtin.set_fact:
-        _resolved_id: "{{ _pwd_lookup.instance.id }}"
+        _resolved_id: "{{ _cwd_lookup.instance.id }}"
 
 # Step 2: Single query with the resolved ID
 - name: Look up resolved instance

--- a/roles/common/tasks/resolve_instance.yml
+++ b/roles/common/tasks/resolve_instance.yml
@@ -71,11 +71,41 @@
     - id is not defined or id == ''
     - _ri_saved_host == 'localhost' and _ri_saved_conn != 'ssh'
   block:
+    - name: Determine PWD for lookup
+      ansible.builtin.set_fact:
+        _ri_pwd: "{{ lookup('env', 'CANASTA_HOST_PWD') | default(lookup('env', 'PWD'), true) }}"
+
     - name: Look up by PWD
       canasta_registry:
-        path: "{{ lookup('env', 'CANASTA_HOST_PWD') | default(lookup('env', 'PWD'), true) }}"
+        path: "{{ _ri_pwd }}"
         state: query_by_path
       register: _pwd_lookup
+      failed_when: false
+
+    - name: Check registry contents on PWD miss
+      canasta_registry:
+        state: query_all
+      register: _ri_all_instances
+      when: _pwd_lookup.failed | default(false) or _pwd_lookup.instance is not defined
+
+    - name: Fail with helpful message if no instances are registered
+      ansible.builtin.fail:
+        msg: |-
+          No Canasta instances are registered yet. Create one first with:
+            canasta create -i <id> -w <wiki>
+      when:
+        - _pwd_lookup.failed | default(false) or _pwd_lookup.instance is not defined
+        - (_ri_all_instances.instances | default({})) | length == 0
+
+    - name: Fail with helpful message if PWD does not match any instance
+      ansible.builtin.fail:
+        msg: |-
+          No Canasta instance is registered for this directory ({{ _ri_pwd }}).
+          Specify --id <id>, or cd into an instance directory.
+          Registered instances: {{ (_ri_all_instances.instances | default({})).keys() | list | join(', ') }}
+      when:
+        - _pwd_lookup.failed | default(false) or _pwd_lookup.instance is not defined
+        - (_ri_all_instances.instances | default({})) | length > 0
 
     - name: Set PWD-resolved ID
       ansible.builtin.set_fact:

--- a/roles/gitops/tasks/init.yml
+++ b/roles/gitops/tasks/init.yml
@@ -1,6 +1,26 @@
 ---
 # GitOps init — dispatches to Compose or Kubernetes variant.
 
+# `gitops init` operates on an *existing* Canasta instance: it converts
+# the instance's extensions/skins into git submodules and pushes the
+# resulting tree to a remote. Bail out early with a gitops-specific
+# message if no instance exists yet, instead of letting resolve_instance
+# emit its generic "no instance for this directory" error.
+- name: Check that at least one Canasta instance exists
+  canasta_registry:
+    state: query_all
+  register: _gitops_init_registry
+  delegate_to: localhost
+
+- name: Fail with gitops-specific guidance if no instances exist
+  ansible.builtin.fail:
+    msg: |-
+      'canasta gitops init' bootstraps gitops for an existing Canasta instance.
+      No Canasta instances are registered yet. Create one first with:
+        canasta create -i <id> -w <wiki>
+      Then run 'canasta gitops init -i <id> ...' to enable gitops on it.
+  when: _gitops_init_registry.instances | length == 0
+
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 


### PR DESCRIPTION
## Summary

Issue #450 surfaced two distinct papercuts when running `canasta gitops init` from an empty registry under canasta-docker (rootless Docker):

1. A spurious `[WARNING]: Failed to create the directory PosixPath('/home/mah/.ansible')`. Workaround `chmod 711 .` + `mkdir .ansible` did not silence it.
2. A real failure that just said `Error: No instance found for path '/home/mah'` — no hint that `gitops init` operates on an *existing* Canasta instance, or that the user's registry was empty.

## Changes

- **canasta-docker**: also set `ANSIBLE_HOME=/tmp/ansible-home` for non-root users. The existing `ANSIBLE_{LOCAL,REMOTE}_TEMP` redirects only covered the per-task scratch path; Ansible still tried to `mkdir ~/.ansible` for collections cache / retry files, which fails under rootless Docker because the in-container subuid can't write to the host home dir even though it owns the host UID.
- **roles/common/tasks/resolve_instance.yml**: when localhost PWD-based resolution misses, distinguish *registry is empty* from *registry has instances but none match this directory* and emit a helpful message in each case. Empty registry → suggest `canasta create`. Registry populated → list known IDs and suggest `--id` or cd-ing into an instance directory.
- **roles/gitops/tasks/init.yml**: gitops-specific preflight that bails out before `resolve_instance` with a message explaining that `gitops init` operates on an existing instance and pointing the user at `canasta create` first.

## Test plan

- [x] `make validate`
- [x] `make test-unit` (604 passed)
- [x] `make lint` (no new warnings)
- [ ] Manual: run `canasta gitops init` with no `conf.json` → should print the gitops-specific preflight message
- [ ] Manual: run `canasta start` with no `conf.json` → should print the empty-registry message from `resolve_instance`
- [ ] Manual: run `canasta start` from a non-instance dir with a populated registry → should print the helpful "Specify --id" message with the list of registered IDs
- [ ] Manual: run `canasta-docker` under rootless Docker with `$HOME` mode 700 → should not emit the `~/.ansible` permission warning

Closes #450