### PR TITLE
Hexmode UX batch: required_unless help, drop --yes hints, doctor -i

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -177,6 +177,14 @@ def add_params_to_parser(parser, params):
         if param.get("sensitive") and "auto-generated" not in desc:
             desc += " (auto-generated if not provided)"
 
+        # Surface required_unless in --help output so the user sees the
+        # conditional requirement before they run the command. argparse
+        # has no native expression for "X is required unless Y is set",
+        # so we encode the constraint in the description.
+        ru = param.get("required_unless")
+        if ru and "(required unless" not in desc:
+            desc += " (required unless --%s is provided)" % ru.replace("_", "-")
+
         long_name = param.get("long", name)
         flag_name = "--" + long_name.replace("_", "-")
         flags = [flag_name]
@@ -903,6 +911,27 @@ def main():
     # Normalize orchestrator alias: k8s → kubernetes.
     if getattr(args, "orchestrator", None) == "k8s":
         args.orchestrator = "kubernetes"
+
+    # Validate required_unless parameters early, before spinning up
+    # Ansible. Mirrors the check in roles/common/tasks/validate_params.yml
+    # so the user sees the same message at parse time instead of waiting
+    # for the playbook to load.
+    for param in cmd_def.get("parameters", []):
+        ru = param.get("required_unless")
+        if not ru:
+            continue
+        own_value = getattr(args, param["name"], None)
+        other_value = getattr(args, ru, None)
+        if not own_value and not other_value:
+            print(
+                "Error: --%s is required unless --%s is provided"
+                % (
+                    param["name"].replace("_", "-"),
+                    ru.replace("_", "-"),
+                ),
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     # Validate orchestrator-specific parameters.
     # If a parameter has orchestrator_only set, reject it when the user

--- a/direct_commands.py
+++ b/direct_commands.py
@@ -1662,6 +1662,32 @@ def _parse_doctor(stdout, hostname):
 @register("doctor")
 def cmd_doctor(args):
     host = getattr(args, "host", None)
+    inst_id = getattr(args, "id", None)
+    # When the caller doesn't pin a host explicitly, derive it from the
+    # registry: --id wins, then cwd-match, then fall back to localhost.
+    # Matches the "instance-aware default" behavior of `canasta status`,
+    # `version`, and other direct commands so users in an instance
+    # directory get its host checked instead of theirs.
+    if not host:
+        conf_path = os.path.join(_get_config_dir(), "conf.json")
+        instances = _read_registry(conf_path)
+        if inst_id:
+            if inst_id not in instances:
+                print(
+                    "Error: Instance '%s' not found in registry" % inst_id,
+                    file=sys.stderr,
+                )
+                return 1
+            host = instances[inst_id].get("host") or "localhost"
+        else:
+            cwd = os.path.abspath(
+                os.environ.get("CANASTA_HOST_PWD") or os.getcwd()
+            )
+            for inst in instances.values():
+                p = inst.get("path", "")
+                if p and os.path.abspath(p) == cwd:
+                    host = inst.get("host") or "localhost"
+                    break
     script = _DOCTOR_SCRIPT % {"delim": _SENTINEL}
 
     if not host or host == "localhost":

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -503,12 +503,20 @@ commands:
     examples:
       - "canasta doctor"
       - "canasta doctor --host prod1.example.com"
+      - "canasta doctor -i mysite"
     direct_only: true
     parameters:
       - name: host
         short: H
         type: string
         description: "Target host (default: localhost)"
+      - name: id
+        short: i
+        type: string
+        description: >-
+          Canasta instance ID — check the host where this instance is
+          registered. Mutually exclusive with --host; --host wins if
+          both are given.
 
   - name: install
     description: "Install dependencies on the target host"

--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -22,7 +22,7 @@
       Instance '{{ id }}' already exists in the registry
       (path: {{ _pre_check.instance.path }},
       host: {{ _pre_check.instance.host | default('localhost') }}).
-      Run 'canasta delete --id {{ id }} --yes' to remove it first.
+      Run 'canasta delete --id {{ id }}' to remove it first.
   when: _pre_check is succeeded
 
 - name: Create Canasta instance

--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -95,7 +95,7 @@
       Instance '{{ id }}' already exists in the registry
       (path: {{ _existing.instance.path }},
       host: {{ _existing.instance.host | default('localhost') }}).
-      Run 'canasta delete --id {{ id }} --yes' to remove it first.
+      Run 'canasta delete --id {{ id }}' to remove it first.
   when: _existing is succeeded
 
 # --- Stale-state check (issue #391) ---

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -183,9 +183,10 @@ class TestCwdResolutionFootnote:
         assert "matching the current directory" in page
 
     def test_command_without_id_param_has_no_footnote(self):
-        # doctor has no -i at all; don't accidentally emit the
-        # footnote via some bug unrelated to the -i param.
-        page = self._page_for("doctor")
+        # `canasta list` has no -i at all; don't accidentally emit the
+        # footnote via some bug unrelated to the -i param. (Picked
+        # over `doctor` after #461 added an -i flag there.)
+        page = self._page_for("list")
         assert "matching the current directory" not in page
 
 


### PR DESCRIPTION
## Summary

Three small UX bugs reported by hexmode while onboarding gitops, all fixed in separate commits.

### #452 — \`canasta create\` should say \`--wiki\` is required

\`canasta create -h\` showed \`[-w WIKI]\` (optional) even though \`-w\` is required unless \`-f\`/\`--yamlfile\` is provided. The constraint was only enforced post-spin-up by Ansible's validate_params.yml.

- \`canasta.py\` \`add_params_to_parser\` appends "(required unless \`--<other>\` provided)" to any \`required_unless\` parameter's description, so it shows up in \`--help\`.
- \`canasta.py\` \`main\` validates \`required_unless\` before launching Ansible, so users get the same error at parse time instead of waiting for the playbook.

### #456 — Don't suggest \`--yes\` in error hints

Per hexmode's policy point: error messages shouldn't steer users at safety-bypass flags. The two copies of the "instance already exists" hint (\`roles/create/tasks/main.yml\`, \`playbooks/create.yml\`) now suggest \`canasta delete --id X\` without \`--yes\`. Users can opt in themselves.

### #461 — \`canasta doctor\` should accept \`-i\`

\`canasta doctor -i mwstake\` was rejected with "unrecognized arguments". Bring doctor in line with \`canasta status\` and \`canasta version\`: \`-i\` selects an instance, and no-args invocation also auto-resolves from cwd before falling back to localhost.

- \`meta/command_definitions.yml\`: add \`id\` parameter to doctor.
- \`direct_commands.py\`: in \`cmd_doctor\`, derive host from registry when --host isn't given (--id → cwd-match → localhost).
- \`tests/unit/test_wiki_publish.py\`: update the "no -i = no footnote" test to use \`canasta list\` instead of \`canasta doctor\` (which now has -i).

## Test plan

- [x] \`make test-unit\` (617 passed)
- [x] \`make validate\`
- [x] \`make lint\` (no new warnings)
- [x] Manual: \`canasta create -h\` shows "(required unless --yamlfile is provided)" on \`-w\`
- [x] Manual: \`canasta create -i mwstake -n mwstake.org\` errors immediately with "Error: --wiki is required unless --yamlfile is provided"
- [x] Manual: \`canasta doctor -h\` lists \`-i ID\`
- [x] Manual: \`canasta doctor -i nonexistent\` errors with "Instance 'nonexistent' not found in registry"

Closes #452, #456, #461