### PR TITLE
canasta_minimal: surface cmd/exception on command failures (closes #459)

### DIFF
--- a/callback_plugins/canasta_minimal.py
+++ b/callback_plugins/canasta_minimal.py
@@ -85,6 +85,8 @@ class CallbackModule(CallbackBase):
         msg = result._result.get("msg", "")
         stderr = result._result.get("stderr", "")
         stdout = result._result.get("stdout", "")
+        cmd = result._result.get("cmd", "")
+        exc = result._result.get("exception", "")
         # Suppress the generic "One or more items failed" — the individual
         # item failures were already displayed via v2_runner_item_on_failed.
         if msg == "One or more items failed":
@@ -94,9 +96,44 @@ class CallbackModule(CallbackBase):
         if stdout and msg and "non-zero return code" in msg:
             self._display.display("Error: %s" % stdout.strip(), color="red", stderr=True)
         elif msg:
-            self._display.display("Error: %s" % msg, color="red", stderr=True)
+            # Surface the command line and the underlying exception for
+            # the OSError-on-spawn path (Ansible's command/shell module
+            # emits msg="Error executing command." with empty stdout/
+            # stderr when execve fails, e.g. binary not on PATH). Without
+            # this the user sees only the opaque generic message.
+            extra = self._format_cmd_diagnostics(cmd, exc)
+            if extra:
+                self._display.display(
+                    "Error: %s%s" % (msg, extra),
+                    color="red", stderr=True,
+                )
+            else:
+                self._display.display("Error: %s" % msg, color="red", stderr=True)
         if stderr:
             self._display.display(stderr, color="red", stderr=True)
+
+    @staticmethod
+    def _format_cmd_diagnostics(cmd, exc):
+        """Render the cmd + last-line-of-exception suffix for command
+        module failures. Returns an empty string when neither is useful."""
+        parts = []
+        if cmd:
+            cmd_str = cmd if isinstance(cmd, str) else " ".join(str(c) for c in cmd)
+            cmd_str = cmd_str.strip()
+            if cmd_str:
+                parts.append("cmd: %s" % cmd_str)
+        if exc:
+            # Tracebacks are multi-line; the most actionable line is the
+            # final non-empty one (e.g. "FileNotFoundError: [Errno 2] No
+            # such file or directory: 'git-crypt'").
+            for line in reversed(str(exc).splitlines()):
+                line = line.strip()
+                if line:
+                    parts.append(line)
+                    break
+        if not parts:
+            return ""
+        return " (%s)" % "; ".join(parts)
 
     def v2_runner_item_on_failed(self, result):
         # Display the specific item's failure message (e.g., missing

--- a/tests/unit/test_canasta_minimal_callback.py
+++ b/tests/unit/test_canasta_minimal_callback.py
@@ -1,0 +1,119 @@
+"""Tests for the canasta_minimal Ansible stdout callback."""
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+sys.path.insert(0, REPO_ROOT)
+sys.path.insert(0, os.path.join(REPO_ROOT, "callback_plugins"))
+
+import canasta_minimal  # noqa: E402
+
+
+def _make_callback():
+    cb = canasta_minimal.CallbackModule()
+    captured = []
+
+    class _Display:
+        def display(self, msg, color=None, stderr=False):
+            captured.append((msg, color, stderr))
+
+    cb._display = _Display()
+    cb._captured = captured
+    return cb
+
+
+def _result(**fields):
+    return SimpleNamespace(_result=dict(fields))
+
+
+class TestFormatCmdDiagnostics:
+    def test_empty(self):
+        assert canasta_minimal.CallbackModule._format_cmd_diagnostics("", "") == ""
+
+    def test_cmd_only_string(self):
+        out = canasta_minimal.CallbackModule._format_cmd_diagnostics(
+            "git-crypt --version", ""
+        )
+        assert out == " (cmd: git-crypt --version)"
+
+    def test_cmd_only_list(self):
+        out = canasta_minimal.CallbackModule._format_cmd_diagnostics(
+            ["git-crypt", "--version"], ""
+        )
+        assert out == " (cmd: git-crypt --version)"
+
+    def test_exception_picks_last_meaningful_line(self):
+        tb = (
+            "Traceback (most recent call last):\n"
+            "  File \"/x.py\", line 1, in <module>\n"
+            "    subprocess.run([\"git-crypt\"])\n"
+            "FileNotFoundError: [Errno 2] No such file: 'git-crypt'\n"
+            "\n"  # trailing blank line — must be skipped
+        )
+        out = canasta_minimal.CallbackModule._format_cmd_diagnostics("", tb)
+        assert out == (
+            " (FileNotFoundError: [Errno 2] No such file: 'git-crypt')"
+        )
+
+    def test_cmd_and_exception_combined(self):
+        out = canasta_minimal.CallbackModule._format_cmd_diagnostics(
+            ["git-crypt", "--version"],
+            "FileNotFoundError: [Errno 2] No such file: 'git-crypt'",
+        )
+        assert out == (
+            " (cmd: git-crypt --version; "
+            "FileNotFoundError: [Errno 2] No such file: 'git-crypt')"
+        )
+
+
+class TestRunnerOnFailed:
+    def test_oserror_on_spawn_surfaces_cmd_and_exception(self):
+        cb = _make_callback()
+        cb.v2_runner_on_failed(_result(
+            msg="Error executing command.",
+            cmd=["git-crypt", "--version"],
+            exception=(
+                "Traceback (most recent call last):\n"
+                "FileNotFoundError: [Errno 2] No such file: 'git-crypt'"
+            ),
+            stdout="",
+            stderr="",
+        ))
+        msgs = [m for (m, _, _) in cb._captured]
+        assert any("Error executing command." in m for m in msgs)
+        assert any("cmd: git-crypt --version" in m for m in msgs)
+        assert any("FileNotFoundError" in m for m in msgs)
+
+    def test_nonzero_return_code_path_unchanged(self):
+        cb = _make_callback()
+        cb.v2_runner_on_failed(_result(
+            msg="non-zero return code",
+            stdout="something failed on stdout",
+            stderr="",
+            cmd=["foo"],
+        ))
+        msgs = [m for (m, _, _) in cb._captured]
+        assert msgs == ["Error: something failed on stdout"]
+
+    def test_plain_msg_without_cmd_unchanged(self):
+        cb = _make_callback()
+        cb.v2_runner_on_failed(_result(msg="plain failure"))
+        msgs = [m for (m, _, _) in cb._captured]
+        assert msgs == ["Error: plain failure"]
+
+    def test_ignore_errors_suppresses_output(self):
+        cb = _make_callback()
+        cb.v2_runner_on_failed(
+            _result(msg="Error executing command.", cmd=["x"]),
+            ignore_errors=True,
+        )
+        assert cb._captured == []
+
+    def test_one_or_more_items_failed_still_suppressed(self):
+        cb = _make_callback()
+        cb.v2_runner_on_failed(_result(msg="One or more items failed"))
+        assert cb._captured == []


### PR DESCRIPTION
## Summary

Issue #459 (follow-up to #457): the `canasta_minimal` Ansible stdout callback only displayed the `msg` field on failure, dropping `cmd` and `exception`. For the `Error executing command.` path (Ansible's `module_utils/basic.py:2132`, which fires on `OSError`/`ENOENT` from `subprocess.Popen`), this leaves users staring at an opaque message with no indication of which command failed or why.

## Changes

- **callback_plugins/canasta_minimal.py**: `v2_runner_on_failed` now appends `(cmd: <command>; <last line of exception>)` when those fields are present in the failure result. New `_format_cmd_diagnostics` helper handles both list and string `cmd` formats and the empty cases.
- **tests/unit/test_canasta_minimal_callback.py**: 10 new unit tests covering the OSError-on-spawn path, the existing "non-zero return code" path (unchanged), the plain-msg path, `ignore_errors` suppression, and the `_format_cmd_diagnostics` helper.

## Effect

A failure that previously read:
```
Error: Error executing command.
```

now reads:
```
Error: Error executing command. (cmd: git-crypt --version; FileNotFoundError: [Errno 2] No such file: 'git-crypt')
```

This generalizes — any command-module failure now self-describes, not just gitops init.

## Test plan

- [x] `make test-unit` (614 passed, 10 new)
- [x] `make validate`
- [x] `make lint` (no new warnings)
- [ ] Manual: run any command that fails to spawn a missing binary and verify the cmd + exception are shown

Closes #459