### PR TITLE
maintenance extension: use find -L to follow extensions/ symlinks (closes #470)

### DIFF
--- a/direct_commands.py
+++ b/direct_commands.py
@@ -1241,12 +1241,15 @@ def cmd_maintenance_extension(args):
     script_args = _normalize_script_args(args)
 
     # No args → list extensions that have a maintenance/ subdirectory.
+    # Each entry under extensions/ in the Canasta image is a symlink
+    # into canasta-extensions/, so -L is required for find to descend
+    # past the symlink and see the maintenance/ dir on the other side.
     if not script_args:
         return _stream_in_container(
             inst_id, inst,
-            "find extensions -mindepth 2 -maxdepth 2 -type d -name maintenance "
-            "2>/dev/null | sed -e 's|^extensions/||' "
-            "-e 's|/maintenance$||' | sort",
+            "find -L extensions -mindepth 2 -maxdepth 2 -type d "
+            "-name maintenance 2>/dev/null "
+            "| sed -e 's|^extensions/||' -e 's|/maintenance$||' | sort",
         )
 
     if not _MAINT_PATH_RE.match(script_args):

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2706,7 +2706,7 @@ class TestMaintenanceExtension:
         monkeypatch.setattr(direct_commands, "_stream_in_container", fake_stream)
         rc = direct_commands.cmd_maintenance_extension(self._args())
         assert rc == 0
-        assert "find extensions" in captured["command"]
+        assert "find -L extensions" in captured["command"]
         assert "-name maintenance" in captured["command"]
 
     def test_runs_named_extension_script(self, monkeypatch):


### PR DESCRIPTION
## Summary

Surfaced while smoke-testing #469 on a real Canasta instance. \`canasta maintenance extension\` (no args) returned empty even on instances with many extensions that have \`maintenance/\` subdirs (CirrusSearch, SemanticMediaWiki, etc.).

Root cause: in the Canasta image, every entry under \`extensions/\` is a symlink into \`canasta-extensions/\`. \`find\` does not follow symlinks unless given \`-L\`, so the listing probe never saw \`extensions/<Name>/maintenance\`.

## Fix

One-character change to the find invocation in \`cmd_maintenance_extension\`, plus the corresponding unit-test assertion.

## Test plan

- [x] \`make test-unit\` (640 passed)
- [x] \`make validate\`
- [x] Manual smoke test on acknowledge.wiki: \`canasta maintenance extension -i smoketest\` now returns the expected list (AJAXPoll, AbuseFilter, Babel, CirrusSearch, …).

Closes #470