### PR TITLE
orchestrator/start: read values.yaml via slurp, not controller-side lookup (#514)

### DIFF
--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -132,6 +132,21 @@
       ansible.builtin.set_fact:
         _k8s_namespace: "canasta-{{ instance_id }}"
 
+    # Slurp values.yaml from the target host once and parse it. All
+    # three downstream reads (web.replicaCount, db.enabled,
+    # argocd.syncPolicy) used to call lookup('file', instance_path ~
+    # '/values.yaml'), which runs on the controller — broken when
+    # controller and target are different hosts (#514). Same fix shape
+    # PR #115 used for init_kubernetes.yml and push_kubernetes.yml.
+    - name: Read values.yaml from target
+      ansible.builtin.slurp:
+        src: "{{ instance_path }}/values.yaml"
+      register: _start_values_raw
+
+    - name: Parse values.yaml
+      ansible.builtin.set_fact:
+        _start_values: "{{ _start_values_raw.content | b64decode | from_yaml }}"
+
     - name: Sync config to ConfigMaps
       ansible.builtin.include_tasks: k8s_sync_config.yml
 
@@ -153,9 +168,7 @@
       block:
         - name: Read web replica count from values
           ansible.builtin.set_fact:
-            _web_replicas: >-
-              {{ (lookup('file', instance_path ~ '/values.yaml')
-                  | from_yaml).get('web', {}).get('replicaCount', 1) }}
+            _web_replicas: "{{ _start_values.get('web', {}).get('replicaCount', 1) }}"
 
         # External-DB instances with Elasticsearch disabled have no
         # StatefulSets; 'kubectl scale --all' errors with "no objects
@@ -199,9 +212,7 @@
     # -db StatefulSet and the rollout-status call errors with NotFound.
     - name: Read db.enabled from values.yaml
       ansible.builtin.set_fact:
-        _db_enabled: >-
-          {{ (lookup('file', instance_path ~ '/values.yaml')
-              | from_yaml).get('db', {}).get('enabled', true) }}
+        _db_enabled: "{{ _start_values.get('db', {}).get('enabled', true) }}"
 
     - name: Wait for DB readiness
       ansible.builtin.command:
@@ -237,9 +248,7 @@
       block:
         - name: Read sync policy from values.yaml
           ansible.builtin.set_fact:
-            _argocd_sync_policy: >-
-              {{ (lookup('file', instance_path ~ '/values.yaml')
-                  | from_yaml).get('argocd', {}).get('syncPolicy', {}) }}
+            _argocd_sync_policy: "{{ _start_values.get('argocd', {}).get('syncPolicy', {}) }}"
 
         - name: Build sync policy patch
           ansible.builtin.set_fact:

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -415,6 +415,54 @@ class TestK8sGitopsNoEncryption:
         )
 
 
+class TestK8sStartReadsValuesFromTarget:
+    """Guard #514: lookup('file', ...) runs on the controller, but
+    instance_path is target-side. canasta start broke against any
+    remote K8s target because three set_fact tasks tried to read the
+    instance's values.yaml via lookup. Ban the anti-pattern here so
+    the same regression can't drift back in (PR #115 had to fix the
+    same shape in init_kubernetes.yml + push_kubernetes.yml; #265 and
+    earlier reintroduced it in start.yml)."""
+
+    START_YML = os.path.join(ORCHESTRATOR_TASKS, "start.yml")
+
+    def test_no_lookup_file_against_instance_path(self):
+        """No `lookup('file', instance_path ~ ...)` calls. They MUST
+        be slurp-based to read on the play target via SSH."""
+        with open(self.START_YML) as f:
+            content = f.read()
+        # Strip comments before checking — explanatory comments may
+        # mention the old pattern legitimately.
+        non_comment_lines = [
+            line for line in content.splitlines()
+            if not line.strip().startswith("#")
+        ]
+        active = "\n".join(non_comment_lines)
+        assert "lookup('file', instance_path" not in active, (
+            "start.yml has a lookup('file', instance_path ~ ...) call. "
+            "lookup runs on the controller but instance_path is the "
+            "target-side path; this breaks canasta start against any "
+            "remote K8s host. Use ansible.builtin.slurp + from_yaml. "
+            "See #514."
+        )
+
+    def test_values_yaml_slurped(self):
+        """The K8s start path must slurp values.yaml from the target
+        and parse it into a single fact (_start_values) so all three
+        downstream reads (web.replicaCount, db.enabled,
+        argocd.syncPolicy) share one source."""
+        with open(self.START_YML) as f:
+            content = f.read()
+        assert "ansible.builtin.slurp:" in content, (
+            "start.yml must slurp values.yaml from the target instead "
+            "of looking it up controller-side (#514)"
+        )
+        assert "_start_values" in content, (
+            "start.yml should parse the slurped values into a "
+            "_start_values fact and reuse it across the three reads"
+        )
+
+
 class TestGitopsDispatchers:
     """Verify that each dispatched gitops command has both variants."""
 


### PR DESCRIPTION
## Summary

Fixes #514 — `canasta start` failed against any remote K8s target with `lookup plugin 'file' failed: Unable to access the file '/home/admin/canasta/<id>/values.yaml'`. Three `lookup('file', instance_path ~ '/values.yaml')` calls in `roles/orchestrator/tasks/start.yml` ran on the controller, but `instance_path` is the target-side path.

PR #115 fixed the same anti-pattern in `init_kubernetes.yml` and `push_kubernetes.yml` back in April 2026, replacing `lookup` with `slurp`. PRs #265 (Skip DB readiness wait when using external database) and #71 reintroduced the pattern in `start.yml` — slipped through review because single-host setups (controller-on-target) coincidentally have `instance_path` locally so the lookup succeeds.

## Fix

Slurp `values.yaml` from the target once at the top of the K8s block, parse into a single `_start_values` fact, reuse for all three downstream reads (`web.replicaCount`, `db.enabled`, `argocd.syncPolicy`).

```yaml
- name: Read values.yaml from target
  ansible.builtin.slurp:
    src: "{{ instance_path }}/values.yaml"
  register: _start_values_raw

- name: Parse values.yaml
  ansible.builtin.set_fact:
    _start_values: "{{ _start_values_raw.content | b64decode | from_yaml }}"
```

## Tests

Two structural guards in `tests/unit/test_kubernetes_structure.py::TestK8sStartReadsValuesFromTarget`:
- No `lookup('file', instance_path ~ ...)` anywhere active in `start.yml` (comments excluded)
- The slurp + `_start_values` fact must exist

## Validation

Re-tested on the same multi-host AWS cluster used for #504/#506/#508/#512: `canasta start -i extdb` against the remote target now reports `Instance 'extdb' started.` instead of the `File not found` error.

## Test plan

- [x] `make test-unit` passes (745 tests; 2 new in this PR)
- [x] `canasta start` works against a remote K8s target
- [ ] Reviewer sanity check that the slurp-based pattern is the same shape PR #115 used elsewhere
