### PR TITLE
install: probe cp-host k3s before fetching join token, fail with guidance

### DIFF
--- a/roles/install/tasks/k3s_worker.yml
+++ b/roles/install/tasks/k3s_worker.yml
@@ -15,6 +15,48 @@
 - name: Resolve cp-host SSH target from hosts.yml
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_cp_host_ssh.yml"
 
+# --- Confirm cp-host actually has a running k3s server ---
+#
+# Without this, a misconfigured invocation (cp-host doesn't have k3s
+# installed yet, cp-host is a worker not a cp, k3s service stopped,
+# SSH key changed) hits the token-fetch task below and fails with a
+# generic "Module failed: non-zero return code" — which `no_log: true`
+# below then censors entirely, leaving the operator with `exit=2` and
+# no diagnostic. Catch the common misuse cases here, before the
+# sensitive task runs, so we can produce an actionable message.
+- name: Probe cp-host for active k3s server
+  ansible.builtin.command:
+    argv:
+      - ssh
+      - -o
+      - StrictHostKeyChecking=accept-new
+      - "{{ _cp_ssh_target }}"
+      - systemctl is-active k3s
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  register: _cp_k3s_active
+  changed_when: false
+  failed_when: false
+
+- name: Fail if cp-host has no active k3s control plane
+  ansible.builtin.fail:
+    msg: |-
+      Host '{{ cp_host }}' is not running a k3s control plane
+      (systemctl is-active k3s returned: {{ (_cp_k3s_active.stdout | default('') | trim) or 'no output (SSH or sudo failure)' }}).
+
+      Common causes:
+        - You haven't installed k3s on '{{ cp_host }}' yet. Run
+            canasta install k8s-cp --host {{ cp_host }}
+          first, then retry this worker install.
+        - The cp-host you specified is itself a worker, not a control plane.
+          The cp-host argument must point at the cluster's control-plane node.
+        - The k3s service is installed but stopped. Start it on '{{ cp_host }}'
+          (sudo systemctl start k3s) and retry.
+  when: >-
+    _cp_k3s_active.rc != 0
+    or (_cp_k3s_active.stdout | default('') | trim) != 'active'
+
 # --- SSH to cp-host, fetch token + cluster-internal IP ---
 
 - name: Fetch k3s join token from cp-host


### PR DESCRIPTION
Fixes #543.

## Summary

`canasta install k8s-worker --cp-host <name>` previously failed silently when `<name>` had no active k3s control plane. Without `--verbose`: `exit=2` and zero output. With `--verbose`: `Module failed: non-zero return code` followed by `the output has been hidden due to the fact that 'no_log: true' was specified for this result.`

This PR adds a precondition probe — `systemctl is-active k3s` over SSH — that runs **before** the sensitive `no_log: true` token-fetch task. If the cp-host has no running k3s, the probe trips a clean `ansible.builtin.fail` with an actionable message walking the operator through the three most common causes.

## Why this fix shape (precondition probe, not removing no_log)

The token-fetch's `no_log: true` is correct — the k3s join token IS sensitive. We don't want it spilled into terminal output / log files / Ansible's task-result accumulators on the success path. The bug isn't that no_log exists; it's that no_log makes the failure case opaque, and the failure case is the common one.

Catching common-misuse failures BEFORE the no_log task runs lets us keep the no_log on the actual sensitive operation while producing a clear error from the probe (which has no sensitive output).

## What's in the error message

When the probe fails (rc != 0 OR stdout != 'active'):

```
Host '<name>' is not running a k3s control plane
(systemctl is-active k3s returned: <status or "no output (SSH or sudo failure)">).

Common causes:
  - You haven't installed k3s on '<name>' yet. Run
      canasta install k8s-cp --host <name>
    first, then retry this worker install.
  - The cp-host you specified is itself a worker, not a control plane.
    The cp-host argument must point at the cluster's control-plane node.
  - The k3s service is installed but stopped. Start it on '<name>'
    (sudo systemctl start k3s) and retry.
```

Each line names a real cause. The operator can act without reading source.

## What's still defended downstream

The existing `Validate fetched values` task (token + IP both non-empty) remains as defense-in-depth. If both fetch tasks succeed but return empty strings — a degenerate case the probe wouldn't catch — that path still produces a generic-but-pointed error.

## Test plan

- [x] `make test-unit` — 779 passed.
- [x] `make validate` clean.
- [ ] Manual reproduction: with the fix in place, run `canasta install k8s-worker --host worker --cp-host worker` on a host where worker has no k3s. Confirm: exit non-zero, the new error message appears (no `--verbose` needed), no `no_log: true` censoring.
- [ ] Manual confirmation that the success path is unchanged: `canasta install k8s-worker --host worker --cp-host cp` against a real cp-host with active k3s still completes the join.

## Related

- Surfaced during #421 test C scenario 4. The wrapping issue's "Error scenarios and recovery" section on `Help:Multi-node Kubernetes` already covers the user-facing recovery; this PR closes the feedback loop by ensuring the operator sees a useful message rather than a silent exit.
- C.2 in #421's test plan ("worker pointing at a host that's itself a worker, not a cp") is the same failure mode — the fix here catches it too, since a worker's `systemctl is-active k3s` will report `inactive` or `not-found` (workers run `k3s-agent`, not `k3s`).
