### PR TITLE
canasta-docker: in-container username = host operator's, not literal 'canasta' (closes #478)

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -183,8 +183,15 @@ if [[ "$PASSWD_STALE" == "true" ]]; then
         : > "$CANASTA_PASSWD"
     fi
 fi
+# Use the host operator's login name as the in-container username
+# (not a literal "canasta") so SSH connections out of the container
+# default to that name. Otherwise an Ansible play that SSHes to a
+# remote without a -u override tries `canasta@<host>` and the remote
+# sshd rejects after too many auth failures because no `canasta` user
+# exists there. See #478.
+_CANASTA_DOCKER_USER="$(id -un 2>/dev/null || echo "${USER:-canasta}")"
 if ! grep -q "^[^:]*:[^:]*:$(id -u):" "$CANASTA_PASSWD" 2>/dev/null; then
-    echo "canasta:x:$(id -u):$(id -g):canasta:$HOME:/bin/sh" >> "$CANASTA_PASSWD"
+    echo "${_CANASTA_DOCKER_USER}:x:$(id -u):$(id -g):${_CANASTA_DOCKER_USER}:$HOME:/bin/sh" >> "$CANASTA_PASSWD"
 fi
 MOUNTS+=(-v "$CANASTA_PASSWD:/etc/passwd:ro")
 # Add only the groups the container actually needs: the Docker socket

--- a/tests/unit/test_canasta_docker.py
+++ b/tests/unit/test_canasta_docker.py
@@ -480,3 +480,53 @@ class TestPodmanDetection:
 def _shell_quote(s):
     """Single-quote a string for safe embedding in a bash heredoc/echo."""
     return "'" + s.replace("'", "'\\''") + "'"
+
+
+class TestPasswdEntryUsesHostUsername:
+    """The /etc/passwd that canasta-docker bind-mounts into the
+    container has to carry the host operator's actual login name as
+    the in-container username — NOT a literal "canasta". Otherwise
+    Ansible plays that SSH from the container to a remote host
+    without an explicit -u override default to `canasta@<host>`,
+    which the remote sshd rejects with "Too many authentication
+    failures" because no `canasta` user exists there. See #478.
+    """
+
+    def test_passwd_entry_uses_host_username_not_literal_canasta(self):
+        argv, _ = run_dry(["version"])
+        config_dir = next(
+            a.split("=", 1)[1]
+            for a in argv
+            if a.startswith("CANASTA_CONFIG_DIR=")
+        )
+        passwd_path = os.path.join(config_dir, ".canasta-passwd")
+        assert os.path.isfile(passwd_path), (
+            "canasta-docker should have written %s" % passwd_path
+        )
+        with open(passwd_path) as f:
+            entries = [
+                line.strip() for line in f
+                if line.strip() and not line.startswith("#")
+            ]
+        my_uid = str(os.getuid())
+        host_username = os.environ.get("USER") or os.getlogin()
+        my_entry = next(
+            (e for e in entries if e.split(":")[2] == my_uid),
+            None,
+        )
+        assert my_entry, (
+            "no /etc/passwd entry for UID %s in:\n%s"
+            % (my_uid, "\n".join(entries))
+        )
+        username = my_entry.split(":", 1)[0]
+        assert username != "canasta", (
+            "canasta-docker should not write a literal 'canasta' "
+            "username — outbound SSH then defaults to "
+            "'canasta@<host>' and trips sshd's auth-failure limit "
+            "(#478). entry=%r" % my_entry
+        )
+        assert username == host_username, (
+            "in-container username should match host operator's "
+            "(%r) — got %r in entry %r"
+            % (host_username, username, my_entry)
+        )


### PR DESCRIPTION
## Summary

Hexmode reported that \`canasta create -H meta.wikiapiary.com\` from canasta-docker died with sshd's "Too many authentication failures", and the remote's journal showed a stream of \`Invalid user canasta from <ip> … Disconnecting invalid user canasta [preauth]\`.

Root cause: \`canasta-docker\` writes a \`/etc/passwd\` entry for the operator's host UID into a file it bind-mounts read-only into the container, so SSH and Ansible can resolve a username inside. The username was hardcoded to the literal string \`canasta\` — meaning \`id -un\` / \`whoami\` returned \`canasta\` inside the container. Ansible's SSH connection plugin then used \`canasta\` as the default username for any \`-H <host>\` connection without an explicit \`-u\` override, and the remote sshd refused after the auth-failure ceiling.

## Fix

\`\`\`diff
-_CANASTA_DOCKER_USER="canasta"
+_CANASTA_DOCKER_USER="$(id -un 2>/dev/null || echo "${USER:-canasta}")"
\`\`\`

The host UID still maps to the same numeric \`--user \$(id -u):\$(id -g)\` the script already plants; only the textual username changes. Group handling (\`--group-add\` for the docker socket GID + 33 for \`www-data\`) is untouched.

After: \`canasta-docker\` against a remote \`-H\` target SSH-es as \`<operator>@<host>\` — the same pair a plain shell prompt would use — instead of \`canasta@<host>\`. \`<operator>@<host>\` shorthand on \`-H\` continues to override.

## Test

\`tests/unit/test_canasta_docker.py::TestPasswdEntryUsesHostUsername\` reads the \`.canasta-passwd\` canasta-docker writes during a dry-run, finds the entry for the host UID, and asserts:

1. The username is **not** the literal \`canasta\`.
2. The username **does** match \`\$USER\` / \`os.getlogin()\`.

Both assertions are tied to the failure mode #478 reported, so silently regressing either resurrects the bug.

\`make test-unit\` (669 passed), \`make validate\` (67 commands, 50 playbooks), \`make lint\` (no new warnings).

Closes #478