### PR TITLE
docker-compose: relax varnish→web dependency for podman compatibility

### DIFF
--- a/roles/orchestrator/files/compose/docker-compose.yml
+++ b/roles/orchestrator/files/compose/docker-compose.yml
@@ -123,9 +123,15 @@ services:
       - varnish
     restart: unless-stopped
     logging: *default-logging
+    # service_started, not service_healthy: the web image's HEALTHCHECK
+    # is declared in the CanastaBase Dockerfile, but podman-compose does
+    # not expose image-level healthchecks to compose dependency
+    # resolution. Asking compose to wait on a healthcheck it can't see
+    # makes 'docker compose up' fail on podman targets. Varnish has its
+    # own healthcheck and tolerates a brief 502 window while web is
+    # still booting.
     depends_on:
-      web:
-        condition: service_healthy
+      - web
     healthcheck:
       test: ["CMD", "varnishadm", "ping"]
       interval: 10s


### PR DESCRIPTION
## Summary
- Drop `condition: service_healthy` on varnish→web; use default `service_started`.
- podman-compose doesn't expose image-level `HEALTHCHECK` to compose's dependency resolver, so `service_healthy` makes `docker compose up` fail on rootless podman targets even though the canasta image's healthcheck is configured (`CanastaBase/Dockerfile`). The image-level healthcheck is unchanged and still drives `docker inspect` health status for monitoring.
- Inline comment in the compose file documents the constraint so a future contributor doesn't try to "fix" it back to `service_healthy`.

Varnish has its own healthcheck and tolerates a brief 502 window while web is still initialising, so the loss of strict ordering is harmless in practice.

## Test plan
- [x] `make test-unit` (680 tests pass)
- [ ] `canasta create` against a rootless podman target — `docker compose up` succeeds and varnish starts
- [ ] `canasta create` against a Docker target — varnish still starts after web; web container reports healthy after the start-period

Closes #484