### PR TITLE
canasta upgrade: refresh pip and ansible-galaxy after self_update

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -215,10 +215,48 @@ def self_update_cli():
                 file=sys.stderr,
             )
 
+    # Refresh Python and Ansible deps in case requirements.txt or
+    # requirements.yml was bumped in the pull. Without this, dep pins
+    # added to the new code don't actually land — operators see new
+    # code with stale collections (Helm 4 / kubernetes.core 6.4 was
+    # the last instance) and hit cryptic playbook errors.
+    def _refresh_deps(label, cmd, timeout):
+        try:
+            subprocess.run(cmd, check=True, timeout=timeout)
+            return True
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
+                OSError) as e:
+            print(
+                "Warning: %s failed (%s).\nRe-run manually:\n  %s"
+                % (label, e, " ".join(cmd)),
+                file=sys.stderr,
+            )
+            return False
+
+    pip_ok = _refresh_deps(
+        "pip install -r requirements.txt",
+        [sys.executable, "-m", "pip", "install", "--quiet",
+         "-r", os.path.join(repo, "requirements.txt")],
+        timeout=180,
+    )
+    galaxy = os.path.join(os.path.dirname(sys.executable), "ansible-galaxy")
+    galaxy_ok = _refresh_deps(
+        "ansible-galaxy collection install",
+        [galaxy, "collection", "install", "--upgrade",
+         "-r", os.path.join(repo, "requirements.yml")],
+        timeout=300,
+    )
+
     print(
         "Updated Canasta CLI from %s (%s) to %s (%s)."
         % (current_version, current_commit, new_version, new_commit)
     )
+    if not (pip_ok and galaxy_ok):
+        print(
+            "Warning: dependency refresh incomplete; see above. "
+            "Instances may still be upgraded against stale deps.",
+            file=sys.stderr,
+        )
 
 
 def internal_name(display_name):

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -1062,7 +1062,7 @@ class TestSelfUpdateCli:
     ):
         self._patch_repo(monkeypatch, tmp_path, version="4.0.0")
         # Sequence: rev-parse current, fetch, log (has updates),
-        # pull, rev-parse new, log -1 date.
+        # pull, rev-parse new, log -1 date, pip install, galaxy install.
         runner, calls = self._make_runner([
             {"stdout": "old1234\n"},
             {"stdout": ""},
@@ -1070,6 +1070,8 @@ class TestSelfUpdateCli:
             {"stdout": ""},                         # pull succeeded
             {"stdout": "new1234\n"},
             {"stdout": "2026-05-05 10:00:00\n"},
+            {"stdout": ""},                         # pip install
+            {"stdout": ""},                         # ansible-galaxy install
         ])
         monkeypatch.setattr(_subprocess, "run", runner)
 
@@ -1102,6 +1104,58 @@ class TestSelfUpdateCli:
         assert (tmp_path / "BUILD_DATE").read_text().strip() == (
             "2026-05-05 10:00:00"
         )
+
+        # pip + ansible-galaxy ran with the right arguments.
+        pip_call = calls[6]
+        assert pip_call[1:] == [
+            "-m", "pip", "install", "--quiet",
+            "-r", str(tmp_path / "requirements.txt"),
+        ]
+        galaxy_call = calls[7]
+        assert galaxy_call[-5:] == [
+            "collection", "install", "--upgrade",
+            "-r", str(tmp_path / "requirements.yml"),
+        ]
+
+    def test_dep_refresh_failure_warns(
+        self, monkeypatch, tmp_path, capsys,
+    ):
+        """If pip install or ansible-galaxy fails after a successful pull,
+        the wrapper warns but doesn't abort the upgrade flow — instances
+        downstream still get their normal upgrade attempt against whatever
+        deps are on disk."""
+        self._patch_repo(monkeypatch, tmp_path, version="4.0.0")
+        runner, calls = self._make_runner([
+            {"stdout": "old1234\n"},
+            {"stdout": ""},
+            {"stdout": "new1234 some change\n"},
+            {"stdout": ""},
+            {"stdout": "new1234\n"},
+            {"stdout": "2026-05-05 10:00:00\n"},
+            {"stdout": "", "returncode": 1},        # pip fails
+            {"stdout": "", "returncode": 1},        # galaxy fails
+        ])
+
+        def runner_with_check(argv, **kwargs):
+            res = runner(argv, **kwargs)
+            if kwargs.get("check") and res.returncode != 0:
+                raise _subprocess.CalledProcessError(
+                    res.returncode, argv,
+                    output=res.stdout, stderr=res.stderr,
+                )
+            return res
+
+        monkeypatch.setattr(_subprocess, "run", runner_with_check)
+        canasta_cli.self_update_cli()
+
+        captured = capsys.readouterr()
+        # The "Updated Canasta CLI ..." success line still prints —
+        # the code update itself succeeded.
+        assert "Updated Canasta CLI" in captured.out
+        # Both refresh failures should produce warnings.
+        assert "pip install -r requirements.txt failed" in captured.err
+        assert "ansible-galaxy collection install failed" in captured.err
+        assert "dependency refresh incomplete" in captured.err
 
     def test_pull_failure_warns_and_continues(
         self, monkeypatch, tmp_path, capsys,


### PR DESCRIPTION
Fixes #530.

## Summary

`canasta upgrade`'s `self_update_cli()` now re-runs `pip install -r requirements.txt` and `ansible-galaxy collection install -r requirements.yml --upgrade` after a successful `git pull`, so dependency pin changes (most recently the `kubernetes.core >= 6.4.0` pin from #525) actually land for native-mode operators on existing installs.

## Why

Before this change, `self_update_cli` did `git fetch` + `git pull --ff-only` + updated `BUILD_COMMIT`/`BUILD_DATE`, but never refreshed the venv's Python packages or Ansible collections. Operators who had installed canasta-CLI before the Helm 4 / `kubernetes.core 6.4` pin then ran `canasta upgrade` got the new code with stale collections — and tripped the exact "Helm 4 incompat" error the new code was supposed to fix.

Failures in `pip` or `ansible-galaxy` emit a warning and a "re-run manually" pointer but don't abort the upgrade flow. The pull itself succeeded; instances downstream still get their normal upgrade attempt against whatever's on disk. The warning makes the inconsistency visible so operators can finish the refresh manually if it failed (commonly: network blip, ansible-galaxy hitting a registry timeout).

## Implementation

A small `_refresh_deps` helper inside `self_update_cli` runs each command via `subprocess.run(check=True, timeout=...)` and prints a uniform warning on failure. Pip uses `sys.executable -m pip` so it always targets the venv that's running canasta. `ansible-galaxy` is found at `os.path.dirname(sys.executable)` (the venv's `bin/`).

Both calls only run after the pull succeeded — same gate as the existing `BUILD_COMMIT`/`BUILD_DATE` update. When the pull is a no-op (already up to date), the function returns earlier and dep refresh doesn't run.

Docker installs (no `.git` in script dir) remain a no-op here; the canasta-docker wrapper handles dependency baking via the image.

## Test plan

- [x] `make test-unit` — 779/779 pass.
- [x] Existing `test_pulls_and_updates_build_files` extended with assertions that the pip + ansible-galaxy invocations happen with the right arguments.
- [x] New `test_dep_refresh_failure_warns` covers the warning path when both refresh steps fail (pip CalledProcessError → warning; galaxy CalledProcessError → warning; final "dependency refresh incomplete" line). Confirms the upgrade flow continues despite dep failure.
- [x] Existing tests (`test_no_op_when_not_a_git_repo`, `test_already_up_to_date`, `test_pull_failure_warns_and_continues`, `test_fetch_failure_warns_and_returns`) still pass — no behavior change in their paths.
- [ ] Manual end-to-end: actually run `canasta upgrade` against a stale-deps install in a test environment. Worth a quick spot-check before/after merge.
