### PR TITLE
rebuild: add canasta rebuild for standalone custom-image rebuilds

### DIFF
--- a/direct_commands/__init__.py
+++ b/direct_commands/__init__.py
@@ -98,6 +98,7 @@ from . import extension_skin  # noqa: F401
 from . import backup      # noqa: F401
 from . import doctor      # noqa: F401
 from . import argocd      # noqa: F401
+from . import rebuild     # noqa: F401
 
 # Per-handler symbols re-exported so test code can reach
 # direct_commands.cmd_list, direct_commands.cmd_doctor, etc.
@@ -141,3 +142,4 @@ from .argocd import (  # noqa: F401
     cmd_argocd_ui,
     _argocd_admin_password,
 )
+from .rebuild import cmd_rebuild, _list_buildable_services  # noqa: F401

--- a/direct_commands/rebuild.py
+++ b/direct_commands/rebuild.py
@@ -1,0 +1,112 @@
+"""rebuild — rebuild buildable services and restart."""
+
+import json
+import subprocess
+import sys
+
+from . import _helpers
+from ._helpers import register
+
+
+def _list_buildable_services(inst):
+    """Return service names with a build: directive in the merged compose config.
+
+    Uses `docker compose config --format json` so docker itself
+    handles the main + override + dev file merging — no need to
+    parse YAML ourselves.
+    """
+    host = inst.get("host") or "localhost"
+    path = inst.get("path", "")
+    devmode = inst.get("devMode", False)
+    file_args = _helpers._compose_file_args(path, host, devmode)
+
+    if _helpers._is_localhost(host):
+        try:
+            result = subprocess.run(
+                ["docker", "compose"] + file_args + ["config", "--format", "json"],
+                cwd=path, capture_output=True, text=True, timeout=30,
+            )
+        except (subprocess.TimeoutExpired, OSError) as e:
+            print("Error querying compose config: %s" % e, file=sys.stderr)
+            return []
+        if result.returncode != 0:
+            print(
+                "Error: docker compose config failed: %s"
+                % (result.stderr or "").strip(),
+                file=sys.stderr,
+            )
+            return []
+        stdout = result.stdout
+    else:
+        rc, stdout = _helpers._ssh_run(
+            host,
+            "cd %s && docker compose %s config --format json" % (
+                _helpers._shell_quote(path), " ".join(file_args),
+            ),
+        )
+        if rc != 0:
+            print("Error: docker compose config failed on %s" % host, file=sys.stderr)
+            return []
+
+    try:
+        data = json.loads(stdout)
+    except (ValueError, TypeError):
+        print("Error: docker compose config returned invalid JSON", file=sys.stderr)
+        return []
+
+    services = data.get("services", {}) or {}
+    return [
+        name for name, svc in services.items()
+        if isinstance(svc, dict) and "build" in svc
+    ]
+
+
+@register("rebuild")
+def cmd_rebuild(args):
+    inst_id, inst = _helpers._resolve_instance(args)
+
+    if inst.get("orchestrator", "compose") in ("kubernetes", "k8s"):
+        print(
+            "Error: 'canasta rebuild' is only supported for Compose "
+            "instances. For Kubernetes instances with a custom image, "
+            "rebuild and push the image to a registry, then run "
+            "'canasta upgrade'.",
+            file=sys.stderr,
+        )
+        return 1
+
+    services = _list_buildable_services(inst)
+    if not services:
+        print(
+            "No services have a build: directive — nothing to rebuild. "
+            "Add a docker-compose.override.yml with a build: section "
+            "to layer a custom image."
+        )
+        return 0
+
+    build_argv = ["build"]
+    if getattr(args, "no_cache", False):
+        build_argv.append("--no-cache")
+    build_argv.extend(services)
+
+    print("Rebuilding: %s" % ", ".join(services))
+    rc = _helpers._run_compose(inst_id, inst, build_argv)
+    if rc != 0:
+        return rc
+
+    if getattr(args, "no_restart", False):
+        print(
+            "Build complete. Skipping restart (--no-restart). "
+            "Run 'canasta restart -i %s' to pick up the new image." % inst_id
+        )
+        return 0
+
+    print("Restarting containers to pick up the rebuilt image...")
+    rc = _helpers._run_compose(inst_id, inst, ["down"])
+    if rc != 0:
+        return rc
+    _helpers._sync_compose_profiles(inst)
+    rc = _helpers._run_compose(inst_id, inst, ["up", "-d"])
+    if rc != 0:
+        _helpers._dump_compose_failure(inst)
+    return rc

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -449,6 +449,42 @@ commands:
         type: string
         description: "Canasta instance ID"
 
+  - name: rebuild
+    description: "Rebuild custom images for a Canasta instance"
+    long_description: |
+      Rebuild every service that has a `build:` directive in the
+      merged compose config (docker-compose.override.yml or
+      docker-compose.dev.yml) and restart the instance to pick up
+      the rebuilt image.
+
+      Use this after editing a custom Dockerfile, or after changing
+      the base CANASTA_IMAGE when you want to refresh a layered
+      custom image. `canasta upgrade` also performs the same
+      rebuild automatically when the configured image changes;
+      `canasta rebuild` is the standalone form for cases where the
+      operator wants to rebuild without an upgrade.
+
+      Compose only. Kubernetes instances must build and push their
+      custom image to a registry manually.
+    examples:
+      - "canasta rebuild"
+      - "canasta rebuild -i mywiki --no-cache"
+      - "canasta rebuild --no-restart"
+    direct_only: true
+    parameters:
+      - name: id
+        short: i
+        type: string
+        description: "Canasta instance ID"
+      - name: no_cache
+        type: bool
+        default: false
+        description: "Pass --no-cache to docker compose build"
+      - name: no_restart
+        type: bool
+        default: false
+        description: "Build images but skip the restart afterward"
+
   - name: list
     description: "List all registered Canasta instances"
     long_description: |

--- a/tests/unit/test_rebuild.py
+++ b/tests/unit/test_rebuild.py
@@ -1,0 +1,236 @@
+"""Tests for `canasta rebuild` (#562)."""
+
+import json
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+sys.path.insert(0, REPO_ROOT)
+
+import direct_commands  # noqa: E402
+
+
+def _args(**kw):
+    defaults = {"id": "test", "no_cache": False, "no_restart": False}
+    defaults.update(kw)
+    return type("Args", (), defaults)()
+
+
+def _patch_compose_inst(monkeypatch):
+    """Stub _resolve_instance to return a Compose instance."""
+    monkeypatch.setattr(direct_commands._helpers, "_resolve_instance",
+        lambda args: ("test", {
+            "path": "/srv/test",
+            "orchestrator": "compose",
+            "host": "localhost",
+            "devMode": False,
+        }),
+    )
+
+
+def _patch_k8s_inst(monkeypatch):
+    monkeypatch.setattr(direct_commands._helpers, "_resolve_instance",
+        lambda args: ("test", {
+            "path": "/srv/test",
+            "orchestrator": "k8s",
+            "host": "localhost",
+            "devMode": False,
+        }),
+    )
+
+
+class TestRebuildRegistered:
+    def test_registered_as_direct(self):
+        assert direct_commands.is_direct_command("rebuild")
+
+
+class TestRebuildK8sRefused:
+    def test_k8s_instance_rejects_with_error(self, monkeypatch, capsys):
+        _patch_k8s_inst(monkeypatch)
+        rc = direct_commands.cmd_rebuild(_args())
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Compose" in err
+        assert "Kubernetes" in err
+
+
+class TestRebuildNoBuildableServices:
+    def test_returns_zero_with_message(self, monkeypatch, capsys):
+        _patch_compose_inst(monkeypatch)
+        monkeypatch.setattr(direct_commands.rebuild, "_list_buildable_services",
+            lambda inst: [],
+        )
+        rc = direct_commands.cmd_rebuild(_args())
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Nothing to rebuild" in out or "nothing to rebuild" in out
+
+
+class TestRebuildBuildAndRestart:
+    def test_default_flow_builds_then_restarts(self, monkeypatch):
+        _patch_compose_inst(monkeypatch)
+        monkeypatch.setattr(direct_commands.rebuild, "_list_buildable_services",
+            lambda inst: ["web"],
+        )
+        calls = []
+
+        def fake_run_compose(inst_id, inst, action_args):
+            calls.append(list(action_args))
+            return 0
+
+        monkeypatch.setattr(direct_commands._helpers, "_run_compose", fake_run_compose)
+        monkeypatch.setattr(direct_commands._helpers, "_sync_compose_profiles",
+            lambda inst: None,
+        )
+
+        rc = direct_commands.cmd_rebuild(_args())
+        assert rc == 0
+        # Expect: build web, down, up -d
+        assert calls[0] == ["build", "web"]
+        assert calls[1] == ["down"]
+        assert calls[2] == ["up", "-d"]
+        assert len(calls) == 3
+
+    def test_no_cache_flag_passes_through(self, monkeypatch):
+        _patch_compose_inst(monkeypatch)
+        monkeypatch.setattr(direct_commands.rebuild, "_list_buildable_services",
+            lambda inst: ["web"],
+        )
+        calls = []
+        monkeypatch.setattr(direct_commands._helpers, "_run_compose",
+            lambda inst_id, inst, action_args: (calls.append(list(action_args)) or 0),
+        )
+        monkeypatch.setattr(direct_commands._helpers, "_sync_compose_profiles",
+            lambda inst: None,
+        )
+
+        direct_commands.cmd_rebuild(_args(no_cache=True))
+        assert calls[0] == ["build", "--no-cache", "web"]
+
+    def test_multiple_buildable_services_all_built(self, monkeypatch):
+        _patch_compose_inst(monkeypatch)
+        monkeypatch.setattr(direct_commands.rebuild, "_list_buildable_services",
+            lambda inst: ["web", "varnish-custom"],
+        )
+        calls = []
+        monkeypatch.setattr(direct_commands._helpers, "_run_compose",
+            lambda inst_id, inst, action_args: (calls.append(list(action_args)) or 0),
+        )
+        monkeypatch.setattr(direct_commands._helpers, "_sync_compose_profiles",
+            lambda inst: None,
+        )
+
+        direct_commands.cmd_rebuild(_args())
+        assert calls[0] == ["build", "web", "varnish-custom"]
+
+    def test_no_restart_skips_down_up(self, monkeypatch, capsys):
+        _patch_compose_inst(monkeypatch)
+        monkeypatch.setattr(direct_commands.rebuild, "_list_buildable_services",
+            lambda inst: ["web"],
+        )
+        calls = []
+        monkeypatch.setattr(direct_commands._helpers, "_run_compose",
+            lambda inst_id, inst, action_args: (calls.append(list(action_args)) or 0),
+        )
+
+        rc = direct_commands.cmd_rebuild(_args(no_restart=True))
+        assert rc == 0
+        assert calls == [["build", "web"]]
+        out = capsys.readouterr().out
+        assert "--no-restart" in out
+        assert "canasta restart" in out
+
+    def test_build_failure_skips_restart_and_returns_code(self, monkeypatch):
+        _patch_compose_inst(monkeypatch)
+        monkeypatch.setattr(direct_commands.rebuild, "_list_buildable_services",
+            lambda inst: ["web"],
+        )
+        calls = []
+
+        def fake_run_compose(inst_id, inst, action_args):
+            calls.append(list(action_args))
+            return 2 if action_args[0] == "build" else 0
+
+        monkeypatch.setattr(direct_commands._helpers, "_run_compose", fake_run_compose)
+        rc = direct_commands.cmd_rebuild(_args())
+        assert rc == 2
+        # Only the build call was attempted, no down/up
+        assert calls == [["build", "web"]]
+
+
+class TestListBuildableServices:
+    def test_extracts_services_with_build_directive(self, monkeypatch):
+        compose_json = {
+            "services": {
+                "web": {"build": {"context": ".", "dockerfile": "Dockerfile.custom"}},
+                "db": {"image": "mariadb:11.4"},
+                "varnish": {"image": "varnish:alpine"},
+                "extra": {"build": {"context": "./other"}},
+            }
+        }
+
+        def fake_subprocess_run(cmd, **kw):
+            class R:
+                returncode = 0
+                stdout = json.dumps(compose_json)
+                stderr = ""
+            return R()
+
+        monkeypatch.setattr(direct_commands._helpers, "_is_localhost", lambda h: True)
+        monkeypatch.setattr(direct_commands._helpers, "_compose_file_args",
+            lambda *a, **kw: ["-f", "docker-compose.yml"],
+        )
+        monkeypatch.setattr(direct_commands.rebuild.subprocess, "run", fake_subprocess_run)
+
+        result = direct_commands._list_buildable_services({
+            "path": "/srv/test",
+            "host": "localhost",
+            "devMode": False,
+        })
+        assert sorted(result) == ["extra", "web"]
+
+    def test_returns_empty_on_invalid_json(self, monkeypatch):
+        def fake_subprocess_run(cmd, **kw):
+            class R:
+                returncode = 0
+                stdout = "not json"
+                stderr = ""
+            return R()
+
+        monkeypatch.setattr(direct_commands._helpers, "_is_localhost", lambda h: True)
+        monkeypatch.setattr(direct_commands._helpers, "_compose_file_args",
+            lambda *a, **kw: [],
+        )
+        monkeypatch.setattr(direct_commands.rebuild.subprocess, "run", fake_subprocess_run)
+
+        result = direct_commands._list_buildable_services({
+            "path": "/srv/test",
+            "host": "localhost",
+            "devMode": False,
+        })
+        assert result == []
+
+    def test_returns_empty_on_compose_config_failure(self, monkeypatch, capsys):
+        def fake_subprocess_run(cmd, **kw):
+            class R:
+                returncode = 1
+                stdout = ""
+                stderr = "compose error"
+            return R()
+
+        monkeypatch.setattr(direct_commands._helpers, "_is_localhost", lambda h: True)
+        monkeypatch.setattr(direct_commands._helpers, "_compose_file_args",
+            lambda *a, **kw: [],
+        )
+        monkeypatch.setattr(direct_commands.rebuild.subprocess, "run", fake_subprocess_run)
+
+        result = direct_commands._list_buildable_services({
+            "path": "/srv/test",
+            "host": "localhost",
+            "devMode": False,
+        })
+        assert result == []
+        err = capsys.readouterr().err
+        assert "compose config failed" in err


### PR DESCRIPTION
## Summary
Add `canasta rebuild` — a Compose-only direct command that rebuilds every service with a `build:` directive in the merged compose config and restarts the instance, so operators don't have to drop to raw `docker compose build` when they add or edit a custom override.

## Motivation
`canasta upgrade` already auto-rebuilds buildable services when the configured image changes (#187, #563). What's missing is the standalone form: an operator adds a `Dockerfile.custom` + override after the instance is running, and wants to apply it now without bumping the base image.

## Behavior
- **Compose only.** K8s is rejected with a message pointing at the manual build-and-push + `canasta upgrade` workflow.
- **Detection:** runs `docker compose config --format json` to get the merged main + override + dev config, then filters to services with a `build:` directive. Covers operator overrides on any service, plus devmode's xdebug build.
- **No-op when nothing to rebuild:** prints a hint about adding a `build:` section to `docker-compose.override.yml` and exits 0.
- **Restart by default** so the running container actually picks up the rebuilt image. `--no-restart` skips that step.
- **`--no-cache`** is passed through to `docker compose build`.

## Test plan
- [x] `make test-unit` — 807/807 (11 new tests in `tests/unit/test_rebuild.py` covering K8s refusal, no-buildable-services no-op, default build-then-restart flow, `--no-cache` passthrough, multi-service rebuild, `--no-restart` short-circuit, build-failure-skips-restart, and the JSON-parsing helper)
- [x] `make validate`
- [x] CLI smoke: `./canasta-native rebuild -h` renders correctly
- [x] Local smoke of `_list_buildable_services` against a real `docker compose config --format json` invocation with a 2-service compose + 1-service override → correctly returns `['web']`

## Out of scope
- K8s rebuild support (requires registry push semantics; deserves its own design).

Refs #562.
