### PR TITLE
backup/k8s: preserve current DB password during snapshot Secret restore (#517)

### DIFF
--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -125,19 +125,53 @@
 # secrets file — that's the 'select match secrets-*.yaml' filter,
 # which evaluates to empty for those.
 #
-# 'kubectl apply -f -' is idempotent: if the cluster already has the
-# Secret with the same value (instance was up before restore), this
-# is a no-op. If the cluster has a different value (fresh-cluster
-# DR scenario where 'canasta create' generated new passwords), the
-# snapshot's value overwrites — required for the restored DB whose
-# user-table hashes match the snapshot's password.
+# Two-step restore mirrors Compose's restore.yml policy
+# (clone-friendly):
+#
+#   1. Apply the snapshot's secrets file blanket — so MW_SECRET_KEY
+#      lands at the snapshot's value. MediaWiki uses MW_SECRET_KEY to
+#      derive HMACs for sessions, password-reset tokens, etc.; the
+#      restored wiki content was encrypted with that key, so the new
+#      pod must use the same key to decrypt.
+#   2. Patch MYSQL_PASSWORD and MYSQL_ROOT_PASSWORD back to the values
+#      they had on the running cluster BEFORE the restore. The
+#      running DB pod's mysql.user table has password hashes set when
+#      the pod first started (canasta create) — those hashes match
+#      the cluster's CURRENT plaintext password, not the snapshot's.
+#      Without this preservation step, a clone-into-fresh-cluster
+#      restore would auth-mismatch on the next web pod restart.
+#
+# Compose handles this in restore.yml via 'Save current DB password
+# before restore' + 'Preserve DB password in restored .env'. The K8s
+# equivalent is below.
 - name: Find canasta-managed Secret manifest in snapshot
   ansible.builtin.set_fact:
     _restore_secrets_filename: >-
       {{ (_restore_db_files.stdout_lines | default([])
           | select('match', '^secrets-.+\\.yaml$') | list | first) | default('') }}
 
-- name: Restore canasta-managed K8s Secrets
+- name: Save current DB credentials before secret restore (clone-friendly)
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ instance_id }}-db-credentials"
+    namespace: "{{ _k8s_namespace }}"
+  register: _restore_current_db_secret
+  when: _restore_secrets_filename != ''
+  no_log: true
+
+- name: Capture current DB password values
+  ansible.builtin.set_fact:
+    _restore_current_mysql_pwd: >-
+      {{ ((_restore_current_db_secret.resources | default([]) | first | default({}))
+          .data.MYSQL_PASSWORD | default('')) | b64decode }}
+    _restore_current_mysql_root_pwd: >-
+      {{ ((_restore_current_db_secret.resources | default([]) | first | default({}))
+          .data.MYSQL_ROOT_PASSWORD | default('')) | b64decode }}
+  when: _restore_secrets_filename != ''
+  no_log: true
+
+- name: Restore canasta-managed K8s Secrets from snapshot
   when: _restore_secrets_filename != ''
   ansible.builtin.shell:
     cmd: >-
@@ -145,6 +179,28 @@
       cat /currentsnapshot/config/backup/{{ _restore_secrets_filename }} |
       kubectl apply -n {{ _k8s_namespace }} -f -
   changed_when: true
+  no_log: true
+
+# Preserve the running cluster's DB credentials over the snapshot's
+# values. The strategic-merge patch updates only MYSQL_PASSWORD and
+# MYSQL_ROOT_PASSWORD; everything else from the snapshot's Secret
+# (notably no other keys exist in db-credentials by design) is
+# unchanged. We re-set BOTH because the wiki user account in
+# mysql.user was hashed against the current root password during
+# pod init.
+- name: Preserve current DB password in restored Secret
+  kubernetes.core.k8s:
+    state: patched
+    api_version: v1
+    kind: Secret
+    name: "{{ instance_id }}-db-credentials"
+    namespace: "{{ _k8s_namespace }}"
+    definition:
+      stringData:
+        MYSQL_PASSWORD: "{{ _restore_current_mysql_pwd }}"
+        MYSQL_ROOT_PASSWORD: "{{ _restore_current_mysql_root_pwd }}"
+  when: _restore_secrets_filename != ''
+        and _restore_current_mysql_pwd != ''
   no_log: true
 
 - name: Delete restore pod

--- a/tests/unit/test_backup_schedule_k8s.py
+++ b/tests/unit/test_backup_schedule_k8s.py
@@ -462,6 +462,91 @@ class TestK8sRestoreReplaysSecrets:
         )
 
 
+class TestK8sRestorePreservesCurrentDBPassword:
+    """When the snapshot's secrets manifest is applied, the running
+    cluster's MYSQL_PASSWORD / MYSQL_ROOT_PASSWORD must be preserved
+    over the snapshot's values — same policy Compose's restore.yml
+    follows ('Save current DB password before restore' + 'Preserve
+    DB password in restored .env'). Without this, a clone-into-fresh-
+    cluster restore auth-mismatches: the running DB pod's mysql.user
+    table has hashes of the cluster's CURRENT password, not the
+    snapshot's."""
+
+    RESTORE_K8S = os.path.join(
+        REPO_ROOT, "roles", "backup", "tasks", "restore_k8s.yml",
+    )
+
+    def _content(self):
+        with open(self.RESTORE_K8S) as f:
+            return f.read()
+
+    def test_saves_current_db_secret_before_apply(self):
+        content = self._content()
+        # Two anchors: the k8s_info read of <id>-db-credentials, and
+        # the set_fact that captures the current MYSQL_PASSWORD.
+        assert "k8s_info:" in content, (
+            "restore_k8s.yml must read the cluster's current "
+            "<id>-db-credentials Secret BEFORE applying the snapshot's "
+            "Secrets, so the live DB user's password can be preserved."
+        )
+        assert "_restore_current_mysql_pwd" in content, (
+            "restore_k8s.yml must capture the running cluster's "
+            "MYSQL_PASSWORD into a fact for re-application post-restore"
+        )
+        assert "_restore_current_mysql_root_pwd" in content, (
+            "restore_k8s.yml must also capture MYSQL_ROOT_PASSWORD; "
+            "both DB user passwords were hashed against the running "
+            "cluster's values during pod init"
+        )
+
+    def test_patches_db_secret_back_after_apply(self):
+        content = self._content()
+        # The strategic-merge patch on <id>-db-credentials with both
+        # password keys, gated on the snapshot's secrets file existing.
+        assert "state: patched" in content, (
+            "restore_k8s.yml must use 'state: patched' (strategic merge) "
+            "to re-apply MYSQL_PASSWORD without touching MW_SECRET_KEY "
+            "in the snapshot-restored Secret"
+        )
+        assert "Preserve current DB password in restored Secret" in content, (
+            "restore_k8s.yml is missing the explicit preserve task — "
+            "without it, fresh-cluster restore auth-mismatches"
+        )
+
+    def test_preserve_step_runs_after_secret_apply(self):
+        """Order matters: snapshot apply MUST come before the patch.
+        If the order were inverted, the patch would land first and
+        then the snapshot's apply would overwrite it back, defeating
+        the preservation."""
+        content = self._content()
+        save_pos = content.find("Save current DB credentials before secret restore")
+        apply_pos = content.find("Restore canasta-managed K8s Secrets from snapshot")
+        patch_pos = content.find("Preserve current DB password in restored Secret")
+        assert save_pos != -1 and apply_pos != -1 and patch_pos != -1, (
+            "Three-step preservation flow expected: save current → "
+            "apply snapshot → patch back. One or more tasks missing."
+        )
+        assert save_pos < apply_pos < patch_pos, (
+            "Order must be: save current creds, then apply snapshot's "
+            "Secrets, then patch the cluster's creds back. Got "
+            "save=%d apply=%d patch=%d." % (save_pos, apply_pos, patch_pos)
+        )
+
+    def test_preserve_uses_stringdata_not_data(self):
+        """stringData lets the K8s API server do the b64 conversion;
+        attempting raw data with un-encoded values would fail."""
+        content = self._content()
+        # Find the Preserve task block and assert stringData appears
+        # after it. (Cheap proximity check — sufficient for a
+        # structural guard.)
+        patch_pos = content.find("Preserve current DB password in restored Secret")
+        block = content[patch_pos:patch_pos + 800]
+        assert "stringData:" in block, (
+            "Preserve task must use 'stringData:' so the K8s API "
+            "server handles the base64 conversion of MYSQL_PASSWORD"
+        )
+
+
 class TestOnDemandBackupCapturesDB:
     """Guard #513: on-demand 'canasta backup create' on K8s must
     capture the wiki database. Pre-fix the dump ran via 'kubectl


### PR DESCRIPTION
## Summary

Fixes #517 — clone-into-fresh-cluster restore on K8s was breaking because #510 (PR #512) added a blanket `kubectl apply -f secrets-<id>.yaml` that overwrote the running cluster's `MYSQL_PASSWORD`. The DB pod's `mysql.user` table has hashes set during pod init by `canasta create`; replacing the plaintext password without rotating the user account breaks auth on the next web pod restart.

Compose handles this correctly with explicit preservation in `restore.yml` ("Save current DB password before restore" / "Preserve DB password in restored .env"). This PR mirrors that pattern on K8s.

## Approach — mirror Compose's two-key policy

`MYSQL_PASSWORD` and `MW_SECRET_KEY` have different lifecycles:

- `MYSQL_PASSWORD` — credential pair with the running DB; `mysql.user` is hashed against it. **Preserve current.**
- `MW_SECRET_KEY` — encryption key for wiki internals (sessions, password-reset tokens). Restored data was encrypted with the snapshot's key. **Restore from snapshot.**

The two keys live on separate K8s Secrets (`<id>-db-credentials` vs. `<id>-mw-secrets`), so the strategic-merge patch only touches what it needs to.

## Changes

`roles/backup/tasks/restore_k8s.yml` — three-step:

1. **Save**: `kubernetes.core.k8s_info` reads the cluster's current `<id>-db-credentials` Secret BEFORE the snapshot's Secrets are applied; captures `MYSQL_PASSWORD` and `MYSQL_ROOT_PASSWORD` into facts
2. **Apply**: existing `kubectl apply -f secrets-<id>.yaml` — gives us the snapshot's `MW_SECRET_KEY` on `<id>-mw-secrets`, and (transiently) the snapshot's old DB passwords on `<id>-db-credentials`
3. **Patch**: `state: patched` strategic-merge on `<id>-db-credentials` with `stringData: { MYSQL_PASSWORD, MYSQL_ROOT_PASSWORD }` set back to the saved current values

For external-DB instances the patch is a vacuous no-op (the snapshot's password and the cluster's password are both copies of the operator's `--envfile` value). For internal-DB on a fresh cluster, the patch is what makes the clone work.

## Tests

`tests/unit/test_backup_schedule_k8s.py::TestK8sRestorePreservesCurrentDBPassword` — four structural guards:

1. `k8s_info` read of `<id>-db-credentials` is present BEFORE the apply
2. `state: patched` preserve task is present
3. Order is **save → apply → patch** (inverted order would defeat preservation)
4. Patch uses `stringData` (server-side b64 conversion)

757 unit tests pass.

## Validation

End-to-end validation **attempted but blocked** by two pre-existing bugs in `restore_k8s.yml` that surfaced during the test:

- **#519** — Cloud-backend `RESTIC_REPOSITORY` (S3, B2, Azure, GCS) fails the restore Pod's container-init with `no such file or directory` because a `local-repo` `hostPath` is unconditionally mounted with the URI as the path. Fix is the same shape as the schedule_set.yml/k8s_run_backup.yml `_local_repo` detection.
- **#520** — External-DB instances (`db.enabled: false`) crash at `Get DB pod name` because the restore is hardcoded for an in-cluster DB pod that doesn't exist for those instances.

Either of these would block the destructive sentinel test. Both are independent of #518's preservation logic and are filed as separate issues for follow-up.

The structural correctness argument for this PR carries on its own:

- Compose has had this preservation logic in `restore.yml` for years (battle-tested)
- K8s diverged from it accidentally in #510 (the bug this PR fixes)
- The four structural tests guard the order and shape of the new code (save → apply → patch with `stringData`)
- The mirror is small and direct

After #519 and #520 land, a full destructive validation of all three fixes together would be valuable.

## Test plan

- [x] `make test-unit` passes (757 tests; 4 new in this PR)
- [x] Three-step preservation flow visibly mirrors Compose's two-line shape
- [x] Attempted on-cluster validation; surfaced #519 and #520 as separate pre-existing bugs blocking the test
- [ ] Reviewer confirmation that `state: patched` + `stringData` is the right K8s primitive for partial Secret update
- [ ] Future: full destructive validation once #519 + #520 land (set Secret to sentinel, restore, verify sentinel survives)
