### PR TITLE
Audit cleanup batch 3: dedup git rev-parse, validate_wiki_id, password resolution; skip duplicate resolve_instance

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,6 +2,12 @@
 inventory = inventory/localhost.yml
 roles_path = roles
 library = roles/common/library:roles/extensions_skins/library:roles/backup/library
+# Role-local module_utils only auto-discover when the role is invoked
+# via the play-level `roles:` keyword. Canasta uses `include_role` /
+# `include_tasks` everywhere, so we have to add the path explicitly
+# here for `from ansible.module_utils.canasta_validate import …` to
+# resolve at runtime (it works in unit tests via conftest only).
+module_utils = roles/common/module_utils
 gathering = explicit
 # Overridden at runtime by canasta.py to canasta_minimal (non-verbose mode)
 stdout_callback = default

--- a/playbooks/_pull_latest_playbooks.yml
+++ b/playbooks/_pull_latest_playbooks.yml
@@ -97,13 +97,26 @@
               register: _new_commit
               changed_when: false
 
-            - name: Update BUILD_COMMIT and BUILD_DATE after pull
-              ansible.builtin.shell:
-                cmd: >-
-                  git rev-parse --short HEAD > BUILD_COMMIT &&
-                  git log -1 --format=%cd --date=format:'%Y-%m-%d %H:%M:%S' > BUILD_DATE
+            - name: Get new build date
+              ansible.builtin.command:
+                cmd: "git log -1 --format=%cd --date=format:'%Y-%m-%d %H:%M:%S'"
                 chdir: "{{ _repo_dir }}"
-              changed_when: true
+              register: _new_build_date
+              changed_when: false
+
+            # Both files derive from values we already captured above —
+            # no need to re-shell out for git rev-parse a second time.
+            - name: Update BUILD_COMMIT after pull
+              ansible.builtin.copy:
+                content: "{{ _new_commit.stdout | trim }}\n"
+                dest: "{{ _repo_dir }}/BUILD_COMMIT"
+                mode: "0644"
+
+            - name: Update BUILD_DATE after pull
+              ansible.builtin.copy:
+                content: "{{ _new_build_date.stdout | trim }}\n"
+                dest: "{{ _repo_dir }}/BUILD_DATE"
+                mode: "0644"
 
             - name: Report update
               ansible.builtin.debug:

--- a/roles/common/library/canasta_farmsettings.py
+++ b/roles/common/library/canasta_farmsettings.py
@@ -31,13 +31,14 @@ options:
 import re
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.canasta_validate import (
+    RESERVED_WIKI_IDS,
+    validate_wiki_id,
+)
 
 
 # From internal/canasta: ^[a-zA-Z0-9]([a-zA-Z0-9-_]*[a-zA-Z0-9])?$
 INSTANCE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9\-_]*[a-zA-Z0-9])?$")
-
-# From internal/farmsettings: no hyphens, not in reserved list
-RESERVED_WIKI_IDS = ["settings", "images", "w", "wiki", "wikis"]
 
 # From internal/extensionsskins: ^[a-zA-Z0-9][a-zA-Z0-9_.\-]*$
 EXTENSION_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.\-]*$")
@@ -50,17 +51,6 @@ def validate_instance_id(value):
     if not INSTANCE_ID_PATTERN.match(value):
         return ("instance ID '%s' is invalid: must start and end with alphanumeric, "
                 "may contain letters, digits, hyphens, underscores" % value)
-    return None
-
-
-def validate_wiki_id(value):
-    """Validate a wiki ID."""
-    if not value:
-        return "wiki ID cannot be empty"
-    if "-" in value:
-        return "wiki ID '%s' cannot contain hyphens" % value
-    if value in RESERVED_WIKI_IDS:
-        return "wiki ID '%s' is reserved (cannot be: %s)" % (value, ", ".join(RESERVED_WIKI_IDS))
     return None
 
 

--- a/roles/common/library/canasta_wikis_yaml.py
+++ b/roles/common/library/canasta_wikis_yaml.py
@@ -52,9 +52,10 @@ import os
 import yaml
 
 from ansible.module_utils.basic import AnsibleModule
-
-
-RESERVED_WIKI_IDS = ["settings", "images", "w", "wiki", "wikis"]
+from ansible.module_utils.canasta_validate import (
+    RESERVED_WIKI_IDS,
+    validate_wiki_id,
+)
 
 
 def wikis_yaml_path(instance_path):
@@ -68,22 +69,6 @@ def wikis_yaml_path(instance_path):
             % (real_path, real_base)
         )
     return path
-
-
-def validate_wiki_id(wiki_id):
-    """Validate a wiki ID (matching Go ValidateWikiID).
-
-    NOTE: This validation is intentionally duplicated from canasta_farmsettings.py
-    because Ansible modules in different role library/ directories cannot import
-    each other. Keep both copies in sync.
-    """
-    if not wiki_id:
-        return "wiki ID cannot be empty"
-    if "-" in wiki_id:
-        return "wiki ID '%s' cannot contain hyphens" % wiki_id
-    if wiki_id in RESERVED_WIKI_IDS:
-        return "wiki ID '%s' is reserved (cannot be: %s)" % (wiki_id, ", ".join(RESERVED_WIKI_IDS))
-    return None
 
 
 def read_wikis(instance_path):

--- a/roles/common/module_utils/canasta_validate.py
+++ b/roles/common/module_utils/canasta_validate.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""Shared validation helpers for canasta_* Ansible modules.
+
+Both canasta_wikis_yaml and canasta_farmsettings need to validate wiki
+IDs the same way. Pre-extraction this file existed twice — once in
+each module — with a "Keep both copies in sync" comment that did not
+keep them in sync. Modules in `roles/common/library/` import this via
+`from ansible.module_utils.canasta_validate import …` (Ansible
+automatically adds each role's `module_utils/` directory to the
+module loader's search path).
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+# Wiki IDs that collide with paths the canasta image expects
+# canasta-controlled (the `wikis/` mount, the `images/` images dir,
+# `w/` and `wiki/` URL prefixes, and `settings/` per-wiki overrides).
+# Identical list shared by both modules.
+RESERVED_WIKI_IDS = ["settings", "images", "w", "wiki", "wikis"]
+
+
+def validate_wiki_id(value):
+    """Return None if `value` is a valid wiki ID, otherwise an error
+    string suitable for `module.fail_json(msg=...)`.
+
+    Mirrors the Go CLI's ValidateWikiID."""
+    if not value:
+        return "wiki ID cannot be empty"
+    if "-" in value:
+        return "wiki ID '%s' cannot contain hyphens" % value
+    if value in RESERVED_WIKI_IDS:
+        return "wiki ID '%s' is reserved (cannot be: %s)" % (
+            value, ", ".join(RESERVED_WIKI_IDS),
+        )
+    return None

--- a/roles/create/tasks/_resolve_password.yml
+++ b/roles/create/tasks/_resolve_password.yml
@@ -1,0 +1,32 @@
+---
+# Resolve a password the user may have supplied via flag, falling back
+# to a generated one. Sets `_resolved_password`, which the caller
+# typically renames into the fact it actually wants
+# (`_rootdbpass`, `_wikidbpass`, `_admin_password`).
+#
+# Inputs:
+#   _rp_input        - the value the operator passed (may be '' or
+#                      undefined; both treated as "not provided")
+#   _rp_report_msg   - optional message printed after generation,
+#                      e.g. "Generated root database password (will be
+#                      saved to .env)"
+
+- name: Use the operator-provided password
+  ansible.builtin.set_fact:
+    _resolved_password: "{{ _rp_input }}"
+  when: (_rp_input | default('')) != ''
+
+- name: Generate password when none provided
+  when: (_rp_input | default('')) == ''
+  block:
+    - name: Run password generator
+      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/generate_password.yml"
+
+    - name: Capture generated password
+      ansible.builtin.set_fact:
+        _resolved_password: "{{ _generated_password }}"
+
+    - name: Report generated password
+      ansible.builtin.debug:
+        msg: "{{ _rp_report_msg }}"
+      when: (_rp_report_msg | default('')) != ''

--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -260,58 +260,44 @@
     - { dir: config/settings/wikis }
 
 # --- Step 6: Generate passwords ---
-- name: Generate root DB password if not provided
-  when: rootdbpass is not defined or rootdbpass == ''
-  block:
-    - name: Generate root DB password
-      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/generate_password.yml"
-    - name: Store root DB password
-      ansible.builtin.set_fact:
-        _rootdbpass: "{{ _generated_password }}"
-    - name: Report root DB password generated
-      ansible.builtin.debug:
-        msg: "Generated root database password (will be saved to .env)"
+- name: Resolve root DB password
+  ansible.builtin.include_tasks: _resolve_password.yml
+  vars:
+    _rp_input: "{{ rootdbpass | default('') }}"
+    _rp_report_msg: "Generated root database password (will be saved to .env)"
 
-- name: Use provided root DB password
+- name: Capture root DB password
   ansible.builtin.set_fact:
-    _rootdbpass: "{{ rootdbpass }}"
-  when: rootdbpass is defined and rootdbpass != ''
+    _rootdbpass: "{{ _resolved_password }}"
 
-- name: Set wiki DB password
+# Wiki DB password follows the root DB password when wikidbuser is
+# 'root' (the canasta default — single account for both); only a
+# distinct wikidbuser warrants a separate password.
+- name: Mirror wiki DB password from root when wikidbuser is root
   ansible.builtin.set_fact:
     _wikidbpass: "{{ _rootdbpass }}"
   when: (wikidbuser | default('root')) == 'root'
 
-- name: Generate wiki DB password if non-root user
-  when: (wikidbuser | default('root')) != 'root' and (wikidbpass is not defined or wikidbpass == '')
-  block:
-    - name: Generate wiki DB password
-      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/generate_password.yml"
-    - name: Store wiki DB password
-      ansible.builtin.set_fact:
-        _wikidbpass: "{{ _generated_password }}"
+- name: Resolve distinct wiki DB password (non-root wikidbuser)
+  ansible.builtin.include_tasks: _resolve_password.yml
+  vars:
+    _rp_input: "{{ wikidbpass | default('') }}"
+  when: (wikidbuser | default('root')) != 'root'
 
-- name: Use provided wiki DB password
+- name: Capture distinct wiki DB password
   ansible.builtin.set_fact:
-    _wikidbpass: "{{ wikidbpass }}"
-  when: wikidbpass is defined and wikidbpass != '' and (wikidbuser | default('root')) != 'root'
+    _wikidbpass: "{{ _resolved_password }}"
+  when: (wikidbuser | default('root')) != 'root'
 
-- name: Generate admin password if not provided
-  when: password is not defined or password == ''
-  block:
-    - name: Generate admin password
-      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/generate_password.yml"
-    - name: Store admin password
-      ansible.builtin.set_fact:
-        _admin_password: "{{ _generated_password }}"
-    - name: Report admin password generated
-      ansible.builtin.debug:
-        msg: "Generated admin password."
+- name: Resolve admin password
+  ansible.builtin.include_tasks: _resolve_password.yml
+  vars:
+    _rp_input: "{{ password | default('') }}"
+    _rp_report_msg: "Generated admin password."
 
-- name: Use provided admin password
+- name: Capture admin password
   ansible.builtin.set_fact:
-    _admin_password: "{{ password }}"
-  when: password is defined and password != ''
+    _admin_password: "{{ _resolved_password }}"
 
 # --- Step 7: Merge custom env file (before wikis.yaml, port may affect domain) ---
 - name: Merge custom env file if provided

--- a/roles/instance_lifecycle/tasks/restart.yml
+++ b/roles/instance_lifecycle/tasks/restart.yml
@@ -2,8 +2,13 @@
 # Restart a Canasta instance.
 # Input: id (optional)
 
-- name: Resolve instance
+# Top-level `canasta restart` needs this; nested callers
+# (config set/unset, add, backup restore) already passed through
+# resolve_instance.yml at their own entry point. Re-running it here
+# would do a needless registry round-trip.
+- name: Resolve instance (skip if caller already resolved it)
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
+  when: instance_path is not defined
 
 - name: Stop containers
   ansible.builtin.include_role:

--- a/roles/instance_lifecycle/tasks/start.yml
+++ b/roles/instance_lifecycle/tasks/start.yml
@@ -2,8 +2,13 @@
 # Start a Canasta instance.
 # Input: id (optional)
 
-- name: Resolve instance
+# Top-level callers (`playbooks/start.yml`) need this; nested callers
+# already passed through resolve_instance.yml or canasta create's
+# explicit fact-setting and have instance_path set. Re-running it
+# would do a needless registry round-trip.
+- name: Resolve instance (skip if caller already resolved it)
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
+  when: instance_path is not defined
 
 - name: Start containers
   ansible.builtin.include_role:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,6 +12,18 @@ ROLES_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "roles")
 sys.path.insert(0, os.path.join(ROLES_DIR, "common", "library"))
 sys.path.insert(0, os.path.join(ROLES_DIR, "extensions_skins", "library"))
 
+# Role-local module_utils — at Ansible runtime modules import these
+# via `from ansible.module_utils.<file> import …`; in unit tests we
+# import the module directly, so we add the dir to sys.path and stash
+# a reference under the `ansible.module_utils.<file>` namespace so
+# the in-module import resolves the same way it would on a real run.
+import importlib  # noqa: E402
+_module_utils_dir = os.path.join(ROLES_DIR, "common", "module_utils")
+sys.path.insert(0, _module_utils_dir)
+for _name in ("canasta_validate",):
+    _mod = importlib.import_module(_name)
+    sys.modules.setdefault("ansible.module_utils.%s" % _name, _mod)
+
 
 @pytest.fixture
 def tmp_dir():

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -488,3 +488,128 @@ class TestGitopsReinit:
         assert os.path.isfile(
             os.path.join(GITOPS_TASKS, "_reinit_cleanup.yml")
         )
+
+
+class TestResolvePasswordHelper:
+    """The audit asked for `_resolve_password.yml` to dedupe the
+    'use-provided-or-generate' pattern that was repeated three times
+    in roles/create/tasks/main.yml. These tests guard against:
+
+    1. The helper getting deleted or moved without updating the call
+       sites.
+    2. Future password-resolution code in main.yml drifting away from
+       the helper and bringing the duplication back.
+    """
+
+    HELPER_PATH = os.path.join(
+        os.path.dirname(__file__), "..", "..",
+        "roles", "create", "tasks", "_resolve_password.yml",
+    )
+    MAIN_PATH = os.path.join(
+        os.path.dirname(__file__), "..", "..",
+        "roles", "create", "tasks", "main.yml",
+    )
+
+    def test_helper_exists(self):
+        assert os.path.isfile(self.HELPER_PATH)
+
+    def test_helper_sets_resolved_password(self):
+        with open(self.HELPER_PATH) as f:
+            tasks = yaml.safe_load(f)
+        # Walk every task (including those in `block:`) and make sure
+        # at least one set_fact targets `_resolved_password` — the
+        # contract the call sites depend on.
+        def walk(items):
+            for t in items or []:
+                if not isinstance(t, dict):
+                    continue
+                yield t
+                for k in ("block", "rescue", "always"):
+                    if k in t:
+                        yield from walk(t[k])
+        sets_resolved = []
+        for t in walk(tasks):
+            sf = t.get("ansible.builtin.set_fact") or t.get("set_fact")
+            if isinstance(sf, dict) and "_resolved_password" in sf:
+                sets_resolved.append(t.get("name", "<unnamed>"))
+        assert sets_resolved, (
+            "_resolve_password.yml must set _resolved_password "
+            "(both the use-provided and generate branches). Found: %r"
+            % sets_resolved
+        )
+
+    def test_main_uses_helper_for_each_password(self):
+        with open(self.MAIN_PATH) as f:
+            content = f.read()
+        # Three password resolutions: root DB, wiki DB (non-root user
+        # branch), admin. Each must include the helper.
+        helper_includes = content.count("include_tasks: _resolve_password.yml")
+        assert helper_includes >= 3, (
+            "Expected at least 3 includes of _resolve_password.yml "
+            "(rootdbpass, wikidbpass non-root branch, admin); "
+            "found %d" % helper_includes
+        )
+
+    def test_main_no_inline_generate_password_for_create_passwords(self):
+        """Defensive: nobody should inline-call generate_password.yml
+        from main.yml for the three passwords the helper now owns. If
+        someone adds a new password type that needs the same pattern,
+        they should call the helper instead of copy-pasting the loop."""
+        with open(self.MAIN_PATH) as f:
+            content = f.read()
+        # The helper itself includes generate_password.yml; main.yml
+        # should not directly include it for create-time passwords.
+        assert "include_tasks:" in content
+        # generate_password.yml may be referenced for non-create
+        # password classes (e.g. observability creds in side_effects);
+        # the test scope is just main.yml.
+        inline_generate = content.count("generate_password.yml")
+        # 0 is the win; tolerate if some other site legitimately
+        # includes it without the helper.
+        assert inline_generate <= 0, (
+            "Found %d inline generate_password.yml include(s) in "
+            "main.yml — these should go through "
+            "_resolve_password.yml. Includes: search for "
+            "'generate_password.yml' in roles/create/tasks/main.yml."
+            % inline_generate
+        )
+
+
+class TestResolveInstanceSkipGate:
+    """`instance_lifecycle/start.yml` and `restart.yml` are entered
+    both top-level (`canasta start` / `canasta restart`) and from
+    nested callers (config set/unset, add, backup restore, devmode
+    enable/disable, upgrade) that already passed through
+    resolve_instance.yml. The include must be gated on
+    `instance_path is not defined` so nested callers skip the
+    redundant registry round-trip."""
+
+    LIFECYCLE_FILES = ["start.yml", "restart.yml"]
+
+    @pytest.mark.parametrize("filename", LIFECYCLE_FILES)
+    def test_resolve_instance_gated_on_instance_path(self, filename):
+        path = os.path.join(
+            os.path.dirname(__file__), "..", "..",
+            "roles", "instance_lifecycle", "tasks", filename,
+        )
+        with open(path) as f:
+            tasks = yaml.safe_load(f)
+        for t in tasks:
+            if not isinstance(t, dict):
+                continue
+            inc = t.get("ansible.builtin.include_tasks") or t.get("include_tasks", "")
+            if "resolve_instance.yml" not in str(inc):
+                continue
+            when = t.get("when", "")
+            assert "instance_path is not defined" in when, (
+                "%s: resolve_instance.yml include must be gated on "
+                "`instance_path is not defined`; got when=%r"
+                % (filename, when)
+            )
+            return
+        # If we never found a resolve_instance include, the file
+        # changed shape — flag it so reviewers don't lose the test.
+        raise AssertionError(
+            "%s no longer includes resolve_instance.yml — the gate "
+            "test needs updating to reflect the new flow." % filename
+        )


### PR DESCRIPTION
## Summary

Four small items knocked off the #430 audit checklist.

## Changes

### 1. `playbooks/_pull_latest_playbooks.yml` — dedup git rev-parse

The "Update BUILD_COMMIT and BUILD_DATE" shell ran \`git rev-parse --short HEAD\` again even though the previous "Get new commit hash" task already captured it. Replace the compound shell with two \`copy:\` tasks driven from already-captured registers (the commit, plus a new register for the build date). Down from 3 git rev-parse invocations in the file to 2.

### 2. `roles/common/module_utils/canasta_validate.py` — extract validate_wiki_id

\`validate_wiki_id\` and \`RESERVED_WIKI_IDS\` were duplicated verbatim across \`canasta_wikis_yaml.py\` and \`canasta_farmsettings.py\` with a "Keep both copies in sync" comment that wasn't keeping anything in sync. Move them to \`roles/common/module_utils/canasta_validate.py\` and import via \`from ansible.module_utils.canasta_validate import …\` from both modules.

For unit tests (which import the module files directly outside Ansible), \`tests/unit/conftest.py\` adds the module_utils dir to \`sys.path\` and stashes the helper under \`ansible.module_utils.canasta_validate\` in \`sys.modules\` so the in-module import resolves identically to the runtime path.

### 3. `roles/create/tasks/_resolve_password.yml` — DRY up password resolution

The "use-provided-or-generate" pattern was repeated three times for \`_rootdbpass\`, \`_wikidbpass\`, \`_admin_password\`. Extract it into a helper that takes \`_rp_input\` and an optional \`_rp_report_msg\`, sets \`_resolved_password\`, and lets the caller rename into the fact it wants. Wiki DB password keeps its \`wikidbuser\`-conditional wrapper but uses the helper for the actual generation step.

### 4. Skip duplicate `resolve_instance` in instance_lifecycle/start.yml + restart.yml

Both files unconditionally included \`resolve_instance.yml\`, even when called from sites that already had \`instance_path\` set (\`config/set.yml\`, \`config/unset.yml\`, \`add.yml\`, \`backup/restore.yml\`, \`devmode/{enable,disable}.yml\`, \`upgrade/main.yml\`). Gate the include on \`instance_path is not defined\` — top-level \`canasta start\` / \`canasta restart\` still trigger it; nested callers skip the redundant registry round-trip.

## Test plan

- [x] \`make test-unit\` (654 passed)
- [x] \`make validate\`
- [x] \`make lint\` (no new warnings)
- [ ] Manual: confirm gates work end-to-end on a multi-step flow like \`canasta config set\` (which calls restart.yml from a context where instance_path is already set).

Closes 4 of 5 remaining items from #430. Items still open: split \`direct_commands.py\` (now 2.3K lines).