### PR TITLE
maintenance script/extension: list available items when no args given (closes #444)

### DIFF
--- a/roles/maintenance/tasks/extension.yml
+++ b/roles/maintenance/tasks/extension.yml
@@ -1,26 +1,48 @@
 ---
 # canasta maintenance extension - Run extension maintenance scripts.
-# Input: id (optional), wiki (optional), script_args (str)
+# Input: id (optional), wiki (optional), script_args (str, optional —
+#   when empty, lists extensions that have a maintenance/ directory).
 
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
-- name: Validate extension script path
-  ansible.builtin.fail:
-    msg: "Invalid script path '{{ script_args }}'. Must match pattern: alphanumeric, slashes, dots, hyphens, colons."
-  when: script_args | regex_search('[^a-zA-Z0-9/_. :-]') is not none
+- name: List extensions with maintenance scripts when no args given
+  when: (script_args | default('') | trim) == ''
+  block:
+    - name: Probe extensions/*/maintenance directories
+      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+      vars:
+        exec_service: web
+        exec_command: >-
+          find extensions -mindepth 2 -maxdepth 2 -type d -name maintenance
+          2>/dev/null
+          | sed -e 's|^extensions/||' -e 's|/maintenance$||'
+          | sort
 
-- name: Build extension script command
-  ansible.builtin.set_fact:
-    _ext_cmd: "php extensions/{{ script_args }}{{ ((wiki | default('')) != '') | ternary(' --wiki=' + (wiki | default('')), '') }}"
+    - name: Display extension list
+      ansible.builtin.debug:
+        msg: "{{ exec_result.stdout }}"
+      when: exec_result.stdout | default('') | length > 0
 
-- name: Run extension maintenance script
-  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
-  vars:
-    exec_service: web
-    exec_command: "{{ _ext_cmd }}"
+- name: Run a named extension maintenance script
+  when: (script_args | default('') | trim) != ''
+  block:
+    - name: Validate extension script path
+      ansible.builtin.fail:
+        msg: "Invalid script path '{{ script_args }}'. Must match pattern: alphanumeric, slashes, dots, hyphens, colons."
+      when: script_args | regex_search('[^a-zA-Z0-9/_. :-]') is not none
 
-- name: Display output
-  ansible.builtin.debug:
-    msg: "{{ exec_result.stdout }}"
-  when: exec_result.stdout | default('') | length > 0
+    - name: Build extension script command
+      ansible.builtin.set_fact:
+        _ext_cmd: "php extensions/{{ script_args }}{{ ((wiki | default('')) != '') | ternary(' --wiki=' + (wiki | default('')), '') }}"
+
+    - name: Run extension maintenance script
+      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+      vars:
+        exec_service: web
+        exec_command: "{{ _ext_cmd }}"
+
+    - name: Display output
+      ansible.builtin.debug:
+        msg: "{{ exec_result.stdout }}"
+      when: exec_result.stdout | default('') | length > 0

--- a/roles/maintenance/tasks/script.yml
+++ b/roles/maintenance/tasks/script.yml
@@ -1,26 +1,47 @@
 ---
-# canasta maintenance script - Run arbitrary maintenance scripts.
-# Input: id (optional), wiki (optional), script_args (str)
+# canasta maintenance script - Run maintenance scripts.
+# Input: id (optional), wiki (optional), script_args (str, optional —
+#   when empty, lists available scripts).
 
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
-- name: Validate script path
-  ansible.builtin.fail:
-    msg: "Invalid script path '{{ script_args }}'. Must match pattern: alphanumeric, slashes, dots, hyphens, colons."
-  when: script_args | regex_search('[^a-zA-Z0-9/_. :-]') is not none
+- name: List available maintenance scripts when no script name given
+  when: (script_args | default('') | trim) == ''
+  block:
+    - name: Run ls in container
+      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+      vars:
+        exec_service: web
+        exec_command: >-
+          ls maintenance/*.php 2>/dev/null
+          | sed 's|^maintenance/||'
+          | sort
 
-- name: Build script command
-  ansible.builtin.set_fact:
-    _script_cmd: "php maintenance/{{ script_args }}{{ ((wiki | default('')) != '') | ternary(' --wiki=' + (wiki | default('') | quote), '') }}"
+    - name: Display script list
+      ansible.builtin.debug:
+        msg: "{{ exec_result.stdout }}"
+      when: exec_result.stdout | default('') | length > 0
 
-- name: Run maintenance script
-  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
-  vars:
-    exec_service: web
-    exec_command: "{{ _script_cmd }}"
+- name: Run a named maintenance script
+  when: (script_args | default('') | trim) != ''
+  block:
+    - name: Validate script path
+      ansible.builtin.fail:
+        msg: "Invalid script path '{{ script_args }}'. Must match pattern: alphanumeric, slashes, dots, hyphens, colons."
+      when: script_args | regex_search('[^a-zA-Z0-9/_. :-]') is not none
 
-- name: Display output
-  ansible.builtin.debug:
-    msg: "{{ exec_result.stdout }}"
-  when: exec_result.stdout | default('') | length > 0
+    - name: Build script command
+      ansible.builtin.set_fact:
+        _script_cmd: "php maintenance/{{ script_args }}{{ ((wiki | default('')) != '') | ternary(' --wiki=' + (wiki | default('') | quote), '') }}"
+
+    - name: Run maintenance script
+      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+      vars:
+        exec_service: web
+        exec_command: "{{ _script_cmd }}"
+
+    - name: Display output
+      ansible.builtin.debug:
+        msg: "{{ exec_result.stdout }}"
+      when: exec_result.stdout | default('') | length > 0


### PR DESCRIPTION
## Summary

Both \`canasta maintenance script\` and \`canasta maintenance extension\` have a long_description in \`meta/command_definitions.yml\` promising that running them with no arguments lists what's available. But the playbooks unconditionally referenced \`script_args\`, so the no-args path errored with \`'script_args' is undefined\` before reaching the listing logic. Reported by silverhikari (#444).

## Changes

- **\`roles/maintenance/tasks/script.yml\`**: split into two when:-gated branches.
  - Empty \`script_args\` → exec \`ls maintenance/*.php | sed s|^maintenance/|| | sort\` inside the web container and print the result.
  - Non-empty → existing validate / build / run / display flow unchanged.
- **\`roles/maintenance/tasks/extension.yml\`**: same shape. Probe is \`find extensions -mindepth 2 -maxdepth 2 -type d -name maintenance | sed -e 's|^extensions/||' -e 's|/maintenance$||' | sort\` so the listing surfaces extensions that actually have a maintenance/ subdirectory.

## Notes

- The streaming-output concern in #433 is orthogonal and is being tackled in a follow-up — the listing case here doesn't need streaming because the output is small. When #433 ports these commands to \`direct_commands.py\`, the listing logic will move with them.

## Test plan

- [x] \`make test-unit\` (617 passed)
- [x] \`make validate\`
- [x] \`make lint\` (no new warnings)
- [ ] Manual: \`canasta maintenance script -i <id>\` lists \`*.php\` in maintenance/ on the instance
- [ ] Manual: \`canasta maintenance extension -i <id>\` lists extensions with maintenance/ subdirs
- [ ] Manual: \`canasta maintenance script -i <id> rebuildall.php\` still runs the named script

Closes #444