### PR TITLE
gitops: forward ssh-agent and accept-new the forge host key (closes #465)

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -791,10 +791,18 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
     # commands, not just -H commands — when the host is resolved from
     # the registry, the SSH connection still needs this. Known hosts
     # with changed keys are still rejected.
+    #
+    # ForwardAgent=yes lets `canasta gitops` (and any other command
+    # whose remote-side work shells out to ssh — e.g. `git push` to a
+    # private repo) reuse the operator's local ssh-agent on the
+    # target host. With no agent loaded the option is a no-op; with
+    # one loaded, the user's keys flow through to the remote without
+    # having to provision deploy keys on every gitops host.
     os.environ.setdefault(
         "ANSIBLE_SSH_ARGS",
         "-o StrictHostKeyChecking=accept-new "
-        "-o UserKnownHostsFile=~/.ssh/known_hosts",
+        "-o UserKnownHostsFile=~/.ssh/known_hosts "
+        "-o ForwardAgent=yes",
     )
 
     # Hand the platform-correct config dir to Ansible. get_config_dir()

--- a/direct_commands.py
+++ b/direct_commands.py
@@ -495,9 +495,13 @@ def _filter_by_host(instances, host):
 
 
 def _ssh_args():
+    # ForwardAgent in the fallback matches the default canasta.py
+    # plants when running through Ansible — direct commands that SSH
+    # to a remote should expose the same agent so any forge auth
+    # (gitops one-shots, future scripts) works the same way.
     extra = os.environ.get(
         "ANSIBLE_SSH_ARGS",
-        "-o StrictHostKeyChecking=accept-new",
+        "-o StrictHostKeyChecking=accept-new -o ForwardAgent=yes",
     )
     return extra.split() if extra else []
 

--- a/roles/gitops/tasks/init_compose.yml
+++ b/roles/gitops/tasks/init_compose.yml
@@ -84,6 +84,7 @@
 - name: Check remote is empty
   ansible.builtin.command:
     cmd: "git ls-remote {{ repo }}"
+  environment: "{{ gitops_git_env }}"
   register: _remote_check
   changed_when: false
   ignore_errors: true  # OK if remote unreachable
@@ -371,6 +372,7 @@
   ansible.builtin.command:
     cmd: "git push {{ (force | default(false) | bool) | ternary('--force', '') }} -u origin main"
     chdir: "{{ instance_path }}"
+  environment: "{{ gitops_git_env }}"
   changed_when: true
 
 - name: Report gitops initialized

--- a/roles/gitops/tasks/join.yml
+++ b/roles/gitops/tasks/join.yml
@@ -83,6 +83,7 @@
   ansible.builtin.command:
     cmd: "git clone {{ repo }} ."
     chdir: "{{ _join_tmpdir.path }}"
+  environment: "{{ gitops_git_env }}"
   changed_when: true
 
 # --- Step 3: Copy key to remote and unlock git-crypt ---
@@ -309,6 +310,7 @@
   ansible.builtin.command:
     cmd: "git push {{ (force | default(false) | bool) | ternary('--force', '') }}"
     chdir: "{{ instance_path }}"
+  environment: "{{ gitops_git_env }}"
   changed_when: true
 
 # --- Step 11: Clean up temp dir ---

--- a/roles/gitops/tasks/pull_compose.yml
+++ b/roles/gitops/tasks/pull_compose.yml
@@ -46,6 +46,7 @@
   ansible.builtin.command:
     cmd: "git pull"
     chdir: "{{ instance_path }}"
+  environment: "{{ gitops_git_env }}"
   register: _pull_result
   changed_when: "'Already up to date' not in _pull_result.stdout"
 

--- a/roles/gitops/tasks/push_compose.yml
+++ b/roles/gitops/tasks/push_compose.yml
@@ -180,6 +180,7 @@
       ansible.builtin.command:
         cmd: "git push origin main"
         chdir: "{{ instance_path }}"
+      environment: "{{ gitops_git_env }}"
       changed_when: true
 
     - name: Report pushed
@@ -212,6 +213,7 @@
       ansible.builtin.command:
         cmd: "git push origin {{ _push_branch }}"
         chdir: "{{ instance_path }}"
+      environment: "{{ gitops_git_env }}"
       changed_when: true
 
     - name: Create pull request

--- a/roles/gitops/vars/main.yml
+++ b/roles/gitops/vars/main.yml
@@ -29,3 +29,18 @@ gitops_shared_credential_prefixes:
   - st_
   - rclone_
   - smtp_
+
+# Environment applied to every git command in the Compose-side gitops
+# flows (init, push, pull, join). accept-new lets the first contact
+# with a forge (github.com etc.) silently add its host key instead of
+# failing with "Host key verification failed". Pair with
+# ForwardAgent=yes in ANSIBLE_SSH_ARGS (set by canasta.py) so the
+# operator's local ssh-agent reaches the target host and authenticates
+# against private repos without per-host deploy keys. The Kubernetes
+# gitops flows generate their own deploy key and override
+# GIT_SSH_COMMAND with `-i <key>`, so this default doesn't apply
+# there.
+gitops_git_env:
+  GIT_SSH_COMMAND: >-
+    ssh -o StrictHostKeyChecking=accept-new
+    -o UserKnownHostsFile=~/.ssh/known_hosts

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -348,6 +348,35 @@ class TestBuildAnsibleArgs:
         extra = self._get_vars(result)
         assert extra["host_name"] == "prod"
 
+    def test_default_ansible_ssh_args_carries_required_options(
+        self, data, monkeypatch,
+    ):
+        """build_ansible_args plants a default ANSIBLE_SSH_ARGS that has
+        to include three things at once for remote operations to work
+        without operator ceremony:
+
+        - StrictHostKeyChecking=accept-new so first contact with a new
+          host doesn't fail the play.
+        - UserKnownHostsFile=~/.ssh/known_hosts so the accepted key
+          actually persists for next time.
+        - ForwardAgent=yes so the operator's local ssh-agent reaches
+          the target host (gitops `git push` to a private repo on a
+          remote then authenticates against the forge with the
+          operator's keys; see #465).
+
+        Guard against any of those silently disappearing.
+        """
+        monkeypatch.delenv("ANSIBLE_SSH_ARGS", raising=False)
+        from argparse import Namespace
+        args = Namespace(command="version", host=None, verbose=False)
+        canasta_cli.build_ansible_args(
+            "/usr/bin/ansible-playbook", "version", args, data,
+        )
+        ssh_args = os.environ.get("ANSIBLE_SSH_ARGS", "")
+        assert "StrictHostKeyChecking=accept-new" in ssh_args
+        assert "UserKnownHostsFile=" in ssh_args
+        assert "ForwardAgent=yes" in ssh_args
+
 
 class TestHostCommandsBehavior:
     """Test that --host is passed through for commands that declare it

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -348,3 +348,99 @@ class TestOrchestratorTasks:
         with open(os.path.join(ORCHESTRATOR_TASKS, "destroy.yml")) as f:
             content = f.read()
         assert "helm_uninstall" in content
+
+
+class TestGitopsComposeGitEnv:
+    """Every git command in the Compose-side gitops flows must run with
+    `environment: "{{ gitops_git_env }}"` so the operator gets:
+
+    - ssh-agent forwarding (via ANSIBLE_SSH_ARGS' ForwardAgent=yes,
+      tested separately) chained with this env's GIT_SSH_COMMAND, so
+      `git push` on the remote authenticates against private forges.
+    - StrictHostKeyChecking=accept-new + UserKnownHostsFile=… so a
+      first contact with github.com etc. doesn't kill the play.
+
+    Drift here is invisible at runtime until someone tries to
+    onboard a private repo, so the structural check is worth its
+    weight in cheap-and-mechanical lines.
+
+    The Kubernetes-side flows generate their own deploy key and
+    set GIT_SSH_COMMAND with `-i <key>`; they're allowed to use a
+    different env (or no env reference at all).
+    """
+
+    # Files on the Compose path that contain at least one git command.
+    COMPOSE_FILES = [
+        "init_compose.yml",
+        "pull_compose.yml",
+        "push_compose.yml",
+        "join.yml",  # Compose join (k8s join is in join_kubernetes.yml)
+    ]
+
+    GIT_VERBS = (
+        "git push",
+        "git pull",
+        "git clone",
+        "git fetch",
+        "git ls-remote",
+    )
+
+    @pytest.mark.parametrize("filename", COMPOSE_FILES)
+    def test_every_git_command_has_gitops_git_env(self, filename):
+        path = os.path.join(GITOPS_TASKS, filename)
+        with open(path) as f:
+            tasks = yaml.safe_load(f) or []
+        # Recursive walk: gitops_*_compose files nest tasks inside
+        # block: structures, so we descend into block/rescue/always
+        # rather than just iterating the top level.
+        offending = []
+        for entry in self._walk_tasks(tasks):
+            cmd = self._extract_cmd(entry)
+            if not cmd:
+                continue
+            if not any(verb in cmd for verb in self.GIT_VERBS):
+                continue
+            env = entry.get("environment")
+            ok = (
+                isinstance(env, str)
+                and "gitops_git_env" in env
+            ) or (
+                isinstance(env, dict)
+                and any(
+                    "GIT_SSH_COMMAND" in str(v) for v in env.values()
+                )
+                # The k8s-style override (-i <_ssh_key_path>) doesn't
+                # apply on the Compose side; require gitops_git_env.
+                and "gitops_git_env" in str(env)
+            )
+            if not ok:
+                offending.append(
+                    "%s: task '%s' ran '%s' without gitops_git_env"
+                    % (filename, entry.get("name", "<unnamed>"), cmd)
+                )
+        assert not offending, "\n".join(offending)
+
+    @classmethod
+    def _walk_tasks(cls, items):
+        """Yield every task dict regardless of nesting depth."""
+        if not isinstance(items, list):
+            return
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            yield item
+            for child_key in ("block", "rescue", "always"):
+                if child_key in item:
+                    yield from cls._walk_tasks(item[child_key])
+
+    @staticmethod
+    def _extract_cmd(task):
+        """Pull the cmd string out of an ansible.builtin.command task."""
+        for key in ("ansible.builtin.command", "command"):
+            mod = task.get(key)
+            if isinstance(mod, dict):
+                cmd = mod.get("cmd")
+                return cmd if isinstance(cmd, str) else ""
+            if isinstance(mod, str):
+                return mod
+        return ""


### PR DESCRIPTION
## Summary

Hexmode reported that \`canasta gitops init\` against a remote host fails with "Host key verification failed" / "Permission denied (publickey)" when the remote tries to \`git push\` to a private GitHub repo. They had to manually \`ssh -A root@…\` and \`ssh-keyscan github.com\` first to make it work. Two complementary fixes here so the canasta-ansible flow does both automatically.

## Changes

### 1. ForwardAgent in ANSIBLE_SSH_ARGS

\`canasta.py\`:803 (and matching fallback in \`direct_commands.py:_ssh_args\`) appends \`-o ForwardAgent=yes\` to the default. If the operator has an ssh-agent loaded on the controller, the agent is forwarded through Ansible's SSH connection to the target host. \`git push\` then authenticates against the forge with the operator's local keys — no need to provision deploy keys on every gitops host. With no agent loaded the option is a no-op.

### 2. accept-new for git operations

A new \`gitops_git_env\` value in \`roles/gitops/vars/main.yml\` carries:

\`\`\`yaml
GIT_SSH_COMMAND: ssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=~/.ssh/known_hosts
\`\`\`

Applied via \`environment: "{{ gitops_git_env }}"\` to every git command in the Compose-side gitops flows:

- \`init_compose.yml\` — \`git ls-remote\`, \`git push\`
- \`pull_compose.yml\` — \`git pull\`
- \`push_compose.yml\` — both \`git push\` sites (main and PR-branch)
- \`join.yml\` — \`git clone\`, \`git push\`

First-contact host-key prompts no longer fail the play. The Kubernetes-side flows already override \`GIT_SSH_COMMAND\` with their per-instance deploy key, so this change is intentionally Compose-only.

## Test plan

- [x] \`make test-unit\` (640 passed)
- [x] \`make validate\`
- [x] \`make lint\` (no new warnings)
- [ ] Manual: \`canasta gitops init -i <id> --repo git@github.com:org/repo.git --key /tmp/k\` against a remote-registered instance with the operator's ssh-agent loaded — should succeed without manual \`ssh-keyscan\` or \`ssh -A\` ceremony.

Closes #465