### PR TITLE
Robustify resolve_instance and delete connection-state dance (closes #426)

### DIFF
--- a/roles/common/tasks/resolve_instance.yml
+++ b/roles/common/tasks/resolve_instance.yml
@@ -17,120 +17,131 @@
 # Input: id (optional)
 # Output: instance_id, instance_path, instance_orchestrator,
 #   instance_devmode, instance_managed_cluster
+#
+# Implementation note: this file uses a save/switch/restore dance on
+# ansible_host/ansible_connection because the alternative
+# `delegate_to: localhost` + `vars: { ansible_connection: local }`
+# does NOT reliably override connection state previously set via
+# set_fact (e.g. when this file is included a second time after
+# switch_connection.yml has set ansible_connection=ssh on the play
+# host). See commits 0d392a6 and b7d3ed2 for the original incidents
+# this is guarding against. Save the inbound state into a single dict
+# (so a future field addition can't drift) and restore it inside an
+# `always:` (so a registry-task failure cannot leave the play stuck
+# in the switched state).
 
-# Save current connection state so we can restore after registry queries.
-# This is needed because resolve_instance may be called after
-# switch_connection.yml has set ansible_connection to ssh.
 - name: Save connection state before registry queries
   ansible.builtin.set_fact:
-    _ri_saved_host: "{{ ansible_host | default('localhost') }}"
-    _ri_saved_conn: "{{ ansible_connection | default('local') }}"
-    _ri_saved_user: "{{ ansible_user | default('') }}"
-    _ri_saved_python: "{{ ansible_python_interpreter | default(ansible_playbook_python) }}"
+    _ri_saved:
+      host: "{{ ansible_host | default('localhost') }}"
+      conn: "{{ ansible_connection | default('local') }}"
+      user: "{{ ansible_user | default('') }}"
+      python: "{{ ansible_python_interpreter | default(ansible_playbook_python) }}"
 
-- name: Switch to local for registry queries
-  ansible.builtin.set_fact:
-    ansible_host: "localhost"
-    ansible_connection: "local"
-    ansible_user: ""
-    ansible_python_interpreter: "{{ ansible_playbook_python }}"
-
-# Step 1: Determine which ID to look up
-- name: Use provided ID
-  ansible.builtin.set_fact:
-    _resolved_id: "{{ id }}"
-  when: id is defined and id != ''
-
-- name: Resolve ID from host (remote, no ID)
-  when:
-    - id is not defined or id == ''
-    - _ri_saved_host != 'localhost' or _ri_saved_conn == 'ssh'
-  block:
-    - name: Query instances on this host
-      canasta_registry:
-        state: query_all
-        filter_host: "{{ _ri_saved_host }}"
-      register: _host_instances
-
-    - name: Fail if no instances on this host
-      ansible.builtin.fail:
-        msg: >-
-          No Canasta instances registered on
-          '{{ _ri_saved_host }}'.
-      when: _host_instances.instances | length == 0
-
-    - name: Fail if multiple instances on this host
-      ansible.builtin.fail:
-        msg: >-
-          Multiple instances on '{{ _ri_saved_host }}'.
-          Specify --id:
-          {{ _host_instances.instances.keys()
-             | list | join(', ') }}
-      when: _host_instances.instances | length > 1
-
-    - name: Set auto-resolved ID
+- block:
+    - name: Switch to local for registry queries
       ansible.builtin.set_fact:
-        _resolved_id: "{{ (_host_instances.instances | dict2items | first).key }}"
-      when: _host_instances.instances | length == 1
+        ansible_host: "localhost"
+        ansible_connection: "local"
+        ansible_user: ""
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
-- name: Resolve ID from working directory (localhost)
-  when:
-    - id is not defined or id == ''
-    - _ri_saved_host == 'localhost' and _ri_saved_conn != 'ssh'
-  block:
-    - name: Determine current working directory for lookup
+    # Step 1: Determine which ID to look up
+    - name: Use provided ID
       ansible.builtin.set_fact:
-        _ri_cwd: "{{ lookup('env', 'CANASTA_HOST_PWD') | default(lookup('env', 'PWD'), true) }}"
+        _resolved_id: "{{ id }}"
+      when: id is defined and id != ''
 
-    - name: Look up by current working directory
-      canasta_registry:
-        path: "{{ _ri_cwd }}"
-        state: query_by_path
-      register: _cwd_lookup
-      failed_when: false
-
-    - name: Check registry contents on cwd miss
-      canasta_registry:
-        state: query_all
-      register: _ri_all_instances
-      when: _cwd_lookup.failed | default(false) or _cwd_lookup.instance is not defined
-
-    - name: Fail with helpful message if no instances are registered
-      ansible.builtin.fail:
-        msg: |-
-          No Canasta instances are registered yet. Create one first with:
-            canasta create -i <id> -w <wiki>
+    - name: Resolve ID from host (remote, no ID)
       when:
-        - _cwd_lookup.failed | default(false) or _cwd_lookup.instance is not defined
-        - (_ri_all_instances.instances | default({})) | length == 0
+        - id is not defined or id == ''
+        - _ri_saved.host != 'localhost' or _ri_saved.conn == 'ssh'
+      block:
+        - name: Query instances on this host
+          canasta_registry:
+            state: query_all
+            filter_host: "{{ _ri_saved.host }}"
+          register: _host_instances
 
-    - name: Fail with helpful message if cwd does not match any instance
-      ansible.builtin.fail:
-        msg: |-
-          No Canasta instance is registered for this directory ({{ _ri_cwd }}).
-          Specify --id <id>, or cd into an instance directory.
-          Registered instances: {{ (_ri_all_instances.instances | default({})).keys() | list | join(', ') }}
+        - name: Fail if no instances on this host
+          ansible.builtin.fail:
+            msg: >-
+              No Canasta instances registered on
+              '{{ _ri_saved.host }}'.
+          when: _host_instances.instances | length == 0
+
+        - name: Fail if multiple instances on this host
+          ansible.builtin.fail:
+            msg: >-
+              Multiple instances on '{{ _ri_saved.host }}'.
+              Specify --id:
+              {{ _host_instances.instances.keys()
+                 | list | join(', ') }}
+          when: _host_instances.instances | length > 1
+
+        - name: Set auto-resolved ID
+          ansible.builtin.set_fact:
+            _resolved_id: "{{ (_host_instances.instances | dict2items | first).key }}"
+          when: _host_instances.instances | length == 1
+
+    - name: Resolve ID from working directory (localhost)
       when:
-        - _cwd_lookup.failed | default(false) or _cwd_lookup.instance is not defined
-        - (_ri_all_instances.instances | default({})) | length > 0
+        - id is not defined or id == ''
+        - _ri_saved.host == 'localhost' and _ri_saved.conn != 'ssh'
+      block:
+        - name: Determine current working directory for lookup
+          ansible.builtin.set_fact:
+            _ri_cwd: "{{ lookup('env', 'CANASTA_HOST_PWD') | default(lookup('env', 'PWD'), true) }}"
 
-    - name: Set cwd-resolved ID
+        - name: Look up by current working directory
+          canasta_registry:
+            path: "{{ _ri_cwd }}"
+            state: query_by_path
+          register: _cwd_lookup
+          failed_when: false
+
+        - name: Check registry contents on cwd miss
+          canasta_registry:
+            state: query_all
+          register: _ri_all_instances
+          when: _cwd_lookup.failed | default(false) or _cwd_lookup.instance is not defined
+
+        - name: Fail with helpful message if no instances are registered
+          ansible.builtin.fail:
+            msg: |-
+              No Canasta instances are registered yet. Create one first with:
+                canasta create -i <id> -w <wiki>
+          when:
+            - _cwd_lookup.failed | default(false) or _cwd_lookup.instance is not defined
+            - (_ri_all_instances.instances | default({})) | length == 0
+
+        - name: Fail with helpful message if cwd does not match any instance
+          ansible.builtin.fail:
+            msg: |-
+              No Canasta instance is registered for this directory ({{ _ri_cwd }}).
+              Specify --id <id>, or cd into an instance directory.
+              Registered instances: {{ (_ri_all_instances.instances | default({})).keys() | list | join(', ') }}
+          when:
+            - _cwd_lookup.failed | default(false) or _cwd_lookup.instance is not defined
+            - (_ri_all_instances.instances | default({})) | length > 0
+
+        - name: Set cwd-resolved ID
+          ansible.builtin.set_fact:
+            _resolved_id: "{{ _cwd_lookup.instance.id }}"
+
+    # Step 2: Single query with the resolved ID
+    - name: Look up resolved instance
+      canasta_registry:
+        id: "{{ _resolved_id }}"
+        state: query
+      register: _instance_result
+  always:
+    - name: Restore connection state after registry queries
       ansible.builtin.set_fact:
-        _resolved_id: "{{ _cwd_lookup.instance.id }}"
-
-# Step 2: Single query with the resolved ID
-- name: Look up resolved instance
-  canasta_registry:
-    id: "{{ _resolved_id }}"
-    state: query
-  register: _instance_result
-
-- name: Restore connection state after registry queries
-  ansible.builtin.set_fact:
-    ansible_host: "{{ _ri_saved_host }}"
-    ansible_connection: "{{ _ri_saved_conn }}"
-    ansible_user: "{{ _ri_saved_user }}"
-    ansible_python_interpreter: "{{ _ri_saved_python }}"
+        ansible_host: "{{ _ri_saved.host }}"
+        ansible_connection: "{{ _ri_saved.conn }}"
+        ansible_user: "{{ _ri_saved.user }}"
+        ansible_python_interpreter: "{{ _ri_saved.python }}"
 
 - name: Set instance facts
   ansible.builtin.set_fact:

--- a/roles/delete/tasks/main.yml
+++ b/roles/delete/tasks/main.yml
@@ -223,28 +223,38 @@
     - not (_inst_dir.stat.exists | default(false))
     - _instance_registered | default(false) | bool
   block:
-    - name: Switch to local for controller deregistration
+    # Save inbound connection state into one dict, switch + deregister
+    # inside a block so an `always:` restore fires even if the registry
+    # write fails. See resolve_instance.yml for the full rationale and
+    # commits 0d392a6 / b7d3ed2 for why delegate_to: localhost is not a
+    # safe substitute here.
+    - name: Save connection state before controller deregistration
       ansible.builtin.set_fact:
-        _saved_host: "{{ ansible_host | default('localhost') }}"
-        _saved_conn: "{{ ansible_connection | default('local') }}"
-        _saved_user: "{{ ansible_user | default('') }}"
-        _saved_python: "{{ ansible_python_interpreter | default('auto') }}"
-        ansible_host: "localhost"
-        ansible_connection: "local"
-        ansible_user: ""
-        ansible_python_interpreter: "{{ ansible_playbook_python }}"
+        _del_saved:
+          host: "{{ ansible_host | default('localhost') }}"
+          conn: "{{ ansible_connection | default('local') }}"
+          user: "{{ ansible_user | default('') }}"
+          python: "{{ ansible_python_interpreter | default('auto') }}"
 
-    - name: Deregister already-removed instance from controller
-      canasta_registry:
-        id: "{{ instance_id }}"
-        state: absent
+    - block:
+        - name: Switch to local for controller deregistration
+          ansible.builtin.set_fact:
+            ansible_host: "localhost"
+            ansible_connection: "local"
+            ansible_user: ""
+            ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
-    - name: Restore connection for target deregistration
-      ansible.builtin.set_fact:
-        ansible_host: "{{ _saved_host }}"
-        ansible_connection: "{{ _saved_conn }}"
-        ansible_user: "{{ _saved_user }}"
-        ansible_python_interpreter: "{{ _saved_python }}"
+        - name: Deregister already-removed instance from controller
+          canasta_registry:
+            id: "{{ instance_id }}"
+            state: absent
+      always:
+        - name: Restore connection for target deregistration
+          ansible.builtin.set_fact:
+            ansible_host: "{{ _del_saved.host }}"
+            ansible_connection: "{{ _del_saved.conn }}"
+            ansible_user: "{{ _del_saved.user }}"
+            ansible_python_interpreter: "{{ _del_saved.python }}"
 
     - name: Deregister already-removed instance from target host
       canasta_registry:
@@ -263,28 +273,33 @@
 # if subsequent cleanup steps fail (e.g., directory already gone from
 # a previous partial delete). Better to have an orphaned directory
 # than an orphaned registry entry.
-- name: Temporarily switch to local for controller deregistration
+- name: Save connection state before controller deregistration
   ansible.builtin.set_fact:
-    _saved_ansible_host: "{{ ansible_host | default('localhost') }}"
-    _saved_ansible_connection: "{{ ansible_connection | default('local') }}"
-    _saved_ansible_user: "{{ ansible_user | default('') }}"
-    _saved_ansible_python: "{{ ansible_python_interpreter | default('auto') }}"
-    ansible_host: "localhost"
-    ansible_connection: "local"
-    ansible_user: ""
-    ansible_python_interpreter: "{{ ansible_playbook_python }}"
+    _del_saved:
+      host: "{{ ansible_host | default('localhost') }}"
+      conn: "{{ ansible_connection | default('local') }}"
+      user: "{{ ansible_user | default('') }}"
+      python: "{{ ansible_python_interpreter | default('auto') }}"
 
-- name: Deregister instance from controller
-  canasta_registry:
-    id: "{{ instance_id }}"
-    state: absent
+- block:
+    - name: Switch to local for controller deregistration
+      ansible.builtin.set_fact:
+        ansible_host: "localhost"
+        ansible_connection: "local"
+        ansible_user: ""
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
-- name: Restore connection after controller deregistration
-  ansible.builtin.set_fact:
-    ansible_host: "{{ _saved_ansible_host }}"
-    ansible_connection: "{{ _saved_ansible_connection }}"
-    ansible_user: "{{ _saved_ansible_user }}"
-    ansible_python_interpreter: "{{ _saved_ansible_python }}"
+    - name: Deregister instance from controller
+      canasta_registry:
+        id: "{{ instance_id }}"
+        state: absent
+  always:
+    - name: Restore connection after controller deregistration
+      ansible.builtin.set_fact:
+        ansible_host: "{{ _del_saved.host }}"
+        ansible_connection: "{{ _del_saved.conn }}"
+        ansible_user: "{{ _del_saved.user }}"
+        ansible_python_interpreter: "{{ _del_saved.python }}"
 
 - name: Deregister instance from target host
   canasta_registry:


### PR DESCRIPTION
## Summary

Issue #426 raised two valid concerns about the existing save/switch/restore-connection pattern:

1. **Failure between save and restore** leaves the play stuck in the switched state.
2. **Save and restore lists must mirror exactly** — any new field added to one but not the other drifts silently.

#449 attempted to fix these by replacing the pattern with `delegate_to: localhost` + `vars: { ansible_connection: local }`, but #464's regression test demonstrates that approach reintroduces the historical b7d3ed2 bug (delete deregistration routes to the remote host, leaving the controller's `conf.json` stale).

This PR addresses #426's two concerns *without* abandoning the working save/switch/restore pattern.

## Changes

- **roles/common/tasks/resolve_instance.yml**: collapse the four parallel `_ri_saved_*` set_facts into a single `_ri_saved` dict (no more parallel lists to drift). Wrap the switch + queries in a `block:` with the restore in `always:` (Ansible runs `always:` even when block tasks fail, so a registry-task failure can no longer leave the play in the switched state). Add a header comment documenting why `delegate_to: localhost` is not a safe substitute, with pointers to the original incidents (0d392a6, b7d3ed2).
- **roles/delete/tasks/main.yml**: same treatment for both deregistration sites — the already-removed branch and the post-stop controller deregistration. Both now use a `_del_saved` dict and `block`/`always:`.

## Empirical verification

Built on top of #464 and run against the remote-integration suite on `acknowledge.wiki`:

```
Tests run: 10
Passed:    10
Failed:    0
```

For comparison, #449's `delegate_to`-based simplification scored 9/10 on the same suite, with Test 8 (post-delete `canasta list`) failing exactly the way b7d3ed2 originally fixed.

## Test plan

- [x] `make test-unit` (617 passed)
- [x] `make validate`
- [x] `make lint` (no new warnings beyond two pre-existing line-length notes on lines I changed)
- [x] Remote integration suite (`tests/integration/remote/run_tests.sh`) on `acknowledge.wiki` — 10/10 pass
- [ ] Land #464 (regression test) first so the test gates this on push-to-main going forward

## Notes

- This PR depends on #464 for the regression test, but only structurally — the refactor itself is independent. If preferred, this can land first and #464 can rebase on top.
- #449 should be closed once this lands. The empirical evidence is captured in a comment on #449.

Closes #426