### PR TITLE
backup/k8s: skip local-repo hostPath mount on restore for cloud backends (#519)

### DIFF
--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -17,6 +17,43 @@
   register: _restore_env
   no_log: true
 
+# Cloud-backend RESTIC_REPOSITORY values are URIs (s3:..., b2:...,
+# azure:..., gs:...), not filesystem paths. Mounting them as a
+# hostPath fails container init with 'no such file or directory'.
+# Only local-path repos (RESTIC_REPOSITORY beginning with /) need
+# the hostPath bind. Mirrors the same detection in schedule_set.yml
+# and k8s_run_backup.yml for the backup direction. See #519.
+- name: Detect local restic repository
+  ansible.builtin.set_fact:
+    _restore_local_repo: >-
+      {{ (_restore_env.variables.RESTIC_REPOSITORY | default('')) is match('^/') }}
+
+- name: Build restore pod volume mounts
+  ansible.builtin.set_fact:
+    _restore_volume_mounts:
+      - { name: restore-data, mountPath: /currentsnapshot }
+
+- name: Add local-repo mount when RESTIC_REPOSITORY is a path
+  ansible.builtin.set_fact:
+    _restore_volume_mounts: >-
+      {{ _restore_volume_mounts + [{'name': 'local-repo',
+         'mountPath': _restore_env.variables.RESTIC_REPOSITORY}] }}
+  when: _restore_local_repo | bool
+
+- name: Build restore pod volumes
+  ansible.builtin.set_fact:
+    _restore_volumes:
+      - name: restore-data
+        emptyDir: {}
+
+- name: Add local-repo hostPath volume when RESTIC_REPOSITORY is a path
+  ansible.builtin.set_fact:
+    _restore_volumes: >-
+      {{ _restore_volumes + [{'name': 'local-repo',
+         'hostPath': {'path': _restore_env.variables.RESTIC_REPOSITORY,
+                      'type': 'DirectoryOrCreate'}}] }}
+  when: _restore_local_repo | bool
+
 # If a previous restore failed mid-run, the restic-restore pod may
 # still exist. kubernetes.core.k8s state: present then refuses to
 # update it because Pod spec changes are forbidden post-creation
@@ -59,18 +96,8 @@
             envFrom:
               - secretRef:
                   name: "canasta-{{ instance_id }}-backup-env"
-            volumeMounts:
-              - name: restore-data
-                mountPath: /currentsnapshot
-              - name: local-repo
-                mountPath: "{{ _restore_env.variables.RESTIC_REPOSITORY }}"
-        volumes:
-          - name: restore-data
-            emptyDir: {}
-          - name: local-repo
-            hostPath:
-              path: "{{ _restore_env.variables.RESTIC_REPOSITORY }}"
-              type: DirectoryOrCreate
+            volumeMounts: "{{ _restore_volume_mounts }}"
+        volumes: "{{ _restore_volumes }}"
 
 - name: Wait for restore pod to be running
   ansible.builtin.command:

--- a/tests/unit/test_backup_schedule_k8s.py
+++ b/tests/unit/test_backup_schedule_k8s.py
@@ -905,3 +905,97 @@ class TestDumpSecretsStripsEphemeralMetadata:
             "resourceVersion / uid / creationTimestamp; same "
             "rationale as schedule_set.yml"
         )
+
+
+class TestK8sRestoreCloudBackendDoesNotMountHostPath:
+    """Guard #519: cloud-backend RESTIC_REPOSITORY values (s3:...,
+    b2:..., azure:..., gs:...) are URIs, not filesystem paths.
+    Pre-fix, restore_k8s.yml unconditionally mounted RESTIC_REPOSITORY
+    as a hostPath; for cloud URIs this failed container init with
+    'no such file or directory' and the entire restore aborted.
+    Only local-path repos (^/...) should get the hostPath bind.
+    Mirrors the same detection schedule_set.yml and k8s_run_backup.yml
+    use for the backup direction."""
+
+    RESTORE_K8S = os.path.join(
+        REPO_ROOT, "roles", "backup", "tasks", "restore_k8s.yml",
+    )
+
+    def _content(self):
+        with open(self.RESTORE_K8S) as f:
+            return f.read()
+
+    def test_local_repo_detection_present(self):
+        """A `_restore_local_repo` fact must be set from a regex
+        check of the RESTIC_REPOSITORY against `^/`. That mirrors the
+        backup-side detection in schedule_set.yml and k8s_run_backup.yml."""
+        c = self._content()
+        assert "_restore_local_repo:" in c, (
+            "restore_k8s.yml must define _restore_local_repo to "
+            "distinguish path-style RESTIC_REPOSITORY from URIs (#519)"
+        )
+        assert "is match('^/')" in c, (
+            "restore_local_repo detection must use the same regex as "
+            "the backup paths: RESTIC_REPOSITORY is match('^/')"
+        )
+
+    def test_volumes_built_conditionally(self):
+        """The local-repo volume + mount must be added via a
+        conditional set_fact, NOT inlined unconditionally in the
+        Pod definition."""
+        c = self._content()
+        # The conditional add tasks
+        assert "Add local-repo mount when RESTIC_REPOSITORY is a path" in c, (
+            "restore_k8s.yml needs the conditional volume-mount append"
+        )
+        assert "Add local-repo hostPath volume when RESTIC_REPOSITORY is a path" in c, (
+            "restore_k8s.yml needs the conditional volume append"
+        )
+        # And both gated on _restore_local_repo
+        # Each conditional add should have when: _restore_local_repo
+        for task_marker in (
+            "Add local-repo mount when RESTIC_REPOSITORY is a path",
+            "Add local-repo hostPath volume when RESTIC_REPOSITORY is a path",
+        ):
+            idx = c.find(task_marker)
+            block = c[idx:idx + 600]
+            assert "when: _restore_local_repo" in block, (
+                "%r must be gated on _restore_local_repo" % task_marker
+            )
+
+    def test_pod_uses_built_volumes_facts(self):
+        """The Create restore pod task should reference
+        `_restore_volume_mounts` and `_restore_volumes`, not inline
+        volumes/volumeMounts. Inline values would re-introduce the
+        unconditional hostPath mount that #519 was about."""
+        c = self._content()
+        # The Create restore pod block should reference the facts
+        idx = c.find("Create restore pod")
+        block = c[idx:idx + 1500]
+        assert "_restore_volume_mounts" in block, (
+            "Create restore pod must read volumeMounts from "
+            "_restore_volume_mounts fact (built conditionally)"
+        )
+        assert "_restore_volumes" in block, (
+            "Create restore pod must read volumes from "
+            "_restore_volumes fact (built conditionally)"
+        )
+
+    def test_no_unconditional_local_repo_volume(self):
+        """The old shape — inline `local-repo` volume with a hardcoded
+        hostPath of `RESTIC_REPOSITORY` — must NOT be present. That
+        was the #519 bug."""
+        c = self._content()
+        # Find the Create restore pod block and assert no inline
+        # local-repo volume in it.
+        idx = c.find("- name: Create restore pod")
+        end = c.find("- name: Wait for restore pod", idx)
+        block = c[idx:end] if end != -1 else c[idx:idx + 2000]
+        # The literal pattern that was wrong: hostPath: path: "{{ ... }}"
+        # under a volumes: stanza in the Pod definition.
+        assert "type: DirectoryOrCreate" not in block, (
+            "Create restore pod should not contain an inline "
+            "hostPath/DirectoryOrCreate — that was the #519 bug "
+            "(cloud backends fail container init). The conditional "
+            "_restore_volumes append handles local-path repos only."
+        )


### PR DESCRIPTION
## Summary

Fixes #519 — `canasta backup restore` on K8s aborted before the restore Pod could come up when `RESTIC_REPOSITORY` was a cloud URI (S3, B2, Azure, GCS). The Pod's unconditional `local-repo` `hostPath` volume tried to mount the URI as a filesystem path; kubelet returned `no such file or directory`; Pod went `StartError`; `kubectl wait` timed out at 120s; restore aborted.

This blocked **every realistic production K8s deployment** since the recommended setup uses an off-host cloud backend.

## Approach

Mirror the same fix #503 / #504 / #516 added in `schedule_set.yml` and `k8s_run_backup.yml` for the backup direction:

```yaml
- name: Detect local restic repository
  ansible.builtin.set_fact:
    _restore_local_repo: >-
      {{ (_restore_env.variables.RESTIC_REPOSITORY | default('')) is match('^/') }}
```

Build `_restore_volume_mounts` and `_restore_volumes` via `set_fact`, starting from the always-present `restore-data` emptyDir. Conditionally append the `local-repo` mount + hostPath volume only when `_restore_local_repo` is true.

The Pod definition references the two facts via `"{{ ... }}"` — no inline volumes / volumeMounts.

## Tests

4 new structural guards in `tests/unit/test_backup_schedule_k8s.py::TestK8sRestoreCloudBackendDoesNotMountHostPath`:

- `_restore_local_repo` detection present, using the same `'^/'` regex the backup paths use
- Conditional append tasks exist and are gated on `_restore_local_repo`
- Create restore pod references both facts (not inline volumes)
- Create restore pod block has no `type: DirectoryOrCreate` (the old shape's distinguishing feature)

768 unit tests pass (was 764).

## Validation

End-to-end on the AWS test cluster:

1. Switched `intdb` (internal DB instance) to S3 backend: `RESTIC_REPOSITORY=s3:s3.amazonaws.com/canasta-test-backups-cicalese-2026-05/intdb`
2. `canasta backup init` created the S3 repo cleanly
3. `canasta backup create` produced snapshot `0cfe37ec` to S3
4. **Sentinel test:**
   - Insert `dr_test` row 2 (post-snapshot mutation)
   - Set Secret `MYSQL_PASSWORD` / `MYSQL_ROOT_PASSWORD` to `PRESERVE_TEST_519_S3`
   - Run `canasta backup restore -i intdb --snapshot 0cfe37ec`
5. **Result:**
   - Restore Pod brought up cleanly against the S3-backed RESTIC_REPOSITORY (no hostPath mount attempted) ✓
   - `dr_test` post-restore has only row 1 (DB dump from S3 replayed) ✓
   - Secret post-restore = `PRESERVE_TEST_519_S3` (preservation from #517 holds with cloud backend) ✓
   - Wiki HTTP 200 after Secret reset to V1 ✓

This is the same sentinel pattern that #522 used to validate the local-path path. Now confirmed to work with S3 too.

## Out of scope, still open

- **#520** — external-DB restore unsupported (next priority — together with this PR, the only remaining gap for cloud-backend + external-DB restore on K8s)
- **#511** — encrypted Secret manifest in gitops repo (parity with Compose)
- **#509** — git-crypt scaffolding cleanup

## Test plan

- [x] `make test-unit` passes (768 tests; 4 new in this PR)
- [x] On-cluster: cloud-backend restore Pod comes up cleanly (no hostPath mount attempted)
- [x] On-cluster: full sentinel test passes against S3 (DB import + Secret preservation)
- [x] Wiki returns HTTP 200 after the test cycle
- [ ] Reviewer sanity check on the `set_fact`-based volume/volumeMount construction (matches the pattern from #516's `k8s_run_backup.yml`)
