### PR TITLE
canasta_minimal: suppress "(traceback unavailable)" placeholder

### DIFF
--- a/callback_plugins/canasta_minimal.py
+++ b/callback_plugins/canasta_minimal.py
@@ -128,9 +128,18 @@ class CallbackModule(CallbackBase):
             # such file or directory: 'git-crypt'").
             for line in reversed(str(exc).splitlines()):
                 line = line.strip()
-                if line:
-                    parts.append(line)
-                    break
+                if not line:
+                    continue
+                # Ansible sets exception="(traceback unavailable)" for
+                # task types that have no real traceback (notably
+                # ansible.builtin.fail). Skip — surfacing it as
+                # diagnostic text just produces "Error: real-msg
+                # ((traceback unavailable))" which adds noise without
+                # information.
+                if line == "(traceback unavailable)":
+                    continue
+                parts.append(line)
+                break
         if not parts:
             return ""
         return " (%s)" % "; ".join(parts)

--- a/tests/unit/test_canasta_minimal_callback.py
+++ b/tests/unit/test_canasta_minimal_callback.py
@@ -69,6 +69,35 @@ class TestFormatCmdDiagnostics:
             "FileNotFoundError: [Errno 2] No such file: 'git-crypt')"
         )
 
+    def test_traceback_unavailable_placeholder_suppressed(self):
+        """Ansible sets exception='(traceback unavailable)' for tasks
+        with no real traceback (notably ansible.builtin.fail). The
+        callback must not surface that placeholder — without filtering,
+        a fail task's user-facing error becomes 'Error: <msg>
+        ((traceback unavailable))', which is meaningless noise."""
+        out = canasta_minimal.CallbackModule._format_cmd_diagnostics(
+            "", "(traceback unavailable)"
+        )
+        assert out == ""
+
+    def test_traceback_unavailable_with_cmd_keeps_cmd(self):
+        out = canasta_minimal.CallbackModule._format_cmd_diagnostics(
+            ["git-crypt", "--version"], "(traceback unavailable)"
+        )
+        assert out == " (cmd: git-crypt --version)"
+
+    def test_traceback_unavailable_in_multiline_skips_to_real_line(self):
+        """Multi-line exception where the last line is the placeholder
+        and the prior line is the real error: prefer the real error."""
+        exc = (
+            "FileNotFoundError: [Errno 2] No such file: 'git-crypt'\n"
+            "(traceback unavailable)\n"
+        )
+        out = canasta_minimal.CallbackModule._format_cmd_diagnostics("", exc)
+        assert out == (
+            " (FileNotFoundError: [Errno 2] No such file: 'git-crypt')"
+        )
+
 
 class TestRunnerOnFailed:
     def test_oserror_on_spawn_surfaces_cmd_and_exception(self):
@@ -104,6 +133,20 @@ class TestRunnerOnFailed:
         cb.v2_runner_on_failed(_result(msg="plain failure"))
         msgs = [m for (m, _, _) in cb._captured]
         assert msgs == ["Error: plain failure"]
+
+    def test_fail_task_with_traceback_unavailable_placeholder(self):
+        """End-to-end: ansible.builtin.fail sets exception=
+        '(traceback unavailable)' alongside its real msg. The user
+        should see only the real message, not the placeholder."""
+        cb = _make_callback()
+        cb.v2_runner_on_failed(_result(
+            msg="Instance 'mwstake' not found in the registry or Kubernetes.",
+            exception="(traceback unavailable)",
+        ))
+        msgs = [m for (m, _, _) in cb._captured]
+        assert msgs == [
+            "Error: Instance 'mwstake' not found in the registry or Kubernetes."
+        ]
 
     def test_ignore_errors_suppresses_output(self):
         cb = _make_callback()


### PR DESCRIPTION
## Summary
- `ansible.builtin.fail` (and other task types with no real traceback) sets `exception="(traceback unavailable)"` on the result. The callback's `_format_cmd_diagnostics` was wrapping that placeholder in another set of parens, producing user-facing output like:

  `Error: Instance 'foo' not found in the registry or Kubernetes. ((traceback unavailable))`

- Skip the literal `(traceback unavailable)` line in `_format_cmd_diagnostics`. Multi-line exceptions where the real error is one line above still surface correctly.

## Test plan
- [x] `make test-unit` (684 tests, +4 new)
- [x] Existing OSError-on-spawn diagnostics path unchanged

Closes #483