### PR TITLE
gitops: --reinit wipes partial state so init/join can retry (closes #462)

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1563,6 +1563,16 @@ commands:
         type: bool
         default: false
         description: "Force push to non-empty remote"
+      - name: reinit
+        type: bool
+        default: false
+        description: >-
+          Wipe local gitops state (.git, .gitops-host, env.template,
+          wikis.yaml.template, hosts/, plus K8s chart files) before
+          starting. Use after a previous init died mid-run, e.g.
+          before the git push succeeded. Submodule structure is not
+          fully restorable — extensions whose conversion finished
+          before the failure may end up tracked as flat directories.
       - name: pull_requests
         type: bool
         default: false
@@ -1609,6 +1619,13 @@ commands:
         type: path
         required: true
         description: "Path to git-crypt key"
+      - name: reinit
+        type: bool
+        default: false
+        description: >-
+          Wipe local gitops state before joining. Use after a
+          previous init or join died mid-run and left this instance
+          unable to retry.
       - name: git_user_name
         type: string
         description: "Git user.name for commits on the target host (set if not already configured)"

--- a/roles/gitops/tasks/_reinit_cleanup.yml
+++ b/roles/gitops/tasks/_reinit_cleanup.yml
@@ -1,0 +1,47 @@
+---
+# Wipe gitops-specific state from a partially-initialized instance so
+# `canasta gitops init --reinit` (or `gitops join --reinit`) can start
+# fresh after a previous attempt died midway. The full init flow
+# touches a dozen files in the instance directory; if it fails on the
+# git push, the operator was previously stuck — `init` refused with
+# "GitOps already initialized", and `join` refused for the same
+# reason. See #462.
+#
+# We only delete files that gitops itself creates (or, in the K8s
+# case, copies in from the chart). Files that pre-exist canasta
+# create — .env, config/, the wiki tree, and on K8s values.yaml
+# (which init *merges into* in place) — are left alone.
+#
+# Submodule conversion (Compose: extensions/<X>/.git becomes a
+# gitlink under .git/modules/) cannot be cleanly reversed once the
+# parent .git/ is gone; on a re-init the submodule conversion task
+# will see the stale gitlinks and skip those directories. The
+# resulting repo will not have submodule structure for any extension
+# whose conversion completed before the failure. This is documented
+# in the --reinit help text.
+
+- name: Reinit cleanup — common gitops files
+  ansible.builtin.file:
+    path: "{{ instance_path }}/{{ item }}"
+    state: absent
+  loop:
+    - .git
+    - .gitmodules
+    - .gitignore
+    - .gitattributes
+    - .gitops-host
+    - env.template
+    - wikis.yaml.template
+    - hosts
+
+- name: Reinit cleanup — Kubernetes-only gitops files
+  ansible.builtin.file:
+    path: "{{ instance_path }}/{{ item }}"
+    state: absent
+  loop:
+    - Chart.yaml
+    - templates
+    - values.template.yaml
+    - values-configdata.yaml
+    - argocd
+  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']

--- a/roles/gitops/tasks/init_compose.yml
+++ b/roles/gitops/tasks/init_compose.yml
@@ -66,6 +66,10 @@
   when: _git_identity.rc != 0
 
 # --- Step 2: Check no existing repo ---
+- name: Reinit — wipe partial gitops state before re-running init
+  ansible.builtin.include_tasks: _reinit_cleanup.yml
+  when: reinit | default(false) | bool
+
 - name: Check for existing .git directory
   ansible.builtin.stat:
     path: "{{ instance_path }}/.git"
@@ -73,7 +77,12 @@
 
 - name: Fail if git repo already exists
   ansible.builtin.fail:
-    msg: "GitOps already initialized ({{ instance_path }}/.git exists). Use 'gitops join' to join an existing repo."
+    msg: >-
+      GitOps already initialized ({{ instance_path }}/.git exists).
+      Use 'gitops join' to attach this host to an existing remote
+      repo, or pass --reinit to wipe the local gitops state and
+      retry (typical when a previous init died mid-run before the
+      git push succeeded).
   when: _existing_git.stat.exists
 
 # --- Step 3: Key file overwrite check skipped ---

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -68,6 +68,10 @@
       (or `canasta install -H <host> git-crypt`).
   when: _gitcrypt_check.rc != 0
 
+- name: Reinit — wipe partial gitops state before re-running init
+  ansible.builtin.include_tasks: _reinit_cleanup.yml
+  when: reinit | default(false) | bool
+
 - name: Check for existing .git directory
   ansible.builtin.stat:
     path: "{{ instance_path }}/.git"
@@ -77,7 +81,10 @@
   ansible.builtin.fail:
     msg: >-
       GitOps already initialized ({{ instance_path }}/.git exists).
-      Use 'gitops join' to join an existing repo.
+      Use 'gitops join' to attach this host to an existing remote
+      repo, or pass --reinit to wipe the local gitops state and
+      retry (typical when a previous init died mid-run before the
+      git push succeeded).
   when: _gitops_existing.stat.exists
 
 # --- SSH deploy key ---

--- a/roles/gitops/tasks/join.yml
+++ b/roles/gitops/tasks/join.yml
@@ -55,6 +55,10 @@
       Pass --git-user-name and --git-user-email to this command.
   when: _git_identity.rc != 0
 
+- name: Reinit — wipe partial gitops state before re-running join
+  ansible.builtin.include_tasks: _reinit_cleanup.yml
+  when: reinit | default(false) | bool
+
 - name: Check for existing .git directory
   ansible.builtin.stat:
     path: "{{ instance_path }}/.git"
@@ -65,6 +69,9 @@
     msg: >-
       GitOps already initialized ({{ instance_path }}/.git exists).
       This instance is already connected to a gitops repository.
+      Pass --reinit to wipe the local gitops state and re-clone
+      from the remote (typical when a previous init or join died
+      mid-run).
   when: _join_existing_git.stat.exists
 
 # --key is a controller-local path. The ansible.builtin.copy task

--- a/roles/gitops/tasks/join_kubernetes.yml
+++ b/roles/gitops/tasks/join_kubernetes.yml
@@ -20,6 +20,10 @@
     cmd: "git-crypt --version"
   changed_when: false
 
+- name: Reinit — wipe partial gitops state before re-running join
+  ansible.builtin.include_tasks: _reinit_cleanup.yml
+  when: reinit | default(false) | bool
+
 - name: Check for existing .git directory
   ansible.builtin.stat:
     path: "{{ instance_path }}/.git"
@@ -30,6 +34,9 @@
     msg: >-
       GitOps already initialized ({{ instance_path }}/.git exists).
       This instance is already connected to a gitops repository.
+      Pass --reinit to wipe the local gitops state and re-clone
+      from the remote (typical when a previous init or join died
+      mid-run).
   when: _join_existing_git.stat.exists
 
 # --- Clone repo to temp location ---

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -444,3 +444,47 @@ class TestGitopsComposeGitEnv:
             if isinstance(mod, str):
                 return mod
         return ""
+
+
+class TestGitopsReinit:
+    """Every init/join entry point must include _reinit_cleanup.yml
+    gated on the reinit flag, and surface --reinit in the
+    "already initialized" failure message. Drift is silent: the user
+    gets stuck with a partial init and no way out, which is exactly
+    the failure mode #462 reported. Cheap to gate against."""
+
+    INIT_JOIN_FILES = [
+        "init_compose.yml",
+        "init_kubernetes.yml",
+        "join.yml",
+        "join_kubernetes.yml",
+    ]
+
+    @pytest.mark.parametrize("filename", INIT_JOIN_FILES)
+    def test_includes_reinit_cleanup(self, filename):
+        with open(os.path.join(GITOPS_TASKS, filename)) as f:
+            content = f.read()
+        assert "_reinit_cleanup.yml" in content, (
+            "%s should include _reinit_cleanup.yml so --reinit can "
+            "wipe partial gitops state" % filename
+        )
+        assert "reinit | default(false) | bool" in content, (
+            "%s should gate the cleanup on the reinit flag" % filename
+        )
+
+    @pytest.mark.parametrize("filename", INIT_JOIN_FILES)
+    def test_already_initialized_message_mentions_reinit(self, filename):
+        with open(os.path.join(GITOPS_TASKS, filename)) as f:
+            content = f.read()
+        assert "already initialized" in content
+        # The error has to point users at the recovery flag, otherwise
+        # the message is the same brick wall #462 was reported about.
+        assert "--reinit" in content, (
+            "%s's 'already initialized' message must mention --reinit "
+            "so users have a documented recovery path" % filename
+        )
+
+    def test_cleanup_file_exists(self):
+        assert os.path.isfile(
+            os.path.join(GITOPS_TASKS, "_reinit_cleanup.yml")
+        )


### PR DESCRIPTION
## Summary

Hexmode reported that \`canasta gitops init\` died mid-run (typo'd repo URL caused git push to fail) and the next attempt — whether \`init\` or \`join\` — refused with "GitOps already initialized" with no documented recovery path. The operator was stuck.

Add \`--reinit\` to both \`gitops init\` and \`gitops join\`. When set, the flow deletes the gitops-specific files before the safety check fires.

## What gets cleaned up

Compose + K8s:
- \`.git\`, \`.gitmodules\`, \`.gitignore\`, \`.gitattributes\`, \`.gitops-host\`
- \`env.template\`, \`wikis.yaml.template\`, \`hosts/\`

K8s only:
- \`Chart.yaml\`, \`templates/\`, \`values.template.yaml\`, \`values-configdata.yaml\`, \`argocd/\`

Files that pre-exist canasta create (the wiki tree, \`.env\`, \`config/\`, and on K8s \`values.yaml\` — which init *merges into* in place) are intentionally left alone.

The cleanup is shared via \`roles/gitops/tasks/_reinit_cleanup.yml\`, included from all four entry points (\`init_compose\`, \`init_kubernetes\`, \`join\`, \`join_kubernetes\`) gated on \`reinit | default(false) | bool\`.

## Error message updates

All four "GitOps already initialized" errors now mention \`--reinit\` as the recovery path, so the next operator who hits the brick wall has a documented next step.

## Submodule caveat (called out in --reinit help)

Submodule conversion is one-way: once \`extensions/X\` has become a gitlink under \`.git/modules/\`, removing the parent \`.git/\` breaks the gitlink and the next conversion pass skips that directory. The \`--reinit\` help text calls this out — extensions whose conversion finished before the failure may end up tracked as flat directories. Full submodule restoration would mean backing up the original ext/skin trees before each conversion; that's a separate, larger effort.

## Test plan

- [x] \`make test-unit\` (654 passed, 9 new)
- [x] \`make validate\`
- [x] \`make lint\` (no new warnings)
- 9 new structural tests parametrize over the four init/join files and assert each (a) includes \`_reinit_cleanup.yml\`, (b) gates it on the reinit flag, and (c) mentions \`--reinit\` in the "already initialized" error.
- [ ] Manual: trigger a failed gitops init, then re-run with \`--reinit\` — should succeed.

Closes #462