### PR TITLE
backup/k8s: capture wiki DB and Secrets in on-demand snapshots (#513)

### DIFF
--- a/roles/backup/tasks/_k8s_backup_rbac.yml
+++ b/roles/backup/tasks/_k8s_backup_rbac.yml
@@ -1,0 +1,59 @@
+---
+# RBAC for K8s backup Pods.
+#
+# Creates a per-instance ServiceAccount + Role + RoleBinding so backup
+# Pods can read the canasta-managed Secrets (for dump-secrets) without
+# the default ServiceAccount's lack of Secret-read perms blocking
+# them. Scoped: only 'get' verb, only the two specific Secret names
+# we capture in the snapshot.
+#
+# Included by both schedule_set.yml (CronJob path) and k8s_run_backup.yml
+# (on-demand path) — idempotent, so running both keeps a single set
+# of resources in the namespace.
+#
+# Input: instance_id
+
+- name: Create ServiceAccount for backup Pod
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: "canasta-backup-{{ instance_id }}"
+        namespace: "canasta-{{ instance_id }}"
+
+- name: Create Role granting read on canasta-managed Secrets
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: "canasta-backup-{{ instance_id }}"
+        namespace: "canasta-{{ instance_id }}"
+      rules:
+        - apiGroups: [""]
+          resources: ["secrets"]
+          resourceNames:
+            - "{{ instance_id }}-db-credentials"
+            - "{{ instance_id }}-mw-secrets"
+          verbs: ["get"]
+
+- name: Bind Role to backup ServiceAccount
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: "canasta-backup-{{ instance_id }}"
+        namespace: "canasta-{{ instance_id }}"
+      subjects:
+        - kind: ServiceAccount
+          name: "canasta-backup-{{ instance_id }}"
+          namespace: "canasta-{{ instance_id }}"
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: "canasta-backup-{{ instance_id }}"

--- a/roles/backup/tasks/create.yml
+++ b/roles/backup/tasks/create.yml
@@ -22,14 +22,28 @@
   register: _backup_dbpass
   no_log: true
 
-- name: Create backup staging directory
+# Compose path: dump DBs into the live web container's
+# /mediawiki/config/backup, which is bind-mounted from the host's
+# instance_path/config — restic's container then mounts the same host
+# path and the dumps appear in the snapshot.
+#
+# K8s path: SKIP this — it would write into the live web pod's
+# emptyDir, which the separately-spawned restic Job has no access to
+# (the Job mounts the web-config ConfigMap, not the live pod's
+# emptyDir). Pre-#513, this dance ran on K8s anyway and the dumps
+# silently vanished from on-demand snapshots, leaving wiki content
+# unprotected. The K8s path now does the dump as an init container
+# inside the restic Job itself — see k8s_run_backup.yml's
+# _backup_init_containers.
+- name: Create backup staging directory (Compose)
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/orchestrator/tasks/exec.yml
   vars:
     exec_service: web
     exec_command: "mkdir -p /mediawiki/config/backup"
+  when: instance_orchestrator | default('compose') == 'compose'
 
-- name: Dump each wiki database
+- name: Dump each wiki database (Compose)
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/orchestrator/tasks/exec.yml
   vars:
@@ -43,6 +57,7 @@
       > /mediawiki/config/backup/db_{{ item | quote }}.sql
   loop: "{{ _backup_wikis.wiki_ids }}"
   no_log: true
+  when: instance_orchestrator | default('compose') == 'compose'
 
 - name: Get hostname for tag
   ansible.builtin.command:
@@ -101,10 +116,13 @@
   ansible.builtin.debug:
     msg: "{{ _restic_result.stdout }}"
 
-- name: Clean up backup staging directory (from inside container)
+# Compose-only cleanup. The K8s path's dump-databases init container
+# uses an emptyDir that's torn down with the Job — no cleanup needed.
+- name: Clean up backup staging directory (Compose)
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/orchestrator/tasks/exec.yml
   vars:
     exec_service: web
     exec_command: "rm -rf /mediawiki/config/backup"
+  when: instance_orchestrator | default('compose') == 'compose'
   ignore_errors: true  # OK if backup dir doesn't exist

--- a/roles/backup/tasks/schedule_set.yml
+++ b/roles/backup/tasks/schedule_set.yml
@@ -64,55 +64,12 @@
              | ternary('&& restic --cache-dir /tmp/restic-cache forget --prune --keep-within ' +
                (purge_older_than | default('')), '') }}
 
-    # ServiceAccount + Role + RoleBinding for the dump-secrets init
-    # container. Without this, the Pod's default ServiceAccount has no
-    # permission to read Secrets and the kubectl get fails. Scoped to
-    # the canasta-<id> namespace and to the two specific Secret names
-    # we need — least privilege. See #510 for the DR gap this closes.
-    - name: Create ServiceAccount for backup Pod
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          apiVersion: v1
-          kind: ServiceAccount
-          metadata:
-            name: "canasta-backup-{{ instance_id }}"
-            namespace: "canasta-{{ instance_id }}"
-
-    - name: Create Role granting read on canasta-managed Secrets
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          apiVersion: rbac.authorization.k8s.io/v1
-          kind: Role
-          metadata:
-            name: "canasta-backup-{{ instance_id }}"
-            namespace: "canasta-{{ instance_id }}"
-          rules:
-            - apiGroups: [""]
-              resources: ["secrets"]
-              resourceNames:
-                - "{{ instance_id }}-db-credentials"
-                - "{{ instance_id }}-mw-secrets"
-              verbs: ["get"]
-
-    - name: Bind Role to backup ServiceAccount
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          apiVersion: rbac.authorization.k8s.io/v1
-          kind: RoleBinding
-          metadata:
-            name: "canasta-backup-{{ instance_id }}"
-            namespace: "canasta-{{ instance_id }}"
-          subjects:
-            - kind: ServiceAccount
-              name: "canasta-backup-{{ instance_id }}"
-              namespace: "canasta-{{ instance_id }}"
-          roleRef:
-            apiGroup: rbac.authorization.k8s.io
-            kind: Role
-            name: "canasta-backup-{{ instance_id }}"
+    # SA + Role + RoleBinding for backup Pods (used by both the
+    # CronJob path here and the on-demand Job in k8s_run_backup.yml).
+    # Extracted to a shared task file so both paths stay in lockstep
+    # — see #513 for the on-demand path's mirror of this logic.
+    - name: Create RBAC for backup Pods
+      ansible.builtin.include_tasks: _k8s_backup_rbac.yml
 
     - name: Create backup CronJob
       kubernetes.core.k8s:

--- a/roles/orchestrator/tasks/k8s_run_backup.yml
+++ b/roles/orchestrator/tasks/k8s_run_backup.yml
@@ -34,6 +34,30 @@
   ansible.builtin.set_fact:
     _restic_local_repo: "{{ _restic_repo is match('^/') }}"
 
+# Detect 'backup' verb in backup_args. The on-demand Job is also used
+# for non-snapshot operations (forget, snapshots, init, unlock, etc.);
+# only true backup operations need the DB-dump and Secret-dump init
+# containers. See #513 for the bug this closes — pre-fix, on-demand
+# 'canasta backup create' on K8s captured static files only and
+# silently lost the wiki database.
+- name: Detect backup operation
+  ansible.builtin.set_fact:
+    _is_backup_op: "{{ 'backup' in backup_args }}"
+
+- name: Read DB password for dump-databases (backup ops only)
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read
+    key: MYSQL_PASSWORD
+  register: _backup_dbpass
+  when: _is_backup_op | bool
+  no_log: true
+
+- name: Create RBAC for backup Pods (backup ops only)
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/backup/tasks/_k8s_backup_rbac.yml
+  when: _is_backup_op | bool
+
 - name: Generate unique job name
   ansible.builtin.set_fact:
     _backup_job_name: "restic-{{ lookup('pipe', 'date +%s') }}"
@@ -81,6 +105,72 @@
          'hostPath': {'path': _restic_repo, 'type': 'DirectoryOrCreate'}}] }}
   when: _restic_local_repo | bool
 
+# Backup ops add a 'dumps' emptyDir + mount-on-mount over the
+# web-config ConfigMap subdir at /currentsnapshot/config/backup. The
+# init containers write SQL dumps and the Secret manifest there;
+# restic captures the merged tree. Same mount-on-mount pattern the
+# scheduled CronJob uses (see roles/backup/tasks/schedule_set.yml).
+- name: Add dumps volume + mount-on-mount for backup ops
+  when: _is_backup_op | bool
+  ansible.builtin.set_fact:
+    _restic_volumes: "{{ _restic_volumes + [{'name': 'dumps', 'emptyDir': {}}] }}"
+    _restic_volume_mounts: >-
+      {{ _restic_volume_mounts + [{'name': 'dumps',
+         'mountPath': '/currentsnapshot/config/backup', 'readOnly': true}] }}
+
+# Build the init container list. Empty for non-backup ops (forget,
+# snapshots, etc. don't need DB or Secret dumps). For backup ops:
+# 1) dump-databases (mariadb-dump → /currentsnapshot/config/backup/db_*.sql)
+# 2) dump-secrets (canasta-managed K8s Secrets → secrets-<id>.yaml)
+- name: Default empty init containers
+  ansible.builtin.set_fact:
+    _backup_init_containers: []
+
+- name: Build init containers for backup ops
+  when: _is_backup_op | bool
+  ansible.builtin.set_fact:
+    _backup_init_containers:
+      # canasta-<id>-backup-env carries MYSQL_HOST, MYSQL_USER,
+      # MYSQL_PASSWORD per #498. Internal-db falls back to the
+      # 'db' / 'root' defaults baked into the script.
+      - name: dump-databases
+        image: "{{ _backup_env.variables.CANASTA_IMAGE | default('ghcr.io/canastawiki/canasta:latest') }}"
+        command:
+          - sh
+          - -c
+          - |
+            EXCLUDE='^(information_schema|performance_schema|mysql|sys)$'
+            for db in $(mariadb -h "${MYSQL_HOST:-db}" -u "${MYSQL_USER:-root}" -p"$MYSQL_PASSWORD" \
+              -N -e "SHOW DATABASES" | grep -vE "$EXCLUDE"); do
+              mariadb-dump -h "${MYSQL_HOST:-db}" -u "${MYSQL_USER:-root}" -p"$MYSQL_PASSWORD" \
+                --single-transaction --databases "$db" \
+                > "/currentsnapshot/config/backup/db_${db}.sql"
+            done
+        envFrom:
+          - secretRef:
+              name: "canasta-{{ instance_id }}-backup-env"
+        volumeMounts:
+          - name: dumps
+            mountPath: /currentsnapshot/config/backup
+      # Captures canasta-managed Secrets so a fresh-cluster restore
+      # can bring back MYSQL_PASSWORD / MW_SECRET_KEY (#510). Same
+      # by-name dump strategy the scheduled CronJob uses.
+      - name: dump-secrets
+        image: bitnami/kubectl:latest
+        command:
+          - sh
+          - -c
+          - |
+            kubectl get secret \
+              {{ instance_id }}-db-credentials \
+              {{ instance_id }}-mw-secrets \
+              -n canasta-{{ instance_id }} \
+              -o yaml \
+              > /currentsnapshot/config/backup/secrets-{{ instance_id }}.yaml
+        volumeMounts:
+          - name: dumps
+            mountPath: /currentsnapshot/config/backup
+
 - name: Create restic Job
   kubernetes.core.k8s:
     state: present
@@ -96,6 +186,11 @@
         template:
           spec:
             restartPolicy: Never
+            # Both init containers (when present) and the restic
+            # main container can use the dedicated backup SA. For
+            # non-backup ops the SA is unused and harmless.
+            serviceAccountName: "{{ (_is_backup_op | bool) | ternary('canasta-backup-' + instance_id, omit) }}"
+            initContainers: "{{ _backup_init_containers }}"
             containers:
               - name: restic
                 image: restic/restic:latest

--- a/tests/unit/test_backup_schedule_k8s.py
+++ b/tests/unit/test_backup_schedule_k8s.py
@@ -355,13 +355,23 @@ class TestK8sSecretBackupCapture:
 
 
 class TestK8sSecretBackupRBAC:
-    """The CronJob's ServiceAccount must have a Role + RoleBinding
+    """The backup Pod's ServiceAccount must have a Role + RoleBinding
     that grants read on the canasta-managed Secrets. Scoped narrowly:
     only the two Secret names we dump, only `get` verb, namespace-
-    local. Least-privilege RBAC."""
+    local. Least-privilege RBAC.
+
+    Source of truth is roles/backup/tasks/_k8s_backup_rbac.yml — both
+    the CronJob path (schedule_set.yml) and the on-demand path
+    (k8s_run_backup.yml) include this file (#513 refactor)."""
+
+    SHARED_RBAC_PATH = os.path.join(
+        REPO_ROOT, "roles", "backup", "tasks", "_k8s_backup_rbac.yml",
+    )
 
     def _find_resources(self, kind):
-        for task in _walk_tasks(_load_tasks()):
+        with open(self.SHARED_RBAC_PATH) as f:
+            tasks = yaml.safe_load(f)
+        for task in _walk_tasks(tasks):
             k8s = task.get("kubernetes.core.k8s") or task.get("k8s")
             if not isinstance(k8s, dict):
                 continue
@@ -449,4 +459,189 @@ class TestK8sRestoreReplaysSecrets:
         assert "_restore_secrets_filename != ''" in content, (
             "restore_k8s.yml's secrets-restore task must guard "
             "on the filename being non-empty (pre-#510 snapshots)"
+        )
+
+
+class TestOnDemandBackupCapturesDB:
+    """Guard #513: on-demand 'canasta backup create' on K8s must
+    capture the wiki database. Pre-fix the dump ran via 'kubectl
+    exec' into the live web pod's emptyDir; the restic Job spawned
+    separately and mounted the web-config ConfigMap (different
+    volume), so the SQL dumps silently vanished from the snapshot.
+    """
+
+    K8S_RUN_BACKUP = os.path.join(
+        REPO_ROOT, "roles", "orchestrator", "tasks", "k8s_run_backup.yml",
+    )
+    CREATE_YML = os.path.join(
+        REPO_ROOT, "roles", "backup", "tasks", "create.yml",
+    )
+
+    @staticmethod
+    def _walk(tasks):
+        for t in tasks or []:
+            if not isinstance(t, dict):
+                continue
+            yield t
+            for nested in ("block", "rescue", "always"):
+                if nested in t:
+                    yield from TestOnDemandBackupCapturesDB._walk(t[nested])
+
+    def _load_run_backup(self):
+        with open(self.K8S_RUN_BACKUP) as f:
+            return yaml.safe_load(f)
+
+    def test_detects_backup_operation(self):
+        """The on-demand path must distinguish 'backup' from
+        'forget'/'snapshots'/'init'/etc., so init-container overhead
+        only runs when actually needed."""
+        for task in self._walk(self._load_run_backup()):
+            sf = task.get("ansible.builtin.set_fact") or task.get("set_fact")
+            if isinstance(sf, dict) and "_is_backup_op" in sf:
+                expr = sf["_is_backup_op"]
+                assert "'backup' in backup_args" in expr, (
+                    "_is_backup_op should test for 'backup' in backup_args"
+                )
+                return
+        raise AssertionError(
+            "k8s_run_backup.yml must define _is_backup_op so the DB- "
+            "and Secret-dump init containers only fire on backup ops "
+            "(#513)"
+        )
+
+    def test_init_containers_built_for_backup_ops(self):
+        """A _backup_init_containers fact must be defined and
+        populated only on backup ops."""
+        # Default-empty case
+        found_default_empty = False
+        # Backup-op-conditional case
+        found_backup_op_conditional = False
+        for task in self._walk(self._load_run_backup()):
+            sf = task.get("ansible.builtin.set_fact") or task.get("set_fact")
+            if not (isinstance(sf, dict) and "_backup_init_containers" in sf):
+                continue
+            value = sf["_backup_init_containers"]
+            when = task.get("when", "")
+            if value == [] or value == "[]":
+                found_default_empty = True
+            elif "_is_backup_op" in str(when):
+                # Conditional set_fact for backup ops — value should
+                # be a list of two init containers.
+                if isinstance(value, list) and len(value) == 2:
+                    names = [c.get("name") for c in value]
+                    assert "dump-databases" in names, (
+                        "Backup-op init containers must include "
+                        "dump-databases"
+                    )
+                    assert "dump-secrets" in names, (
+                        "Backup-op init containers must include "
+                        "dump-secrets (matches scheduled CronJob, "
+                        "consolidates with #510)"
+                    )
+                    found_backup_op_conditional = True
+        assert found_default_empty, (
+            "k8s_run_backup.yml must default _backup_init_containers "
+            "to [] so non-backup ops (forget, snapshots, etc.) skip "
+            "the dump overhead"
+        )
+        assert found_backup_op_conditional, (
+            "k8s_run_backup.yml must conditionally populate "
+            "_backup_init_containers with both dump-databases and "
+            "dump-secrets when _is_backup_op (#513 + #510 symmetry)"
+        )
+
+    def test_dumps_volume_added_for_backup_ops(self):
+        """The dumps emptyDir + mount-on-mount under
+        /currentsnapshot/config/backup must exist when backup-op,
+        matching the schedule_set.yml CronJob's pattern."""
+        with open(self.K8S_RUN_BACKUP) as f:
+            content = f.read()
+        # Both the volume and the mount point must be added together
+        # in a backup-op-gated set_fact.
+        assert "'name': 'dumps'" in content, (
+            "k8s_run_backup.yml must add a 'dumps' emptyDir volume "
+            "for backup ops"
+        )
+        assert "/currentsnapshot/config/backup" in content, (
+            "k8s_run_backup.yml must mount the dumps emptyDir at "
+            "/currentsnapshot/config/backup (mount-on-mount over "
+            "the web-config ConfigMap subdir)"
+        )
+
+    def test_rbac_included_for_backup_ops(self):
+        """k8s_run_backup.yml must include the shared _k8s_backup_rbac
+        task when running a backup op so the SA/Role/RoleBinding for
+        dump-secrets exists. The same shared file is included by
+        schedule_set.yml — single source of truth."""
+        with open(self.K8S_RUN_BACKUP) as f:
+            content = f.read()
+        assert "_k8s_backup_rbac.yml" in content, (
+            "k8s_run_backup.yml must include the shared "
+            "_k8s_backup_rbac.yml task file (factored out per #513)"
+        )
+
+    def test_create_dump_gated_on_compose(self):
+        """create.yml's mariadb-dump-via-kubectl-exec is a no-op on
+        K8s (the dump lands in the live web pod's emptyDir, invisible
+        to the restic Job). Must be gated on Compose so it doesn't
+        run uselessly on K8s."""
+        with open(self.CREATE_YML) as f:
+            tasks = yaml.safe_load(f)
+        for task in self._walk(tasks):
+            name = task.get("name", "")
+            if "Dump each wiki database" not in name:
+                continue
+            when = task.get("when", "")
+            assert "compose" in str(when).lower(), (
+                "create.yml's 'Dump each wiki database' task must be "
+                "gated on the Compose orchestrator — running on K8s "
+                "writes to a transient emptyDir the restic Job can't "
+                "see (#513)"
+            )
+            return
+        raise AssertionError(
+            "create.yml has no 'Dump each wiki database' task"
+        )
+
+
+class TestSharedBackupRBAC:
+    """The SA + Role + RoleBinding live in roles/backup/tasks/
+    _k8s_backup_rbac.yml so the CronJob (schedule_set.yml) and the
+    on-demand Job (k8s_run_backup.yml) stay in lockstep. Schedule_set
+    must include the shared file (refactored per #513)."""
+
+    SHARED_RBAC = os.path.join(
+        REPO_ROOT, "roles", "backup", "tasks", "_k8s_backup_rbac.yml",
+    )
+
+    def test_shared_file_exists(self):
+        assert os.path.isfile(self.SHARED_RBAC), (
+            "Expected shared RBAC file at roles/backup/tasks/"
+            "_k8s_backup_rbac.yml (#513)"
+        )
+
+    def test_shared_file_creates_three_resources(self):
+        """ServiceAccount, Role, RoleBinding."""
+        with open(self.SHARED_RBAC) as f:
+            tasks = yaml.safe_load(f)
+        kinds = []
+        for task in tasks:
+            k8s = task.get("kubernetes.core.k8s") or task.get("k8s") or {}
+            defn = k8s.get("definition") or {}
+            if defn.get("kind"):
+                kinds.append(defn["kind"])
+        assert kinds == ["ServiceAccount", "Role", "RoleBinding"], (
+            "Shared RBAC file must create exactly: ServiceAccount, "
+            "Role, RoleBinding (got %r)" % kinds
+        )
+
+    def test_schedule_set_uses_shared_include(self):
+        """schedule_set.yml must include the shared file rather than
+        defining its own copy — single source of truth, no drift."""
+        with open(SCHEDULE_SET) as f:
+            content = f.read()
+        assert "_k8s_backup_rbac.yml" in content, (
+            "schedule_set.yml must include the shared "
+            "_k8s_backup_rbac.yml task file (refactored per #513 to "
+            "share with k8s_run_backup.yml)"
         )


### PR DESCRIPTION
## Summary

Fixes #513 — high-severity DR bug where on-demand `canasta backup create` on K8s was producing snapshots with no wiki database content, only static config + PVC files. Pre-fix, K8s on-demand snapshots were 2.145 KiB; should have been ~70 KiB matching the scheduled CronJob output.

Root cause: `create.yml`'s `kubectl exec mariadb-dump` wrote SQL files into the live web pod's `emptyDir`. The restic Job spawned separately and mounted the `web-config` ConfigMap (different volume, different Pod). On Compose, both containers bind-mount the same host path, so the dumps are visible. On K8s, `emptyDir` is pod-isolated, and the restic Job had no path to those files. The Compose pattern was lifted into K8s without adapting to the K8s volume model.

## Approach

Move the DB dump (and the #510 Secret dump for symmetry) into the restic Job's own Pod as init containers, with a shared `emptyDir` mounted into both init containers (writable) and the restic main container (read-only via mount-on-mount). Same shape the scheduled CronJob already uses post-#503.

## Changes

1. **`roles/backup/tasks/_k8s_backup_rbac.yml`** — NEW shared file creating SA + Role + RoleBinding for backup Pods. Both `schedule_set.yml` (CronJob) and `k8s_run_backup.yml` (on-demand) include it. Idempotent. Single source of truth for least-privilege RBAC (only `get`, only the two named Secrets).

2. **`roles/orchestrator/tasks/k8s_run_backup.yml`** — when `backup_args` contains `'backup'`, add `dump-databases` + `dump-secrets` init containers, the `dumps` emptyDir, and the `mount-on-mount` over `/currentsnapshot/config/backup`. Non-backup ops (forget, snapshots, init, unlock) skip all this — they don't need DB or Secret dumps.

3. **`roles/backup/tasks/schedule_set.yml`** — replace the inline RBAC block (#510) with the `include_tasks` to the shared file.

4. **`roles/backup/tasks/create.yml`** — gate the now-pointless `kubectl exec mariadb-dump` and its companion mkdir/cleanup tasks on `compose` only.

5. **`tests/unit/test_backup_schedule_k8s.py`** — 8 new structural guards across two new classes (`TestOnDemandBackupCapturesDB`, `TestSharedBackupRBAC`); existing #510 RBAC tests repointed at the shared file path.

## Validation

End-to-end on the multi-host AWS cluster used for #504/#506/#508/#512/#515 (real S3 backend). After `canasta backup create -i extdb --tag fix-513-validation`:

| Check | Pre-fix | Post-fix |
|---|---|---|
| Snapshot files | 7 | 9 |
| Snapshot size | 2.145 KiB | 70.468 KiB |
| `db_main.sql` in snapshot | absent | present |
| `secrets-extdb.yaml` in snapshot | absent | present |
| `canasta backup list` (non-backup op) | works | still works |
| On-demand vs scheduled size match | no | yes (both 70.468 KiB) |

## Test plan

- [x] `make test-unit` passes (751 tests; 8 new in this PR; 3 existing #510 tests repointed)
- [x] On-demand `canasta backup create` produces a snapshot with `db_*.sql` files
- [x] On-demand `canasta backup create` produces a snapshot with the Secret manifest (matching #510 symmetry)
- [x] Non-backup ops (`canasta backup list`, which calls `restic snapshots`) still work — the conditional gating is correct
- [x] Validated against real AWS S3 backend (not just local-path)
- [ ] Reviewer confirmation that the `_k8s_backup_rbac.yml` extraction is the right shape for future shared backup-RBAC needs

## Out of scope (deferred)

- Fresh-cluster DR semantics: see analysis in #512's PR description. After this lands, capture is complete — making restore truly idempotent against fresh-cluster Secrets needs additional logic.
- Encrypted Secret manifest in the gitops repo (#511) — second backup pathway for parity with Compose.
