### PR TITLE
doctor: warn when rootless Docker can't bind privileged ports

### DIFF
--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -29,6 +29,7 @@ command -v crontab >/dev/null 2>&1 && echo OK || echo MISSING; echo "$D"
 uname -s 2>/dev/null || echo unknown; echo "$D"
 python3 -c "import os; mem=os.sysconf('SC_PAGE_SIZE')*os.sysconf('SC_PHYS_PAGES')//(1024**3); print(str(mem)+' GB')" 2>/dev/null || echo unknown; echo "$D"
 df -h / | awk 'NR==2{print $4}' 2>/dev/null || echo unknown; echo "$D"
+cat /proc/sys/net/ipv4/ip_unprivileged_port_start 2>/dev/null || echo unknown; echo "$D"
 runtime="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"; for sock in "$runtime/podman/podman.sock" "$runtime/docker.sock"; do if [ -S "$sock" ]; then echo "unix://$sock"; exit 0; fi; done; echo ""
 """
 
@@ -56,7 +57,8 @@ def _parse_doctor(stdout, hostname):
     host_os = p(13)
     memory = p(14)
     disk = p(15) if len(parts) > 15 else "unknown"
-    rootless_sock = p(16) if len(parts) > 16 else ""
+    unpriv_port_start = p(16) if len(parts) > 16 else "unknown"
+    rootless_sock = p(17) if len(parts) > 17 else ""
 
     lines = [
         "Canasta Dependency Check (%s)" % hostname,
@@ -78,6 +80,27 @@ def _parse_doctor(stdout, hostname):
             "(canasta create will auto-set --docker-host to this)"
             % rootless_sock
         )
+        try:
+            port_floor = int(unpriv_port_start)
+        except (TypeError, ValueError):
+            port_floor = None
+        if port_floor is not None and port_floor > 80:
+            lines.append(
+                "  Privileged ports: BLOCKED — "
+                "net.ipv4.ip_unprivileged_port_start=%d. Rootless Docker "
+                "cannot bind Canasta's port 80/443. Fix with:\n"
+                "                     sudo sysctl "
+                "net.ipv4.ip_unprivileged_port_start=80\n"
+                "                     echo "
+                "net.ipv4.ip_unprivileged_port_start=80 | sudo tee "
+                "/etc/sysctl.d/canasta-privport.conf"
+                % port_floor
+            )
+        elif port_floor is not None:
+            lines.append(
+                "  Privileged ports: OK (ip_unprivileged_port_start=%d)"
+                % port_floor
+            )
     else:
         lines.append(
             "  Rootless socket: none detected "

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2232,6 +2232,7 @@ class TestDoctor:
             "Linux",
             "16 GB",
             "50G",
+            "1024",
         ]
         stdout = ("\n" + d + "\n").join(parts) + "\n"
         result = direct_commands._parse_doctor(stdout, "myhost")
@@ -2250,7 +2251,7 @@ class TestDoctor:
             "user", "MISSING", "MISSING", "MISSING",
             "UNREACHABLE", "MISSING", "MISSING", "MISSING",
             "MISSING", "Linux",
-            "unknown", "unknown",
+            "unknown", "unknown", "unknown",
         ]
         stdout = ("\n" + d + "\n").join(parts) + "\n"
         result = direct_commands._parse_doctor(stdout, "myhost")
@@ -2273,7 +2274,7 @@ class TestDoctor:
             "git version 2.45.0", "OK",
             "OK",
             "Darwin",
-            "16 GB", "50G",
+            "16 GB", "50G", "unknown",
         ]
         stdout = ("\n" + d + "\n").join(parts) + "\n"
         result = direct_commands._parse_doctor(stdout, "myhost")
@@ -2293,7 +2294,7 @@ class TestDoctor:
             "git version 2.45.0", "OK",
             "OK",
             "Linux",
-            "16 GB", "50G",
+            "16 GB", "50G", "80",
             "unix:///run/user/1000/podman/podman.sock",
         ]
         stdout = ("\n" + d + "\n").join(parts) + "\n"
@@ -2316,13 +2317,58 @@ class TestDoctor:
             "git version 2.45.0", "OK",
             "OK",
             "Linux",
-            "16 GB", "50G",
+            "16 GB", "50G", "1024",
             "",
         ]
         stdout = ("\n" + d + "\n").join(parts) + "\n"
         result = direct_commands._parse_doctor(stdout, "myhost")
         assert "Rootless socket: none detected" in result
         assert "/var/run/docker.sock" in result
+        assert "Privileged ports" not in result
+
+    def test_parse_doctor_rootless_with_blocked_priv_ports(self):
+        d = direct_commands._SENTINEL
+        parts = [
+            "Python 3.12.0",
+            "Docker version 27.0.0",
+            "Docker Compose version v2.30.0",
+            "OK",
+            "user docker www-data",
+            "OK", "v3.15.0", "k3s version v1.30.0",
+            "REACHABLE", "INSTALLED",
+            "git version 2.45.0", "OK",
+            "OK",
+            "Linux",
+            "16 GB", "50G", "1024",
+            "unix:///run/user/1000/docker.sock",
+        ]
+        stdout = ("\n" + d + "\n").join(parts) + "\n"
+        result = direct_commands._parse_doctor(stdout, "myhost")
+        assert "Privileged ports: BLOCKED" in result
+        assert "ip_unprivileged_port_start=1024" in result
+        assert "sudo sysctl net.ipv4.ip_unprivileged_port_start=80" in result
+        assert "/etc/sysctl.d/canasta-privport.conf" in result
+
+    def test_parse_doctor_rootless_with_priv_ports_ok(self):
+        d = direct_commands._SENTINEL
+        parts = [
+            "Python 3.12.0",
+            "Docker version 27.0.0",
+            "Docker Compose version v2.30.0",
+            "OK",
+            "user docker www-data",
+            "OK", "v3.15.0", "k3s version v1.30.0",
+            "REACHABLE", "INSTALLED",
+            "git version 2.45.0", "OK",
+            "OK",
+            "Linux",
+            "16 GB", "50G", "80",
+            "unix:///run/user/1000/docker.sock",
+        ]
+        stdout = ("\n" + d + "\n").join(parts) + "\n"
+        result = direct_commands._parse_doctor(stdout, "myhost")
+        assert "Privileged ports: OK (ip_unprivileged_port_start=80)" in result
+        assert "BLOCKED" not in result
 
 
 class TestCanastaStatus:


### PR DESCRIPTION
## Summary
- Detect rootless Docker + `ip_unprivileged_port_start > 80` during `canasta doctor` and surface the exact `sysctl` fix.
- No change on rootful Docker hosts or where `/proc/sys/net/ipv4/ip_unprivileged_port_start` isn't readable.

## Why
`canasta create` on a rootless host fails at `docker compose up` with `rootlessport cannot expose privileged port 80`. Today there's no pre-flight signal — operators only see the failure mid-create. This adds a clear warning + fix to `canasta doctor` so the problem is diagnosable before attempting a create.

## Test plan
- [x] `make test-unit` — 781/781 pass, including 7 doctor tests (2 new: blocked, OK)
- [x] Local `./canasta-native doctor` smoke test on macOS (no rootless socket → new line correctly hidden)
- [ ] Reviewer to spot-check on a rootless Linux host if convenient

Refs #555.
