### PR TITLE
config: block secret-bearing keys on K8s with kubectl-rotation guidance

### DIFF
--- a/roles/config/tasks/_validate_key.yml
+++ b/roles/config/tasks/_validate_key.yml
@@ -12,6 +12,39 @@
       Delete the instance and recreate with the new database configuration.
   when: _config_key in ['USE_EXTERNAL_DB', 'MYSQL_HOST', 'MYSQL_PORT', 'MYSQL_USER', 'MYSQL_SSL']
 
+# Secret-bearing keys on Kubernetes live in K8s Secret resources
+# (<id>-db-credentials, <id>-mw-secrets); pods read via secretKeyRef
+# and never see .env directly. Updating .env via 'canasta config set'
+# leaves the K8s Secret at its old value, so the running wiki keeps
+# authenticating with the previous credential — a silent no-op that
+# misleads operators who expect rotation. Block these keys on K8s
+# and point at the kubectl-based rotation flow. Compose reads .env
+# directly at container start, so the same keys are mutable there
+# (config set + canasta restart propagates).
+- name: Block secret-bearing keys on Kubernetes (K8s Secret is the source of truth)
+  ansible.builtin.fail:
+    msg: |
+      '{{ _config_key }}' cannot be set via 'canasta config set' on a
+      Kubernetes instance. The wiki's pods read this value from a K8s
+      Secret via secretKeyRef; updating .env alone leaves the running
+      wiki authenticating with the previous value.
+
+      To rotate this credential:
+        1. Update the value at its source (e.g., on the database server
+           for MYSQL_PASSWORD; generate a fresh random value for
+           MW_SECRET_KEY — note that rotating MW_SECRET_KEY invalidates
+           all sessions and password-reset tokens).
+        2. Update the K8s Secret in the cluster:
+             kubectl create secret generic <id>-db-credentials \
+               --from-literal=MYSQL_PASSWORD='<new-value>' \
+               --dry-run=client -o yaml | kubectl apply -f -
+           (Use <id>-mw-secrets and key MW_SECRET_KEY for the MW key.)
+        3. Restart the wiki pods so they pick up the new value:
+             canasta restart -i {{ id | default('<id>') }}
+  when:
+    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+    - _config_key in ['MYSQL_PASSWORD', 'WIKI_DB_PASSWORD', 'MYSQL_ROOT_PASSWORD', 'MW_SECRET_KEY']
+
 - name: Check if key is recognized
   ansible.builtin.fail:
     msg: >-


### PR DESCRIPTION
Fixes #541.

## Summary

`canasta config set MYSQL_PASSWORD=new` on a Kubernetes instance previously updated the on-disk `.env` but did NOT update the canasta-managed K8s Secret that the running pods authenticate from. The wiki kept using the previous credential — a silent no-op that misled operators expecting rotation to take effect.

This change blocks `canasta config set` (and `canasta config unset`) for the secret-bearing keys on K8s instances and prints the kubectl-based rotation recipe instead. Compose is unchanged — the same keys are mutable there because `.env` IS the runtime view.

## Why block instead of implementing rotation

Proper rotation needs Canasta-side coordination with DB-server-side rotation (e.g., `ALTER USER ... IDENTIFIED BY 'new'` on a bundled MariaDB; running it on RDS/Aurora is operator-owned for external DB). And `MW_SECRET_KEY` rotation invalidates all sessions, password-reset tokens, and CSRF tokens — that's a deliberate operation that shouldn't quietly happen via `canasta config set`. Both deserve their own design.

Block-with-guidance closes the silent-no-op bug cheaply, makes the operator's options explicit, and doesn't lock us into a specific rotation shape for the future.

## Source-of-truth divergence

After `canasta create`, where the wiki actually authenticates from differs by orchestrator:

- **Compose**: `.env` IS the runtime view. The bundled `db` container reads env on startup; the wiki reads via `getenv()`. `canasta config set` + `canasta restart` re-reads `.env` on container start, so rotation propagates correctly.
- **Kubernetes**: pods read from `<id>-db-credentials` / `<id>-mw-secrets` via `secretKeyRef`. The `.env` on the operator's instance dir becomes a record/snapshot, not the live source. Updating `.env` alone does nothing to the running wiki.

This PR encodes that divergence in the validation layer.

## What's blocked

On K8s only, for both `canasta config set <key>=<value>` and `canasta config unset <key>`:

- `MYSQL_PASSWORD`
- `WIKI_DB_PASSWORD`
- `MYSQL_ROOT_PASSWORD`
- `MW_SECRET_KEY`

The error message walks the operator through the kubectl-based rotation:

```
'MYSQL_PASSWORD' cannot be set via 'canasta config set' on a
Kubernetes instance. The wiki's pods read this value from a K8s
Secret via secretKeyRef; updating .env alone leaves the running
wiki authenticating with the previous value.

To rotate this credential:
  1. Update the value at its source (e.g., on the database server
     for MYSQL_PASSWORD; generate a fresh random value for
     MW_SECRET_KEY — note that rotating MW_SECRET_KEY invalidates
     all sessions and password-reset tokens).
  2. Update the K8s Secret in the cluster:
       kubectl create secret generic <id>-db-credentials \
         --from-literal=MYSQL_PASSWORD='<new-value>' \
         --dry-run=client -o yaml | kubectl apply -f -
     (Use <id>-mw-secrets and key MW_SECRET_KEY for the MW key.)
  3. Restart the wiki pods so they pick up the new value:
       canasta restart -i <id>
```

## Implementation

One new `ansible.builtin.fail` block in `roles/config/tasks/_validate_key.yml`, gated on `instance_orchestrator in ['kubernetes', 'k8s']` AND key membership. Both `_set_single.yml` and `_unset_single.yml` go through `_validate_key.yml`, so the same block covers both directions with no duplication.

## Test plan

- [x] `make test-unit` — 779 passed.
- [x] `make validate` clean.
- [ ] Manual verification on a real K8s instance:
  - `canasta config set -i <id> MYSQL_PASSWORD=new` → fails fast with the new error message; `.env` unchanged
  - `canasta config set -i <id> MW_SECRET_KEY=new` → same
  - `canasta config unset -i <id> MYSQL_PASSWORD` → same
  - `canasta config set -i <id> MW_SITE_FQDN=...` → still works (not in the blocked list)
- [ ] Manual verification on a real Compose instance:
  - `canasta config set -i <id> MYSQL_PASSWORD=new` → still works (Compose unchanged)

## Related

- The companion documentation issue #540 will explain the source-of-truth divergence and recovery pathways for both orchestrators on canasta.wiki, with the post-fix `config set` behavior reflected in the doc.
