### PR TITLE
Add remote regression test for config set + restart (closes #463)

### DIFF
--- a/tests/integration/remote/run_tests.sh
+++ b/tests/integration/remote/run_tests.sh
@@ -177,8 +177,49 @@ else
 fi
 echo ""
 
-# --- Test 6: Delete without -H (resolved from registry) ---
-echo "Test 6: canasta delete without -H"
+# --- Test 6: config set with restart against remote (multi-resolve_instance) ---
+# Regression coverage for the "delegate_to: localhost after switch_connection
+# leaks the SSH connection" failure mode that 0d392a6 (resolve_instance) and
+# b7d3ed2 (delete deregistration) originally fixed by replacing delegate_to
+# with a save/switch/restore-connection dance. `canasta config set` without
+# --no-restart is the simplest remote command that calls resolve_instance.yml
+# twice in one play: once at the top of set.yml, then again from the restart
+# it triggers at the end. The second call inherits ansible_connection=ssh
+# from the first switch_connection.yml, and any future regression to bare
+# delegate_to would route the registry lookup to the remote host instead of
+# the controller. Symptoms: command exits non-zero, controller registry is
+# corrupted, or the remote .env never reflects the change. The three
+# assertions below catch each symptom independently.
+echo "Test 6: canasta config set with restart against remote"
+NEW_PHPVAR=2000
+if canasta config set -i "${INSTANCE_ID}" "PHP_MAX_INPUT_VARS=${NEW_PHPVAR}" 2>&1; then
+    pass "config set with restart succeeds"
+else
+    fail "config set with restart failed (regression in resolve_instance multi-call path)"
+fi
+
+LIST_OUTPUT=$(canasta list 2>&1) || true
+if echo "${LIST_OUTPUT}" | grep -q "${INSTANCE_ID}"; then
+    pass "registry still has instance after config set + restart"
+else
+    fail "registry lost instance after config set + restart (output: ${LIST_OUTPUT})"
+fi
+
+ENV_VALUE=$(ssh -F "${SSH_CONFIG}" "${REMOTE_HOST}" \
+    "grep '^PHP_MAX_INPUT_VARS=' '${CANASTA_TEST_DATA}/${INSTANCE_ID}/.env'" \
+    2>/dev/null | tail -n 1 | cut -d= -f2 | tr -d '\r\n ') || true
+if [ "${ENV_VALUE}" = "${NEW_PHPVAR}" ]; then
+    pass "remote .env reflects new PHP_MAX_INPUT_VARS"
+else
+    fail "remote .env PHP_MAX_INPUT_VARS is '${ENV_VALUE}' (expected ${NEW_PHPVAR})"
+fi
+echo ""
+
+# --- Test 7: Delete without -H (resolved from registry) ---
+# Also exercises the controller-deregistration path b7d3ed2 fixed.
+# If the registry write inside delete is routed to the remote (regression),
+# Test 8's `canasta list` will still show the instance.
+echo "Test 7: canasta delete without -H"
 if canasta delete -i "${INSTANCE_ID}" -y 2>&1; then
     pass "delete without -H"
 else
@@ -186,8 +227,8 @@ else
 fi
 echo ""
 
-# --- Test 7: List (verify empty) ---
-echo "Test 7: canasta list (should be empty)"
+# --- Test 8: List (verify empty) ---
+echo "Test 8: canasta list (should be empty)"
 LIST_OUTPUT=$(canasta list 2>&1) || true
 if echo "${LIST_OUTPUT}" | grep -q "${INSTANCE_ID}"; then
     fail "list still shows deleted instance (output: ${LIST_OUTPUT})"

--- a/tests/integration/remote/setup.sh
+++ b/tests/integration/remote/setup.sh
@@ -35,9 +35,14 @@ docker compose -f "${SCRIPT_DIR}/docker-compose.yml" -f "${OVERRIDE}" up -d --bu
 # Change testuser's home to the shared data path so sshd finds authorized_keys
 docker exec "${CONTAINER_NAME}" usermod -d "${CANASTA_TEST_DATA}" testuser
 
-# Create .ssh directory in the shared data path
+# Create .ssh directory in the shared data path. Also chown the parent
+# itself to testuser, otherwise sshd's StrictModes rejects the login
+# whenever the host-side user running these tests has a UID different
+# from testuser's container UID (1001) — the bind-mount preserves
+# numeric ownership, so e.g. host UID 1000 shows up inside the
+# container as a non-testuser owner of testuser's home directory.
 docker exec "${CONTAINER_NAME}" bash -c \
-    "mkdir -p ${CANASTA_TEST_DATA}/.ssh && chmod 700 ${CANASTA_TEST_DATA}/.ssh && chown testuser:testuser ${CANASTA_TEST_DATA}/.ssh"
+    "mkdir -p ${CANASTA_TEST_DATA}/.ssh && chmod 700 ${CANASTA_TEST_DATA}/.ssh && chown testuser:testuser ${CANASTA_TEST_DATA}/.ssh ${CANASTA_TEST_DATA}"
 
 # Create canasta config directory
 docker exec "${CONTAINER_NAME}" bash -c \


### PR DESCRIPTION
## Summary

Adds the regression test described in #463 to `tests/integration/remote/run_tests.sh`. Before this PR, no automated test exercised the multi-call \`resolve_instance.yml\` path that 0d392a6 and b7d3ed2 fixed — every existing \`canasta config set\` integration call passes \`--no-restart\` to skip the restart that triggers the second \`resolve_instance\`.

## Test added (Test 6)

\`canasta config set -i <id> PHP_MAX_INPUT_VARS=2000\` against the mock SSH host (no \`--no-restart\`, no \`-H\`). Three independent assertions:

1. command exits 0
2. controller's registry still has the instance afterwards (catches registry-write-routed-to-remote)
3. remote .env reflects the new value (catches restart never actually applying)

\`PHP_MAX_INPUT_VARS\` is chosen because it has no side-effect cascade — a clean write + restart, nothing else.

Existing Tests 6/7 (delete + post-delete list) renumbered to 7/8.

## Caveat

The remote-integration job is gated to \`github.event_name != 'pull_request'\` (workflows/tests.yml:203, ref #67), so this test runs on push-to-main, not on PRs. That's a separate workflow concern but worth noting: this PR provides regression coverage on merge, not pre-merge.

## Test plan

- [x] \`make test-unit\` (617 passed)
- [x] \`make validate\`
- [x] \`make lint\`
- [x] \`bash -n tests/integration/remote/run_tests.sh\` (syntax)
- [ ] Manual: run the remote suite locally on a Linux host with Docker — verify Test 6 passes against current main
- [ ] Manual: apply PR #449 on top of this branch and re-run — verify Test 6 fails (confirming the test catches the historical regression)

Closes #463