### PR TITLE
canasta scale: set web replica count for K8s instances (closes #392)

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -802,7 +802,13 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
         "ANSIBLE_SSH_ARGS",
         "-o StrictHostKeyChecking=accept-new "
         "-o UserKnownHostsFile=~/.ssh/known_hosts "
-        "-o ForwardAgent=yes",
+        "-o ForwardAgent=yes "
+        # Long-running remote commands (helm upgrade --wait, gitops
+        # init's git push, maintenance update) can outlast a NAT or
+        # firewall idle timeout. ServerAliveInterval keeps the SSH
+        # session warm so the parent doesn't see a "Broken pipe"
+        # while the remote is still working.
+        "-o ServerAliveInterval=30 -o ServerAliveCountMax=20",
     )
 
     # Hand the platform-correct config dir to Ansible. get_config_dir()

--- a/direct_commands.py
+++ b/direct_commands.py
@@ -2100,9 +2100,16 @@ def cmd_scale(args):
     inst_id, inst = _resolve_instance(args)
     orchestrator = inst.get("orchestrator", "compose")
     if orchestrator not in ("kubernetes", "k8s"):
+        # Kubernetes-only by design: Compose runs all replicas on the
+        # same host with no built-in cross-replica load balancing, so
+        # the spread-across-nodes / horizontal-capacity model that
+        # motivates this command doesn't apply. Bump PHP-FPM worker
+        # limits inside the image instead.
         print(
-            "Error: `canasta scale` is currently Kubernetes-only. "
-            "Compose support is tracked as a follow-up.",
+            "Error: `canasta scale` is Kubernetes-only by design. "
+            "On Compose, raise PHP-FPM worker limits inside the web "
+            "image rather than running multiple replicas of the same "
+            "container.",
             file=sys.stderr,
         )
         return 1

--- a/direct_commands.py
+++ b/direct_commands.py
@@ -2040,6 +2040,191 @@ def _kubectl_section(host, ns, cmd_args, label):
     return (label, out.rstrip())
 
 
+# ---------------------------------------------------------------------------
+# canasta scale
+# ---------------------------------------------------------------------------
+
+def _read_remote_or_local_file(path, host):
+    """Read a file from localhost or a remote host. Returns content or
+    None on error."""
+    if _is_localhost(host):
+        try:
+            with open(path) as f:
+                return f.read()
+        except OSError as e:
+            print("Error reading %s: %s" % (path, e), file=sys.stderr)
+            return None
+    rc, content = _ssh_run(host, "cat %s 2>/dev/null" % _shell_quote(path))
+    if rc != 0:
+        print("Error reading remote %s" % path, file=sys.stderr)
+        return None
+    return content
+
+
+def _write_remote_or_local_file(path, host, content):
+    """Write content to path on localhost or a remote host. Returns True
+    on success."""
+    if _is_localhost(host):
+        try:
+            with open(path, "w") as f:
+                f.write(content)
+            return True
+        except OSError as e:
+            print("Error writing %s: %s" % (path, e), file=sys.stderr)
+            return False
+    target = _resolve_ssh_target(host)
+    ssh_cmd = ["ssh"] + _ssh_args() + [target, "cat > %s" % _shell_quote(path)]
+    try:
+        result = subprocess.run(
+            ssh_cmd, input=content, text=True,
+            capture_output=True, timeout=30,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        print("Error writing remote %s: %s" % (path, e), file=sys.stderr)
+        return False
+    if result.returncode != 0:
+        print(
+            "Error writing remote %s: %s"
+            % (path, (result.stderr or "").strip()),
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+_SCALE_SUPPORTED_COMPONENTS = ("web",)
+
+
+@register("scale")
+def cmd_scale(args):
+    inst_id, inst = _resolve_instance(args)
+    orchestrator = inst.get("orchestrator", "compose")
+    if orchestrator not in ("kubernetes", "k8s"):
+        print(
+            "Error: `canasta scale` is currently Kubernetes-only. "
+            "Compose support is tracked as a follow-up.",
+            file=sys.stderr,
+        )
+        return 1
+
+    component = (getattr(args, "component", None) or "web").lower()
+    if component not in _SCALE_SUPPORTED_COMPONENTS:
+        print(
+            "Error: only 'web' supports replica scaling in this "
+            "release. Component '%s' is not supported (jobrunner, "
+            "varnish, etc. are tracked as follow-ups)." % component,
+            file=sys.stderr,
+        )
+        return 1
+
+    replicas_raw = getattr(args, "replicas", None)
+    if replicas_raw is None:
+        print("Error: --replicas is required", file=sys.stderr)
+        return 1
+    try:
+        replicas = int(replicas_raw)
+    except (TypeError, ValueError):
+        print(
+            "Error: --replicas must be an integer (got %r)" % replicas_raw,
+            file=sys.stderr,
+        )
+        return 1
+    if replicas < 1:
+        print("Error: --replicas must be ≥ 1", file=sys.stderr)
+        return 1
+
+    path = inst.get("path", "")
+    host = inst.get("host") or "localhost"
+    if not path:
+        print("Error: instance '%s' has no path" % inst_id, file=sys.stderr)
+        return 1
+
+    values_path = os.path.join(path, "values.yaml")
+    content = _read_remote_or_local_file(values_path, host)
+    if content is None:
+        return 1
+
+    try:
+        data = yaml.safe_load(content) or {}
+    except yaml.YAMLError as e:
+        print("Error: %s is not valid YAML: %s" % (values_path, e), file=sys.stderr)
+        return 1
+    if not isinstance(data, dict):
+        print("Error: %s does not parse as a mapping" % values_path, file=sys.stderr)
+        return 1
+
+    section = data.setdefault(component, {}) or {}
+    if not isinstance(section, dict):
+        print(
+            "Error: %s.%s is not a mapping; refusing to overwrite "
+            "scalar with a replicaCount key." % (values_path, component),
+            file=sys.stderr,
+        )
+        return 1
+    current = section.get("replicaCount")
+    if current == replicas:
+        print(
+            "%s.replicaCount is already %d; nothing to do." % (component, replicas)
+        )
+        return 0
+    section["replicaCount"] = replicas
+    data[component] = section
+
+    new_content = yaml.safe_dump(
+        data, default_flow_style=False, sort_keys=False,
+    )
+    if not _write_remote_or_local_file(values_path, host, new_content):
+        return 1
+
+    # Apply via helm upgrade. Mirror the args helm_deploy.yml uses so
+    # the result matches what `canasta start` / `canasta restart`
+    # would render — including values-configdata.yaml when present.
+    namespace = "canasta-%s" % inst_id
+    chart = os.path.join(path, "_chart")
+    configdata = os.path.join(path, "values-configdata.yaml")
+    cmd_parts = [
+        "helm upgrade --install canasta-%s %s" % (inst_id, _shell_quote(chart)),
+        "--namespace %s --create-namespace" % namespace,
+        "-f %s" % _shell_quote(values_path),
+    ]
+    # Probe for the optional configdata file the same way helm_deploy.yml does.
+    if _is_localhost(host):
+        has_configdata = os.path.isfile(configdata)
+    else:
+        rc, _ = _ssh_run(
+            host, "test -f %s" % _shell_quote(configdata),
+        )
+        has_configdata = (rc == 0)
+    if has_configdata:
+        cmd_parts.append("-f %s" % _shell_quote(configdata))
+    cmd_parts.extend(["--reset-values", "--wait", "--timeout 10m"])
+    helm_cmd = " ".join(cmd_parts)
+
+    print("Scaling %s to %d replica(s)…" % (component, replicas))
+    if _is_localhost(host):
+        rc = subprocess.call(["bash", "-c", helm_cmd])
+    else:
+        rc, _ = _ssh_run(host, helm_cmd)
+    if rc != 0:
+        print(
+            "Error: helm upgrade failed; values.yaml is updated but "
+            "the deployment may not match. Re-run after fixing the "
+            "underlying error.",
+            file=sys.stderr,
+        )
+        return rc
+
+    print(
+        "Scaled %s to %d replica(s). Persisted to %s."
+        % (component, replicas, values_path)
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# canasta status
+# ---------------------------------------------------------------------------
+
 @register("status")
 def cmd_status(args):
     inst_id, inst = _resolve_status_instance(args)

--- a/direct_commands.py
+++ b/direct_commands.py
@@ -499,9 +499,14 @@ def _ssh_args():
     # plants when running through Ansible — direct commands that SSH
     # to a remote should expose the same agent so any forge auth
     # (gitops one-shots, future scripts) works the same way.
+    # ServerAliveInterval keeps long-running commands (e.g.
+    # `helm upgrade --wait --timeout 10m` from `canasta scale`) from
+    # tripping a NAT / firewall idle drop and reporting a bogus
+    # "Broken pipe" while the remote is still working.
     extra = os.environ.get(
         "ANSIBLE_SSH_ARGS",
-        "-o StrictHostKeyChecking=accept-new -o ForwardAgent=yes",
+        "-o StrictHostKeyChecking=accept-new -o ForwardAgent=yes "
+        "-o ServerAliveInterval=30 -o ServerAliveCountMax=20",
     )
     return extra.split() if extra else []
 
@@ -2207,10 +2212,21 @@ def cmd_scale(args):
     helm_cmd = " ".join(cmd_parts)
 
     print("Scaling %s to %d replica(s)…" % (component, replicas))
+    # Don't go through _ssh_run for the helm call — its 30s timeout is
+    # short by an order of magnitude vs helm's own `--wait --timeout
+    # 10m`, which would falsely report failure on a slow rollout.
+    # Stream the helm output through to the operator so they can see
+    # progress / diagnose stuck rollouts.
     if _is_localhost(host):
-        rc = subprocess.call(["bash", "-c", helm_cmd])
+        argv = ["bash", "-c", helm_cmd]
     else:
-        rc, _ = _ssh_run(host, helm_cmd)
+        target = _resolve_ssh_target(host)
+        argv = ["ssh"] + _ssh_args() + [target, helm_cmd]
+    try:
+        rc = subprocess.call(argv)
+    except OSError as e:
+        print("Error running helm upgrade: %s" % e, file=sys.stderr)
+        return 1
     if rc != 0:
         print(
             "Error: helm upgrade failed; values.yaml is updated but "

--- a/direct_commands.py
+++ b/direct_commands.py
@@ -2117,9 +2117,8 @@ def cmd_scale(args):
     component = (getattr(args, "component", None) or "web").lower()
     if component not in _SCALE_SUPPORTED_COMPONENTS:
         print(
-            "Error: only 'web' supports replica scaling in this "
-            "release. Component '%s' is not supported (jobrunner, "
-            "varnish, etc. are tracked as follow-ups)." % component,
+            "Error: only 'web' supports replica scaling. "
+            "Component '%s' is not supported." % component,
             file=sys.stderr,
         )
         return 1

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1955,10 +1955,9 @@ commands:
       instance, raise PHP-FPM worker limits inside the web image
       rather than running multiple replicas of the same container.
 
-      Scaling other components (jobrunner, varnish) is tracked as a
-      follow-up; only `web` is accepted in this release because the
-      Helm chart currently parameterizes the replica count only on
-      the web Deployment.
+      Only `web` is currently supported. The Helm chart's other
+      Deployments (jobrunner, caddy, varnish) run a single replica
+      and do not accept a replica-count override.
     examples:
       - "canasta scale -i mysite --replicas 3"
     direct_only: true

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1934,7 +1934,7 @@ commands:
         description: "Target host (default: localhost)"
 
   - name: scale
-    description: "Set the number of replicas for the web tier"
+    description: "Set the number of replicas for the web tier (Kubernetes)"
     long_description: |
       Set the number of replicas for the web tier of a Canasta
       instance running on Kubernetes. The new count is persisted to
@@ -1947,9 +1947,18 @@ commands:
       pods will fail to start with `Multi-Attach` errors — see
       `canasta storage list` and `canasta storage setup`.
 
-      Compose support and scaling other components (jobrunner,
-      varnish) are tracked as follow-ups; only `web` and only on
-      Kubernetes are accepted in this release.
+      Kubernetes-only by design. Compose runs all replicas on a
+      single host with no built-in load balancing between them, so
+      the multi-replica model that motivates this command (spread
+      across cluster nodes, fault tolerance, horizontal capacity)
+      doesn't apply. If you need more concurrency on a Compose
+      instance, raise PHP-FPM worker limits inside the web image
+      rather than running multiple replicas of the same container.
+
+      Scaling other components (jobrunner, varnish) is tracked as a
+      follow-up; only `web` is accepted in this release because the
+      Helm chart currently parameterizes the replica count only on
+      the web Deployment.
     examples:
       - "canasta scale -i mysite --replicas 3"
     direct_only: true

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1933,6 +1933,44 @@ commands:
         type: string
         description: "Target host (default: localhost)"
 
+  - name: scale
+    description: "Set the number of replicas for the web tier"
+    long_description: |
+      Set the number of replicas for the web tier of a Canasta
+      instance running on Kubernetes. The new count is persisted to
+      the instance's `values.yaml` and applied via `helm upgrade`,
+      so it survives a later `canasta upgrade` (which would
+      otherwise reset the chart's default).
+
+      Multi-replica web requires a ReadWriteMany storage class for
+      the config and images PVCs. With ReadWriteOnce, additional
+      pods will fail to start with `Multi-Attach` errors — see
+      `canasta storage list` and `canasta storage setup`.
+
+      Compose support and scaling other components (jobrunner,
+      varnish) are tracked as follow-ups; only `web` and only on
+      Kubernetes are accepted in this release.
+    examples:
+      - "canasta scale -i mysite --replicas 3"
+    direct_only: true
+    parameters:
+      - name: id
+        short: i
+        type: string
+        description: "Canasta instance ID"
+      - name: replicas
+        short: r
+        type: integer
+        required: true
+        description: "Desired replica count (must be ≥ 1)"
+      - name: component
+        short: c
+        type: string
+        default: web
+        description: >-
+          Component to scale. Currently only `web` is supported;
+          other values are rejected.
+
   - name: status
     description: "Show pod/PVC/ingress/cert state for a single instance"
     long_description: |

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -352,7 +352,7 @@ class TestBuildAnsibleArgs:
         self, data, monkeypatch,
     ):
         """build_ansible_args plants a default ANSIBLE_SSH_ARGS that has
-        to include three things at once for remote operations to work
+        to include four things at once for remote operations to work
         without operator ceremony:
 
         - StrictHostKeyChecking=accept-new so first contact with a new
@@ -363,6 +363,11 @@ class TestBuildAnsibleArgs:
           the target host (gitops `git push` to a private repo on a
           remote then authenticates against the forge with the
           operator's keys; see #465).
+        - ServerAliveInterval keeps long-running remote commands
+          (helm upgrade --wait, gitops init's git push, maintenance
+          update) from tripping a NAT or firewall idle drop and
+          reporting a bogus "Broken pipe" while the remote is still
+          working.
 
         Guard against any of those silently disappearing.
         """
@@ -376,6 +381,7 @@ class TestBuildAnsibleArgs:
         assert "StrictHostKeyChecking=accept-new" in ssh_args
         assert "UserKnownHostsFile=" in ssh_args
         assert "ForwardAgent=yes" in ssh_args
+        assert "ServerAliveInterval=" in ssh_args
 
 
 class TestHostCommandsBehavior:

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2842,3 +2842,141 @@ class TestMaintenanceUpdate:
         assert any("--wiki='draft'" in c for c in commands)
         assert not any("--wiki='main'" in c for c in commands)
         assert not any("--wiki='foo'" in c for c in commands)
+
+
+# ---------------------------------------------------------------------------
+# canasta scale
+# ---------------------------------------------------------------------------
+
+class TestScale:
+    def _args(self, **kw):
+        from argparse import Namespace
+        defaults = {"id": "mysite", "replicas": 3, "component": "web"}
+        defaults.update(kw)
+        return Namespace(**defaults)
+
+    def _k8s_inst(self, **kw):
+        return {
+            "id": "mysite",
+            "path": "/srv/mysite",
+            "host": "localhost",
+            "orchestrator": "kubernetes",
+            **kw,
+        }
+
+    def test_registered(self):
+        assert direct_commands.is_direct_command("scale")
+
+    def test_rejects_compose(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            direct_commands, "_resolve_instance",
+            lambda args: ("mysite", {
+                "id": "mysite", "path": "/srv/mysite",
+                "host": "localhost", "orchestrator": "compose",
+            }),
+        )
+        rc = direct_commands.cmd_scale(self._args())
+        assert rc == 1
+        assert "Kubernetes-only" in capsys.readouterr().err
+
+    def test_rejects_unsupported_component(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            direct_commands, "_resolve_instance",
+            lambda args: ("mysite", self._k8s_inst()),
+        )
+        rc = direct_commands.cmd_scale(self._args(component="varnish"))
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "varnish" in err
+        assert "only 'web'" in err
+
+    def test_rejects_zero_replicas(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            direct_commands, "_resolve_instance",
+            lambda args: ("mysite", self._k8s_inst()),
+        )
+        rc = direct_commands.cmd_scale(self._args(replicas=0))
+        assert rc == 1
+        assert "≥ 1" in capsys.readouterr().err
+
+    def test_rejects_non_integer_replicas(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            direct_commands, "_resolve_instance",
+            lambda args: ("mysite", self._k8s_inst()),
+        )
+        rc = direct_commands.cmd_scale(self._args(replicas="abc"))
+        assert rc == 1
+        assert "must be an integer" in capsys.readouterr().err
+
+    def test_no_op_when_already_at_target(self, monkeypatch, capsys, tmp_path):
+        inst_path = tmp_path / "mysite"
+        inst_path.mkdir()
+        (inst_path / "values.yaml").write_text(
+            "web:\n  replicaCount: 3\n",
+        )
+        monkeypatch.setattr(
+            direct_commands, "_resolve_instance",
+            lambda args: ("mysite", self._k8s_inst(path=str(inst_path))),
+        )
+        called = {"helm": False}
+
+        def fail_helm(*a, **kw):
+            called["helm"] = True
+            return 0
+
+        monkeypatch.setattr(subprocess, "call", fail_helm)
+        rc = direct_commands.cmd_scale(self._args(replicas=3))
+        assert rc == 0
+        assert "already 3" in capsys.readouterr().out
+        assert called["helm"] is False  # no helm invoked when no-op
+
+    def test_writes_values_and_invokes_helm(
+        self, monkeypatch, capsys, tmp_path,
+    ):
+        inst_path = tmp_path / "mysite"
+        inst_path.mkdir()
+        (inst_path / "values.yaml").write_text(
+            "instance:\n  id: mysite\nweb:\n  replicaCount: 1\n",
+        )
+        monkeypatch.setattr(
+            direct_commands, "_resolve_instance",
+            lambda args: ("mysite", self._k8s_inst(path=str(inst_path))),
+        )
+        captured = {}
+
+        def fake_call(cmd, *a, **kw):
+            captured["cmd"] = cmd
+            return 0
+
+        monkeypatch.setattr(subprocess, "call", fake_call)
+        rc = direct_commands.cmd_scale(self._args(replicas=5))
+        assert rc == 0
+
+        # values.yaml updated in place
+        new_content = (inst_path / "values.yaml").read_text()
+        assert "replicaCount: 5" in new_content
+        # helm command shape
+        cmd_str = " ".join(captured["cmd"])
+        assert "helm upgrade --install canasta-mysite" in cmd_str
+        assert "--namespace canasta-mysite" in cmd_str
+        assert "values.yaml" in cmd_str
+        assert "--reset-values" in cmd_str
+        assert "--wait" in cmd_str
+
+    def test_helm_failure_reports_partial_state(
+        self, monkeypatch, capsys, tmp_path,
+    ):
+        inst_path = tmp_path / "mysite"
+        inst_path.mkdir()
+        (inst_path / "values.yaml").write_text("web:\n  replicaCount: 1\n")
+        monkeypatch.setattr(
+            direct_commands, "_resolve_instance",
+            lambda args: ("mysite", self._k8s_inst(path=str(inst_path))),
+        )
+        monkeypatch.setattr(subprocess, "call", lambda *a, **kw: 7)
+        rc = direct_commands.cmd_scale(self._args(replicas=4))
+        assert rc == 7
+        err = capsys.readouterr().err
+        assert "helm upgrade failed" in err
+        # values.yaml was already written before helm ran
+        assert "replicaCount: 4" in (inst_path / "values.yaml").read_text()

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2877,7 +2877,10 @@ class TestScale:
         )
         rc = direct_commands.cmd_scale(self._args())
         assert rc == 1
-        assert "Kubernetes-only" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert "Kubernetes-only" in err
+        # Message should also tell Compose users what to do instead.
+        assert "PHP-FPM" in err
 
     def test_rejects_unsupported_component(self, monkeypatch, capsys):
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Closes the gap #392 reported. Multi-node K8s with `--access-mode ReadWriteMany` ships as of #349/#350, but the only way to actually set web replica count was direct `kubectl scale` — and any subsequent `canasta upgrade` silently undid it because the chart re-renders from `values.yaml` where the default is 1.

## Behavior

```
canasta scale -i <instance> --replicas <N>
```

- Reads the instance's `values.yaml`
- Sets `web.replicaCount: N`
- Runs `helm upgrade --install canasta-<id> <chart> -f values.yaml -f values-configdata.yaml --reset-values --wait --timeout 10m` — exact args helm_deploy.yml uses
- Result survives `canasta upgrade`

No-op fast path when the count already matches the stored value (skips helm entirely).

## Scope: Kubernetes only, by design

- **K8s only.** Not a Compose follow-up — Compose runs all replicas on a single host with no built-in cross-replica load balancing, so the spread-across-nodes / fault-tolerance / horizontal-capacity model that motivates this command doesn't apply. The error message on a Compose instance points operators at PHP-FPM worker limits as the right knob for "more concurrency" on Compose.
- **`--component web` only.** The chart currently parameterizes `replicas` only on `deployment-web.yaml`; jobrunner / caddy / varnish are hardcoded `replicas: 1`. Other components are rejected up front rather than silently editing values.yaml under a key the chart ignores. Adding more is a follow-up that needs both chart and CLI changes.
- **Auto-scaling (HPA) explicitly out of scope.** This is the manual-set primitive.

## Implementation

- New `direct_only` command in `direct_commands.py` (fits the pattern for K8s state ops that don't benefit from Ansible's per-task overhead).
- Two new helpers `_read_remote_or_local_file` / `_write_remote_or_local_file` so the command works against `-H <remote>` instances via SSH cat / cat-write.
- Validation: rejects non-K8s, rejects non-`web` components, requires integer `--replicas ≥ 1`.

## Test plan

- [x] `make test-unit` (668 passed, 8 new)
- [x] `make validate` (67 commands, 50 playbooks)
- [x] `make lint` (no new warnings)
- 8 unit tests cover: registration; orchestrator + component rejection; integer / range validation; no-op fast path; write+helm happy path (asserts on values.yaml content + helm command shape); and helm-failure-after-values-write (rc propagated, partial-state warning).
- [ ] Manual: smoke test on the existing k3s cluster on acknowledge.wiki — verify pods scale up/down and the count survives a `canasta restart`.

Closes #392