### PR TITLE
backup: fix two latent bugs in K8s scheduled backup CronJob (#503)

### DIFF
--- a/roles/backup/tasks/schedule_set.yml
+++ b/roles/backup/tasks/schedule_set.yml
@@ -44,6 +44,17 @@
       register: _sched_env
       no_log: true
 
+    # Local-path restic repos (RESTIC_REPOSITORY beginning with /)
+    # need a hostPath bind on the restic container so the container's
+    # view of that path matches the host. Cloud-backend repos don't —
+    # they're URIs, not filesystem paths. Mirrors the same detection
+    # in k8s_run_backup.yml's on-demand backup.
+    - name: Detect local restic repository
+      ansible.builtin.set_fact:
+        _sched_restic_repo: "{{ _sched_env.variables.RESTIC_REPOSITORY | default('') }}"
+        _sched_local_repo: >-
+          {{ (_sched_env.variables.RESTIC_REPOSITORY | default('')) is match('^/') }}
+
     - name: Build restic command
       ansible.builtin.set_fact:
         _k8s_backup_cmd: >-
@@ -86,7 +97,6 @@
                           - sh
                           - -c
                           - |
-                            mkdir -p /currentsnapshot/config/backup
                             EXCLUDE='^(information_schema|performance_schema|mysql|sys)$'
                             for db in $(mariadb -h "${MYSQL_HOST:-db}" -u "${MYSQL_USER:-root}" -p"$MYSQL_PASSWORD" \
                               -N -e "SHOW DATABASES" | grep -vE "$EXCLUDE"); do
@@ -103,9 +113,17 @@
                         envFrom:
                           - secretRef:
                               name: "canasta-{{ instance_id }}-backup-env"
+                        # The dumps emptyDir is mounted AT
+                        # /currentsnapshot/config/backup so the SQL
+                        # files land at the same path the on-demand
+                        # path uses. restore_k8s.yml looks there for
+                        # files matching db_*.sql, so keeping the
+                        # paths aligned means scheduled-snapshot
+                        # restore Just Works without a path-flavor
+                        # branch in the restore flow.
                         volumeMounts:
-                          - name: web-config
-                            mountPath: /currentsnapshot/config
+                          - name: dumps
+                            mountPath: /currentsnapshot/config/backup
                     containers:
                       - name: restic
                         image: restic/restic:latest
@@ -117,9 +135,24 @@
                         envFrom:
                           - secretRef:
                               name: "canasta-{{ instance_id }}-backup-env"
+                        # Mount the dumps scratch volume under the
+                        # /currentsnapshot tree so restic captures the
+                        # SQL files as part of the snapshot. Restored
+                        # snapshots will contain
+                        # /currentsnapshot/db-dumps/db_<wiki>.sql, which
+                        # the restore flow can replay against the wiki
+                        # DB on first boot.
+                        # The dumps emptyDir mounts on TOP of the
+                        # web-config ConfigMap subdir (K8s allows
+                        # mount-on-mount). Restic sees a merged tree:
+                        # ConfigMap content at /currentsnapshot/config,
+                        # SQL dumps at /currentsnapshot/config/backup.
                         volumeMounts:
                           - name: web-config
                             mountPath: /currentsnapshot/config
+                            readOnly: true
+                          - name: dumps
+                            mountPath: /currentsnapshot/config/backup
                             readOnly: true
                           - name: images
                             mountPath: /currentsnapshot/images
@@ -138,6 +171,12 @@
                         configMap:
                           name: "canasta-{{ instance_id }}-web-config"
                           optional: true
+                      # Pod-lifetime scratch dir for the DB dumps. The
+                      # init container writes db_*.sql here; the restic
+                      # container reads them from
+                      # /currentsnapshot/db-dumps.
+                      - name: dumps
+                        emptyDir: {}
                       - name: images
                         persistentVolumeClaim:
                           claimName: "canasta-{{ instance_id }}-images"
@@ -150,6 +189,37 @@
                       - name: public-assets
                         persistentVolumeClaim:
                           claimName: "canasta-{{ instance_id }}-public-assets"
+
+    # Local-path restic repos need a hostPath mount on the restic
+    # container; cloud-backend repos don't. Patch the local-repo
+    # volume + mount into the CronJob via strategic-merge so a
+    # second `canasta backup schedule set` doesn't duplicate the
+    # entries (volumes are keyed by .name; volumeMounts by
+    # .mountPath — strategic merge replaces by key).
+    - name: Patch local-repo volume into CronJob (local-path repo only)
+      kubernetes.core.k8s:
+        state: patched
+        kind: CronJob
+        api_version: batch/v1
+        name: "canasta-backup-{{ instance_id }}"
+        namespace: "canasta-{{ instance_id }}"
+        definition:
+          spec:
+            jobTemplate:
+              spec:
+                template:
+                  spec:
+                    volumes:
+                      - name: local-repo
+                        hostPath:
+                          path: "{{ _sched_restic_repo }}"
+                          type: DirectoryOrCreate
+                    containers:
+                      - name: restic
+                        volumeMounts:
+                          - name: local-repo
+                            mountPath: "{{ _sched_restic_repo }}"
+      when: _sched_local_repo | bool
 
 - name: Report schedule set
   ansible.builtin.debug:

--- a/tests/unit/test_backup_schedule_k8s.py
+++ b/tests/unit/test_backup_schedule_k8s.py
@@ -139,6 +139,65 @@ class TestBackupEnvSecret:
         names = [e.get("secretRef", {}).get("name") for e in env_from]
         assert self._expected_secret_name() in names
 
+    def test_init_container_writes_to_writable_dumps_volume(self):
+        """The init container's mariadb-dump output must land in a
+        writable volume. Previously dumped to /currentsnapshot/config
+        which is the read-only ConfigMap mount — every scheduled run
+        crashed with "Read-only file system" until the dumps emptyDir
+        was added."""
+        spec = _find_cronjob_definition()["spec"]
+        init = self._pod_template(spec)["initContainers"][0]
+        assert init["name"] == "dump-databases"
+
+        mounted = {m["name"] for m in init.get("volumeMounts") or []}
+        assert "web-config" not in mounted, (
+            "dump-databases initContainer should not mount the "
+            "read-only web-config ConfigMap; use the writable dumps "
+            "emptyDir for SQL files."
+        )
+        assert "dumps" in mounted, (
+            "dump-databases initContainer must mount the dumps "
+            "emptyDir to write SQL files."
+        )
+
+        cmd = " ".join(init["command"])
+        # The dump path must align with what restore_k8s.yml looks
+        # for (it iterates /currentsnapshot/config/backup/db_*.sql).
+        # Diverging paths here would make scheduled-snapshot restores
+        # silently skip the DB restore step.
+        assert "/currentsnapshot/config/backup/" in cmd, (
+            "dump-databases script must write to "
+            "/currentsnapshot/config/backup/ to match the path "
+            "restore_k8s.yml reads from."
+        )
+
+    def test_dumps_volume_is_emptydir_at_config_backup_subpath(self):
+        """The dumps volume must mount AT /currentsnapshot/config/backup
+        in both the init container (writable) and the restic container
+        (read-only) so SQL files are captured at the same path the
+        on-demand backup path uses — keeps restore_k8s.yml happy with
+        a single path."""
+        spec = _find_cronjob_definition()["spec"]
+        pod = self._pod_template(spec)
+
+        volumes = {v["name"]: v for v in pod["volumes"]}
+        assert "dumps" in volumes
+        assert "emptyDir" in volumes["dumps"]
+
+        # Init container — writable mount at the canonical dump path
+        init = pod["initContainers"][0]
+        init_dumps = [m for m in init.get("volumeMounts") or []
+                      if m["name"] == "dumps"]
+        assert len(init_dumps) == 1
+        assert init_dumps[0]["mountPath"] == "/currentsnapshot/config/backup"
+
+        # Restic container — same path, this time read-only
+        restic = next(c for c in pod["containers"] if c["name"] == "restic")
+        restic_dumps = [m for m in restic.get("volumeMounts") or []
+                        if m["name"] == "dumps"]
+        assert len(restic_dumps) == 1
+        assert restic_dumps[0]["mountPath"] == "/currentsnapshot/config/backup"
+
     def test_no_inline_restic_env_anymore(self):
         """The pre-fix layout passed RESTIC_REPOSITORY/PASSWORD as
         inline `env:` entries. After #497 the Secret is the canonical


### PR DESCRIPTION
## Summary

Two latent bugs in K8s scheduled backup CronJob (`roles/backup/tasks/schedule_set.yml`), both caught when the CronJob actually fired during multi-host AWS testing:

- **Read-only dumps target** — init container's `mariadb-dump` output went to `/currentsnapshot/config/backup/`, which is the read-only `web-config` ConfigMap mount. Every firing crashed before restic started. Fix: pod-lifetime `dumps` emptyDir mounted AT `/currentsnapshot/config/backup` in both containers (mount-on-mount overlays the ConfigMap subdir).
- **Missing local-repo hostPath** — local-path `RESTIC_REPOSITORY` values (e.g. `/home/admin/restic-test`) needed a `hostPath` bind on the restic container, but the CronJob path had no such logic. Fix: detect local-path repos and patch the `local-repo` volume + mount in via a second `state: patched` (strategic merge) task. Idempotent — keys are `.name` (volumes) and `.mountPath` (volumeMounts).

Two new structural tests guard both fixes (`tests/unit/test_backup_schedule_k8s.py`).

Refs #503.

## Validation

End-to-end on a 2-node AWS cluster (`extdb` instance, external MariaDB):
- 7 successive CronJob firings produced clean snapshots
- Each snapshot contains the SQL dump under `/currentsnapshot/config/backup/db_*.sql` (matches what `restore_k8s.yml` reads)
- `canasta backup schedule set` is idempotent (verified by running twice — single `local-repo` entry in the spec)

## Test plan

- [x] `make test-unit` passes (new structural tests included)
- [x] CronJob fires successfully against external-DB instance with local-path restic repo
- [x] Snapshot contains the SQL dump at the canonical restore path
- [x] Re-running `canasta backup schedule set` doesn't duplicate `local-repo` volume/mount
- [ ] Reviewer sanity check on the strategic-merge patch task
