### PR TITLE
security: stop committing SSH deploy private key to the gitops repo (#505)

### DIFF
--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -337,19 +337,22 @@
     chdir: "{{ instance_path }}"
   changed_when: true
 
-- name: Write .gitignore
+# Source the canonical gitignore.default so the security-critical
+# entries (.gitops-deploy-key, admin-password_*, config/wikis.yaml,
+# etc.) cannot drift out of the K8s path. K8s-only additions are
+# appended after — never replace the shared list. See #505 for the
+# regression this guards against.
+- name: Write .gitignore (canonical base + K8s additions)
   ansible.builtin.copy:
     content: |
-      .env
-      .gitops-host
-      .gitops-applied
+      {{ lookup('file', role_path + '/files/gitignore.default') }}
+
+      # K8s-specific additions
       _initdb/
       docker-compose*.yml
       my.cnf
       scripts/
-      admin-password_*
       values-configdata.yaml
-      images/
       extensions/
       skins/
       public_assets/

--- a/tests/unit/test_gitops_init_security.py
+++ b/tests/unit/test_gitops_init_security.py
@@ -1,0 +1,127 @@
+"""Security-regression guards for gitops init.
+
+The K8s gitops init writes a .gitignore on the target instance dir.
+A regression where that file omits .gitops-deploy-key causes the SSH
+deploy private key (with write access to the gitops repo) to be
+committed into that same repo on the next push, exposing it to every
+reader of the repo. See issue #505.
+
+These tests parse init_kubernetes.yml's .gitignore-writing task and
+assert both that it sources the canonical gitignore.default file and
+that the canonical file still contains the security-critical entries.
+"""
+
+import os
+import re
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+INIT_K8S = os.path.join(
+    REPO_ROOT, "roles", "gitops", "tasks", "init_kubernetes.yml",
+)
+GITIGNORE_DEFAULT = os.path.join(
+    REPO_ROOT, "roles", "gitops", "files", "gitignore.default",
+)
+
+
+def _walk_tasks(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk_tasks(t[nested])
+
+
+def _find_gitignore_task():
+    with open(INIT_K8S) as f:
+        tasks = yaml.safe_load(f)
+    for task in _walk_tasks(tasks):
+        copy = task.get("ansible.builtin.copy") or task.get("copy")
+        if not isinstance(copy, dict):
+            continue
+        dest = copy.get("dest", "")
+        if dest.endswith("/.gitignore"):
+            return copy
+    raise AssertionError(
+        "init_kubernetes.yml has no task writing .gitignore — "
+        "the security-regression guard cannot run"
+    )
+
+
+class TestGitopsDeployKeyNotCommitted:
+    """The K8s gitops init MUST NOT drop .gitops-deploy-key from the
+    deployed .gitignore. This caused the deploy private key to be
+    committed into the gitops repo (#505) — anyone with read access
+    to the repo could extract the key and push."""
+
+    def test_canonical_gitignore_default_contains_deploy_key(self):
+        """The shared list must keep .gitops-deploy-key. The K8s and
+        Compose paths both depend on it."""
+        with open(GITIGNORE_DEFAULT) as f:
+            content = f.read()
+        assert ".gitops-deploy-key" in content, (
+            "gitignore.default no longer ignores .gitops-deploy-key — "
+            "without that entry the SSH deploy private key gets "
+            "committed into the gitops repo on the first push (#505)."
+        )
+
+    def test_k8s_init_sources_canonical_gitignore_default(self):
+        """The K8s init must compose .gitignore from gitignore.default
+        rather than inlining its own list — past inlines drifted and
+        dropped security-critical entries (#505)."""
+        copy = _find_gitignore_task()
+        content = copy.get("content") or ""
+        # The Jinja lookup is the canonical wiring; it pulls
+        # gitignore.default verbatim. If a future edit drops the
+        # lookup and re-inlines the list, the next test will catch
+        # the .gitops-deploy-key omission directly — this assertion
+        # makes the structural intent explicit.
+        assert "gitignore.default" in content, (
+            "init_kubernetes.yml's .gitignore-writing task no longer "
+            "sources roles/gitops/files/gitignore.default. Reverting "
+            "to an inline list invites the same drift that caused "
+            "#505 — re-source the canonical file."
+        )
+
+    def test_k8s_deployed_gitignore_includes_deploy_key(self):
+        """Direct check: whatever the K8s path ends up writing must
+        include .gitops-deploy-key. Belt-and-suspenders against any
+        future templating change that bypasses the canonical file."""
+        copy = _find_gitignore_task()
+        content = copy.get("content") or ""
+
+        # Resolve the lookup (or any other reference to the canonical
+        # file) by inlining the file contents. If the task drops
+        # gitignore.default entirely, the inline content is taken as
+        # authoritative.
+        if "gitignore.default" in content:
+            with open(GITIGNORE_DEFAULT) as f:
+                content = content + "\n" + f.read()
+
+        assert ".gitops-deploy-key" in content, (
+            "K8s gitops init's .gitignore would omit .gitops-deploy-key. "
+            "The SSH deploy private key would be committed into the "
+            "gitops repo on the next push (#505)."
+        )
+
+    def test_k8s_deployed_gitignore_includes_other_credential_entries(self):
+        """admin-password_* and config/wikis.yaml are also security-
+        relevant — admin-password_* leaks the wiki admin password,
+        config/wikis.yaml can carry per-wiki secrets in some
+        deployments. Any path that bypasses gitignore.default must
+        also keep these."""
+        copy = _find_gitignore_task()
+        content = copy.get("content") or ""
+        if "gitignore.default" in content:
+            with open(GITIGNORE_DEFAULT) as f:
+                content = content + "\n" + f.read()
+
+        for required in ("admin-password_*", "config/wikis.yaml"):
+            assert required in content, (
+                "K8s gitops init's .gitignore would omit %r — past "
+                "inline-list drift dropped this; keep the canonical "
+                "gitignore.default as the single source." % required
+            )


### PR DESCRIPTION
## Summary

Fixes #505 — `canasta gitops init` on Kubernetes was committing the SSH deploy private key (`.gitops-deploy-key`) into the gitops repo it pushes to. The key is registered with **write access**, so any reader of the repo could extract it and push.

Root cause was an inline `.gitignore` in `roles/gitops/tasks/init_kubernetes.yml` that had drifted from the canonical `roles/gitops/files/gitignore.default` and dropped `.gitops-deploy-key` (plus several other security-relevant entries: `admin-password_*`, `config/wikis.yaml`, `config/backup/`, `config/persistent/`, etc.).

## Fix

Read `gitignore.default` via `lookup('file', ...)` and append only the genuinely K8s-specific patterns. Single source of truth, same shape #501 used for the backup-env Secret filter. The Compose path was already correct — it always sourced the canonical file.

## Tests

Four structural guards in `tests/unit/test_gitops_init_security.py`:
- `gitignore.default` must keep `.gitops-deploy-key`
- `init_kubernetes.yml` must source the canonical file
- The resolved `.gitignore` must include `.gitops-deploy-key`
- The resolved `.gitignore` must include `admin-password_*` and `config/wikis.yaml`

The first guard catches drift in the canonical file; the second catches an inline-list re-introduction; the last two are belt-and-suspenders for whatever templating change might happen.

## Validation

Validated end-to-end on a 2-node AWS K8s cluster (the same one used for #504):
- Re-ran `canasta gitops init --reinit --force` against a fresh deploy key on a recreated test repo
- GitHub Contents API confirms `.gitops-deploy-key` returns 404 in the resulting repo
- The pushed `.gitignore` now contains every entry from `gitignore.default` plus the K8s-specific additions

## Operator remediation for already-affected installs

Detailed in #505. Short version: revoke the leaked deploy key on the forge, register a fresh one, scrub the file from repo history (`git filter-repo` — `git rm` is not enough), then re-run `canasta gitops init` once this lands.

## Test plan

- [x] `make test-unit` passes (728 tests, 4 new)
- [x] On-cluster: `.gitops-deploy-key` is not in the gitops repo after init
- [x] On-cluster: `.gitignore` contains the canonical entries plus K8s additions
- [ ] Reviewer sanity check on `lookup('file', role_path + '/files/gitignore.default')` — runs on the controller, role_path resolves to the role dir
