### PR TITLE
canasta: --docker-host flag for rootless podman/Docker (phase 1 of #479)

### DIFF
--- a/canasta.yml
+++ b/canasta.yml
@@ -15,6 +15,23 @@
     canasta_root: "{{ playbook_dir }}"
     canasta_default_image: "ghcr.io/canastawiki/canasta:{{ lookup('file', playbook_dir + '/CANASTA_VERSION') | trim }}"
 
+  # DOCKER_HOST applies to every `docker` / `docker compose` invocation
+  # in the play. Operators on rootless podman / rootless Docker need
+  # this to point at their per-user socket
+  # (e.g. unix:///run/user/<uid>/podman/podman.sock); without it,
+  # `docker info` connects to the default `/var/run/docker.sock` and
+  # fails. Precedence:
+  #   1. --docker-host on the current invocation (e.g. canasta create
+  #      --docker-host=…). Bound as `docker_host`.
+  #   2. dockerHost from the registry, set by resolve_instance.yml on
+  #      a previous create. Bound as `instance_docker_host`.
+  #   3. omit — let docker fall back to its compiled-in default.
+  environment:
+    DOCKER_HOST: >-
+      {{ docker_host
+         | default(instance_docker_host | default(''), true)
+         | default(omit, true) }}
+
   pre_tasks:
     - name: Validate command parameter
       ansible.builtin.assert:

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -194,6 +194,14 @@ commands:
         short: H
         type: string
         description: "Target host for the new instance (default: localhost)"
+      - name: docker_host
+        type: string
+        description: >-
+          Docker API socket on the target. Set this when the target
+          uses rootless podman (typically `unix:///run/user/<uid>/podman/podman.sock`)
+          or rootless Docker. Persisted to the instance registry so
+          subsequent `start`, `stop`, `config set`, etc. inherit it.
+          Leave unset for system Docker on `/var/run/docker.sock`.
       - name: path
         short: p
         type: path
@@ -510,6 +518,13 @@ commands:
         short: H
         type: string
         description: "Target host (default: localhost)"
+      - name: docker_host
+        type: string
+        description: >-
+          Docker API socket on the target. Set this when the target
+          uses rootless podman or rootless Docker (e.g.
+          `unix:///run/user/1000/podman/podman.sock`). Defaults to
+          system Docker's `/var/run/docker.sock`.
       - name: id
         short: i
         type: string
@@ -560,6 +575,13 @@ commands:
         short: H
         type: string
         description: "Target host (default: localhost)"
+      - name: docker_host
+        type: string
+        description: >-
+          Docker API socket on the target. Set this when the target
+          uses rootless podman or rootless Docker (e.g.
+          `unix:///run/user/1000/podman/podman.sock`). Defaults to
+          system Docker's `/var/run/docker.sock`.
       - name: id
         short: i
         type: string
@@ -614,6 +636,12 @@ commands:
         short: H
         type: string
         description: "Target host (default: localhost)"
+      - name: docker_host
+        type: string
+        description: >-
+          Docker API socket on the target. Set this when the target
+          uses rootless podman or rootless Docker. Defaults to system
+          Docker's `/var/run/docker.sock`.
       - name: packages
         type: string
         positional: true

--- a/roles/common/library/canasta_registry.py
+++ b/roles/common/library/canasta_registry.py
@@ -174,6 +174,8 @@ def instance_to_dict(instance):
         result["kindCluster"] = instance["kindCluster"]
     if instance.get("buildFrom"):
         result["buildFrom"] = instance["buildFrom"]
+    if instance.get("dockerHost"):
+        result["dockerHost"] = instance["dockerHost"]
     return result
 
 
@@ -208,6 +210,7 @@ def run_module():
         kind_cluster=dict(type="str", required=False),
         build_from=dict(type="str", required=False),
         host=dict(type="str", required=False),
+        docker_host=dict(type="str", required=False),
         filter_host=dict(type="str", required=False),
         config_dir=dict(type="str", required=False),
     )
@@ -289,6 +292,7 @@ def run_module():
             "registry": module.params.get("registry"),
             "kindCluster": module.params.get("kind_cluster"),
             "buildFrom": module.params.get("build_from"),
+            "dockerHost": module.params.get("docker_host"),
         })
 
         if inst_id in instances:

--- a/roles/common/tasks/resolve_instance.yml
+++ b/roles/common/tasks/resolve_instance.yml
@@ -150,6 +150,10 @@
     instance_orchestrator: "{{ _instance_result.instance.orchestrator | default('compose') }}"
     instance_devmode: "{{ _instance_result.instance.devMode | default(false) }}"
     instance_managed_cluster: "{{ _instance_result.instance.managedCluster | default(false) }}"
+    # instance_docker_host feeds canasta.yml's play-level
+    # `environment: DOCKER_HOST: …`. Empty string when the registry
+    # has no override so the env-var ternary picks the next default.
+    instance_docker_host: "{{ _instance_result.instance.dockerHost | default('') }}"
     _instance_host: "{{ _instance_result.instance.host | default('localhost') }}"
 
 # Switch connection to the instance's registered host so commands

--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -745,6 +745,7 @@
     path: "{{ instance_path }}"
     orchestrator: "{{ orchestrator | default('compose') }}"
     host: "{{ _registry_host }}"
+    docker_host: "{{ docker_host | default(omit) }}"
     managed_cluster: false
     build_from: "{{ build_from | default(omit) }}"
     state: present
@@ -758,6 +759,7 @@
     id: "{{ id }}"
     path: "{{ instance_path }}"
     orchestrator: "{{ orchestrator | default('compose') }}"
+    docker_host: "{{ docker_host | default(omit) }}"
     managed_cluster: false
     build_from: "{{ build_from | default(omit) }}"
     state: present

--- a/tests/unit/test_canasta_registry.py
+++ b/tests/unit/test_canasta_registry.py
@@ -115,6 +115,31 @@ class TestInstanceToDict:
         })
         assert "host" not in result
 
+    def test_includes_docker_host(self):
+        result = canasta_registry.instance_to_dict({
+            "id": "test", "path": "/test",
+            "dockerHost": "unix:///run/user/1000/podman/podman.sock",
+        })
+        assert (
+            result["dockerHost"]
+            == "unix:///run/user/1000/podman/podman.sock"
+        )
+
+    def test_omits_empty_docker_host(self):
+        result = canasta_registry.instance_to_dict({
+            "id": "test", "path": "/test", "dockerHost": ""
+        })
+        assert "dockerHost" not in result
+
+    def test_omits_missing_docker_host(self):
+        # The default — instances created without --docker-host should
+        # not carry the field at all (so existing instances stay
+        # byte-identical in conf.json).
+        result = canasta_registry.instance_to_dict({
+            "id": "test", "path": "/test"
+        })
+        assert "dockerHost" not in result
+
 
 class TestFindByPath:
     def test_exact_match(self, sample_config):

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -613,3 +613,45 @@ class TestResolveInstanceSkipGate:
             "%s no longer includes resolve_instance.yml — the gate "
             "test needs updating to reflect the new flow." % filename
         )
+
+
+class TestPlayLevelDockerHost:
+    """canasta.yml's play-level `environment:` exposes DOCKER_HOST so
+    every Ansible-routed command's docker / docker compose calls
+    inherit it. Operators on rootless podman or rootless Docker
+    set this via `canasta create --docker-host=…` (see #479).
+
+    Drift here is invisible until someone tries the rootless setup,
+    so the structural check is cheap insurance."""
+
+    CANASTA_YML = os.path.join(
+        os.path.dirname(__file__), "..", "..", "canasta.yml",
+    )
+
+    def test_play_environment_exports_docker_host(self):
+        with open(self.CANASTA_YML) as f:
+            plays = yaml.safe_load(f)
+        # The file has one play.
+        play = plays[0]
+        env = play.get("environment", {})
+        assert "DOCKER_HOST" in env, (
+            "canasta.yml must declare a play-level "
+            "`environment: { DOCKER_HOST: … }` so docker tasks "
+            "honor --docker-host / registry dockerHost."
+        )
+
+    def test_docker_host_precedence_flag_then_registry(self):
+        # The expression has to:
+        #   - prefer the `docker_host` var (from --docker-host on the
+        #     current invocation) over the registry value
+        #   - fall back to `instance_docker_host` (set by
+        #     resolve_instance.yml from the registry) when the flag
+        #     wasn't passed
+        #   - omit the env var entirely when neither is set, so
+        #     Docker keeps using its compiled-in default socket
+        with open(self.CANASTA_YML) as f:
+            plays = yaml.safe_load(f)
+        expr = plays[0]["environment"]["DOCKER_HOST"]
+        assert "docker_host" in expr
+        assert "instance_docker_host" in expr
+        assert "omit" in expr


### PR DESCRIPTION
## Summary

Hexmode reported in #479 that \`canasta create -H <rootless-podman-host>\` died with:

\`\`\`
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running
\`\`\`

Rootless podman puts its socket at \`/run/user/<uid>/podman/podman.sock\`, not the system path. Ansible's \`command:\` module runs in a non-interactive shell that doesn't read the operator's profile, so \`DOCKER_HOST\` set in \`.bashrc\` never reaches the play.

This PR is **phase 1**: explicit opt-in via flag, persisted to the registry so the operator only types it once per instance. Phase 2 (auto-detect rootless on probe) is a separate follow-up.

## Behavior

\`\`\`
canasta create -H mah@meta.wikiapiary.com -i mwstake -w mwstake … \\
    --docker-host unix:///run/user/1000/podman/podman.sock
\`\`\`

The flag persists into \`conf.json\` as the instance's \`dockerHost\` field. Subsequent \`canasta start\`, \`stop\`, \`config set\`, \`scale\`, etc. read it back via \`resolve_instance.yml\` and don't need the flag again.

## Implementation

- \`meta/command_definitions.yml\`: \`--docker-host\` parameter on \`create\`, \`install\`, \`uninstall\`, \`doctor\` — the four user-facing host-targeting commands.
- \`roles/common/library/canasta_registry.py\`: new \`docker_host\` param and \`dockerHost\` field. Existing instances stay byte-identical in conf.json — the field is only written when explicitly set.
- \`roles/create/tasks/main.yml\`: persist to both controller and target registries on create.
- \`roles/common/tasks/resolve_instance.yml\`: bind \`instance_docker_host\` from the registry so later commands can read it back.
- \`canasta.yml\`: play-level \`environment: { DOCKER_HOST: … }\` with precedence
  1. \`docker_host\` (flag on the current invocation)
  2. \`instance_docker_host\` (registry, set by resolve_instance.yml)
  3. \`omit\` — let docker fall back to its compiled-in default

The play-level env propagates to all 35 \`docker\` / \`docker compose\` invocations across the roles without per-task plumbing.

## Tests

- \`TestInstanceToDict\`: 3 new cases for the \`dockerHost\` field (included when set, omitted when empty/missing).
- \`TestPlayLevelDockerHost\`: 2 structural tests on \`canasta.yml\` — the play declares \`environment: { DOCKER_HOST: … }\`, and the expression references both \`docker_host\` (flag), \`instance_docker_host\` (registry), and \`omit\` (default).
- \`make test-unit\` (674 passed, 5 new); \`make validate\` (67 commands, 50 playbooks); \`make lint\` (no new warnings).

## Phase 2 (separate PR)

Adds auto-detection: probe the target for \`/run/user/<uid>/podman/podman.sock\` (or \`/run/user/<uid>/docker.sock\` for rootless Docker) and set \`docker_host\` automatically when \`--docker-host\` wasn't given. \`canasta doctor\` reports the detected socket. Once both PRs land, the operator's \`canasta create -H mah@meta…\` from #479 just works without a flag.

Closes #479 (phase 1)