### PR TITLE
canasta-docker: reject 'canasta install' commands with a clear error

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -17,6 +17,30 @@
 
 set -euo pipefail
 
+# `canasta install` provisions software ON THE HOST — k3s as a systemd
+# unit, the docker engine package, etc. That work can't run inside the
+# canasta-ansible container, which has no systemd and no privilege over
+# the host package manager. Reject these commands early with a clear
+# pointer to the supported alternatives, instead of failing later with
+# a cryptic "Can not find systemd" from the k3s installer.
+if [[ "${1:-}" == "install" ]]; then
+    cat >&2 <<'INSTALL_GUARD_EOF'
+Error: 'canasta install' is not supported in canasta-docker mode.
+
+These commands install system packages on the host (k3s as a systemd
+unit, docker engine, etc.) which can't run from inside a container.
+
+Either:
+  - Use canasta-native:
+      curl -fsSL https://get.canasta.wiki | bash -s -- --native
+  - Or install the dependency manually on the host (e.g.
+      curl -sfL https://get.k3s.io | sh -
+    for k3s) and use canasta-docker for the rest of the workflow
+    (create, start, backup, restore, etc.).
+INSTALL_GUARD_EOF
+    exit 1
+fi
+
 # CANASTA_CLI_IMAGE is the post-rename name; CANASTA_ANSIBLE_IMAGE
 # remains a backwards-compatible fallback for users who already
 # set the old name in their environment.


### PR DESCRIPTION
Fixes #533.

## Summary

Reject `canasta install <package>` invocations in the `canasta-docker` wrapper before launching the container. Print a clear two-option fix-it message (switch to canasta-native, or install the dependency manually).

## Why

`canasta install` provisions software on the host: k3s as a systemd unit, the docker engine package, git-crypt, etc. That work can't run from inside the canasta-ansible container, which has no systemd and no privilege over the host's package manager. Without this guard, the user sees:

```
Error: non-zero return code (cmd: curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='' sh -)
[ERROR]  Can not find systemd or openrc to use as a process supervisor for k3s
```

— which is cryptic and looks like a k3s problem, not a canasta-mode problem. The new guard hits before the container ever launches and explains the actual situation.

## Test plan

- [x] `canasta install k8s-cp` exits 1 with the new message.
- [x] `canasta version`, `canasta list`, `canasta create ...` continue to dispatch normally (no regression on non-install commands).
