### PR TITLE
backup: route cloud creds + DB host through canasta-<id>-backup-env Secret

### DIFF
--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -38,11 +38,13 @@
                 restic --cache-dir /tmp/restic-cache restore {{ _resolved_snapshot }} --target / && \
                 touch /tmp/restore-done && \
                 sleep 3600
-            env:
-              - name: RESTIC_REPOSITORY
-                value: "{{ _restore_env.variables.RESTIC_REPOSITORY }}"
-              - name: RESTIC_PASSWORD
-                value: "{{ _restore_env.variables.RESTIC_PASSWORD }}"
+            # canasta-<id>-backup-env carries every cloud-backend
+            # credential restic might need (RESTIC_*, AWS_*, B2_*,
+            # AZURE_*, GOOGLE_*, OS_*, ST_*) — same Secret the on-
+            # demand backup Job and scheduled CronJob use (#497).
+            envFrom:
+              - secretRef:
+                  name: "canasta-{{ instance_id }}-backup-env"
             volumeMounts:
               - name: restore-data
                 mountPath: /currentsnapshot

--- a/roles/backup/tasks/schedule_set.yml
+++ b/roles/backup/tasks/schedule_set.yml
@@ -94,12 +94,15 @@
                                 --single-transaction --databases "$db" \
                                 > "/currentsnapshot/config/backup/db_${db}.sql"
                             done
-                        env:
-                          - name: MYSQL_PASSWORD
-                            valueFrom:
-                              secretKeyRef:
-                                name: "{{ instance_id }}-db-credentials"
-                                key: MYSQL_PASSWORD
+                        # canasta-<id>-backup-env carries MYSQL_HOST,
+                        # MYSQL_USER, and MYSQL_PASSWORD. Internal-db
+                        # instances fall back to the in-script defaults
+                        # (db / root) when the Secret omits them;
+                        # external-db instances pick up the values from
+                        # .env (#498).
+                        envFrom:
+                          - secretRef:
+                              name: "canasta-{{ instance_id }}-backup-env"
                         volumeMounts:
                           - name: web-config
                             mountPath: /currentsnapshot/config
@@ -107,11 +110,13 @@
                       - name: restic
                         image: restic/restic:latest
                         command: ["sh", "-c", "{{ _k8s_backup_cmd }}"]
-                        env:
-                          - name: RESTIC_REPOSITORY
-                            value: "{{ _sched_env.variables.RESTIC_REPOSITORY | default('') }}"
-                          - name: RESTIC_PASSWORD
-                            value: "{{ _sched_env.variables.RESTIC_PASSWORD | default('') }}"
+                        # canasta-<id>-backup-env carries every cloud-
+                        # backend credential restic might need (RESTIC_*,
+                        # AWS_*, B2_*, AZURE_*, GOOGLE_*, OS_*, ST_*) —
+                        # see #497.
+                        envFrom:
+                          - secretRef:
+                              name: "canasta-{{ instance_id }}-backup-env"
                         volumeMounts:
                           - name: web-config
                             mountPath: /currentsnapshot/config

--- a/roles/orchestrator/tasks/k8s_run_backup.yml
+++ b/roles/orchestrator/tasks/k8s_run_backup.yml
@@ -103,11 +103,13 @@
                   - sh
                   - -c
                   - "restic --cache-dir /tmp/restic-cache {{ backup_args | join(' ') }}"
-                env:
-                  - name: RESTIC_REPOSITORY
-                    value: "{{ _restic_repo }}"
-                  - name: RESTIC_PASSWORD
-                    value: "{{ _restic_password }}"
+                # canasta-<id>-backup-env carries RESTIC_*, AWS_*,
+                # B2_*, AZURE_*, GOOGLE_*, OS_*, ST_* — every cloud-
+                # backend credential restic might need (#497). Mirrors
+                # what Compose's --env-file pattern provides.
+                envFrom:
+                  - secretRef:
+                      name: "canasta-{{ instance_id }}-backup-env"
                 volumeMounts: "{{ _restic_volume_mounts }}"
             volumes: "{{ _restic_volumes }}"
 

--- a/roles/orchestrator/tasks/k8s_sync_config.yml
+++ b/roles/orchestrator/tasks/k8s_sync_config.yml
@@ -150,6 +150,42 @@
           | ternary({'Caddyfile.global': _sync_caddyfile_global.content | default('') | b64decode}, {}))
       }}
 
+# --- Backup environment Secret ---
+# The on-demand backup Job (k8s_run_backup.yml) and the scheduled
+# CronJob (roles/backup/tasks/schedule_set.yml) both need restic +
+# DB env to land on the backup containers. Build a single Secret
+# from .env so envFrom: secretRef gives both flows everything they
+# need — including cloud-backend creds (#497) and external-DB
+# host/user (#498) — without per-task plumbing.
+#
+# Filter to backup-relevant prefixes plus the explicit MYSQL_HOST/
+# USER/PASSWORD that the dump-databases init container uses. Other
+# .env entries (MW_SITE_FQDN, CANASTA_ENABLE_*, …) stay out of this
+# Secret — they're not relevant to backup, and a leaner Secret is
+# easier to inspect with kubectl describe.
+- name: Build backup env data
+  ansible.builtin.set_fact:
+    _backup_env_data: >-
+      {{ _sync_env_dict.variables | default({}) | dict2items
+         | selectattr('key', 'match',
+             '^(RESTIC_|AWS_|B2_|AZURE_|GOOGLE_|OS_|ST_|MYSQL_HOST$|MYSQL_USER$|MYSQL_PASSWORD$)')
+         | items2dict }}
+  no_log: true
+
+- name: Apply backup env Secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "canasta-{{ instance_id }}-backup-env"
+        namespace: "{{ _k8s_namespace }}"
+      type: Opaque
+      stringData: "{{ _backup_env_data }}"
+  when: _backup_env_data | length > 0
+  no_log: true
+
 # --- Write configData into values.yaml ---
 # The Helm chart templates render ConfigMaps from configData values.
 # This allows both Ansible-driven and Argo CD-driven workflows to use

--- a/tests/unit/test_backup_schedule_k8s.py
+++ b/tests/unit/test_backup_schedule_k8s.py
@@ -98,3 +98,105 @@ class TestCronJobHistoryLimits:
             "CronJob.spec.concurrencyPolicy must be 'Forbid' so a "
             "long-running backup doesn't get a parallel firing."
         )
+
+
+class TestBackupEnvSecret:
+    """Both the init container (DB dump) and the restic container in
+    the scheduled CronJob must envFrom the same canasta-<id>-backup-
+    env Secret. That Secret is the only path for cloud-backend creds
+    (#497) and external-DB host/user (#498) to reach the Job."""
+
+    @staticmethod
+    def _pod_template(spec):
+        return spec["jobTemplate"]["spec"]["template"]["spec"]
+
+    def _expected_secret_name(self):
+        return 'canasta-{{ instance_id }}-backup-env'
+
+    def test_dump_databases_init_container_envfroms_backup_secret(self):
+        spec = _find_cronjob_definition()["spec"]
+        init = self._pod_template(spec)["initContainers"][0]
+        assert init["name"] == "dump-databases"
+        env_from = init.get("envFrom") or []
+        assert env_from, (
+            "dump-databases initContainer must envFrom the backup-env "
+            "Secret — without it MYSQL_HOST/USER fall back to in-script "
+            "defaults and external-DB instances fail (#498)."
+        )
+        names = [e.get("secretRef", {}).get("name") for e in env_from]
+        assert self._expected_secret_name() in names
+
+    def test_restic_container_envfroms_backup_secret(self):
+        spec = _find_cronjob_definition()["spec"]
+        containers = self._pod_template(spec)["containers"]
+        restic = next(c for c in containers if c["name"] == "restic")
+        env_from = restic.get("envFrom") or []
+        assert env_from, (
+            "restic container must envFrom the backup-env Secret — "
+            "without it cloud backends (S3/B2/Azure/GCS) can't "
+            "authenticate (#497)."
+        )
+        names = [e.get("secretRef", {}).get("name") for e in env_from]
+        assert self._expected_secret_name() in names
+
+    def test_no_inline_restic_env_anymore(self):
+        """The pre-fix layout passed RESTIC_REPOSITORY/PASSWORD as
+        inline `env:` entries. After #497 the Secret is the canonical
+        source — drift back to inline values would silently re-break
+        cloud backends, so guard against it."""
+        spec = _find_cronjob_definition()["spec"]
+        containers = self._pod_template(spec)["containers"]
+        restic = next(c for c in containers if c["name"] == "restic")
+        inline_env = restic.get("env") or []
+        names = [e.get("name") for e in inline_env]
+        for forbidden in ("RESTIC_REPOSITORY", "RESTIC_PASSWORD"):
+            assert forbidden not in names, (
+                "%s must come from the backup-env Secret, not an "
+                "inline env entry (#497)." % forbidden
+            )
+
+
+class TestBackupEnvSecretSyncTask:
+    """The Secret is created by k8s_sync_config.yml from the .env
+    backup-relevant subset. Verify the task exists and uses the
+    expected name + filter."""
+
+    SYNC_PATH = os.path.join(
+        REPO_ROOT, "roles", "orchestrator", "tasks", "k8s_sync_config.yml",
+    )
+
+    def _load(self):
+        with open(self.SYNC_PATH) as f:
+            return yaml.safe_load(f)
+
+    def test_apply_secret_task_present(self):
+        for task in _walk_tasks(self._load()):
+            k8s = task.get("kubernetes.core.k8s") or task.get("k8s")
+            if not isinstance(k8s, dict):
+                continue
+            defn = k8s.get("definition") or {}
+            if (defn.get("kind") == "Secret"
+                    and "backup-env" in (defn.get("metadata", {}) or {})
+                    .get("name", "")):
+                return
+        raise AssertionError(
+            "k8s_sync_config.yml is missing the canasta-<id>-backup-env "
+            "Secret task — without it both the on-demand and scheduled "
+            "backup paths fail to authenticate to cloud backends."
+        )
+
+    def test_filter_covers_known_backup_env_prefixes(self):
+        """The filter regex must match every prefix the consumers
+        rely on. Keeping the assertion explicit makes a future
+        accidental tightening of the filter visible in tests."""
+        with open(self.SYNC_PATH) as f:
+            content = f.read()
+        for prefix_or_key in (
+            "RESTIC_", "AWS_", "B2_", "AZURE_", "GOOGLE_", "OS_", "ST_",
+            "MYSQL_HOST", "MYSQL_USER", "MYSQL_PASSWORD",
+        ):
+            assert prefix_or_key in content, (
+                "k8s_sync_config.yml's backup-env filter must "
+                "cover %r (used by restic backends or the "
+                "dump-databases init container)." % prefix_or_key
+            )


### PR DESCRIPTION
## Summary
Compose's `canasta backup create` passes the entire `.env` to the restic container via `--env-file`, so cloud-backend credentials flow naturally. The K8s side only set `RESTIC_REPOSITORY` / `RESTIC_PASSWORD` inline, so anything beyond a local-path repository silently failed auth. Same gap on the `dump-databases` init container: it shell-defaulted `MYSQL_HOST` / `MYSQL_USER` to `db` / `root`, breaking every external-DB instance.

Fix: one new `canasta-<id>-backup-env` Secret built in `k8s_sync_config.yml` from the backup-relevant subset of `.env`:

- **Cloud-backend prefixes restic recognises**: `RESTIC_*`, `AWS_*`, `B2_*`, `AZURE_*`, `GOOGLE_*`, `OS_*`, `ST_*`
- **DB connection**: `MYSQL_HOST`, `MYSQL_USER`, `MYSQL_PASSWORD`

Three consumers `envFrom` it:

- `roles/orchestrator/tasks/k8s_run_backup.yml` — on-demand `canasta backup create`
- `roles/backup/tasks/schedule_set.yml` — scheduled CronJob (both init + restic containers)
- `roles/backup/tasks/restore_k8s.yml` — `canasta backup restore`

Future restic env vars need only the regex in `k8s_sync_config.yml` extended; the Secret + `envFrom` plumbing covers everything matched.

Other `.env` entries (`MW_SITE_FQDN`, `CANASTA_ENABLE_*`, …) stay out of the Secret — leaner Secret, clearer `kubectl describe` output, nothing irrelevant leaks into backup containers.

## Test plan
- [x] `make test-unit` (722 pass; 8 in `test_backup_schedule_k8s.py`)
- [x] `make validate`
- [ ] On acknowledge.wiki K8s: create instance, run `canasta backup create -i <id>` against a local-path restic repo — verify Secret exists, restic Job authenticates
- [ ] Same against an S3 backend — verify `AWS_*` creds reach the container
- [ ] Set scheduled backup, wait for one firing, verify `dump-databases` produced SQL files AND restic ran
- [ ] External-DB instance: verify init container connects to the right host

Closes #497, #498