### PR TITLE
create: refuse non-empty target dir; don't delete pre-existing dir on failure

### DIFF
--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -57,6 +57,9 @@
         - (orchestrator | default('compose')) in ['kubernetes', 'k8s']
       ignore_errors: true  # Best-effort cleanup on failure
 
+    # Only remove the directory if this run created it. A pre-existing
+    # directory (e.g., the operator was using it as a staging area for
+    # an upgrade) belongs to the operator and must not be deleted.
     - name: Clean up on failure (remove directory)
       ansible.builtin.file:
         path: "{{ instance_path }}"
@@ -64,6 +67,7 @@
       when:
         - instance_path is defined
         - not (keep_config | default(false) | bool)
+        - instance_dir_was_created | default(false) | bool
       ignore_errors: true  # Best-effort cleanup on failure
 
     - name: Deregister instance on failure

--- a/roles/create/tasks/_validate_inputs.yml
+++ b/roles/create/tasks/_validate_inputs.yml
@@ -33,6 +33,59 @@
       Run 'canasta delete --id {{ id }}' to remove it first.
   when: _existing is succeeded
 
+# --- Target directory check ---
+# Refuse to enter a non-empty existing directory. Without this guard,
+# `file: state: directory` would silently claim the directory and the
+# rescue handler in playbooks/create.yml would recursively delete it
+# (along with the operator's pre-existing files) on any later failure.
+- name: Resolve target directory absolute path
+  ansible.builtin.command:
+    argv:
+      - python3
+      - "-c"
+      - "import os, sys; print(os.path.abspath(sys.argv[1]))"
+      - "{{ (path | default('.')) ~ '/' ~ id }}"
+  register: _target_path
+  changed_when: false
+
+- name: Probe target directory
+  ansible.builtin.stat:
+    path: "{{ _target_path.stdout }}"
+  register: _target_dir
+
+- name: Probe target directory contents
+  ansible.builtin.find:
+    paths: "{{ _target_path.stdout }}"
+    file_type: any
+    hidden: true
+  register: _target_contents
+  when:
+    - _target_dir.stat.exists
+    - _target_dir.stat.isdir | default(false)
+
+- name: Fail if target path exists but is not a directory
+  ansible.builtin.fail:
+    msg: >-
+      Target path '{{ _target_path.stdout }}' exists but is not a
+      directory. Remove or rename it before running canasta create.
+  when:
+    - _target_dir.stat.exists
+    - not (_target_dir.stat.isdir | default(false))
+
+- name: Fail if target directory is not empty
+  ansible.builtin.fail:
+    msg: >-
+      Target directory '{{ _target_path.stdout }}' already exists and
+      is not empty ({{ _target_contents.matched }} entries). canasta
+      create would copy stack files into this location and (on any
+      mid-flight failure) recursively delete its entire contents.
+      Move or remove the existing contents first, or pass --path to a
+      different parent directory.
+  when:
+    - _target_dir.stat.exists
+    - _target_dir.stat.isdir | default(false)
+    - (_target_contents.matched | default(0)) > 0
+
 # --- Stale-state check ---
 # Even when the registry has no entry for this instance, a prior
 # 'canasta create' that failed mid-flight may have left orchestrator

--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -56,6 +56,20 @@
     instance_managed_cluster: false
     instance_devmode: false
 
+# Record whether the target directory existed BEFORE this run so the
+# rescue handler in playbooks/create.yml can refuse to remove a
+# pre-existing directory on failure. The pre-flight check refuses to
+# enter a non-empty directory, but an empty directory created by the
+# operator (or a symlink target with a race) can still pre-exist.
+- name: Stat target before directory creation
+  ansible.builtin.stat:
+    path: "{{ instance_path }}"
+  register: _pre_existing_target
+
+- name: Record whether this run created the instance directory
+  ansible.builtin.set_fact:
+    instance_dir_was_created: "{{ not _pre_existing_target.stat.exists }}"
+
 - name: Create instance directory
   ansible.builtin.file:
     path: "{{ instance_path }}"

--- a/tests/unit/test_create_no_clobber.py
+++ b/tests/unit/test_create_no_clobber.py
@@ -1,0 +1,134 @@
+"""Static guards against the data-loss bug in #560.
+
+`canasta create` must (a) refuse to enter a non-empty existing target
+directory and (b) never delete a pre-existing directory from the
+on-failure rescue handler. Removing either protection re-opens the
+silent-data-loss path.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+VALIDATE_INPUTS = os.path.join(
+    REPO_ROOT, "roles", "create", "tasks", "_validate_inputs.yml"
+)
+CREATE_MAIN = os.path.join(
+    REPO_ROOT, "roles", "create", "tasks", "main.yml"
+)
+CREATE_PLAYBOOK = os.path.join(REPO_ROOT, "playbooks", "create.yml")
+
+
+def _load_tasks(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+class TestRefuseNonEmptyTargetDir:
+    def test_validate_inputs_probes_target_directory(self):
+        tasks = _load_tasks(VALIDATE_INPUTS)
+        names = [t.get("name", "") for t in tasks]
+        assert any(
+            "Probe target directory" in n for n in names
+        ), "_validate_inputs.yml must stat the target directory"
+        assert any(
+            "Probe target directory contents" in n for n in names
+        ), "_validate_inputs.yml must enumerate target directory contents"
+
+    def test_validate_inputs_fails_on_non_directory_path(self):
+        tasks = _load_tasks(VALIDATE_INPUTS)
+        names = [t.get("name", "") for t in tasks]
+        assert any(
+            "not a directory" in n for n in names
+        ), (
+            "_validate_inputs.yml must fail when the target path exists "
+            "but is a file/symlink, not a directory"
+        )
+
+    def test_validate_inputs_fails_on_non_empty_directory(self):
+        tasks = _load_tasks(VALIDATE_INPUTS)
+        names = [t.get("name", "") for t in tasks]
+        assert any(
+            "not empty" in n for n in names
+        ), (
+            "_validate_inputs.yml must fail when the target directory "
+            "is non-empty — refusing to enter it is the only thing "
+            "preventing the rescue handler from deleting the operator's "
+            "pre-existing files (#560)"
+        )
+
+    def test_fail_task_runs_only_when_dir_exists_and_non_empty(self):
+        tasks = _load_tasks(VALIDATE_INPUTS)
+        fail = next(
+            t for t in tasks
+            if "not empty" in t.get("name", "")
+        )
+        conditions = fail.get("when", [])
+        # Conditions can be a list or a single string; normalize to list.
+        if isinstance(conditions, str):
+            conditions = [conditions]
+        joined = " ".join(conditions)
+        assert "_target_dir.stat.exists" in joined
+        assert "isdir" in joined
+        assert "matched" in joined, (
+            "Fail condition must reference the find module's `matched` "
+            "count so the task only fires when the directory has entries"
+        )
+
+
+class TestRescueOnlyRemovesNewlyCreatedDir:
+    def test_main_records_pre_existing_target(self):
+        tasks = _load_tasks(CREATE_MAIN)
+        names = [t.get("name", "") for t in tasks]
+        assert any(
+            "Stat target before directory creation" in n for n in names
+        ), "main.yml must stat the target before creating it"
+        assert any(
+            "Record whether this run created the instance directory" in n
+            for n in names
+        ), (
+            "main.yml must set instance_dir_was_created so the rescue "
+            "handler can refuse to delete a pre-existing directory"
+        )
+
+    def test_stat_runs_before_directory_creation(self):
+        tasks = _load_tasks(CREATE_MAIN)
+        names = [t.get("name", "") for t in tasks]
+        stat_idx = next(
+            (i for i, n in enumerate(names)
+             if "Stat target before directory creation" in n),
+            -1,
+        )
+        create_idx = next(
+            (i for i, n in enumerate(names)
+             if n == "Create instance directory"),
+            -1,
+        )
+        assert stat_idx >= 0 and create_idx >= 0
+        assert stat_idx < create_idx, (
+            "The stat task must run BEFORE the directory is created — "
+            "otherwise it always observes the directory as existing"
+        )
+
+    def test_playbook_rescue_remove_directory_gated_on_fact(self):
+        tasks = _load_tasks(CREATE_PLAYBOOK)
+        rescue_block = next(
+            t for t in tasks
+            if isinstance(t, dict)
+            and "rescue" in t
+            and isinstance(t.get("rescue"), list)
+        )
+        remove = next(
+            t for t in rescue_block["rescue"]
+            if "remove directory" in t.get("name", "").lower()
+        )
+        conditions = remove.get("when", [])
+        if isinstance(conditions, str):
+            conditions = [conditions]
+        joined = " ".join(conditions)
+        assert "instance_dir_was_created" in joined, (
+            "The on-failure 'remove directory' task must be gated on "
+            "instance_dir_was_created so it cannot delete a "
+            "pre-existing operator-owned directory (#560)"
+        )


### PR DESCRIPTION
## Summary
Fix a data-loss bug: `canasta create` could silently overwrite, then on failure recursively delete, an operator-provided directory (full reproducer in #560).

## Changes
1. **Pre-flight refusal** (`roles/create/tasks/_validate_inputs.yml`) — stat the target path; fail if it exists and is non-empty, or exists but isn't a directory. Refusing to enter someone else's directory removes the original trigger.
2. **Narrow rescue blast radius** (`roles/create/tasks/main.yml` + `playbooks/create.yml`) — record `instance_dir_was_created` before the directory-create task and gate the on-failure `state: absent` cleanup on that fact. A pre-existing directory is never deleted by the rescue handler, even if fix 1 is somehow bypassed (race, symlink, contents added between check and create).

## Test plan
- [x] `make test-unit` — 796/796 (7 new static guards in `test_create_no_clobber.py`)
- [x] `make validate`
- [x] `make lint` — no new warnings; pre-existing line-length warnings unchanged
- [x] Local smoke test: created `~/canasta-smoke/preexisting/dump.sql`, then ran `canasta create -p ~/canasta-smoke -i preexisting -w main -n localhost` → fails with the new error message naming the target directory and the entry count; `dump.sql` survives intact.

Closes #560.
