### PR TITLE
backup/k8s: actually make K8s restore work end-to-end (#517 + 4 buried bugs)

### DIFF
--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -17,6 +17,20 @@
   register: _restore_env
   no_log: true
 
+# If a previous restore failed mid-run, the restic-restore pod may
+# still exist. kubernetes.core.k8s state: present then refuses to
+# update it because Pod spec changes are forbidden post-creation
+# (immutable fields). Delete first to make this idempotent.
+- name: Clean up any stale restic-restore pod from a prior failed run
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: Pod
+    name: restic-restore
+    namespace: "{{ _k8s_namespace }}"
+    wait: true
+    wait_timeout: 60
+
 - name: Create restore pod
   kubernetes.core.k8s:
     state: present
@@ -117,7 +131,7 @@
       mariadb -u root -p"{{ _restore_dbpass.value }}"
   loop: >-
     {{ _restore_db_files.stdout_lines | default([])
-       | select('match', '^db_.*\\.sql$') | list }}
+       | select('match', '^db_.*\.sql$') | list }}
   no_log: true
 
 # Restore the canasta-managed K8s Secrets if the snapshot includes
@@ -148,7 +162,7 @@
   ansible.builtin.set_fact:
     _restore_secrets_filename: >-
       {{ (_restore_db_files.stdout_lines | default([])
-          | select('match', '^secrets-.+\\.yaml$') | list | first) | default('') }}
+          | select('match', '^secrets-.+\.yaml$') | list | first) | default('') }}
 
 - name: Save current DB credentials before secret restore (clone-friendly)
   kubernetes.core.k8s_info:
@@ -211,20 +225,17 @@
     name: restic-restore
     namespace: "{{ _k8s_namespace }}"
 
-# Re-render gitops templates after restore. The snapshot contains the
-# SOURCE host's rendered .env and config. On this host those need to
-# be re-rendered from templates + current host vars.
-- name: Detect gitops instance
-  ansible.builtin.stat:
-    path: "{{ instance_path }}/.gitops-host"
-  register: _restore_k8s_gitops_stat
-
-- name: Re-render gitops templates against this host's vars
-  ansible.builtin.include_role:
-    name: gitops
-    tasks_from: render_compose.yml
-  when: _restore_k8s_gitops_stat.stat.exists | default(false)
-
+# NOTE: Compose's restore.yml re-renders env.template + host vars
+# here via render_compose.yml. K8s gitops uses a different layout
+# (values.template.yaml + hosts/<name>/vars.yaml + rendered-values.yaml,
+# none of which are produced by render_compose.yml), so invoking
+# render_compose for K8s gitops crashed with "File not found:
+# env.template" and aborted the restore. For K8s we skip the
+# re-render entirely — k8s_sync_config below rebuilds the ConfigMaps
+# from the restored .env and config files, and Argo CD reconciles
+# from the gitops repo on next sync. Cross-host gitops clones that
+# need a fresh render should run `canasta gitops pull` or its K8s
+# equivalent after restore.
 - name: Sync config to ConfigMaps
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/orchestrator/tasks/k8s_sync_config.yml

--- a/roles/backup/tasks/schedule_set.yml
+++ b/roles/backup/tasks/schedule_set.yml
@@ -157,11 +157,19 @@
                           - sh
                           - -c
                           - |
+                            # Strip ephemeral metadata (resourceVersion,
+                            # uid, creationTimestamp) so 'kubectl apply'
+                            # at restore time doesn't fail with a
+                            # resourceVersion conflict against the live
+                            # object's current rv.
                             kubectl get secret \
                               {{ instance_id }}-db-credentials \
                               {{ instance_id }}-mw-secrets \
                               -n canasta-{{ instance_id }} \
                               -o yaml \
+                              | sed -E \
+                                -e '/^  (resourceVersion|uid|creationTimestamp):/d' \
+                                -e '/^    (resourceVersion|uid|creationTimestamp):/d' \
                               > /currentsnapshot/config/backup/secrets-{{ instance_id }}.yaml
                         volumeMounts:
                           - name: dumps

--- a/roles/gitops/tasks/diff_compose.yml
+++ b/roles/gitops/tasks/diff_compose.yml
@@ -79,10 +79,10 @@
 
       {% endif %}
       {% set needs_restart = (lc_files + rc_files)
-         | select('match', '.*\\.(env|yml|yaml)$')
+         | select('match', '.*\.(env|yml|yaml)$')
          | list | length > 0 %}
       {% set needs_update = (lc_files + rc_files)
-         | select('match', '.*\\.php$')
+         | select('match', '.*\.php$')
          | list | length > 0 %}
       {% if needs_restart %}
       A restart would be needed after pulling.

--- a/roles/orchestrator/tasks/k8s_run_backup.yml
+++ b/roles/orchestrator/tasks/k8s_run_backup.yml
@@ -161,11 +161,18 @@
           - sh
           - -c
           - |
+            # Strip ephemeral metadata (resourceVersion, uid,
+            # creationTimestamp) so 'kubectl apply' at restore time
+            # doesn't fail with a resourceVersion conflict against
+            # the live object's current rv.
             kubectl get secret \
               {{ instance_id }}-db-credentials \
               {{ instance_id }}-mw-secrets \
               -n canasta-{{ instance_id }} \
               -o yaml \
+              | sed -E \
+                -e '/^  (resourceVersion|uid|creationTimestamp):/d' \
+                -e '/^    (resourceVersion|uid|creationTimestamp):/d' \
               > /currentsnapshot/config/backup/secrets-{{ instance_id }}.yaml
         volumeMounts:
           - name: dumps

--- a/tests/unit/test_backup_schedule_k8s.py
+++ b/tests/unit/test_backup_schedule_k8s.py
@@ -730,3 +730,178 @@ class TestSharedBackupRBAC:
             "_k8s_backup_rbac.yml task file (refactored per #513 to "
             "share with k8s_run_backup.yml)"
         )
+
+
+class TestK8sRestoreImportRegexNotDoubleEscaped:
+    """The restore loop's regex `'^db_.*\.sql$'` and the secrets-
+    filename regex `'^secrets-.+\.yaml$'` must use a SINGLE backslash
+    in the YAML block scalar context. With `\\.` (two), Ansible's
+    Jinja parses the literal `\\.` regex which is "literal backslash
+    + any char" — never matches `.sql` / `.yaml`. The Import + all
+    secrets-restore tasks were silently skipping for every K8s
+    restore. Surfaced during PR #518 validation."""
+
+    RESTORE_K8S = os.path.join(
+        REPO_ROOT, "roles", "backup", "tasks", "restore_k8s.yml",
+    )
+
+    def _content(self):
+        with open(self.RESTORE_K8S) as f:
+            return f.read()
+
+    def test_db_dump_regex_uses_single_backslash(self):
+        c = self._content()
+        assert "'^db_.*\\.sql$'" in c, (
+            "restore_k8s.yml must filter dumps with `'^db_.*\\.sql$'`"
+        )
+        assert "'^db_.*\\\\.sql$'" not in c, (
+            "restore_k8s.yml has `\\\\.sql` (double-escaped) in the "
+            "dump-import regex; in YAML block scalar this becomes the "
+            "regex `\\.` for 'literal backslash + any char', never "
+            "matches *.sql, and the import task silently skips."
+        )
+
+    def test_secrets_filename_regex_uses_single_backslash(self):
+        c = self._content()
+        assert "'^secrets-.+\\.yaml$'" in c
+        assert "'^secrets-.+\\\\.yaml$'" not in c, (
+            "Same regex bug for the secrets-filename match — would "
+            "silently skip every secrets-restore task"
+        )
+
+
+class TestK8sRestoreStalePodCleanup:
+    """If a previous restore failed mid-run, the restic-restore pod
+    persists. kubernetes.core.k8s state: present then can't update
+    it (Pod spec is immutable post-creation), and the restore aborts.
+    Need to delete first."""
+
+    RESTORE_K8S = os.path.join(
+        REPO_ROOT, "roles", "backup", "tasks", "restore_k8s.yml",
+    )
+
+    def test_stale_pod_cleanup_before_create(self):
+        with open(self.RESTORE_K8S) as f:
+            tasks = yaml.safe_load(f)
+        clean_idx = create_idx = -1
+        for i, t in enumerate(tasks):
+            if not isinstance(t, dict):
+                continue
+            name = t.get("name", "")
+            if name.startswith("Clean up any stale restic-restore"):
+                clean_idx = i
+                # Must be state: absent on the pod
+                k8s = t.get("kubernetes.core.k8s") or t.get("k8s") or {}
+                assert k8s.get("state") == "absent", (
+                    "Stale-pod cleanup must use state: absent"
+                )
+            elif name == "Create restore pod":
+                create_idx = i
+        assert clean_idx != -1, (
+            "restore_k8s.yml must have a stale-pod cleanup task before "
+            "Create restore pod (kubernetes.core.k8s state: present "
+            "can't update an existing Pod)"
+        )
+        assert create_idx != -1
+        assert clean_idx < create_idx, (
+            "Cleanup must run before Create restore pod, not after"
+        )
+
+
+class TestK8sRestoreNoComposeRenderForK8sGitops:
+    """K8s gitops uses values.template.yaml + hosts/<name>/vars.yaml,
+    not env.template. restore_k8s.yml previously invoked
+    render_compose.yml which crashes with 'File not found:
+    env.template' for K8s gitops instances. The include must be
+    removed or replaced with K8s-aware logic."""
+
+    RESTORE_K8S = os.path.join(
+        REPO_ROOT, "roles", "backup", "tasks", "restore_k8s.yml",
+    )
+
+    def test_does_not_invoke_render_compose(self):
+        """Strip comment lines before checking — explanatory comments
+        may legitimately mention the old anti-pattern."""
+        with open(self.RESTORE_K8S) as f:
+            non_comment = "\n".join(
+                line for line in f.read().splitlines()
+                if not line.lstrip().startswith("#")
+            )
+        assert "render_compose.yml" not in non_comment, (
+            "restore_k8s.yml must not invoke render_compose.yml — that "
+            "task expects env.template (Compose-only artifact) and "
+            "fails for K8s gitops instances. See #521."
+        )
+
+
+class TestDiffComposeMatchRegex:
+    """canasta gitops diff's display message uses regexes for filename
+    matching. Same `\\.` block-scalar bug as restore_k8s.yml — the
+    regex never matches anything, so 'A restart would be needed' /
+    'A maintenance update may be needed' messages would never trigger
+    even when there are matching .env / .yml / .php changes."""
+
+    DIFF_COMPOSE = os.path.join(
+        REPO_ROOT, "roles", "gitops", "tasks", "diff_compose.yml",
+    )
+
+    def test_regex_uses_single_backslash(self):
+        with open(self.DIFF_COMPOSE) as f:
+            content = f.read()
+        # Should have single backslash for literal dot
+        assert "'.*\\.(env|yml|yaml)$'" in content
+        assert "'.*\\.php$'" in content
+        # Must not have the broken double-backslash form
+        assert "'.*\\\\.(env|yml|yaml)$'" not in content, (
+            "diff_compose.yml has `\\\\.` in regex; would never match"
+        )
+        assert "'.*\\\\.php$'" not in content, (
+            "diff_compose.yml has `\\\\.php` in regex; would never match"
+        )
+
+
+class TestDumpSecretsStripsEphemeralMetadata:
+    """`kubectl get secret -o yaml` emits resourceVersion, uid, and
+    creationTimestamp. `kubectl apply -f` then refuses to apply,
+    erroring with 'object has been modified'. Both dump-secrets init
+    containers (scheduled CronJob + on-demand Job) must strip those
+    fields with sed."""
+
+    SCHEDULE_SET = os.path.join(
+        REPO_ROOT, "roles", "backup", "tasks", "schedule_set.yml",
+    )
+    K8S_RUN_BACKUP = os.path.join(
+        REPO_ROOT, "roles", "orchestrator", "tasks", "k8s_run_backup.yml",
+    )
+
+    def _has_strip_in_dump_secrets(self, path):
+        with open(path) as f:
+            content = f.read()
+        # The dump-secrets command must include the sed strip
+        # and target the three ephemeral fields. Check both
+        # at-once.
+        return all(
+            field in content
+            for field in (
+                "dump-secrets",
+                "resourceVersion",
+                "uid",
+                "creationTimestamp",
+                "sed",
+            )
+        )
+
+    def test_schedule_set_strips_metadata(self):
+        assert self._has_strip_in_dump_secrets(self.SCHEDULE_SET), (
+            "schedule_set.yml dump-secrets must sed-strip "
+            "resourceVersion / uid / creationTimestamp; without it "
+            "kubectl apply at restore time fails with 'object has "
+            "been modified' resourceVersion conflict"
+        )
+
+    def test_k8s_run_backup_strips_metadata(self):
+        assert self._has_strip_in_dump_secrets(self.K8S_RUN_BACKUP), (
+            "k8s_run_backup.yml dump-secrets must sed-strip "
+            "resourceVersion / uid / creationTimestamp; same "
+            "rationale as schedule_set.yml"
+        )


### PR DESCRIPTION
## Summary

PR #518's preservation logic was only the original purpose. End-to-end on-cluster validation surfaced **four pre-existing bugs** that had been silently breaking the K8s restore path for as long as it existed. Two of them were the reason the earlier "SENTINEL survived" validation in #518 was a false positive — the secrets-restore tasks were skipping silently, so "preservation" was vacuous.

Fixes #517 fully (real validation now), and closes #521.

## The four bugs, in order of severity

### 1. Regex `\\.` in YAML block scalar never matches (HIGHEST)

`restore_k8s.yml`'s import-DB-dump loop used:

```yaml
loop: >-
  {{ ... | select('match', '^db_.*\\.sql$') | list }}
```

In a YAML block scalar (`>-`), `\\.` is preserved literally. Jinja parses the regex as "literal backslash + any char" — never matches `*.sql`. The Import task silently iterated over zero items and "skipped" for every K8s restore. Same bug on the secrets filename match (`'^secrets-.+\\.yaml$'`), which made every secrets-restore task silently skip too — including #517's preservation patch.

Same shape in `roles/gitops/tasks/diff_compose.yml` lines 82, 85 inside a `|-` debug-msg block scalar. Display-only impact, but `canasta gitops diff` always says "0 file(s) need restart" / "0 file(s) need maintenance update" even when changes match.

Fix: drop the leading backslash in YAML block scalar context. Validated empirically: with `\\.` the loop resolves to `[]`; with `\.` it resolves to `['db_main.sql']`.

### 2. dump-secrets emits ephemeral metadata

`kubectl get secret -o yaml` includes `resourceVersion`, `uid`, `creationTimestamp`. `kubectl apply -f` then refuses with "object has been modified". Both dump-secrets init containers (`schedule_set.yml`, `k8s_run_backup.yml`) now sed-strip the three fields before writing the YAML to the snapshot.

### 3. Stale `restic-restore` Pod blocks subsequent restore

If a previous restore failed mid-run (which bug 1 + the cloud-backend `hostPath` bug #519 made common), the Pod persists. `kubernetes.core.k8s state: present` on a Pod-shaped definition tries to UPDATE the existing Pod and errors with "pod updates may not change fields other than ... (immutable spec)". New `Clean up any stale restic-restore pod from a prior failed run` task does `state: absent` + wait first.

### 4. `render_compose.yml` invoked for K8s gitops (#521)

`restore_k8s.yml` unconditionally called `render_compose.yml` when `.gitops-host` existed. `render_compose` reads `env.template` which K8s gitops doesn't produce. Restore aborted with "File not found: env.template" for any K8s gitops instance.

Fix: drop the include. K8s gitops doesn't need a Compose-style render at restore time — `k8s_sync_config` rebuilds ConfigMaps from the restored `.env`, and Argo CD reconciles from the gitops repo on next sync. Cross-host gitops clones that need a fresh render should run `canasta gitops pull` (or the K8s equivalent) after restore. A future `render_kubernetes.yml` could replace this if a use case emerges.

## Validation

End-to-end on the multi-host AWS cluster against the `intdb` instance (internal DB + local-path restic). Both **path 2** (gitops marker hidden — non-gitops restore) and **path 3** (gitops marker in place — gitops restore).

Concrete sentinel test:

| Step | Pre-restore | Post-restore | Pass? |
|---|---|---|---|
| Insert `dr_test` row 1, snapshot, insert row 2, restore | rows 1+2 | row 1 only | ✓ DB dump replayed |
| Pre-restore Secret = `PRESERVE_TEST_INTDB`, snapshot has V1 | sentinel | sentinel | ✓ #517 preservation works |
| Wiki HTTP after Secret reset to V1 | — | 200 | ✓ |

Both paths pass. Two independent end-to-end signals (DB content AND Secret content).

## Tests

7 new structural guards in `tests/unit/test_backup_schedule_k8s.py`:

- `TestK8sRestoreImportRegexNotDoubleEscaped` (2) — both regexes use `\.` not `\\.`
- `TestK8sRestoreStalePodCleanup` (1) — cleanup task present + before Create
- `TestK8sRestoreNoComposeRenderForK8sGitops` (1) — render_compose not invoked (active code only; comments allowed)
- `TestDiffComposeMatchRegex` (1) — both regexes use `\.` not `\\.`
- `TestDumpSecretsStripsEphemeralMetadata` (2) — sed-strip in both schedule_set.yml + k8s_run_backup.yml

764 unit tests pass (was 757 in main).

## Out of scope, still open

- **#519** — cloud-backend `hostPath` mount failure (separate; affects S3/B2/Azure/GCS users)
- **#520** — external-DB restore unsupported (separate; affects external-DB users)
- Cross-host K8s gitops re-render after restore — could write `render_kubernetes.yml` in a follow-up if a real use case emerges; for now operators use `canasta gitops pull`

## Test plan

- [x] `make test-unit` passes (764 tests; 7 new in this PR)
- [x] On-cluster: path-2 restore (internal DB, local-path, non-gitops) — DB dump replays, Secret preserved
- [x] On-cluster: path-3 restore (internal DB, local-path, gitops) — same checks pass with .gitops-host in place
- [x] Wiki returns HTTP 200 after each test cycle
- [ ] Reviewer sanity check on the YAML block-scalar regex semantics (the `\\.` → `\.` change)
- [ ] Future on-cluster validation pass after #519 + #520 land (cloud-backend + external DB)
