### PR TITLE
orchestrator: wait for web container to report healthy after compose up

### DIFF
--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -75,6 +75,56 @@
           {{ _start_logs.stdout | default('(not captured)') }}
       when: _start_result.rc != 0
 
+    # Wait for the web container to finish booting before returning.
+    # /run-all.sh in the canasta image runs `composer update`
+    # synchronously before starting apache; install.php and any other
+    # `docker compose exec web php …` task that runs immediately after
+    # `up -d` will race composer and crash with "vendor/composer/...
+    # bootstrap.php: No such file or directory" if vendor is mid-write.
+    # The CanastaBase HEALTHCHECK probes /server-status, which only
+    # responds once both composer AND apache have finished — so
+    # "healthy" is the right gate. Custom images that do not declare a
+    # HEALTHCHECK skip the wait (we trust them to define their own
+    # readiness contract).
+    - name: Get web container id
+      ansible.builtin.command:
+        cmd: "docker compose {{ _compose_files | join(' ') }} ps -q web"
+        chdir: "{{ instance_path }}"
+      register: _start_web_cid
+      changed_when: false
+
+    - name: Probe whether web declares a healthcheck
+      ansible.builtin.command:
+        argv:
+          - docker
+          - inspect
+          - "-f"
+          - "{% raw %}{{if .State.Health}}has{{end}}{% endraw %}"
+          - "{{ _start_web_cid.stdout | trim }}"
+      register: _start_web_has_health
+      changed_when: false
+      when: _start_web_cid.stdout | trim != ''
+
+    # Up to 60 retries × 10s = 10 min — comfortably above the
+    # CanastaBase healthcheck's 5 min --start-period plus a slow
+    # first-time composer install.
+    - name: Wait for web container to report healthy
+      ansible.builtin.command:
+        argv:
+          - docker
+          - inspect
+          - "-f"
+          - "{% raw %}{{.State.Health.Status}}{% endraw %}"
+          - "{{ _start_web_cid.stdout | trim }}"
+      register: _start_web_health
+      changed_when: false
+      retries: 60
+      delay: 10
+      until: _start_web_health.stdout | trim == 'healthy'
+      when:
+        - _start_web_cid.stdout | trim != ''
+        - _start_web_has_health.stdout | default('') | trim == 'has'
+
 - name: Start (Kubernetes)
   when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
   block:


### PR DESCRIPTION
## Summary
- PR #485 (varnish→web `service_started`) removed an implicit wait that `condition: service_healthy` had been providing — `docker compose up -d` no longer blocks until web's HEALTHCHECK passes.
- That wait was load-bearing: install.php and other immediate `docker compose exec web php …` calls race composer mid-write and crash with `vendor/composer/.../bootstrap.php: No such file or directory`. CI on main started failing on the merge of #485 (run 25281005941, both `Remote Host Integration Tests` and `Integration: Features`).
- Add an explicit poll on web's `Health.Status` in `roles/orchestrator/tasks/start.yml` (10 min budget, comfortably above the canasta image's 5 min `--start-period`).
- Skips the wait gracefully when the image doesn't declare a HEALTHCHECK (custom images own their own readiness contract).

install.php's correctness no longer depends on compose's dependency-graph side effects — works the same on Docker, podman, or any compose-compatible runtime, regardless of varnish state.

## Test plan
- [x] `make test-unit` (680 tests pass)
- [ ] CI green on Docker (the failing scenario from main run 25281005941)
- [ ] Re-test on rootless podman — no regression of the #484 fix