### PR TITLE
upgrade: collapse per-migration probes into one round-trip

### DIFF
--- a/roles/upgrade/files/probe_migration_state.py
+++ b/roles/upgrade/files/probe_migration_state.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Probe migration-relevant state for `canasta upgrade` in one
+SSH round-trip. The migration play registers this script's stdout
+as a fact (_mig); each migration then reads its own decision off
+the fact instead of running its own stat / find / canasta_env-read.
+
+Defensive: missing or unparseable files always produce sensible
+defaults rather than failing the probe.
+
+Output JSON shape:
+  {
+    "env": {KEY: value-string-or-empty},
+    "env_present": {KEY: bool},  # distinguish "set to empty" from "absent"
+    "files": {flag-name: bool},
+    "old_wiki_dirs": [str],
+    "stray_php": [absolute-path-str],
+    "host_dirs": [str]
+  }
+"""
+import json
+import os
+import sys
+
+
+# .env keys consumed by individual migrations or by the post-migration
+# Compose image-tag block in main.yml.
+ENV_KEYS_OF_INTEREST = (
+    "MW_SECRET_KEY",
+    "CANASTA_IMAGE",
+    "COMPOSE_PROFILES",
+    "USE_EXTERNAL_DB",
+)
+
+# Subdirs of config/ that are NOT per-wiki state and must not be
+# moved by the directory-structure migration.
+CONFIG_NON_WIKI = ("settings", "logstash", "backup", "persistent")
+
+
+def parse_env(path):
+    """Return (values, present) for ENV_KEYS_OF_INTEREST.
+
+    `values` maps key → raw string (empty string when key is absent).
+    `present` maps key → True iff the key appears in the .env file
+    at all (even with an empty value, which is meaningful for
+    COMPOSE_PROFILES on external-DB instances).
+    """
+    values = {k: "" for k in ENV_KEYS_OF_INTEREST}
+    present = {k: False for k in ENV_KEYS_OF_INTEREST}
+    try:
+        with open(path) as f:
+            for raw in f:
+                line = raw.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                k = k.strip()
+                if k not in ENV_KEYS_OF_INTEREST:
+                    continue
+                v = v.strip()
+                if len(v) >= 2 and v[0] == v[-1] and v[0] in ('"', "'"):
+                    v = v[1:-1]
+                values[k] = v
+                present[k] = True
+    except OSError:
+        pass
+    return values, present
+
+
+def file_contains(path, needle):
+    """True iff `needle` appears anywhere in the file's text. Used
+    as a cheap "is this migration relevant?" gate — false positives
+    are fine (the migration re-checks)."""
+    try:
+        with open(path) as f:
+            return needle in f.read()
+    except OSError:
+        return False
+
+
+def composer_local_empty_include(path):
+    """True iff composer.local.json parses and has an empty
+    extra.merge-plugin.include array. Anything else (missing,
+    malformed, populated) returns False — the migration only fires
+    on the empty-array case."""
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return False
+    try:
+        return len(data["extra"]["merge-plugin"]["include"]) == 0
+    except (KeyError, TypeError):
+        return False
+
+
+def list_subdirs(path, exclude=()):
+    if not os.path.isdir(path):
+        return []
+    return sorted(
+        name for name in os.listdir(path)
+        if name not in exclude
+        and os.path.isdir(os.path.join(path, name))
+    )
+
+
+def list_files_matching(dir_path, suffix):
+    if not os.path.isdir(dir_path):
+        return []
+    return sorted(
+        os.path.join(dir_path, name)
+        for name in os.listdir(dir_path)
+        if name.endswith(suffix)
+        and os.path.isfile(os.path.join(dir_path, name))
+    )
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(json.dumps(
+            {"error": "usage: probe_migration_state.py <instance_path>"}
+        ))
+        sys.exit(1)
+    base = sys.argv[1]
+
+    env_path = os.path.join(base, ".env")
+    vector_php = os.path.join(base, "config", "settings", "global", "Vector.php")
+    composer_local = os.path.join(base, "config", "composer.local.json")
+    mycnf = os.path.join(base, "my.cnf")
+    gitops_host = os.path.join(base, ".gitops-host")
+    legacy_git = os.path.join(base, ".git")
+    hosts_yaml = os.path.join(base, "hosts", "hosts.yaml")
+
+    env_values, env_present = parse_env(env_path)
+
+    state = {
+        "env": env_values,
+        "env_present": env_present,
+        "files": {
+            "vector_php": os.path.isfile(vector_php),
+            "vector_php_has_default_skin": file_contains(vector_php, "wgDefaultSkin"),
+            "composer_local": os.path.isfile(composer_local),
+            "composer_local_empty_include": composer_local_empty_include(composer_local),
+            "mycnf": os.path.isfile(mycnf),
+            "mycnf_has_skip_binary_as_hex": file_contains(mycnf, "skip-binary-as-hex"),
+            "gitops_host": os.path.isfile(gitops_host),
+            "legacy_git": os.path.isdir(legacy_git),
+            "hosts_yaml": os.path.isfile(hosts_yaml),
+        },
+        "old_wiki_dirs": list_subdirs(
+            os.path.join(base, "config"), exclude=CONFIG_NON_WIKI,
+        ),
+        "stray_php": list_files_matching(
+            os.path.join(base, "config", "settings"), ".php",
+        ),
+        "host_dirs": list_subdirs(
+            os.path.join(base, "hosts"), exclude=("_shared",),
+        ),
+    }
+
+    print(json.dumps(state))
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -28,6 +28,13 @@
   ansible.builtin.debug:
     msg: "Checking for config migrations..."
 
+# Single round-trip that gathers every stat / find / .env-read each
+# migration would otherwise do for itself. Each migration consults
+# `_mig` and skips entirely on no-op, collapsing what used to be
+# ~12-15 round-trips on a steady-state upgrade into one.
+- name: Probe migration-relevant state
+  ansible.builtin.include_tasks: pre_migration_probe.yml
+
 - name: Run migrations
   ansible.builtin.include_tasks: "migrations/{{ _migration }}"
   loop:
@@ -125,24 +132,18 @@
   when:
     - instance_orchestrator | default('compose') == 'compose'
     - _upgrade_inst.instance.buildFrom | default('') == ''
+    # CANASTA_IMAGE was already read by the migration probe; reuse
+    # those values instead of re-reading .env.
+    - _mig.env_present.CANASTA_IMAGE
+    - _mig.env.CANASTA_IMAGE is match('^ghcr\\.io/canastawiki/canasta:')
+    - _mig.env.CANASTA_IMAGE != canasta_default_image
   block:
-    - name: Read current CANASTA_IMAGE
-      canasta_env:
-        path: "{{ instance_path }}/.env"
-        state: read
-        key: CANASTA_IMAGE
-      register: _upgrade_current_image
-
     - name: Update CANASTA_IMAGE to latest default tag
       canasta_env:
         path: "{{ instance_path }}/.env"
         state: set
         key: CANASTA_IMAGE
         value: "{{ canasta_default_image }}"
-      when:
-        - _upgrade_current_image.found
-        - _upgrade_current_image.value is match('^ghcr\\.io/canastawiki/canasta:')
-        - _upgrade_current_image.value != canasta_default_image
 
 # --- Pull and restart ---
 - name: Report pulling images

--- a/roles/upgrade/tasks/migrations/backfill_canasta_image.yml
+++ b/roles/upgrade/tasks/migrations/backfill_canasta_image.yml
@@ -5,17 +5,10 @@
   ansible.builtin.debug:
     msg: "Checking CANASTA_IMAGE..."
 
-- name: Check if CANASTA_IMAGE is set
-  canasta_env:
-    path: "{{ instance_path }}/.env"
-    state: read
-    key: CANASTA_IMAGE
-  register: _img_check
-
 - name: Set CANASTA_IMAGE if missing
   canasta_env:
     path: "{{ instance_path }}/.env"
     state: set
     key: CANASTA_IMAGE
     value: "{{ canasta_default_image }}"
-  when: not _img_check.found or _img_check.value == ''
+  when: not (_mig.env.CANASTA_IMAGE | default(''))

--- a/roles/upgrade/tasks/migrations/backfill_compose_profiles.yml
+++ b/roles/upgrade/tasks/migrations/backfill_compose_profiles.yml
@@ -2,25 +2,14 @@
 # Migration: Ensure COMPOSE_PROFILES is set for existing instances.
 # New instances get this at create time. Existing instances need it
 # backfilled so the db service profile (internal-db) is active.
+#
+# Distinction matters: COMPOSE_PROFILES set to empty is intentional
+# on external-DB instances. Only backfill when the key is absent
+# entirely — env_present catches that.
 
 - name: Display a progress message
   ansible.builtin.debug:
     msg: "Checking COMPOSE_PROFILES..."
-
-- name: Check if COMPOSE_PROFILES is set
-  canasta_env:
-    path: "{{ instance_path }}/.env"
-    state: read
-    key: COMPOSE_PROFILES
-  register: _profiles_check
-
-- name: Check USE_EXTERNAL_DB
-  canasta_env:
-    path: "{{ instance_path }}/.env"
-    state: read
-    key: USE_EXTERNAL_DB
-  register: _ext_db_check
-  when: not _profiles_check.found
 
 - name: Set COMPOSE_PROFILES if missing
   canasta_env:
@@ -28,7 +17,6 @@
     state: set
     key: COMPOSE_PROFILES
     value: >-
-      {{ (_ext_db_check.found | default(false) and
-          (_ext_db_check.value | default('false')) | lower == 'true')
+      {{ ((_mig.env.USE_EXTERNAL_DB | default('false')) | lower == 'true')
          | ternary('', 'internal-db') }}
-  when: not _profiles_check.found
+  when: not _mig.env_present.COMPOSE_PROFILES

--- a/roles/upgrade/tasks/migrations/backfill_hosts_yaml.yml
+++ b/roles/upgrade/tasks/migrations/backfill_hosts_yaml.yml
@@ -16,48 +16,17 @@
   ansible.builtin.debug:
     msg: "Checking hosts/hosts.yaml..."
 
-- name: Check for .gitops-host (instance has gitops set up)
-  ansible.builtin.stat:
-    path: "{{ instance_path }}/.gitops-host"
-  register: _hosts_yaml_gitops_marker
-
-- name: Check for existing hosts.yaml
-  ansible.builtin.stat:
-    path: "{{ instance_path }}/hosts/hosts.yaml"
-  register: _hosts_yaml_existing
-  when: _hosts_yaml_gitops_marker.stat.exists
-
-- name: Find per-host directories under hosts/
-  ansible.builtin.find:
-    paths: "{{ instance_path }}/hosts"
-    file_type: directory
-    excludes:
-      - "_shared"
-    recurse: false
-  register: _hosts_yaml_host_dirs
-  when:
-    - _hosts_yaml_gitops_marker.stat.exists
-    - not (_hosts_yaml_existing.stat.exists | default(false))
-
 - name: Backfill hosts.yaml from existing per-host directories
   when:
-    - _hosts_yaml_gitops_marker.stat.exists
-    - not (_hosts_yaml_existing.stat.exists | default(false))
-    - (_hosts_yaml_host_dirs.files | default([]) | length) > 0
+    - _mig.files.gitops_host
+    - not _mig.files.hosts_yaml
+    - (_mig.host_dirs | length) > 0
   block:
-    - name: Collect host names from directory listing
-      ansible.builtin.set_fact:
-        _hosts_yaml_entries: >-
-          {{ _hosts_yaml_host_dirs.files
-             | map(attribute='path')
-             | map('basename')
-             | sort | list }}
-
     - name: Write hosts.yaml
       ansible.builtin.copy:
         content: |
           hosts:
-          {% for _h in _hosts_yaml_entries %}
+          {% for _h in _mig.host_dirs %}
             - name: {{ _h }}
               role: both
               pull_requests: false
@@ -69,7 +38,7 @@
       ansible.builtin.debug:
         msg: >-
           Backfilled hosts/hosts.yaml with
-          {{ _hosts_yaml_entries | length }} host(s):
-          {{ _hosts_yaml_entries | join(', ') }}.
+          {{ _mig.host_dirs | length }} host(s):
+          {{ _mig.host_dirs | join(', ') }}.
           Roles default to 'both'; edit hosts.yaml if any host should
           be source-only or sink-only.

--- a/roles/upgrade/tasks/migrations/extract_secret_key.yml
+++ b/roles/upgrade/tasks/migrations/extract_secret_key.yml
@@ -6,15 +6,8 @@
   ansible.builtin.debug:
     msg: "Checking secret key..."
 
-- name: Check if MW_SECRET_KEY already in .env
-  canasta_env:
-    path: "{{ instance_path }}/.env"
-    state: read
-    key: MW_SECRET_KEY
-  register: _sk_check
-
 - name: Extract secret key if not in .env
-  when: not _sk_check.found or _sk_check.value == ''
+  when: not (_mig.env.MW_SECRET_KEY | default(''))
   block:
     - name: Search for wgSecretKey in PHP files
       ansible.builtin.shell:

--- a/roles/upgrade/tasks/migrations/fix_vector_default_skin.yml
+++ b/roles/upgrade/tasks/migrations/fix_vector_default_skin.yml
@@ -5,24 +5,11 @@
   ansible.builtin.debug:
     msg: "Checking default skin..."
 
-- name: Check if Vector.php exists
-  ansible.builtin.stat:
+- name: Append wgDefaultSkin line to Vector.php
+  ansible.builtin.lineinfile:
     path: "{{ instance_path }}/config/settings/global/Vector.php"
-  register: _vector_php
-
-- name: Add default skin setting if missing
-  when: _vector_php.stat.exists
-  block:
-    - name: Check if wgDefaultSkin already set
-      ansible.builtin.command:
-        cmd: "grep -c 'wgDefaultSkin' {{ instance_path }}/config/settings/global/Vector.php"
-      register: _has_default_skin
-      changed_when: false
-      ignore_errors: true  # OK if grep finds no matches
-
-    - name: Append wgDefaultSkin line
-      ansible.builtin.lineinfile:
-        path: "{{ instance_path }}/config/settings/global/Vector.php"
-        line: '$wgDefaultSkin = "vector-2022";'
-        insertbefore: EOF
-      when: _has_default_skin.stdout | default('0') | trim == '0'
+    line: '$wgDefaultSkin = "vector-2022";'
+    insertbefore: EOF
+  when:
+    - _mig.files.vector_php
+    - not _mig.files.vector_php_has_default_skin

--- a/roles/upgrade/tasks/migrations/migrate_directory_structure.yml
+++ b/roles/upgrade/tasks/migrations/migrate_directory_structure.yml
@@ -7,19 +7,8 @@
   ansible.builtin.debug:
     msg: "Checking directory structure..."
 
-- name: Check for old per-wiki config directories
-  ansible.builtin.find:
-    paths: "{{ instance_path }}/config"
-    file_type: directory
-    excludes:
-      - settings
-      - logstash
-      - backup
-      - persistent
-  register: _old_wiki_dirs
-
 - name: Migrate per-wiki directories
-  when: _old_wiki_dirs.files | length > 0
+  when: _mig.old_wiki_dirs | length > 0
   block:
     - name: Create new wikis settings directory
       ansible.builtin.file:
@@ -29,23 +18,15 @@
 
     - name: Move per-wiki directories
       ansible.builtin.command:
-        cmd: "mv {{ item.path }} {{ instance_path }}/config/settings/wikis/{{ item.path | basename }}"
-      loop: "{{ _old_wiki_dirs.files }}"
+        cmd: "mv {{ instance_path }}/config/{{ item }} {{ instance_path }}/config/settings/wikis/{{ item }}"
+      loop: "{{ _mig.old_wiki_dirs }}"
       loop_control:
-        label: "{{ item.path | basename }}"
-      when: item.path | basename not in ['settings', 'logstash', 'backup']
+        label: "{{ item }}"
       changed_when: true
       ignore_errors: true  # OK if dir already moved
 
-- name: Check for PHP files in config/settings/ (not in global/)
-  ansible.builtin.find:
-    paths: "{{ instance_path }}/config/settings"
-    patterns: "*.php"
-    recurse: false
-  register: _stray_php
-
 - name: Migrate stray PHP files to global/
-  when: _stray_php.files | length > 0
+  when: _mig.stray_php | length > 0
   block:
     - name: Ensure global settings directory exists
       ansible.builtin.file:
@@ -55,8 +36,8 @@
 
     - name: Move PHP files to global/
       ansible.builtin.command:
-        cmd: "mv {{ item.path }} {{ instance_path }}/config/settings/global/{{ item.path | basename }}"
-      loop: "{{ _stray_php.files }}"
+        cmd: "mv {{ item }} {{ instance_path }}/config/settings/global/{{ item | basename }}"
+      loop: "{{ _mig.stray_php }}"
       loop_control:
-        label: "{{ item.path | basename }}"
+        label: "{{ item | basename }}"
       changed_when: true

--- a/roles/upgrade/tasks/migrations/remove_empty_composer_local.yml
+++ b/roles/upgrade/tasks/migrations/remove_empty_composer_local.yml
@@ -5,30 +5,10 @@
   ansible.builtin.debug:
     msg: "Checking composer.local.json..."
 
-- name: Check if composer.local.json exists
-  ansible.builtin.stat:
+- name: Remove composer.local.json with empty merge-plugin include
+  ansible.builtin.file:
     path: "{{ instance_path }}/config/composer.local.json"
-  register: _composer_json
-
-- name: Check and remove if empty include
-  when: _composer_json.stat.exists
-  block:
-    - name: Read composer.local.json
-      ansible.builtin.slurp:
-        src: "{{ instance_path }}/config/composer.local.json"
-      register: _composer_content
-
-    - name: Parse and check include array
-      ansible.builtin.set_fact:
-        _composer_data: "{{ _composer_content.content | b64decode | from_json }}"
-
-    - name: Remove if include array is empty
-      ansible.builtin.file:
-        path: "{{ instance_path }}/config/composer.local.json"
-        state: absent
-      when: >-
-        _composer_data.extra is defined and
-        _composer_data.extra['merge-plugin'] is defined and
-        _composer_data.extra['merge-plugin'].include is defined and
-        _composer_data.extra['merge-plugin'].include | length == 0
-  ignore_errors: true  # OK if JSON structure unexpected
+    state: absent
+  when:
+    - _mig.files.composer_local
+    - _mig.files.composer_local_empty_include

--- a/roles/upgrade/tasks/migrations/remove_legacy_git_dir.yml
+++ b/roles/upgrade/tasks/migrations/remove_legacy_git_dir.yml
@@ -6,18 +6,10 @@
   ansible.builtin.debug:
     msg: "Checking for legacy .git directories..."
 
-- name: Check for .gitops-host
-  ansible.builtin.stat:
-    path: "{{ instance_path }}/.gitops-host"
-  register: _gitops_host
-
-- name: Check for .git directory
-  ansible.builtin.stat:
-    path: "{{ instance_path }}/.git"
-  register: _legacy_git
-
 - name: Remove legacy .git directory
   ansible.builtin.file:
     path: "{{ instance_path }}/.git"
     state: absent
-  when: _legacy_git.stat.exists and not _gitops_host.stat.exists
+  when:
+    - _mig.files.legacy_git
+    - not _mig.files.gitops_host

--- a/roles/upgrade/tasks/migrations/remove_skip_binary_as_hex.yml
+++ b/roles/upgrade/tasks/migrations/remove_skip_binary_as_hex.yml
@@ -6,13 +6,13 @@
   ansible.builtin.debug:
     msg: "Checking my.cnf..."
 
-- name: Check if my.cnf exists
-  ansible.builtin.stat:
-    path: "{{ instance_path }}/my.cnf"
-  register: _mycnf
-
+# Only slurp + recompute when my.cnf actually mentions
+# skip-binary-as-hex; the probe pre-checked, so the steady-state
+# upgrade pays no extra round-trips.
 - name: Remove skip-binary-as-hex from non-mysql sections
-  when: _mycnf.stat.exists
+  when:
+    - _mig.files.mycnf
+    - _mig.files.mycnf_has_skip_binary_as_hex
   block:
     - name: Read my.cnf
       ansible.builtin.slurp:

--- a/roles/upgrade/tasks/pre_migration_probe.yml
+++ b/roles/upgrade/tasks/pre_migration_probe.yml
@@ -1,0 +1,16 @@
+---
+# One-shot probe of migration-relevant state. Replaces the
+# per-migration stat / find / canasta_env-read calls with a single
+# script run that returns JSON. Each migration in the loop below
+# reads its own decision off `_mig` instead of paying its own SSH
+# round-trip just to check whether it has work to do.
+
+- name: Probe migration-relevant state
+  ansible.builtin.script:
+    cmd: "{{ canasta_root }}/roles/upgrade/files/probe_migration_state.py {{ instance_path | quote }}"
+  register: _mig_probe_raw
+  changed_when: false
+
+- name: Parse probe output
+  ansible.builtin.set_fact:
+    _mig: "{{ _mig_probe_raw.stdout | from_json }}"

--- a/tests/unit/test_probe_migration_state.py
+++ b/tests/unit/test_probe_migration_state.py
@@ -1,0 +1,253 @@
+"""Tests for roles/upgrade/files/probe_migration_state.py.
+
+The probe runs on the target host and emits JSON consumed by the
+upgrade migration tasks. The tests below build small instance-dir
+fixtures under tmp_path and assert the JSON shape and content.
+"""
+
+import importlib.util
+import json
+import os
+
+import pytest
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+PROBE_PATH = os.path.join(
+    REPO_ROOT, "roles", "upgrade", "files", "probe_migration_state.py",
+)
+
+
+def _load_probe():
+    spec = importlib.util.spec_from_file_location(
+        "probe_migration_state", PROBE_PATH,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def probe():
+    return _load_probe()
+
+
+@pytest.fixture
+def instance_dir(tmp_path):
+    """A skeleton instance directory the probe can chew on."""
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "settings").mkdir()
+    return tmp_path
+
+
+def _run(probe, base):
+    """Drive the probe like Ansible would. Returns the parsed JSON."""
+    import io
+    import sys
+    saved = sys.argv, sys.stdout
+    sys.argv = ["probe_migration_state.py", str(base)]
+    sys.stdout = io.StringIO()
+    try:
+        probe.main()
+        return json.loads(sys.stdout.getvalue())
+    finally:
+        sys.argv, sys.stdout = saved
+
+
+# --- .env parsing ----------------------------------------------------
+
+
+class TestEnvParsing:
+    def test_missing_env_yields_empty_present_map(self, probe, instance_dir):
+        result = _run(probe, instance_dir)
+        assert result["env_present"] == {
+            "MW_SECRET_KEY": False,
+            "CANASTA_IMAGE": False,
+            "COMPOSE_PROFILES": False,
+            "USE_EXTERNAL_DB": False,
+        }
+        assert result["env"]["MW_SECRET_KEY"] == ""
+
+    def test_present_keys_are_extracted(self, probe, instance_dir):
+        (instance_dir / ".env").write_text(
+            "HTTP_PORT=80\n"
+            "MW_SECRET_KEY=abc123\n"
+            "CANASTA_IMAGE=ghcr.io/canastawiki/canasta:3.5.7\n"
+        )
+        result = _run(probe, instance_dir)
+        assert result["env"]["MW_SECRET_KEY"] == "abc123"
+        assert result["env"]["CANASTA_IMAGE"] == "ghcr.io/canastawiki/canasta:3.5.7"
+        assert result["env_present"]["MW_SECRET_KEY"] is True
+        assert result["env_present"]["COMPOSE_PROFILES"] is False
+
+    def test_empty_value_is_present_but_empty(self, probe, instance_dir):
+        """COMPOSE_PROFILES= (set to empty) is meaningful — external-DB
+        instances intentionally have an empty profiles list. The probe
+        must distinguish "present but empty" from "absent."""
+        (instance_dir / ".env").write_text("COMPOSE_PROFILES=\n")
+        result = _run(probe, instance_dir)
+        assert result["env_present"]["COMPOSE_PROFILES"] is True
+        assert result["env"]["COMPOSE_PROFILES"] == ""
+
+    def test_quoted_values_are_unquoted(self, probe, instance_dir):
+        (instance_dir / ".env").write_text(
+            'MW_SECRET_KEY="abc123"\n'
+            "CANASTA_IMAGE='ghcr.io/canastawiki/canasta:latest'\n"
+        )
+        result = _run(probe, instance_dir)
+        assert result["env"]["MW_SECRET_KEY"] == "abc123"
+        assert result["env"]["CANASTA_IMAGE"] == "ghcr.io/canastawiki/canasta:latest"
+
+    def test_comments_and_blank_lines_skipped(self, probe, instance_dir):
+        (instance_dir / ".env").write_text(
+            "# a comment\n"
+            "\n"
+            "MW_SECRET_KEY=secret\n"
+        )
+        result = _run(probe, instance_dir)
+        assert result["env"]["MW_SECRET_KEY"] == "secret"
+
+
+# --- File probes ----------------------------------------------------
+
+
+class TestFileProbes:
+    def test_vector_php_absent(self, probe, instance_dir):
+        result = _run(probe, instance_dir)
+        assert result["files"]["vector_php"] is False
+        assert result["files"]["vector_php_has_default_skin"] is False
+
+    def test_vector_php_with_default_skin(self, probe, instance_dir):
+        (instance_dir / "config" / "settings" / "global").mkdir()
+        (instance_dir / "config" / "settings" / "global" / "Vector.php").write_text(
+            "<?php\n$wgDefaultSkin = \"vector-2022\";\n"
+        )
+        result = _run(probe, instance_dir)
+        assert result["files"]["vector_php"] is True
+        assert result["files"]["vector_php_has_default_skin"] is True
+
+    def test_vector_php_without_default_skin(self, probe, instance_dir):
+        (instance_dir / "config" / "settings" / "global").mkdir()
+        (instance_dir / "config" / "settings" / "global" / "Vector.php").write_text(
+            "<?php\n// just a comment\n"
+        )
+        result = _run(probe, instance_dir)
+        assert result["files"]["vector_php"] is True
+        assert result["files"]["vector_php_has_default_skin"] is False
+
+    def test_legacy_git_dir_detected(self, probe, instance_dir):
+        (instance_dir / ".git").mkdir()
+        result = _run(probe, instance_dir)
+        assert result["files"]["legacy_git"] is True
+        assert result["files"]["gitops_host"] is False
+
+    def test_gitops_host_marker(self, probe, instance_dir):
+        (instance_dir / ".gitops-host").write_text("primary\n")
+        result = _run(probe, instance_dir)
+        assert result["files"]["gitops_host"] is True
+        assert result["files"]["legacy_git"] is False
+
+
+class TestComposerLocal:
+    def test_absent(self, probe, instance_dir):
+        result = _run(probe, instance_dir)
+        assert result["files"]["composer_local"] is False
+        assert result["files"]["composer_local_empty_include"] is False
+
+    def test_empty_include_array(self, probe, instance_dir):
+        (instance_dir / "config" / "composer.local.json").write_text(
+            json.dumps({"extra": {"merge-plugin": {"include": []}}})
+        )
+        result = _run(probe, instance_dir)
+        assert result["files"]["composer_local"] is True
+        assert result["files"]["composer_local_empty_include"] is True
+
+    def test_populated_include_array(self, probe, instance_dir):
+        (instance_dir / "config" / "composer.local.json").write_text(
+            json.dumps({"extra": {"merge-plugin": {"include": ["foo/composer.json"]}}})
+        )
+        result = _run(probe, instance_dir)
+        assert result["files"]["composer_local"] is True
+        assert result["files"]["composer_local_empty_include"] is False
+
+    def test_malformed_json_does_not_crash(self, probe, instance_dir):
+        (instance_dir / "config" / "composer.local.json").write_text("{not json")
+        result = _run(probe, instance_dir)
+        assert result["files"]["composer_local"] is True
+        assert result["files"]["composer_local_empty_include"] is False
+
+
+class TestMyCnf:
+    def test_absent(self, probe, instance_dir):
+        result = _run(probe, instance_dir)
+        assert result["files"]["mycnf"] is False
+        assert result["files"]["mycnf_has_skip_binary_as_hex"] is False
+
+    def test_present_clean(self, probe, instance_dir):
+        (instance_dir / "my.cnf").write_text("[mysqld]\nlog-bin=mysql-bin\n")
+        result = _run(probe, instance_dir)
+        assert result["files"]["mycnf"] is True
+        assert result["files"]["mycnf_has_skip_binary_as_hex"] is False
+
+    def test_present_with_skip_binary_as_hex(self, probe, instance_dir):
+        (instance_dir / "my.cnf").write_text(
+            "[client]\nskip-binary-as-hex\n"
+        )
+        result = _run(probe, instance_dir)
+        assert result["files"]["mycnf_has_skip_binary_as_hex"] is True
+
+
+# --- Directory probes -----------------------------------------------
+
+
+class TestOldWikiDirs:
+    def test_only_system_dirs_yields_empty(self, probe, instance_dir):
+        for sys_dir in ("settings", "logstash", "backup", "persistent"):
+            (instance_dir / "config" / sys_dir).mkdir(exist_ok=True)
+        result = _run(probe, instance_dir)
+        assert result["old_wiki_dirs"] == []
+
+    def test_per_wiki_dirs_listed(self, probe, instance_dir):
+        for d in ("settings", "wiki1", "wiki2"):
+            (instance_dir / "config" / d).mkdir(exist_ok=True)
+        result = _run(probe, instance_dir)
+        assert result["old_wiki_dirs"] == ["wiki1", "wiki2"]
+
+    def test_files_under_config_are_ignored(self, probe, instance_dir):
+        (instance_dir / "config" / "wikis.yaml").write_text("wikis: []\n")
+        result = _run(probe, instance_dir)
+        assert result["old_wiki_dirs"] == []
+
+
+class TestStrayPhp:
+    def test_no_php_files(self, probe, instance_dir):
+        result = _run(probe, instance_dir)
+        assert result["stray_php"] == []
+
+    def test_php_files_listed(self, probe, instance_dir):
+        (instance_dir / "config" / "settings" / "Foo.php").write_text("<?php\n")
+        (instance_dir / "config" / "settings" / "Bar.php").write_text("<?php\n")
+        result = _run(probe, instance_dir)
+        names = sorted(os.path.basename(p) for p in result["stray_php"])
+        assert names == ["Bar.php", "Foo.php"]
+
+    def test_php_in_subdirs_not_listed(self, probe, instance_dir):
+        """global/ and wikis/<id>/ subdirs already have the right
+        layout; only loose .php under config/settings/ counts as stray."""
+        (instance_dir / "config" / "settings" / "global").mkdir()
+        (instance_dir / "config" / "settings" / "global" / "Foo.php").write_text("<?php\n")
+        result = _run(probe, instance_dir)
+        assert result["stray_php"] == []
+
+
+class TestHostDirs:
+    def test_no_hosts(self, probe, instance_dir):
+        result = _run(probe, instance_dir)
+        assert result["host_dirs"] == []
+
+    def test_lists_per_host_dirs_excluding_shared(self, probe, instance_dir):
+        (instance_dir / "hosts").mkdir()
+        for d in ("host1", "host2", "_shared"):
+            (instance_dir / "hosts" / d).mkdir()
+        result = _run(probe, instance_dir)
+        assert result["host_dirs"] == ["host1", "host2"]


### PR DESCRIPTION
## Summary
The `canasta upgrade` migration phase ran ~12-15 separate SSH round-trips just to check whether each migration had work to do — a per-migration `stat` / `find` / `canasta_env: read` for every probe. Replace those with a single `ansible.builtin.script:` invocation that runs a small Python helper on the target and returns JSON with every gate decision in one shot.

Each migration now reads from the registered `_mig` fact instead of doing its own check, skipping entirely on no-op. The post-migration Compose image-tag block in `main.yml` reuses `_mig.env.CANASTA_IMAGE` too.

### Probe shape
```json
{
  "env":         { "MW_SECRET_KEY": "...", "CANASTA_IMAGE": "...", ... },
  "env_present": { "COMPOSE_PROFILES": false, ... },
  "files":       { "vector_php": true, "vector_php_has_default_skin": false,
                   "composer_local_empty_include": false, ... },
  "old_wiki_dirs": [], "stray_php": [], "host_dirs": []
}
```

The `env_present` map keeps the "set to empty value" vs "key absent" distinction that the COMPOSE_PROFILES backfill needs (external-DB instances intentionally have an empty value).

### Effect on a no-op upgrade against a remote target
Migration phase: **~12-15 SSH round-trips → 1**. Plus another round-trip saved on the image-tag check.

Real migrations pay the same cost as before — only the cheap "is this needed?" gates are collapsed.

### Defensive behavior
Missing or malformed files always produce sensible defaults (false / empty list / empty string). The probe never aborts the upgrade.

## Test plan
- [x] `make test-unit` (709 pass; 25 new probe tests)
- [x] `make validate`
- [x] `make lint` (no new warnings)
- [ ] `canasta upgrade` against a clean instance — see no-op log path complete in noticeably less time
- [ ] `canasta upgrade` against an instance still missing `MW_SECRET_KEY` — see real-migration path still works

Closes #492