### PR TITLE
requirements: pin kubernetes.core >=6.4.0 for Helm 4 support (#525)

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,8 @@
 ---
 collections:
+  # 6.4.0 added Helm 4 CLI support. Earlier versions reject
+  # Helm 4 with "Helm version must be >=3.0.0,<4.0.0", which
+  # blocks canasta create on K8s for any operator whose system
+  # helm is brew's default (now Helm 4). See #525.
   - name: kubernetes.core
-    version: ">=3.0.0"
+    version: ">=6.4.0"

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -860,3 +860,44 @@ class TestPlayLevelDockerHost:
         assert "docker_host" in expr
         assert "instance_docker_host" in expr
         assert "omit" in expr
+
+
+class TestRequirementsCollectionsHelm4Compat:
+    """Guard #525: kubernetes.core must be pinned to a version that
+    supports Helm 4. Pre-fix `requirements.yml` had `>=3.0.0` which
+    let pip install collection 6.3.0 — which rejects Helm 4 with
+    'Helm version must be >=3.0.0,<4.0.0'. Helm 4 is now what
+    `brew install helm` provides on macOS by default, so any
+    operator on a fresh laptop hits this immediately. 6.4.0 added
+    Helm 4 support."""
+
+    REQUIREMENTS = os.path.join(REPO_ROOT, "requirements.yml")
+
+    def _kubernetes_core_pin(self):
+        with open(self.REQUIREMENTS) as f:
+            req = yaml.safe_load(f)
+        for c in req.get("collections", []):
+            if c.get("name") == "kubernetes.core":
+                return c.get("version")
+        raise AssertionError("kubernetes.core not pinned in requirements.yml")
+
+    def test_kubernetes_core_min_version_is_helm4_compatible(self):
+        pin = self._kubernetes_core_pin()
+        # The pin should require >= 6.4.0 (or any later version with
+        # known Helm 4 support).
+        assert ">=6.4" in pin or ">= 6.4" in pin or ">=6.5" in pin or ">=7" in pin or ">= 7" in pin, (
+            "requirements.yml pins kubernetes.core %r — must be "
+            ">=6.4.0 to support Helm 4 (#525). Earlier versions "
+            "reject Helm 4 at module load." % pin
+        )
+
+    def test_kubernetes_core_lower_bound_not_below_6_4(self):
+        """Belt-and-suspenders: catch a future regression where the
+        lower bound gets relaxed below 6.4.0 again."""
+        pin = self._kubernetes_core_pin()
+        for bad in (">=3.0", ">=4.", ">=5.", ">=6.0", ">=6.1", ">=6.2", ">=6.3"):
+            assert bad not in pin, (
+                "requirements.yml has kubernetes.core lower bound "
+                "%r which lets pip install pre-Helm-4 versions; "
+                "must be >=6.4.0 (#525)" % pin
+            )


### PR DESCRIPTION
## Summary

Fixes #525 — `canasta create -o k8s` aborted on systems where Helm 4 was the active CLI:

```
Installing Argo CD...
Error: Helm version must be >=3.0.0,<4.0.0, current version is 4.1.4
Error: Instance creation failed. Files cleaned up.
```

The error came from the `kubernetes.core.helm` Ansible module. Collection v6.3.0 (which is what pip installed against the previous `requirements.yml: kubernetes.core: >=3.0.0` pin) excluded Helm 4 in its compatibility check. Helm 4 went GA in early 2026 and is now what `brew install helm` produces by default on macOS — so any operator running canasta-CLI on a stock brew-equipped laptop hit this immediately.

`canasta install k8s-cp` ships its own Helm 3 install (`get-helm-3` script), so existing canasta installs were unaffected. The failure surfaced specifically when canasta-CLI was used against an externally-provisioned cluster (AWS EKS in this case) on a laptop with brew Helm 4 in `PATH`.

## Fix

Bump the lower bound to `>=6.4.0`. That's the kubernetes.core release that added Helm 4 CLI support. The collection still supports Helm 3, so existing k3s installs (which have Helm 3 from `get-helm-3`) keep working unchanged.

```yaml
collections:
  - name: kubernetes.core
    version: ">=6.4.0"
```

## Tests

Two structural guards in `tests/unit/test_kubernetes_structure.py::TestRequirementsCollectionsHelm4Compat`:

- Lower bound is `>=6.4` (positive: pinned at the Helm-4-supporting threshold or later)
- Lower bound is NOT in the pre-Helm-4 range (negative: regression guard against a future relaxation below 6.4)

772 unit tests pass.

## Validation

End-to-end on AWS EKS during the canasta-on-EKS+RDS walkthrough:

1. Switched local helm to v4.1.4 (`brew link --overwrite helm`)
2. Installed kubernetes.core 6.4.0 (`ansible-galaxy collection install kubernetes.core --upgrade`)
3. Re-ran the failing `canasta create -i ekstest --orchestrator k8s -e <envfile> -n ekstest.acknowledge.wiki --ingress-class nginx --tls-email <addr> --staging-certs` against the EKS cluster
4. Result: succeeded end-to-end. All pods Running. Wiki returns HTTP 200.
5. Also exercised `canasta start -i ekstest` (which hits the same `kubernetes.core.helm` upgrade path that was the original failure mode) — succeeded.

## Workaround for operators on canasta-CLI < this PR

Install Helm 3 explicitly:

```bash
brew install helm@3
brew link --overwrite --force helm@3
```

After this PR lands they no longer need to.

## Out of scope

`canasta install k8s-cp` continues to use the `get-helm-3` install script. Switching that to install Helm 4 by default would mean every new k3s install gets Helm 4 — a bigger change to test that's worth its own discussion. This PR only loosens the compatibility constraint so brew-Helm-4 setups work; it doesn't change which Helm canasta installs.

## Test plan

- [x] `make test-unit` passes (772 tests; 2 new in this PR)
- [x] On-cluster: canasta create succeeds against EKS with Helm 4 in PATH
- [x] On-cluster: canasta start (which hits `helm upgrade --install`) succeeds with Helm 4
- [ ] Reviewer confirmation: Helm 3 still works after the bump (kubernetes.core 6.4 supports both per upstream changelog)
