### PR TITLE
gitops/k8s: stop duplicating Secret-backed creds in configData; drop encryption (#507)

### DIFF
--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -360,9 +360,20 @@
     dest: "{{ instance_path }}/.gitignore"
     mode: "0644"
 
-- name: Write .gitattributes for git-crypt
+# K8s gitops repo carries no secrets after #507 — MYSQL_PASSWORD and
+# MW_SECRET_KEY are pulled at deploy time from the per-instance K8s
+# Secrets (<id>-db-credentials, <id>-mw-secrets) via secretKeyRef, and
+# k8s_sync_config.yml strips them out of the configData.web['.env']
+# blob before rendering. With no secret-bearing files left, no
+# git-crypt filter is needed; encrypting rendered-values.yaml broke
+# Argo CD's ability to parse it as Helm values. The git-crypt init/
+# export scaffolding below stays in place for now (still useful if a
+# future addition wants per-file encryption) but no patterns are
+# registered for filtering. Follow-up cleanup will remove the dead
+# scaffolding.
+- name: Write empty .gitattributes (no files marked for git-crypt)
   ansible.builtin.copy:
-    src: "{{ role_path }}/files/gitattributes.default"
+    content: ""
     dest: "{{ instance_path }}/.gitattributes"
     mode: "0644"
 

--- a/roles/orchestrator/tasks/k8s_sync_config.yml
+++ b/roles/orchestrator/tasks/k8s_sync_config.yml
@@ -75,11 +75,26 @@
   loop_control:
     label: "{{ item.path | regex_replace('^.*/config/settings/', 'settings/') }}"
 
+# Strip secret-bearing keys from the .env content before embedding
+# it in the web ConfigMap. The chart's web/jobrunner deployments read
+# MYSQL_PASSWORD / MW_SECRET_KEY exclusively via secretKeyRef from the
+# canonical K8s Secrets (<id>-db-credentials, <id>-mw-secrets); the
+# .env file at /mediawiki/config/.env is never sourced. Leaving the
+# secrets in the ConfigMap-backed file duplicated them in plaintext
+# and forced the gitops repo to encrypt rendered-values.yaml, which
+# Argo CD couldn't read. See #507.
+- name: Filter secret-bearing keys out of .env for ConfigMap embedding
+  ansible.builtin.set_fact:
+    _sync_env_no_secrets: >-
+      {{ (_sync_env.content | b64decode).splitlines()
+         | reject('match', '^(MYSQL_PASSWORD|MW_SECRET_KEY)=')
+         | join('\n') + '\n' }}
+
 - name: Build web config data
   ansible.builtin.set_fact:
     _web_config_data: >-
       {{
-        {'.env': _sync_env.content | b64decode,
+        {'.env': _sync_env_no_secrets,
          'wikis.yaml': _sync_wikis.content | b64decode}
         | combine(
           (_sync_composer_stat.stat.exists | default(false))

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -269,6 +269,152 @@ class TestExternalDatabase:
         )
 
 
+class TestK8sSyncConfigSecretsStripped:
+    """Guard the #507 regression class: secret-bearing keys must NOT
+    end up duplicated in the configData.web['.env'] blob — the chart
+    pulls MYSQL_PASSWORD / MW_SECRET_KEY from the canonical K8s
+    Secrets via secretKeyRef, and any plaintext copy in the
+    ConfigMap-backed .env file (a) duplicates the secret in the
+    cluster and (b) forces the gitops repo to encrypt
+    rendered-values.yaml, which Argo CD can't read."""
+
+    SYNC_PATH = os.path.join(ORCHESTRATOR_TASKS, "k8s_sync_config.yml")
+
+    def _load(self):
+        with open(self.SYNC_PATH) as f:
+            return yaml.safe_load(f)
+
+    @staticmethod
+    def _walk_tasks(tasks):
+        for t in tasks or []:
+            if not isinstance(t, dict):
+                continue
+            yield t
+            for nested in ("block", "rescue", "always"):
+                if nested in t:
+                    yield from TestK8sSyncConfigSecretsStripped._walk_tasks(
+                        t[nested],
+                    )
+
+    def test_sync_env_no_secrets_fact_is_set(self):
+        """A set_fact must define _sync_env_no_secrets — the filtered
+        version of .env that web ConfigMap embedding uses."""
+        for task in self._walk_tasks(self._load()):
+            sf = task.get("ansible.builtin.set_fact") or task.get("set_fact")
+            if isinstance(sf, dict) and "_sync_env_no_secrets" in sf:
+                return
+        raise AssertionError(
+            "k8s_sync_config.yml does not define _sync_env_no_secrets — "
+            "without it, configData.web['.env'] would carry MYSQL_PASSWORD "
+            "and MW_SECRET_KEY duplicated from the K8s Secrets, which "
+            "forces git-crypt encryption of rendered-values.yaml and "
+            "breaks Argo CD reconciliation (#507)."
+        )
+
+    def test_sync_env_no_secrets_rejects_password_and_secret_key(self):
+        """The filter must specifically drop MYSQL_PASSWORD and
+        MW_SECRET_KEY — those are the keys the chart pulls via
+        secretKeyRef and therefore the keys that would be duplicated
+        if left in the .env content."""
+        for task in self._walk_tasks(self._load()):
+            sf = task.get("ansible.builtin.set_fact") or task.get("set_fact")
+            if not (isinstance(sf, dict) and "_sync_env_no_secrets" in sf):
+                continue
+            expr = sf["_sync_env_no_secrets"]
+            assert "MYSQL_PASSWORD" in expr, (
+                "_sync_env_no_secrets filter must drop MYSQL_PASSWORD"
+            )
+            assert "MW_SECRET_KEY" in expr, (
+                "_sync_env_no_secrets filter must drop MW_SECRET_KEY"
+            )
+            return
+
+    def test_web_config_data_uses_filtered_env(self):
+        """configData.web['.env'] must come from the filtered
+        _sync_env_no_secrets, not from the raw _sync_env."""
+        for task in self._walk_tasks(self._load()):
+            sf = task.get("ansible.builtin.set_fact") or task.get("set_fact")
+            if not (isinstance(sf, dict) and "_web_config_data" in sf):
+                continue
+            expr = sf["_web_config_data"]
+            assert "_sync_env_no_secrets" in expr, (
+                "_web_config_data must reference _sync_env_no_secrets — "
+                "raw _sync_env carries MYSQL_PASSWORD/MW_SECRET_KEY (#507)."
+            )
+            assert "_sync_env.content" not in expr, (
+                "_web_config_data must NOT reference _sync_env.content "
+                "directly — that's the unfiltered .env containing secrets "
+                "the chart already pulls via secretKeyRef (#507)."
+            )
+            return
+        raise AssertionError(
+            "k8s_sync_config.yml has no _web_config_data set_fact"
+        )
+
+
+class TestK8sGitopsNoEncryption:
+    """Guard the #507 regression class for the gitops side: K8s init
+    must not register hosts/** for git-crypt filtering. After the
+    fix, rendered-values.yaml carries no secrets so encryption is
+    unnecessary; the encryption rule was what broke Argo CD's ability
+    to parse the values file."""
+
+    INIT_K8S = os.path.join(GITOPS_TASKS, "init_kubernetes.yml")
+
+    @staticmethod
+    def _walk_tasks(tasks):
+        for t in tasks or []:
+            if not isinstance(t, dict):
+                continue
+            yield t
+            for nested in ("block", "rescue", "always"):
+                if nested in t:
+                    yield from TestK8sGitopsNoEncryption._walk_tasks(
+                        t[nested],
+                    )
+
+    def test_gitattributes_does_not_filter_hosts(self):
+        """The .gitattributes that K8s gitops init writes must not
+        register `hosts/**` (or any pattern) for git-crypt filtering.
+        Argo CD reads hosts/<name>/rendered-values.yaml as Helm values
+        and has no git-crypt awareness — encrypted bytes break parsing
+        with a 'control characters not allowed' error (#507)."""
+        with open(self.INIT_K8S) as f:
+            tasks = yaml.safe_load(f)
+        for task in self._walk_tasks(tasks):
+            copy = task.get("ansible.builtin.copy") or task.get("copy")
+            if not isinstance(copy, dict):
+                continue
+            dest = copy.get("dest", "")
+            if not dest.endswith("/.gitattributes"):
+                continue
+            content = copy.get("content")
+            src = copy.get("src", "")
+            # Either the task uses inline content (must not register
+            # hosts/** for git-crypt) or a src file (the canonical
+            # gitattributes.default still has the encryption rule for
+            # the Compose path; that's outside K8s scope).
+            if content is not None:
+                assert "filter=git-crypt" not in content, (
+                    "K8s gitops init writes a .gitattributes that "
+                    "registers files for git-crypt encryption. After "
+                    "#507, rendered-values.yaml is cleartext and Argo "
+                    "CD must be able to parse it — no encryption rules."
+                )
+                return
+            assert "gitattributes.default" not in src, (
+                "K8s gitops init still copies the canonical "
+                "gitattributes.default (which encrypts hosts/**). "
+                "After #507 the K8s path has no secrets in repo, so it "
+                "must write its own .gitattributes without the "
+                "encryption rule."
+            )
+            return
+        raise AssertionError(
+            "init_kubernetes.yml has no .gitattributes-writing task"
+        )
+
+
 class TestGitopsDispatchers:
     """Verify that each dispatched gitops command has both variants."""
 


### PR DESCRIPTION
## Summary

Fixes #507 — the K8s gitops path was end-to-end broken. `canasta gitops init` succeeded, the repo got pushed, but Argo CD couldn't parse `rendered-values.yaml` (`error converting YAML to JSON: yaml: control characters are not allowed`) because the file was git-crypt-encrypted and Argo CD has no git-crypt awareness.

Root cause: a redundant secret duplication. The Helm chart's `deployment-web.yaml` and `deployment-jobrunner.yaml` already pull `MYSQL_PASSWORD` and `MW_SECRET_KEY` from the canonical K8s Secrets (`<id>-db-credentials`, `<id>-mw-secrets`) via `secretKeyRef`. But `k8s_sync_config.yml` *also* embedded the raw `.env` file (containing those same passwords) into `configData.web` — duplicating secrets in plaintext inside the cluster ConfigMap, AND forcing the gitops repo to encrypt `rendered-values.yaml`. The `/mediawiki/config/.env` file in the running pod is never read by anything.

## Changes

1. **`roles/orchestrator/tasks/k8s_sync_config.yml`** — strip `MYSQL_PASSWORD=` / `MW_SECRET_KEY=` lines from `.env` before embedding it in `_web_config_data`. The `cp /configmap-flat/.env /config/.env || true` in the assemble-config init container gracefully handles the absent keys.

2. **`roles/gitops/tasks/init_kubernetes.yml`** — write an empty `.gitattributes` for the K8s path. The canonical `gitattributes.default` registers `hosts/** filter=git-crypt` which encrypted `rendered-values.yaml`; with secrets out of the values file, nothing in the K8s repo carries secrets, so no encryption rule applies.

3. **`tests/unit/test_kubernetes_structure.py`** — four structural guards in two new test classes (`TestK8sSyncConfigSecretsStripped`, `TestK8sGitopsNoEncryption`).

## Scope

K8s only. The Compose path (`init_compose.yml`) is untouched — Compose creates `hosts/<host>/vars.yaml` containing real secrets (admin passwords, host-specific values), so its `gitattributes.default` encryption is doing real work.

The git-crypt init/export scaffolding in `init_kubernetes.yml` (the `git-crypt init`, key export, `--key` argument plumbing) stays in place — dead but harmless. Removing it, plus updating the related help text and docs, is a separate cleanup PR.

## Validation

End-to-end on the same 2-node AWS cluster used for #504 and #506. After `canasta gitops init --reinit --force`:

| Check | Result |
|---|---|
| `rendered-values.yaml` cleartext in repo | yes |
| `MYSQL_PASSWORD=` / `MW_SECRET_KEY=` in `rendered-values.yaml` | absent |
| `.gitattributes` in repo | empty |
| Argo CD sync | `Synced` |
| Argo CD health | `Healthy` |
| Argo CD actually reconciled | yes (rotated web pod via own ReplicaSet) |
| Wiki HTTP response | `200` |
| `MYSQL_PASSWORD` / `MW_SECRET_KEY` env vars in pod | set (via `secretKeyRef`) |
| `/mediawiki/config/.env` in pod | no longer contains those keys |

## Migration for affected installs

`canasta gitops init --reinit --force` after this lands. Re-renders without secrets, overwrites the repo, Argo CD picks up the cleartext file on next refresh.

## Test plan

- [x] `make test-unit` (732 tests pass, 4 new)
- [x] On-cluster: rendered-values.yaml is cleartext after init
- [x] On-cluster: secrets absent from rendered-values.yaml AND from `/mediawiki/config/.env`
- [x] On-cluster: Argo CD reconciles successfully (Synced + Healthy + ReplicaSet rotation)
- [x] On-cluster: wiki still returns HTTP 200 with secrets reaching pod env via secretKeyRef
- [ ] Reviewer sanity check on the `reject('match', '^(MYSQL_PASSWORD|MW_SECRET_KEY)=')` filter (any other secret-bearing keys in `.env` worth dropping?)
