### PR TITLE
install: auto-add operator to the canasta group

### DIFF
--- a/roles/install/tasks/canasta.yml
+++ b/roles/install/tasks/canasta.yml
@@ -131,9 +131,32 @@
         dest: /usr/local/bin/canasta
         state: link
 
+    # ansible_user is the SSH user we connected as; ansible_user_id is
+    # the local-run fallback. Either way, this is the user who will be
+    # invoking 'canasta upgrade' / 'canasta install' on the target, so
+    # they're the one who needs canasta-group membership.
+    - name: Determine operator user
+      ansible.builtin.set_fact:
+        _operator_user: "{{ ansible_user | default(ansible_user_id) }}"
+
+    - name: Add operator to the canasta group
+      ansible.builtin.user:
+        name: "{{ _operator_user }}"
+        groups: canasta
+        append: true
+      register: _operator_group_add
+      when: _operator_user | length > 0
+
     - name: Report canasta installed
       ansible.builtin.debug:
+        msg: "canasta-native installed at /opt/canasta-ansible."
+
+    - name: Report operator group membership
+      ansible.builtin.debug:
         msg: >-
-          canasta-native installed at /opt/canasta-ansible.
-          Add users to the 'canasta' group to let them run
-          'canasta upgrade' and 'canasta install' without sudo.
+          Added '{{ _operator_user }}' to the 'canasta' group. New SSH
+          sessions on this host will pick this up automatically. If
+          you have an existing shell on this host, log out and back in
+          (or run 'newgrp canasta') before invoking 'canasta upgrade'
+          or 'canasta install'.
+      when: _operator_group_add is changed

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -920,9 +920,12 @@ class TestCmdVersion:
 
     def test_missing_version_file(self, tmp_path, monkeypatch, capsys):
         monkeypatch.setattr(direct_commands, "_get_script_dir", lambda: str(tmp_path))
+        # `stderr` is needed because _ssh_run reads result.stderr.strip();
+        # cmd_version may iterate registered instances on the developer's
+        # machine and reach _ssh_run for any host != localhost.
         monkeypatch.setattr(
             subprocess, "run",
-            lambda *a, **kw: type("R", (), {"returncode": 1, "stdout": ""})(),
+            lambda *a, **kw: type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})(),
         )
         rc = direct_commands.cmd_version(None)
         assert rc == 0
@@ -934,7 +937,7 @@ class TestCmdVersion:
         monkeypatch.setattr(direct_commands, "_get_script_dir", lambda: str(tmp_path))
         monkeypatch.setattr(
             subprocess, "run",
-            lambda *a, **kw: type("R", (), {"returncode": 128, "stdout": ""})(),
+            lambda *a, **kw: type("R", (), {"returncode": 128, "stdout": "", "stderr": ""})(),
         )
         rc = direct_commands.cmd_version(None)
         assert rc == 0


### PR DESCRIPTION
## Summary
`roles/install/tasks/canasta.yml` was creating the `canasta` system group and chgrp-ing the install dir to it, but never adding the invoking user to the group — the post-install message just hinted at it. The first `canasta upgrade` after install would then fail:

```
Error: non-zero return code (cmd: git fetch origin)
error: cannot open '.git/FETCH_HEAD': Permission denied
```

Add an explicit `user: groups: canasta append: true` task using `ansible_user` (SSH install) or `ansible_user_id` (local) and revise the post-install message: log-out-and-back-in is only relevant for shells already open on the target — fresh SSH sessions pick up the new group automatically.

Bundles a small unrelated test fix: `TestCmdVersion::test_missing_version_file` and `test_not_a_git_repo` mock `subprocess.run` with an `R` object missing `stderr`. CI passes (empty registry → `_ssh_run` never called) but locally these fail on any developer machine with a remote instance registered, because `cmd_version` iterates instances and `_ssh_run` reads `result.stderr.strip()` (added in #482). One-line fix: add `stderr=""` to both mocks.

## Test plan
- [x] `make test-unit` (684 pass)
- [x] `make validate`
- [ ] `canasta install canasta -H <host>` — verify post-install message reads cleanly and the operator can run `canasta upgrade` on first try