### PR TITLE
varnish: broaden PURGE ACL to RFC 1918 so K8s purges actually arrive

### DIFF
--- a/instance_template/config/default.vcl
+++ b/instance_template/config/default.vcl
@@ -11,8 +11,29 @@ backend default {
     .between_bytes_timeout = 120s;
 }
 
+# Hosts allowed to send PURGE requests. Must cover the source IP of
+# MediaWiki's `$wgCdnServers` purge requests as Varnish sees them.
+#
+# The previous list was just `"web"`, which Varnish forward-resolves at
+# VCL load. On Docker Compose that resolves correctly to the web
+# container's bridge-network IP, so PURGEs from MediaWiki match. On
+# Kubernetes, `web` resolves to the web Service's ClusterIP, but
+# PURGEs from the web pod arrive with source = pod IP (intra-cluster
+# pod-to-Service traffic preserves the source pod IP — only the
+# destination is DNAT'd by kube-proxy). The old ACL therefore rejected
+# every PURGE on K8s with 405, MediaWiki swallowed the failure, and
+# anonymous users saw stale cached pages until natural TTL expiry.
+#
+# RFC 1918 covers Compose's bridge net (172.17.0.0/16 and similar),
+# k3s's pod CIDR (10.42.0.0/16), EKS / GKE / AKS pod and node CIDRs,
+# and any reasonable on-prem cluster. The Varnish PURGE port isn't
+# internet-reachable in either orchestrator (Compose: bridge-only;
+# K8s: ClusterIP-only), so allowing the full RFC 1918 range doesn't
+# expand the real attack surface. See #443.
 acl purge {
-    "web";
+    "10.0.0.0"/8;
+    "172.16.0.0"/12;
+    "192.168.0.0"/16;
 }
 
 # vcl_recv is called whenever a request is received

--- a/roles/orchestrator/files/helm/canasta/files/default.vcl
+++ b/roles/orchestrator/files/helm/canasta/files/default.vcl
@@ -11,8 +11,29 @@ backend default {
     .between_bytes_timeout = 120s;
 }
 
+# Hosts allowed to send PURGE requests. Must cover the source IP of
+# MediaWiki's `$wgCdnServers` purge requests as Varnish sees them.
+#
+# The previous list was just `"web"`, which Varnish forward-resolves at
+# VCL load. On Docker Compose that resolves correctly to the web
+# container's bridge-network IP, so PURGEs from MediaWiki match. On
+# Kubernetes, `web` resolves to the web Service's ClusterIP, but
+# PURGEs from the web pod arrive with source = pod IP (intra-cluster
+# pod-to-Service traffic preserves the source pod IP — only the
+# destination is DNAT'd by kube-proxy). The old ACL therefore rejected
+# every PURGE on K8s with 405, MediaWiki swallowed the failure, and
+# anonymous users saw stale cached pages until natural TTL expiry.
+#
+# RFC 1918 covers Compose's bridge net (172.17.0.0/16 and similar),
+# k3s's pod CIDR (10.42.0.0/16), EKS / GKE / AKS pod and node CIDRs,
+# and any reasonable on-prem cluster. The Varnish PURGE port isn't
+# internet-reachable in either orchestrator (Compose: bridge-only;
+# K8s: ClusterIP-only), so allowing the full RFC 1918 range doesn't
+# expand the real attack surface. See #443.
 acl purge {
-    "web";
+    "10.0.0.0"/8;
+    "172.16.0.0"/12;
+    "192.168.0.0"/16;
 }
 
 # vcl_recv is called whenever a request is received


### PR DESCRIPTION
Fixes #443.

## Summary

Broaden the Varnish PURGE ACL from `{ "web"; }` to RFC 1918 (`10/8`, `172.16/12`, `192.168/16`). The previous ACL forward-resolved `web` at VCL load and matched correctly on Compose (where the bridge IP is the actual source of PURGE traffic from the web container) but rejected every PURGE on Kubernetes with `405 Not allowed`, because `web` resolves to the web Service's ClusterIP while the actual source IP is the web pod's pod-CIDR address.

Result on K8s before this fix: MediaWiki's `$wgCdnServers = [ 'varnish:80' ]` purges land at Varnish, get 405'd, MediaWiki swallows the failure, anonymous users see stale cached pages until natural TTL expiry. The `feedback_canasta_api_edits_dont_purge_varnish` operator-memory observation about "API edits don't purge Varnish" was specifically the K8s manifestation of this — Compose has been working all along.

## Reproduction (pre-fix, on a fresh single-node k3s + canasta create)

```
$ kubectl exec -n canasta-wiki deploy/canasta-wiki-web -- \
    curl -sSL -X PURGE -D - http://varnish/wiki/Main_Page
HTTP/1.1 405 Not allowed.
Server: Varnish
```

## After patching the live VCL with the RFC 1918 ranges and reloading

```
HTTP/1.1 200 Purged
Server: Varnish
```

## Why RFC 1918 (and not, e.g., reading the actual pod CIDR)

- '''Compose-safe.''' Compose's default bridge is `172.17.0.0/16` — within `172.16/12`. PURGEs from the web container continue to match. No regression on the orchestrator that was already working.
- '''K8s-safe across distributions.''' k3s default pod CIDR is `10.42.0.0/16` (in 10/8); EKS pod CIDRs are typically VPC-derived (10/8 or 192.168/16); GKE uses 10/8; AKS uses 10/8 (or operator-configured).
- '''No real attack-surface expansion.''' The Varnish PURGE port isn't internet-reachable in either orchestrator (Compose: bridge-only; K8s: ClusterIP-only). Anyone with cluster-network or compose-network access can already issue arbitrary HTTP requests to Varnish; PURGE is just one of them. Tightening from "all RFC 1918" to "exactly the pod CIDR" would require Helm-time / Ansible-time templating (read the cluster's pod CIDR at install time, render into the VCL) for a marginal security gain.

## Why both VCL files are updated

`instance_template/config/default.vcl` (Compose) and `roles/orchestrator/files/helm/canasta/files/default.vcl` (K8s Helm chart) are byte-for-byte identical today, but they're maintained as two separate files because each consumer (Ansible's `copy` for Compose, Helm's `.Files.Get` for K8s) needs the file at its expected path.

This PR keeps them identical post-fix. A separate small PR will follow to symlink one to the other so future fixes don't have to remember to touch both. (The drift-risk this fix surfaced is exactly that — landing the fix on K8s but missing it on Compose, or vice versa, would be easy without an enforced-identical relationship.)

## Test plan

- [x] Single-node k3s + canasta create — confirmed PURGE from web pod returns 405 with old VCL, 200 Purged with the new VCL.
- [x] `make test-unit` — 779 passed.
- [x] `make validate` clean.
- [ ] Manual verification on a Compose instance: API edit → fetch anonymously → expect cache-bust. (Confirmed working in production today on canasta.wiki, which is a Compose deployment.)

## Related

- Surfaced during the conversation that closed the ESIP wiki Caddyfile incident this morning, then verified empirically on a single-node k3s harness on EC2.
- Will close `feedback_canasta_api_edits_dont_purge_varnish` operator-memory after the fix lands — the observation will become "fixed in commit X" rather than an active gotcha.
