### PR TITLE
gitops: replace prefix-based shared-key migration with an explicit allowlist

### DIFF
--- a/roles/gitops/tasks/push_compose.yml
+++ b/roles/gitops/tasks/push_compose.yml
@@ -44,12 +44,13 @@
   when: _push_role not in ['source', 'both']
 
 # --- Auto-migrate shared-category keys to _shared/vars.yaml ---
-# Keys matching backup/cloud/mail credential prefixes belong in the
+# Keys named in gitops_shared_keys (vars/main.yml) belong in the
 # shared file so all hosts inherit them. On every push, any such key
 # present in host vars.yaml is moved to _shared/vars.yaml (host's
-# value wins on merge) and removed from host vars.yaml. This also
-# keeps _shared in sync when 'canasta config set' updates a key
-# that already lived there.
+# value wins on merge) and removed from host vars.yaml. Keys not in
+# the list — including environment-identifying values like
+# RESTIC_REPOSITORY and AWS_BUCKET_NAME — stay per-host so dev /
+# staging / prod can address different infrastructure.
 - name: Read host vars
   ansible.builtin.slurp:
     src: "{{ instance_path }}/hosts/{{ _push_hostname }}/vars.yaml"
@@ -77,7 +78,7 @@
   ansible.builtin.set_fact:
     _push_keys_to_migrate: >-
       {{ _push_host_vars | dict2items
-         | selectattr('key', 'match', '(' + gitops_shared_credential_prefixes | join('|') + ')')
+         | selectattr('key', 'in', gitops_shared_keys)
          | list }}
 
 - name: Write migrated shared vars
@@ -107,7 +108,7 @@
       ansible.builtin.copy:
         content: >-
           {{ _push_host_vars | dict2items
-             | rejectattr('key', 'match', '(' + gitops_shared_credential_prefixes | join('|') + ')')
+             | rejectattr('key', 'in', gitops_shared_keys)
              | items2dict
              | to_nice_yaml(indent=2) }}
         dest: "{{ instance_path }}/hosts/{{ _push_hostname }}/vars.yaml"

--- a/roles/gitops/vars/main.yml
+++ b/roles/gitops/vars/main.yml
@@ -16,19 +16,23 @@ gitops_placeholder_keys:
 # credentials and get placeholders in env.template.
 gitops_secret_prefix_pattern: "^(AWS_|AZURE_|B2_|GOOGLE_|OS_|ST_|RCLONE_|SMTP_)"
 
-# Credential-class prefixes (lowercase) whose values belong in
-# hosts/_shared/vars.yaml rather than per-host vars.yaml. Auto-migrated
-# on gitops push.
-gitops_shared_credential_prefixes:
-  - restic_
-  - aws_
-  - azure_
-  - b2_
-  - google_
-  - os_
-  - st_
-  - rclone_
-  - smtp_
+# Keys (lowercase) whose values belong in hosts/_shared/vars.yaml
+# rather than per-host vars.yaml. Auto-migrated on gitops push.
+#
+# Default policy: per-host. A key only joins this list when sharing it
+# across hosts is the right default — the value is opaque secret
+# material that doesn't change between dev / staging / prod, like API
+# credentials and encryption passwords.
+#
+# Environment-identifying values — bucket names, repository URLs,
+# regions, endpoints, hostnames — stay per-host so dev / staging /
+# prod can address different infrastructure under one gitops repo.
+gitops_shared_keys:
+  - aws_access_key_id
+  - aws_secret_access_key
+  - restic_password
+  - smtp_password
+  - smtp_user
 
 # Environment applied to every git command in the Compose-side gitops
 # flows (init, push, pull, join). accept-new lets the first contact

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -1389,16 +1389,20 @@ def test_gitops_push_shared_vars(inst):
         "--key", key_file,
     )
 
-    print("Adding shared-category keys to host vars...")
+    print("Adding mixed shared and host-specific keys to host vars...")
     vars_file = os.path.join(
         inst.instance_path(), "hosts", "testhost", "vars.yaml",
     )
     import yaml
     with open(vars_file) as f:
         vars_data = yaml.safe_load(f) or {}
-    vars_data["restic_repository"] = "s3:s3.example.com/test-backup"
+    # Should migrate to shared (in gitops_shared_keys):
     vars_data["restic_password"] = "test-password"
     vars_data["aws_access_key_id"] = "AKIATEST"
+    vars_data["aws_secret_access_key"] = "secrettest"
+    # Should stay per-host (environment-specific identifiers):
+    vars_data["restic_repository"] = "s3:s3.example.com/test-backup"
+    vars_data["aws_bucket_name"] = "test-bucket"
     with open(vars_file, "w") as f:
         yaml.dump(vars_data, f)
 
@@ -1406,7 +1410,7 @@ def test_gitops_push_shared_vars(inst):
     inst.run_ok("gitops", "add", "-i", inst.id)
     inst.run_ok("gitops", "push", "-i", inst.id)
 
-    print("Checking _shared/vars.yaml was created with migrated keys...")
+    print("Checking shared-list keys migrated to _shared/vars.yaml...")
     shared_file = os.path.join(
         inst.instance_path(), "hosts", "_shared", "vars.yaml",
     )
@@ -1415,19 +1419,42 @@ def test_gitops_push_shared_vars(inst):
     )
     with open(shared_file) as f:
         shared_data = yaml.safe_load(f) or {}
-    assert shared_data.get("restic_repository") == "s3:s3.example.com/test-backup", (
-        "restic_repository not in shared vars: %s" % shared_data
+    assert shared_data.get("restic_password") == "test-password", (
+        "restic_password not in shared vars: %s" % shared_data
     )
     assert shared_data.get("aws_access_key_id") == "AKIATEST", (
         "aws_access_key_id not in shared vars: %s" % shared_data
     )
+    assert shared_data.get("aws_secret_access_key") == "secrettest", (
+        "aws_secret_access_key not in shared vars: %s" % shared_data
+    )
 
-    print("Checking keys were removed from host vars...")
+    print("Checking environment-specific keys stayed per-host...")
+    assert "restic_repository" not in shared_data, (
+        "restic_repository should NOT be in shared (per-host): %s"
+        % shared_data
+    )
+    assert "aws_bucket_name" not in shared_data, (
+        "aws_bucket_name should NOT be in shared (per-host): %s"
+        % shared_data
+    )
+
+    print("Checking host vars: shared-list keys removed, host-specific kept...")
     with open(vars_file) as f:
         host_data = yaml.safe_load(f) or {}
-    assert "restic_repository" not in host_data, (
-        "restic_repository should have been removed from host vars: %s"
+    assert "restic_password" not in host_data, (
+        "restic_password should have moved to shared, still in host: %s"
         % host_data
+    )
+    assert "aws_access_key_id" not in host_data, (
+        "aws_access_key_id should have moved to shared, still in host: %s"
+        % host_data
+    )
+    assert host_data.get("restic_repository") == "s3:s3.example.com/test-backup", (
+        "restic_repository should remain per-host: %s" % host_data
+    )
+    assert host_data.get("aws_bucket_name") == "test-bucket", (
+        "aws_bucket_name should remain per-host: %s" % host_data
     )
 
 


### PR DESCRIPTION
Fixes #434.

## Summary

Replaces gitops's prefix-based shared-vars migration (`restic_`, `aws_`, `azure_`, ...) with an explicit allowlist of full key names. Default membership is conservative — only opaque credentials that genuinely don't change between environments. Environment-identifying values (bucket names, repository URLs, regions, endpoints) stay per-host so dev / staging / prod under one gitops repo can target different infrastructure.

## Why

The previous prefix matching couldn't tell secrets apart from env-specific identifiers that happened to start with the same prefix:

| Key | Old behavior | Right answer |
|---|---|---|
| `AWS_ACCESS_KEY_ID` | shared | shared ✓ |
| `AWS_SECRET_ACCESS_KEY` | shared | shared ✓ |
| `RESTIC_PASSWORD` | shared | shared ✓ |
| `AWS_BUCKET_NAME` | shared | **per-host** |
| `AWS_REGION` | shared | **per-host** |
| `RESTIC_REPOSITORY` | shared | **per-host** |
| `AWS_S3_ENDPOINT` | shared | **per-host** |

The over-promotion blocked dev → staging → prod promotion (the core multi-host gitops use case): all environments ended up sharing whatever values landed in `_shared`. Operators couldn't have different image buckets, different backup repositories, or different regions per environment without hand-editing `_shared/vars.yaml` after every push.

## Design choice: explicit list, not per-host override

Per the design discussion captured separately, this is the explicit-shared-keys shape (Option A in the issue body), not the per-host-override shape (Option B). Reasoning:

- The failure mode if a key is forgotten in the explicit list (credential ends up duplicated per host) is more recoverable than the alternative's failure mode (staging silently points at prod buckets).
- Forces a deliberate decision per credential class rather than relying on naming conventions matching intent.

## Default `gitops_shared_keys`

```yaml
gitops_shared_keys:
  - aws_access_key_id
  - aws_secret_access_key
  - restic_password
  - smtp_password
  - smtp_user
```

Operators who need additional shared keys (e.g., a custom credential not in this set) can extend the list via Ansible's normal var-precedence mechanisms.

## Migration of existing setups

Existing operators with `_shared/vars.yaml` content from the prefix era won't see a regression at render time — host vars still win the merge, so any value that's now per-host correctly overrides whatever's stale in `_shared`. But `_shared/vars.yaml` may contain stale env-specific values (e.g., the last-pushed host's `restic_repository`) that should be cleaned up manually. Subsequent pushes will not re-migrate those keys.

This is intentionally non-destructive — auto-removing them on push could surprise operators who deliberately put a non-shared key there.

## Touched files

- `roles/gitops/vars/main.yml` — replace `gitops_shared_credential_prefixes` with `gitops_shared_keys`; expand the comment with the per-host-default rationale.
- `roles/gitops/tasks/push_compose.yml` — switch the migrate / remove filters from prefix-regex `match` to set-membership `in`.
- `tests/integration/run_tests.py` — extend the gitops-push integration test to cover both directions: shared-list keys migrate, non-shared-list keys stay per-host.

K8s gitops (`push_kubernetes.yml`) has no analogous shared-vars migration step, so no parallel change there.

## Test plan

- [x] `make test-unit` — 779/779 pass.
- [x] `make validate` clean.
- [x] Updated integration test (`test_gitops_push_shared_credential_migration`) now asserts:
  - `restic_password`, `aws_access_key_id`, `aws_secret_access_key` migrate to `_shared/vars.yaml`
  - `restic_repository`, `aws_bucket_name` stay in `hosts/<host>/vars.yaml`
- [ ] Local end-to-end run of the integration test against a real gitops push (recommended before merge).
