### PR TITLE
maintenance: invoke via run.php so .php suffix is optional

### DIFF
--- a/direct_commands/maintenance.py
+++ b/direct_commands/maintenance.py
@@ -77,7 +77,7 @@ def cmd_maintenance_script(args):
         return 1
 
     wiki = getattr(args, "wiki", "") or ""
-    cmd = "php maintenance/%s%s" % (
+    cmd = "php maintenance/run.php %s%s" % (
         script_args,
         " --wiki=%s" % _helpers._shell_quote(wiki) if wiki else "",
     )
@@ -110,7 +110,7 @@ def cmd_maintenance_extension(args):
         return 1
 
     wiki = getattr(args, "wiki", "") or ""
-    cmd = "php extensions/%s%s" % (
+    cmd = "php maintenance/run.php %s%s" % (
         script_args,
         " --wiki=%s" % _helpers._shell_quote(wiki) if wiki else "",
     )

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1142,7 +1142,9 @@ commands:
 
       With no arguments, lists all available maintenance scripts.
       With one or more arguments, runs the specified script. The
-      script name is relative to the `maintenance/` directory.
+      script name is relative to the `maintenance/` directory. The
+      `.php` suffix is optional — `createAndPromote` and
+      `createAndPromote.php` are both valid.
 
       Flags (`-i`, `--wiki`) must come before the script name.
       Everything after the script name is treated as script
@@ -1151,7 +1153,8 @@ commands:
       In a wiki farm, runs on all wikis by default. Use `--wiki` to
       target a specific wiki.
     examples:
-      - "canasta maintenance script -- rebuildall.php"
+      - "canasta maintenance script -- rebuildall"
+      - "canasta maintenance script -- createAndPromote SomeUser --sysop"
     direct_only: true
     parameters:
       - name: id
@@ -1170,25 +1173,21 @@ commands:
   - name: maintenance_extension
     description: "Run extension maintenance scripts"
     long_description: |
-      Run maintenance scripts provided by loaded MediaWiki
-      extensions.
+      Run maintenance scripts provided by MediaWiki extensions.
 
-      With no arguments, lists all loaded extensions that have a
-      `maintenance/` directory. With one argument (extension name),
-      lists available maintenance scripts for that extension. With
-      two or more arguments (extension name, script name, and
-      optional script arguments), runs the specified script.
+      With no arguments, lists all installed extensions that have a
+      `maintenance/` directory. With arguments, runs the specified
+      script using MediaWiki's `run.php` wrapper with the extension-
+      prefix syntax `<ExtName>:<scriptName>`. The `.php` suffix is
+      optional. Anything after the script name is passed through as
+      script arguments — no quotes needed.
 
-      Flags (`-i`, `--wiki`) must come before the extension name.
-      Everything after the extension name is treated as the script
-      and its arguments — no quotes needed.
-
-      Only extensions that are currently loaded (enabled) for the
-      target wiki are shown and allowed to run. In a wiki farm, runs
-      on all wikis by default. Use `--wiki` to target a specific
-      wiki.
+      In a wiki farm, runs on all wikis by default. Use `--wiki` to
+      target a specific wiki.
     examples:
       - "canasta maintenance extension"
+      - "canasta maintenance extension -- Cite:fixHTMLOutputForCite"
+      - "canasta maintenance extension -- SemanticMediaWiki:rebuildData -v"
     direct_only: true
     parameters:
       - name: id

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1153,8 +1153,8 @@ commands:
       In a wiki farm, runs on all wikis by default. Use `--wiki` to
       target a specific wiki.
     examples:
-      - "canasta maintenance script -- rebuildall"
-      - "canasta maintenance script -- createAndPromote SomeUser --sysop"
+      - "canasta maintenance script rebuildall"
+      - "canasta maintenance script createAndPromote SomeUser --sysop"
     direct_only: true
     parameters:
       - name: id
@@ -1186,8 +1186,8 @@ commands:
       target a specific wiki.
     examples:
       - "canasta maintenance extension"
-      - "canasta maintenance extension -- Cite:fixHTMLOutputForCite"
-      - "canasta maintenance extension -- SemanticMediaWiki:rebuildData -v"
+      - "canasta maintenance extension Cite:fixHTMLOutputForCite"
+      - "canasta maintenance extension SemanticMediaWiki:rebuildData -v"
     direct_only: true
     parameters:
       - name: id

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2683,7 +2683,56 @@ class TestMaintenanceScript:
             self._args(script_args="rebuildall.php"),
         )
         assert rc == 0
-        assert "php maintenance/rebuildall.php" in captured["command"]
+        assert "php maintenance/run.php rebuildall.php" in captured["command"]
+
+    def test_runs_script_without_php_extension(self, monkeypatch):
+        self._patch_resolve(monkeypatch)
+        captured = {}
+
+        def fake_stream(inst_id, inst, command, service="web"):
+            captured["command"] = command
+            return 0
+
+        monkeypatch.setattr(direct_commands._helpers, "_stream_in_container", fake_stream)
+        rc = direct_commands.cmd_maintenance_script(
+            self._args(script_args="createAndPromote"),
+        )
+        assert rc == 0
+        assert "php maintenance/run.php createAndPromote" in captured["command"]
+
+    def test_runs_subdirectory_script(self, monkeypatch):
+        self._patch_resolve(monkeypatch)
+        captured = {}
+
+        def fake_stream(inst_id, inst, command, service="web"):
+            captured["command"] = command
+            return 0
+
+        monkeypatch.setattr(direct_commands._helpers, "_stream_in_container", fake_stream)
+        direct_commands.cmd_maintenance_script(
+            self._args(script_args="storage/recompressTracked"),
+        )
+        assert (
+            "php maintenance/run.php storage/recompressTracked"
+            in captured["command"]
+        )
+
+    def test_passes_script_args_through(self, monkeypatch):
+        self._patch_resolve(monkeypatch)
+        captured = {}
+
+        def fake_stream(inst_id, inst, command, service="web"):
+            captured["command"] = command
+            return 0
+
+        monkeypatch.setattr(direct_commands._helpers, "_stream_in_container", fake_stream)
+        direct_commands.cmd_maintenance_script(
+            self._args(script_args="createAndPromote SomeUser --sysop"),
+        )
+        assert (
+            "php maintenance/run.php createAndPromote SomeUser --sysop"
+            in captured["command"]
+        )
 
     def test_wiki_flag_appended(self, monkeypatch):
         self._patch_resolve(monkeypatch)
@@ -2697,6 +2746,7 @@ class TestMaintenanceScript:
         direct_commands.cmd_maintenance_script(
             self._args(script_args="rebuildall.php", wiki="main"),
         )
+        assert "php maintenance/run.php rebuildall.php" in captured["command"]
         assert "--wiki='main'" in captured["command"]
 
 
@@ -2742,11 +2792,64 @@ class TestMaintenanceExtension:
 
         monkeypatch.setattr(direct_commands._helpers, "_stream_in_container", fake_stream)
         direct_commands.cmd_maintenance_extension(
-            self._args(script_args="Cite/maintenance/foo.php"),
+            self._args(script_args="Cite:fixHTMLOutputForCite"),
         )
         assert (
-            "php extensions/Cite/maintenance/foo.php" in captured["command"]
+            "php maintenance/run.php Cite:fixHTMLOutputForCite"
+            in captured["command"]
         )
+
+    def test_extension_script_without_php_extension(self, monkeypatch):
+        self._patch_resolve(monkeypatch)
+        captured = {}
+
+        def fake_stream(inst_id, inst, command, service="web"):
+            captured["command"] = command
+            return 0
+
+        monkeypatch.setattr(direct_commands._helpers, "_stream_in_container", fake_stream)
+        direct_commands.cmd_maintenance_extension(
+            self._args(script_args="SemanticMediaWiki:rebuildData"),
+        )
+        assert (
+            "php maintenance/run.php SemanticMediaWiki:rebuildData"
+            in captured["command"]
+        )
+
+    def test_extension_script_passes_args_through(self, monkeypatch):
+        self._patch_resolve(monkeypatch)
+        captured = {}
+
+        def fake_stream(inst_id, inst, command, service="web"):
+            captured["command"] = command
+            return 0
+
+        monkeypatch.setattr(direct_commands._helpers, "_stream_in_container", fake_stream)
+        direct_commands.cmd_maintenance_extension(
+            self._args(script_args="Cite:foo arg1 --flag"),
+        )
+        assert (
+            "php maintenance/run.php Cite:foo arg1 --flag"
+            in captured["command"]
+        )
+
+    def test_extension_script_with_wiki_flag(self, monkeypatch):
+        self._patch_resolve(monkeypatch)
+        captured = {}
+
+        def fake_stream(inst_id, inst, command, service="web"):
+            captured["command"] = command
+            return 0
+
+        monkeypatch.setattr(direct_commands._helpers, "_stream_in_container", fake_stream)
+        direct_commands.cmd_maintenance_extension(
+            self._args(script_args="Cite:fixHTMLOutputForCite", wiki="main"),
+        )
+        assert (
+            "php maintenance/run.php Cite:fixHTMLOutputForCite"
+            in captured["command"]
+        )
+        assert "--wiki='main'" in captured["command"]
 
 
 class TestMaintenanceUpdate:


### PR DESCRIPTION
## Summary
Switch `canasta maintenance script` and `canasta maintenance extension` to invoke MediaWiki's `run.php` wrapper so the `.php` suffix is optional, and extension scripts resolve via the `ExtName:scriptName` prefix syntax.

## Behavior change
- `canasta maintenance script createAndPromote` now works (previously failed with `Could not open input file: maintenance/createAndPromote`).
- `canasta maintenance extension Cite:fixHTMLOutputForCite` is the new extension form. The previous path form (`Cite/maintenance/fixHTMLOutputForCite.php`) is no longer supported — it relied on the bare-`php` invocation that this PR removes, and didn't match the documented two-positional interface either.
- `.php` suffix still accepted on both forms (run.php is permissive).

## Test plan
- [x] `make test-unit` — 789/789, including 8 new maintenance tests covering bare-name, subdir path, args passthrough, extension prefix, `.php` accepted on both forms, and `--wiki` flag.
- [x] `make validate`
- [x] Local smoke test against a fresh `canasta create -i smoketest -w main -n localhost` wikifarm. Verified, identical results to a parallel run on a remote acknowledge.wiki host:
  - **Core, no `.php`:** `showJobs` → returned `0` (job count)
  - **Core, with `.php`:** `showJobs.php` → returned `0`
  - **Core subdir:** `storage/checkStorage` → script ran
  - **Extension, no `.php`:** `ConfirmEdit:CountFancyCaptchas` → run.php resolved and executed (script failed only on its own internal FancyCaptcha-installed check)
  - **Extension, with `.php`:** `ConfirmEdit:CountFancyCaptchas.php` → same
  - **Extension with installed dep:** `CommentStreams:listCommentBlocks` → stack trace confirms script executed from `extensions/CommentStreams/maintenance/listCommentBlocks.php`
  - **No-args listings** (unchanged code paths) still work

Closes #554.
