### PR TITLE
observability: add bcrypt dependency and fail-loud guards (#551)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ansible-core>=2.15
+bcrypt>=4.0
 kubernetes>=28.1.0
 molecule>=6.0
 molecule-plugins[docker]>=23.0

--- a/roles/orchestrator/tasks/ensure_observability_credentials.yml
+++ b/roles/orchestrator/tasks/ensure_observability_credentials.yml
@@ -16,6 +16,23 @@
 - name: Generate observability credentials
   when: _obs_enabled | bool
   block:
+    - name: Probe for Python bcrypt module
+      ansible.builtin.command:
+        cmd: python3 -c "import bcrypt"
+      register: _bcrypt_probe
+      changed_when: false
+      failed_when: false
+
+    - name: Refuse to proceed without bcrypt
+      ansible.builtin.fail:
+        msg: >-
+          Observability requires the Python 'bcrypt' module on the
+          controller, but 'python3 -c "import bcrypt"' failed.
+          Install it (e.g. 'pip install bcrypt' inside the canasta venv,
+          or rerun 'canasta upgrade' to refresh requirements.txt) and
+          retry. Probe stderr: {{ _bcrypt_probe.stderr | default('(empty)') }}
+      when: _bcrypt_probe.rc != 0
+
     - name: Set OS_USER if empty
       canasta_env:
         path: "{{ instance_path }}/.env"

--- a/roles/orchestrator/tasks/rewrite_caddy.yml
+++ b/roles/orchestrator/tasks/rewrite_caddy.yml
@@ -24,6 +24,18 @@
     _os_user: "{{ _env_caddy.variables.OS_USER | default('admin') }}"
     _os_password_hash: "{{ _env_caddy.variables.OS_PASSWORD_HASH | default('') }}"
 
+- name: Refuse to render Caddyfile with empty observability credentials
+  ansible.builtin.fail:
+    msg: >-
+      CANASTA_ENABLE_OBSERVABILITY is true but OS_PASSWORD_HASH is empty
+      in .env. Rendering the Caddyfile now would produce a basicauth
+      block with no password and crash the caddy container on next
+      start. Run 'canasta config set CANASTA_ENABLE_OBSERVABILITY=true'
+      to regenerate the credentials.
+  when:
+    - _observable | bool
+    - _os_password_hash | length == 0
+
 - name: Determine reverse proxy backend
   ansible.builtin.set_fact:
     _backend: "{{ (_varnish_enabled | bool) | ternary('varnish:80', 'web:80') }}"


### PR DESCRIPTION
## Summary

Three fixes for the empty-password `basicauth` bug Mark reported in #551 (caddy fails to start with `username and password cannot be empty or missing`).

## Why

Tracing #551:

- `roles/orchestrator/templates/Caddyfile.j2` always emits `{{ _os_user }} {{ _os_password_hash }}` inside `basicauth { }` when observability is on.
- `_os_password_hash` defaults to `''` if `OS_PASSWORD_HASH` is missing in `.env`.
- `OS_PASSWORD_HASH` is supposed to be auto-generated by `ensure_observability_credentials.yml`, which hashes `OS_PASSWORD` via `python3 -c 'import bcrypt'`.
- But `bcrypt` is not in `requirements.txt` and not in the Dockerfile — it has never been a declared dependency. On any controller that lacks bcrypt ambiently, the hash step crashes after `OS_PASSWORD` has already been written, leaving `.env` in a half-state. The next code path that re-renders the Caddyfile then writes the broken `basicauth` block.

Reproducible for every operator who tries to enable observability, regardless of release.

## Changes

1. **`requirements.txt`** — add `bcrypt>=4.0`. Both `canasta-native` (pip in venv) and the Dockerfile install from this file, so one line covers both install modes.

2. **`roles/orchestrator/tasks/ensure_observability_credentials.yml`** — probe `python3 -c 'import bcrypt'` at the top of the credentials block, before any `.env` writes. Fail with a targeted message naming the missing module instead of crashing partway through.

3. **`roles/orchestrator/tasks/rewrite_caddy.yml`** — refuse to render the Caddyfile when observability is enabled but `OS_PASSWORD_HASH` is empty. Catches any future code path that re-renders Caddy without running the credentials task first, with a clear error pointing at `canasta config set CANASTA_ENABLE_OBSERVABILITY=true` to regenerate.

## Recovery for existing broken instances

After upgrade:

```bash
canasta upgrade
canasta config set -i <id> CANASTA_ENABLE_OBSERVABILITY=true
```

`canasta upgrade` re-runs `pip install -r requirements.txt` (so bcrypt lands), and the idempotent `config set` re-fires the credentials side effect — `OS_PASSWORD` is preserved, `OS_PASSWORD_HASH` gets written, Caddyfile re-renders cleanly, and the auto-restart brings caddy up.

## Test plan

- [x] `make test-unit` — 779 passed.
- [x] `make validate` — clean.
- [x] `make lint` — no new warnings on touched files (pre-existing line-length warnings on adjacent untouched lines remain).

Closes #551.