### PR TITLE
canasta install: accept --id; better gitops init preflight (closes #457)

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -545,12 +545,21 @@ commands:
       - "canasta install k8s-cp --public-ip 203.0.113.10"
       - "canasta install --host node2 k8s-worker --cp-host node1"
       - "canasta install docker git-crypt"
+      - "canasta install -i mysite git-crypt"
     playbook: install.yml
     parameters:
       - name: host
         short: H
         type: string
         description: "Target host (default: localhost)"
+      - name: id
+        short: i
+        type: string
+        description: >-
+          Canasta instance ID — install on the host where this instance
+          is registered. Mutually exclusive with --host; --host wins
+          if both are given. Useful after `canasta create` to add
+          dependencies (e.g. git-crypt) to the instance's host.
       - name: packages
         type: string
         positional: true

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -3,6 +3,16 @@
 # Accepts one or more package names: docker, k8s-cp, k8s-worker,
 # git-crypt, canasta.
 
+# When --id is given without --host, resolve the instance's registered
+# host and switch the connection to it. This lets `canasta install
+# -i mysite git-crypt` install on whichever host the instance lives on
+# without the user having to recall it.
+- name: Resolve instance host from --id
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
+  when:
+    - id is defined and id != ''
+    - target_host is not defined or target_host == '' or target_host == 'localhost'
+
 - name: Normalize package names
   ansible.builtin.set_fact:
     _install_packages: >-

--- a/roles/gitops/tasks/init_compose.yml
+++ b/roles/gitops/tasks/init_compose.yml
@@ -4,15 +4,39 @@
 # Requires: instance_path, instance_id (set by dispatcher)
 
 # --- Step 1: Validate prerequisites ---
+# git-crypt's package depends on git, so checking git-crypt covers both;
+# the `canasta install ... git-crypt` recovery path also pulls in git
+# transitively.
 - name: Check git is installed
   ansible.builtin.command:
     cmd: "git --version"
+  register: _git_check
   changed_when: false
+  ignore_errors: true
+
+- name: Fail if git is not installed
+  ansible.builtin.fail:
+    msg: >-
+      git is not installed on the gitops target host.
+      Install it with: canasta install -i {{ instance_id }} git-crypt
+      (or `canasta install -H <host> git-crypt`) — the git-crypt
+      package pulls in git as a dependency.
+  when: _git_check.rc | default(1) != 0
 
 - name: Check git-crypt is installed
   ansible.builtin.command:
     cmd: "git-crypt --version"
+  register: _gitcrypt_check
   changed_when: false
+  ignore_errors: true
+
+- name: Fail if git-crypt is not installed
+  ansible.builtin.fail:
+    msg: >-
+      git-crypt is not installed on the gitops target host.
+      Install it with: canasta install -i {{ instance_id }} git-crypt
+      (or `canasta install -H <host> git-crypt`).
+  when: _gitcrypt_check.rc | default(1) != 0
 
 # --- Step 1b: Configure git identity if provided ---
 - name: Set git user.name on target host

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -14,7 +14,18 @@
 - name: Check git is installed
   ansible.builtin.command:
     cmd: git --version
+  register: _git_check
   changed_when: false
+  ignore_errors: true
+
+- name: Fail if git is not installed
+  ansible.builtin.fail:
+    msg: >-
+      git is not installed on the gitops target host.
+      Install it with: canasta install -i {{ instance_id }} git-crypt
+      (or `canasta install -H <host> git-crypt`) — the git-crypt
+      package pulls in git as a dependency.
+  when: _git_check.rc | default(1) != 0
 
 - name: Set git user.name on target host
   ansible.builtin.command:
@@ -52,7 +63,9 @@
 - name: Fail if git-crypt not installed
   ansible.builtin.fail:
     msg: >-
-      git-crypt is not installed. Run 'canasta install git-crypt' first.
+      git-crypt is not installed on the gitops target host.
+      Install it with: canasta install -i {{ instance_id }} git-crypt
+      (or `canasta install -H <host> git-crypt`).
   when: _gitcrypt_check.rc != 0
 
 - name: Check for existing .git directory


### PR DESCRIPTION
## Summary

Issue #457 reported that `canasta gitops init` failed with a bare `Error: Error executing command.` and no further detail. Root cause: when git-crypt isn't installed on the target host, Ansible's command module emits that exact string from a hardcoded `OSError` path, and our `canasta_minimal` callback only displays `msg`. The Compose-side preflight had no `ignore_errors`/`fail` pair to substitute a friendlier message; the K8s side did but its remediation message (`canasta install git-crypt`) implied localhost.

## Changes

- **meta/command_definitions.yml**: `canasta install` now accepts `-i/--id` in addition to `-H/--host`. `--host` still wins if both are passed; `--id` derives the target host from the instance registry. New example added.
- **playbooks/install.yml**: when `--id` is given without `--host`, include `resolve_instance.yml` so the install tasks run on the instance's registered host.
- **roles/gitops/tasks/init_compose.yml**: add the check-and-fail pattern the K8s side already had for `git` / `git-crypt`. Both messages point users at `canasta install -i {{ instance_id }} git-crypt` (the git-crypt package pulls in git transitively, so a single install covers both).
- **roles/gitops/tasks/init_kubernetes.yml**: rewrite the existing git-crypt failure message to use the new `-i`/`-H` form, and add a parallel git preflight so the wording is consistent across orchestrators.

## Test plan

- [x] `make validate`
- [x] `make test-unit` (604 passed)
- [x] `make lint` (no new warnings)
- [ ] Manual: `canasta install -i <id> git-crypt` against a remote-registered instance — should SSH to the instance's host
- [ ] Manual: `canasta gitops init -i <id> ...` on a host with no git-crypt → should now print the helpful preflight message instead of "Error executing command."
- [ ] Manual: `canasta install docker` (no `-i`, no `-H`) — unchanged, still installs locally

Closes #457

## Notes

- This does **not** change the canasta_minimal callback. Surfacing `cmd`/`exception` from generic command-module failures (the broader fix I described in the issue thread) is still worth doing as a separate PR — it benefits every command, not just gitops init.