### PR TITLE
ci: bump Integration: GitOps timeouts (15→20 step, 20→25 job)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,7 +136,7 @@ jobs:
     name: "Integration: GitOps"
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -157,7 +157,7 @@ jobs:
         run: >-
           sg www-data -c '.venv/bin/python tests/integration/run_tests.py
           gitops gitops-pull-diff config-set-gitops gitops-push-shared gitops-push-reporting'
-        timeout-minutes: 15
+        timeout-minutes: 20
 
   integration-k8s:
     name: "Integration: Kubernetes"


### PR DESCRIPTION
## Summary

Bump the `Integration: GitOps` job's step timeout from 15 → 20 minutes, and the job timeout from 20 → 25 minutes. The 5 gitops integration tests cumulatively run ~15 minutes; the prior 15-minute step timeout left zero headroom and any minor variance — a slightly slower CI runner, an extra assertion in one test — pushed the suite over.

## Why

Run 25493272342 reported `=== Results: 5 passed, 0 failed, 0 skipped ===` but the job still failed because the step itself was killed at the 15-minute mark. All five tests passed; the timeout just expired moments after the last result printed.

This isn't a regression-of-tests problem; the suite is genuinely close to 15 minutes of wall-clock now, and trying to keep it under that boundary will keep tripping over runner variance. Other integration jobs in the same workflow already use 30-minute step timeouts; 20 minutes for this one is conservative.

## Test plan

- [x] No code changes — just CI knobs.
- [ ] Confirm next run of the gitops integration job completes inside the new bound (it will, since the previous run took 15:08 and timed out at the boundary; the new bound is 20).

## Discovered during

PR #538's CI run timed out at the 15-minute mark with all 5 tests already reporting passed. The merged change in #538 was correct; this is a follow-up to fix the harness.
