### PR TITLE
canasta-docker: split kubeconfig rewrite by host platform (Linux uses host.docker.internal + --add-host)

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -140,20 +140,59 @@ with open(sys.argv[2], 'w') as f:
 fi
 
 # Sanitize kubeconfig for the container.
-# Docker Desktop on macOS exposes the K8s API server at 127.0.0.1:6443
-# from the host (via port forwarding from the VM). Inside a container,
-# 127.0.0.1 is the container's own loopback — the host is reachable at
-# kubernetes.docker.internal instead (which is also in the API server's
-# TLS certificate SANs, so no --insecure-skip-tls-verify needed).
-# Without this fix, every K8s command via canasta-docker against Docker
-# Desktop fails with "Cannot reach Kubernetes cluster." See #78.
+#
+# Local-cluster kubeconfigs point the K8s API at 127.0.0.1 or localhost
+# from the host's perspective. Inside a container, 127.0.0.1 is the
+# container's own loopback, so the cluster is unreachable without a
+# rewrite to a hostname the container can resolve to the host.
+#
+# - macOS Docker Desktop: kubernetes.docker.internal is pre-resolved
+#   inside containers and is in Docker Desktop's K8s API cert SAN list,
+#   so TLS validation works with no extra flags. See #78.
+#
+# - Linux Docker: kubernetes.docker.internal doesn't exist; use
+#   host.docker.internal added via --add-host. Self-signed local
+#   clusters (k3s, kind, etc.) typically don't include any external
+#   hostname in their cert SANs, so we also drop the CA pin and skip
+#   TLS verification — the connection traverses the docker bridge to
+#   the host's loopback rather than untrusted network. See #534.
 KUBE_CONFIG="$HOME/.kube/config"
 if [[ -f "$KUBE_CONFIG" ]] \
     && grep -qE 'server:.*https://(127\.0\.0\.1|localhost)' "$KUBE_CONFIG" 2>/dev/null; then
     CANASTA_KUBE_CONFIG="$CONFIG_DIR/.kube-config"
-    sed -e 's|server: https://127\.0\.0\.1|server: https://kubernetes.docker.internal|g' \
-        -e 's|server: https://localhost|server: https://kubernetes.docker.internal|g' \
-        "$KUBE_CONFIG" > "$CANASTA_KUBE_CONFIG" 2>/dev/null
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sed -e 's|server: https://127\.0\.0\.1|server: https://kubernetes.docker.internal|g' \
+            -e 's|server: https://localhost|server: https://kubernetes.docker.internal|g' \
+            "$KUBE_CONFIG" > "$CANASTA_KUBE_CONFIG" 2>/dev/null
+    else
+        # Linux Docker. Do the hostname rewrite + drop CA pin + add
+        # insecure-skip-tls-verify in one python pass for robustness
+        # against indentation / formatting variations across kubeconfigs.
+        if command -v python3 &>/dev/null; then
+            python3 - "$KUBE_CONFIG" "$CANASTA_KUBE_CONFIG" <<'PYEOF' 2>/dev/null
+import re, sys
+src, dst = sys.argv[1], sys.argv[2]
+with open(src) as f:
+    text = f.read()
+text = re.sub(r'(server:\s*https://)(127\.0\.0\.1|localhost)\b',
+              r'\1host.docker.internal', text)
+# Drop CA pin lines and inject insecure-skip-tls-verify under each cluster.
+out_lines = []
+for line in text.splitlines():
+    if re.match(r'^\s*certificate-authority-data:', line):
+        continue
+    out_lines.append(line)
+    m = re.match(r'^(\s*)server:\s*https://host\.docker\.internal', line)
+    if m:
+        out_lines.append(f'{m.group(1)}insecure-skip-tls-verify: true')
+with open(dst, 'w') as f:
+    f.write('\n'.join(out_lines) + '\n')
+PYEOF
+        fi
+        if [[ -f "$CANASTA_KUBE_CONFIG" ]]; then
+            MOUNTS+=(--add-host=host.docker.internal:host-gateway)
+        fi
+    fi
     if [[ -f "$CANASTA_KUBE_CONFIG" ]]; then
         MOUNTS+=(-v "$CANASTA_KUBE_CONFIG":"$HOME/.kube/config":ro)
     fi


### PR DESCRIPTION
Fixes #534.

## Summary

Split the canasta-docker kubeconfig rewrite by host platform:

- **macOS Docker Desktop** — unchanged: rewrite `127.0.0.1`/`localhost` → `kubernetes.docker.internal`. Pre-resolved + cert SAN matches; TLS validates with no extra flags.
- **Linux Docker** — rewrite to `host.docker.internal`; add `--add-host=host.docker.internal:host-gateway` so the hostname resolves; drop `certificate-authority-data` and inject `insecure-skip-tls-verify: true` (self-signed local-cluster certs typically don't include any external hostname in their SAN list).

## Why

The prior single-path rewrite assumed Docker Desktop semantics. On a Linux operator host (e.g., a small EC2 instance running canasta-docker against a local k3s install), `kubernetes.docker.internal` doesn't exist — the container kubeconfig pointed at a non-resolvable hostname and every K8s-targeting command surfaced "Cannot reach Kubernetes cluster" even though the host's `kubectl` was fine. This blocked the canasta-docker → self-managed-K8s path entirely on Linux.

## Why insecure-skip-tls-verify on Linux

k3s / kind / microk8s default certs include `127.0.0.1`, `localhost`, and the cluster IP in the SAN list — but not `host.docker.internal` (or any docker-internal hostname). Hostname rewrite without the TLS skip would just trade one connection error for a TLS validation error. The connection traverses the docker bridge to the host's loopback, not untrusted network, so the trade-off is acceptable for this self-managed-cluster-on-localhost case.

Operators who want strict TLS can install k3s with `--tls-san=host.docker.internal` (or use canasta-native, which has none of the container-network indirection in the first place).

## Implementation

A small `python3 -` heredoc handles the rewrite: drop CA pin, swap hostname, inject `insecure-skip-tls-verify`. Cleaner than chained sed for kubeconfigs whose indentation varies (k3s vs kind vs microk8s).

## Test plan

- [x] **macOS Docker Desktop**: rewrite still produces `kubernetes.docker.internal`, TLS validation passes against Docker Desktop's K8s API. No regression on #78.
- [x] **Linux Docker (Ubuntu 24.04 EC2 + k3s on same host)**: `canasta-docker create -i test --orchestrator k8s --ingress-class traefik --storage-class local-path` succeeds end-to-end. Pods Running. Backup CronJob produces snapshots. Restore round-trip completes.
- [ ] kind / microk8s — formats are similar to k3s; not yet tested.
