### PR TITLE
backup/k8s: capture canasta-managed Secrets in restic snapshot (#510)

### DIFF
--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -120,6 +120,33 @@
        | select('match', '^db_.*\\.sql$') | list }}
   no_log: true
 
+# Restore the canasta-managed K8s Secrets if the snapshot includes
+# them (#510). Older snapshots taken before #510 don't have the
+# secrets file — that's the 'select match secrets-*.yaml' filter,
+# which evaluates to empty for those.
+#
+# 'kubectl apply -f -' is idempotent: if the cluster already has the
+# Secret with the same value (instance was up before restore), this
+# is a no-op. If the cluster has a different value (fresh-cluster
+# DR scenario where 'canasta create' generated new passwords), the
+# snapshot's value overwrites — required for the restored DB whose
+# user-table hashes match the snapshot's password.
+- name: Find canasta-managed Secret manifest in snapshot
+  ansible.builtin.set_fact:
+    _restore_secrets_filename: >-
+      {{ (_restore_db_files.stdout_lines | default([])
+          | select('match', '^secrets-.+\\.yaml$') | list | first) | default('') }}
+
+- name: Restore canasta-managed K8s Secrets
+  when: _restore_secrets_filename != ''
+  ansible.builtin.shell:
+    cmd: >-
+      kubectl exec -n {{ _k8s_namespace }} restic-restore --
+      cat /currentsnapshot/config/backup/{{ _restore_secrets_filename }} |
+      kubectl apply -n {{ _k8s_namespace }} -f -
+  changed_when: true
+  no_log: true
+
 - name: Delete restore pod
   kubernetes.core.k8s:
     state: absent

--- a/roles/backup/tasks/schedule_set.yml
+++ b/roles/backup/tasks/schedule_set.yml
@@ -64,6 +64,56 @@
              | ternary('&& restic --cache-dir /tmp/restic-cache forget --prune --keep-within ' +
                (purge_older_than | default('')), '') }}
 
+    # ServiceAccount + Role + RoleBinding for the dump-secrets init
+    # container. Without this, the Pod's default ServiceAccount has no
+    # permission to read Secrets and the kubectl get fails. Scoped to
+    # the canasta-<id> namespace and to the two specific Secret names
+    # we need — least privilege. See #510 for the DR gap this closes.
+    - name: Create ServiceAccount for backup Pod
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: "canasta-backup-{{ instance_id }}"
+            namespace: "canasta-{{ instance_id }}"
+
+    - name: Create Role granting read on canasta-managed Secrets
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            name: "canasta-backup-{{ instance_id }}"
+            namespace: "canasta-{{ instance_id }}"
+          rules:
+            - apiGroups: [""]
+              resources: ["secrets"]
+              resourceNames:
+                - "{{ instance_id }}-db-credentials"
+                - "{{ instance_id }}-mw-secrets"
+              verbs: ["get"]
+
+    - name: Bind Role to backup ServiceAccount
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: "canasta-backup-{{ instance_id }}"
+            namespace: "canasta-{{ instance_id }}"
+          subjects:
+            - kind: ServiceAccount
+              name: "canasta-backup-{{ instance_id }}"
+              namespace: "canasta-{{ instance_id }}"
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: "canasta-backup-{{ instance_id }}"
+
     - name: Create backup CronJob
       kubernetes.core.k8s:
         state: present
@@ -90,6 +140,11 @@
                 template:
                   spec:
                     restartPolicy: Never
+                    # The dump-secrets init container needs RBAC to
+                    # read the canasta-<id>-{db-credentials,mw-secrets}
+                    # Secrets. Without a dedicated SA, the Pod runs as
+                    # 'default' which has no Secret read permission.
+                    serviceAccountName: "canasta-backup-{{ instance_id }}"
                     initContainers:
                       - name: dump-databases
                         image: "{{ _sched_env.variables.CANASTA_IMAGE | default('ghcr.io/canastawiki/canasta:latest') }}"
@@ -121,6 +176,36 @@
                         # paths aligned means scheduled-snapshot
                         # restore Just Works without a path-flavor
                         # branch in the restore flow.
+                        volumeMounts:
+                          - name: dumps
+                            mountPath: /currentsnapshot/config/backup
+                      # Dump canasta-managed K8s Secrets into the same
+                      # snapshot tree so a fresh-cluster restore can
+                      # bring back MYSQL_PASSWORD / MW_SECRET_KEY. Without
+                      # this, restic preserves the database content and
+                      # PVCs, but a freshly-deployed wiki pod can't
+                      # authenticate against the restored DB and all
+                      # MW sessions / password-reset tokens become
+                      # unrecoverable. See #510.
+                      #
+                      # We dump by explicit name (not label-selector)
+                      # so this works against existing instances that
+                      # pre-date the canasta-managed-by label
+                      # convention. The resulting file is YAML with a
+                      # 'kind: List' wrapper that 'kubectl apply -f'
+                      # treats as a multi-document apply.
+                      - name: dump-secrets
+                        image: bitnami/kubectl:latest
+                        command:
+                          - sh
+                          - -c
+                          - |
+                            kubectl get secret \
+                              {{ instance_id }}-db-credentials \
+                              {{ instance_id }}-mw-secrets \
+                              -n canasta-{{ instance_id }} \
+                              -o yaml \
+                              > /currentsnapshot/config/backup/secrets-{{ instance_id }}.yaml
                         volumeMounts:
                           - name: dumps
                             mountPath: /currentsnapshot/config/backup

--- a/tests/unit/test_backup_schedule_k8s.py
+++ b/tests/unit/test_backup_schedule_k8s.py
@@ -259,3 +259,194 @@ class TestBackupEnvSecretSyncTask:
                 "cover %r (used by restic backends or the "
                 "dump-databases init container)." % prefix_or_key
             )
+
+
+class TestK8sSecretBackupCapture:
+    """Guard #510: canasta-managed K8s Secrets must land in the
+    restic snapshot. Without them, a fresh-cluster restore can bring
+    back the DB content but no new wiki pod can authenticate against
+    it (MYSQL_PASSWORD is in the K8s Secret, not in the DB itself).
+    """
+
+    @staticmethod
+    def _pod_template(spec):
+        return spec["jobTemplate"]["spec"]["template"]["spec"]
+
+    def test_dump_secrets_init_container_present(self):
+        spec = _find_cronjob_definition()["spec"]
+        init_names = {c["name"]
+                      for c in self._pod_template(spec)["initContainers"]}
+        assert "dump-secrets" in init_names, (
+            "schedule_set.yml CronJob must include a 'dump-secrets' "
+            "init container that captures canasta-managed K8s Secrets "
+            "into the restic snapshot. Without it, fresh-cluster "
+            "restore loses MYSQL_PASSWORD/MW_SECRET_KEY (#510)."
+        )
+
+    def test_dump_secrets_writes_to_canonical_path(self):
+        spec = _find_cronjob_definition()["spec"]
+        init = next(c for c in self._pod_template(spec)["initContainers"]
+                    if c["name"] == "dump-secrets")
+        cmd = " ".join(init["command"])
+        # Path must align with where restore_k8s.yml looks for the
+        # secrets file (alongside DB dumps, under the dumps emptyDir).
+        assert "/currentsnapshot/config/backup/secrets-" in cmd, (
+            "dump-secrets must write to "
+            "/currentsnapshot/config/backup/secrets-<id>.yaml "
+            "to align with restore_k8s.yml's lookup path."
+        )
+
+    def test_dump_secrets_targets_db_credentials_and_mw_secrets(self):
+        """Dump by explicit name (not label-selector) so this works
+        on instances pre-dating any canasta-managed-by label
+        convention."""
+        spec = _find_cronjob_definition()["spec"]
+        init = next(c for c in self._pod_template(spec)["initContainers"]
+                    if c["name"] == "dump-secrets")
+        cmd = " ".join(init["command"])
+        assert "-db-credentials" in cmd, (
+            "dump-secrets must include the <id>-db-credentials Secret "
+            "(carries MYSQL_PASSWORD)"
+        )
+        assert "-mw-secrets" in cmd, (
+            "dump-secrets must include the <id>-mw-secrets Secret "
+            "(carries MW_SECRET_KEY)"
+        )
+
+    def test_dump_secrets_does_not_capture_backup_env(self):
+        """The canasta-<id>-backup-env Secret carries the credentials
+        needed to READ the snapshot. Including it in the snapshot is
+        chicken-and-egg — operator can't get the bootstrap creds
+        without the snapshot, can't read the snapshot without the
+        creds. Out of scope per #510."""
+        spec = _find_cronjob_definition()["spec"]
+        init = next(c for c in self._pod_template(spec)["initContainers"]
+                    if c["name"] == "dump-secrets")
+        cmd = " ".join(init["command"])
+        assert "backup-env" not in cmd, (
+            "dump-secrets must NOT include the backup-env Secret "
+            "(creds-to-read-the-snapshot must not live IN the snapshot)"
+        )
+
+    def test_dump_secrets_mounts_dumps_emptydir(self):
+        """The init container must mount the same dumps emptyDir the
+        SQL dumps go into, so the secrets file ends up in the
+        snapshot tree restic backs up."""
+        spec = _find_cronjob_definition()["spec"]
+        init = next(c for c in self._pod_template(spec)["initContainers"]
+                    if c["name"] == "dump-secrets")
+        mounts = {m["name"]: m for m in init.get("volumeMounts") or []}
+        assert "dumps" in mounts
+        assert mounts["dumps"]["mountPath"] == "/currentsnapshot/config/backup"
+
+    def test_pod_uses_dedicated_serviceaccount(self):
+        """The dump-secrets init container needs RBAC to read Secrets;
+        the default ServiceAccount has no such permission."""
+        spec = _find_cronjob_definition()["spec"]
+        sa = self._pod_template(spec).get("serviceAccountName")
+        assert sa, (
+            "Backup CronJob Pod must specify a serviceAccountName — "
+            "dump-secrets needs Secret-read RBAC the default SA lacks"
+        )
+        assert "canasta-backup-" in sa, (
+            "ServiceAccount name should be canasta-backup-<id> for "
+            "consistency with the Role/RoleBinding created alongside"
+        )
+
+
+class TestK8sSecretBackupRBAC:
+    """The CronJob's ServiceAccount must have a Role + RoleBinding
+    that grants read on the canasta-managed Secrets. Scoped narrowly:
+    only the two Secret names we dump, only `get` verb, namespace-
+    local. Least-privilege RBAC."""
+
+    def _find_resources(self, kind):
+        for task in _walk_tasks(_load_tasks()):
+            k8s = task.get("kubernetes.core.k8s") or task.get("k8s")
+            if not isinstance(k8s, dict):
+                continue
+            defn = k8s.get("definition") or {}
+            if defn.get("kind") == kind and k8s.get("state") == "present":
+                yield defn
+
+    def test_serviceaccount_created(self):
+        sas = list(self._find_resources("ServiceAccount"))
+        assert len(sas) >= 1, (
+            "schedule_set.yml must create a ServiceAccount for the "
+            "backup Pod (#510)"
+        )
+
+    def test_role_grants_only_get_on_named_secrets(self):
+        roles = list(self._find_resources("Role"))
+        assert len(roles) >= 1, (
+            "schedule_set.yml must create a Role granting Secret read "
+            "to the backup ServiceAccount (#510)"
+        )
+        rules = roles[0]["rules"]
+        # Single rule, get-only, scoped to the two Secret names
+        assert len(rules) == 1, (
+            "Role should have exactly one rule (least-privilege); "
+            "anything else suggests scope creep"
+        )
+        rule = rules[0]
+        assert "secrets" in rule.get("resources", [])
+        assert rule.get("verbs", []) == ["get"], (
+            "Role must grant only 'get' — list/watch/create/etc. would "
+            "exceed what dump-secrets actually needs"
+        )
+        names = rule.get("resourceNames", [])
+        # Dump-secrets reads two Secrets by name
+        assert len(names) == 2, (
+            "Role should be scoped to exactly the two Secret names "
+            "dump-secrets reads — broader scope is unjustified"
+        )
+
+    def test_rolebinding_targets_backup_serviceaccount(self):
+        rbs = list(self._find_resources("RoleBinding"))
+        assert len(rbs) >= 1
+        rb = rbs[0]
+        subjects = rb.get("subjects", [])
+        assert len(subjects) == 1
+        assert subjects[0].get("kind") == "ServiceAccount"
+        assert "canasta-backup-" in subjects[0].get("name", "")
+
+
+class TestK8sRestoreReplaysSecrets:
+    """restore_k8s.yml must apply the snapshot's secrets-<id>.yaml
+    file when present, so a fresh-cluster restore brings back
+    MYSQL_PASSWORD / MW_SECRET_KEY (#510)."""
+
+    RESTORE_K8S = os.path.join(
+        REPO_ROOT, "roles", "backup", "tasks", "restore_k8s.yml",
+    )
+
+    def test_restore_apply_secrets_task_exists(self):
+        with open(self.RESTORE_K8S) as f:
+            content = f.read()
+        # The task name explicitly mentions Secrets; the command pipes
+        # through 'kubectl apply -f -'. Both should be present.
+        assert "Restore canasta-managed K8s Secrets" in content, (
+            "restore_k8s.yml must have a task that restores the "
+            "canasta-managed Secrets from the snapshot (#510)"
+        )
+        assert "kubectl apply" in content, (
+            "restore_k8s.yml's secrets-restore task must use "
+            "'kubectl apply' so it's idempotent against an existing "
+            "Secret with the same value"
+        )
+
+    def test_restore_skips_when_secrets_file_missing(self):
+        """Snapshots taken before #510 won't have a secrets-*.yaml
+        file. Restoring those must skip the secrets task gracefully,
+        not fail."""
+        with open(self.RESTORE_K8S) as f:
+            content = f.read()
+        # The when-guard checks for the filename being non-empty
+        assert "_restore_secrets_filename" in content, (
+            "restore_k8s.yml should resolve the secrets filename "
+            "conditionally so pre-#510 snapshots restore cleanly"
+        )
+        assert "_restore_secrets_filename != ''" in content, (
+            "restore_k8s.yml's secrets-restore task must guard "
+            "on the filename being non-empty (pre-#510 snapshots)"
+        )


### PR DESCRIPTION
## Summary

Fixes #510 — closes the DR gap that opened up when #507 (#508) stopped duplicating Secret-backed creds into the gitops repo. After that change, `MYSQL_PASSWORD` and `MW_SECRET_KEY` lived only in K8s Secrets and weren't captured anywhere by `canasta backup`. If etcd was destroyed and the host's `.env` also lost, the wiki content survived in restic but no new pod could authenticate against the restored DB.

## Approach

Add a `dump-secrets` init container to the scheduled backup `CronJob` that captures the canasta-managed Secrets into the same dumps `emptyDir` the SQL dumps land in. The existing restic container then snapshots the file as part of `/currentsnapshot/config/backup`. Restore (`restore_k8s.yml`) replays via `kubectl apply -f -`, guarded so pre-#510 snapshots restore cleanly without it.

## Changes

1. **`roles/backup/tasks/schedule_set.yml`**:
   - `ServiceAccount canasta-backup-<id>` plus least-privilege `Role` (only `get` verb, only on the two named Secrets) and `RoleBinding`. The default ServiceAccount has no Secret read permission; without dedicated RBAC, `kubectl get` fails.
   - `dump-secrets` init container using `bitnami/kubectl:latest`, mounting the dumps `emptyDir` at `/currentsnapshot/config/backup`, dumping by explicit name.
   - `serviceAccountName` on the CronJob's pod template.
   - Excludes `<id>-backup-env` on purpose: that Secret carries the credentials needed to read the snapshot itself — chicken-and-egg if captured.

2. **`roles/backup/tasks/restore_k8s.yml`**:
   - Find `secrets-<id>.yaml` in the snapshot's backup directory.
   - When present, `kubectl apply -f -` (idempotent — no-op if existing Secret matches; overwrite if different).
   - When absent (pre-#510 snapshot), skip cleanly.

3. **`tests/unit/test_backup_schedule_k8s.py`** — 11 new structural guards across three classes:
   - `TestK8sSecretBackupCapture` (init container shape + path + Secret-name targeting)
   - `TestK8sSecretBackupRBAC` (least-privilege Role/Binding shape)
   - `TestK8sRestoreReplaysSecrets` (idempotent restore + skip-if-missing semantics)

## Validation

End-to-end on the same multi-host AWS cluster used for #504/#506/#508. After re-running `canasta backup schedule set` on the `extdb` instance:

| Check | Result |
|---|---|
| ServiceAccount `canasta-backup-extdb` created | ✓ |
| Role / RoleBinding (least-privilege) created | ✓ |
| CronJob initContainers list = `dump-databases dump-secrets` | ✓ |
| Pod template `serviceAccountName: canasta-backup-extdb` | ✓ |
| First firing post-fix: snapshot saved (9 files / 70.468 KiB) | ✓ |
| File count vs. pre-fix | +1 (`secrets-extdb.yaml`) |
| dump-secrets exit code | 0 |

Also exercised against a **real AWS S3 backend** (not just the local-path test repo): switched `RESTIC_REPOSITORY` to `s3:s3.amazonaws.com/<bucket>/extdb`, re-ran `canasta backup schedule set`, validated snapshot landed in S3 with the standard restic layout (`data/`, `index/`, `keys/`, `snapshots/`, `config`).

## Out of scope, surfaced for follow-up

- **On-demand `canasta backup create` on K8s**: the DB-dump path runs `kubectl exec` into the live web pod's `emptyDir`, but the restic Job mounts the web-config `ConfigMap`, not the web pod's `emptyDir`. The SQL dumps may not reach the snapshot. Needs verification on cluster + dedicated fix.
- **Fresh-cluster DR semantics**: this PR ensures Secrets are *captured*. A complete fresh-cluster restore needs the running DB pod's `mysql.user` table to be re-authenticated against the restored credentials (since `canasta create` generates new ones first). Worth its own issue.
- **Encrypted Secret manifest in gitops repo (#511)**: the second backup pathway that brings K8s to parity with Compose's two-pathway model.
- **`canasta start` against a remote target**: `lookup('file', ...)` runs on the controller, but `instance_path` is target-side. Looks like a regression — needs research before filing an issue.

## Test plan

- [x] `make test-unit` passes (743 tests; 11 new in this PR)
- [x] Scheduled CronJob produces a snapshot containing `secrets-<id>.yaml`
- [x] Validated against both local-path and real S3 restic backends
- [x] dump-secrets has the RBAC it needs (Role/RoleBinding scoped to the two Secret names, `get` only)
- [ ] Reviewer confirmation: bitnami/kubectl image is acceptable (small, kubernetes-distributed-by-default-but-not-officially-K8s-team), or should we pin to a specific tag for reproducibility?
