### PR TITLE
compose: pin user=root on web and varnish for rootless Podman

### DIFF
--- a/roles/orchestrator/files/compose/docker-compose.yml
+++ b/roles/orchestrator/files/compose/docker-compose.yml
@@ -45,6 +45,11 @@ services:
 
   web:
     image: ${CANASTA_IMAGE:-ghcr.io/canastawiki/canasta:latest}
+    # The image entrypoint chowns files and uses runuser to drop to
+    # www-data — both need root. Docker uses the image USER (root),
+    # but podman-compose runs as the calling host user unless this is
+    # set explicitly.
+    user: root
     restart: unless-stopped
     logging: *default-logging
     extra_hosts:
@@ -119,6 +124,9 @@ services:
 
   varnish:
     image: docker.io/library/varnish:7.0.2-alpine
+    # Same as `web`: needed so podman-compose doesn't run as the host
+    # user and lose read access to the bind-mounted default.vcl.
+    user: root
     profiles:
       - varnish
     restart: unless-stopped

--- a/tests/unit/test_compose_stack.py
+++ b/tests/unit/test_compose_stack.py
@@ -1,0 +1,31 @@
+"""Structural guards for the bundled docker-compose.yml."""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+COMPOSE_PATH = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "files", "compose", "docker-compose.yml"
+)
+
+
+def _load_compose():
+    with open(COMPOSE_PATH) as f:
+        return yaml.safe_load(f)
+
+
+class TestComposeUserRoot:
+    def test_web_service_runs_as_root(self):
+        services = _load_compose()["services"]
+        assert services["web"].get("user") == "root", (
+            "web service must declare `user: root` so rootless Podman "
+            "doesn't run the canasta entrypoint as a non-root user"
+        )
+
+    def test_varnish_service_runs_as_root(self):
+        services = _load_compose()["services"]
+        assert services["varnish"].get("user") == "root", (
+            "varnish service must declare `user: root` so rootless "
+            "Podman doesn't lose read access to the bind-mounted VCL"
+        )


### PR DESCRIPTION
## Summary
- Add `user: root` to `web` and `varnish` services in the bundled `docker-compose.yml` so rootless Podman doesn't run them as the calling host user.
- Static test guards both assignments from accidental removal.

## Why
Under rootless Podman, `podman-compose` ignores the image's `USER` directive and runs services as the calling host user (e.g. UID 1001). The Canasta image's entrypoint requires root for `chown` / `runuser` / `/mediawiki` symlink and rsync operations; varnish needs root to read the bind-mounted VCL. Setting `user: root` explicitly matches Mark's documented workaround in #556 and follows the existing precedent set by `db` and `logstash` in the same file.

## No change for Docker users
Verified that both images already default to running as root in Docker (no `USER` directive in `Canasta/Dockerfile` or `CanastaBase/Dockerfile`; varnish `7.0.2-alpine` image config also has `User: ''`). The drop to `www-data` for the long-running web processes happens inside the entrypoint via `runuser`, not via the compose-level `user:` directive — that mechanism is unaffected. Bind-mount file ownership continues to be `www-data` for everything Apache writes.

## Scope
web and varnish only. caddy / elasticsearch / opensearch / opensearch-dashboards weren't in the original reproduction; can be revisited if rootless users hit them.

## Test plan
- [x] `make test-unit` — 783/783 (2 new compose-structure tests)
- [x] `make validate`
- [ ] Reviewer with rootless Podman: confirm `canasta create` succeeds end-to-end and `docker compose ps` shows web and varnish as Up

Closes #556.
