### PR TITLE
storage list: tolerate None value when defaultStorageClass not set

### DIFF
--- a/playbooks/storage_list.yml
+++ b/playbooks/storage_list.yml
@@ -39,7 +39,7 @@
         if (_kubectl_ctx is succeeded) and (_kubectl_ctx.stdout | trim | length > 0)
         else '(unknown)' }}
       Canasta default StorageClass: {{ _default_sc.value
-        if _default_sc.value | default('') | length > 0
+        if _default_sc.value | default('', true) | length > 0
         else '(none — pass --storage-class on canasta create)' }}
 
       {{ _sc_raw.stdout }}


### PR DESCRIPTION
Fixes #544.

## Summary

`canasta storage list` errored out with `object of type 'NoneType' has no len()` whenever the controller hadn't run `canasta storage setup` (i.e., almost every fresh install). One-line fix in `playbooks/storage_list.yml`: `default('') → default('', true)`.

## Root cause

`canasta_registry get_setting` reads `result["value"] = settings.get(setting_key)` (Python's `dict.get` default behavior). For a missing key, that's `None`, not the empty string. The chain in storage_list.yml was:

```yaml
Canasta default StorageClass: {{ _default_sc.value
  if _default_sc.value | default('') | length > 0
  else '(none — pass --storage-class on canasta create)' }}
```

Jinja's `| default('')` only fires when a variable is **undefined**, not when it's `None`. So `_default_sc.value` (which IS defined, as `None`) skipped the default and passed `None` straight through to `| length`, which fails.

The two-argument form `| default('', true)` (boolean=true) makes Jinja treat falsy values — including `None` — as "not set" and apply the default. Same pattern documented in the operator memory `feedback_canasta_env_default_filter` for the `canasta_env` module's `read` state, which has identical "returns falsy for missing key" behavior.

## Why not fix the module instead

`canasta_registry get_setting` returning `None` is correct semantics — it distinguishes "key not present" from "key set to empty string." The bug is at the call site, where the Jinja chain assumed undefined-vs-defined dichotomy. Other call sites of the same module (`roles/create/tasks/_kubernetes_setup.yml`) already handle it correctly with explicit `is not none` and `| length > 0` chains.

## Test plan

- [x] `make test-unit` — 779 passed.
- [x] `make validate` clean.
- [ ] Manual verification on a K8s instance where `defaultStorageClass` was never set: `canasta storage list` now prints the storage classes plus `Canasta default StorageClass: (none — pass --storage-class on canasta create)` without erroring.

## Discovered during

End-to-end execution of #421 test plan (section B, step 6). Two-instance multi-tenancy test on k3s with `local-path` as the only StorageClass.
