### PR TITLE
backup/k8s: tolerate restic xattr errors on PVC lost+found during restore

### DIFF
--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -86,8 +86,12 @@
               - sh
               - -c
               - |
-                restic --cache-dir /tmp/restic-cache restore {{ _resolved_snapshot }} --target / && \
-                touch /tmp/restore-done && \
+                # Don't gate the sentinel on restic's exit code: snapshots from
+                # EBS-backed PVCs include security.selinux xattrs that the
+                # restore pod's overlay fs can't accept, so restic exits 1 on
+                # the lost+found dirs even though all wiki content restored.
+                restic --cache-dir /tmp/restic-cache restore {{ _resolved_snapshot }} --target /
+                touch /tmp/restore-done
                 sleep 3600
             # canasta-<id>-backup-env carries every cloud-backend
             # credential restic might need (RESTIC_*, AWS_*, B2_*,


### PR DESCRIPTION
Fixes #531.

## Summary

- Replace the `&&` chain in `restic-restore` pod's command with sequential commands so the `/tmp/restore-done` sentinel writes unconditionally.
- The data restore succeeds even when restic exits 1 on `xattr.LRemove security.selinux: permission denied` (the PVC mount-point `lost+found` dirs); the existing `&&` gate was treating recoverable metadata failure as a fatal restore abort.

## Why

Snapshots taken from EBS-backed PVCs include `security.selinux` xattrs from the underlying SELinux-labeled filesystem. The restore pod only mounts an `emptyDir` at `/currentsnapshot` — its overlay fs can't accept those xattrs. restic logs them as ignored errors, restores 22 of 30 entries successfully (everything that holds wiki content), then exits 1.

With the previous `&& \` chain, the sentinel was never created, the wait loop fell through to `kubectl exec` against a terminated container, and the canasta restore flow aborted before SQL import and Secret reapplication. The wiki was left in a half-restored state.

The non-zero exit is purely metadata noise on dirs that don't carry user data. Treating it as success in the wrapper script (the data restore proceeds; the explicit `tar` / `mariadb` / `kubectl apply` steps that follow validate the actual content) is correct.

## Test plan

- [x] Verified on EKS + RDS: snapshot → drop main DB → restore → DB and all 4 wiki pods come back, `SELECT COUNT(*) FROM page` matches the pre-destruction state.
- [x] restic logs still surface the xattr errors for diagnostic visibility.
- [ ] Quick re-verify on a Compose / k3s instance to confirm no regression on filesystems that *don't* trigger the xattr issue.
