### PR TITLE
config: make domain/port/scheme changes durable under gitops

### DIFF
--- a/roles/config/tasks/_update_gitops_wiki_url.yml
+++ b/roles/config/tasks/_update_gitops_wiki_url.yml
@@ -1,0 +1,35 @@
+---
+# Propagate a single wiki's URL to the gitops vars.yaml under the
+# wiki_url_<id> placeholder that wikis.yaml.template references. A
+# domain/port change made via 'config set' rewrites config/wikis.yaml
+# (rendered) but not the template source; without this the next
+# 'config regenerate' / 'gitops pull' re-renders the old URL.
+# Input: _gw_wiki (dict with 'id' and 'url'), _config_host_raw, instance_path
+
+- name: Determine vars file path
+  ansible.builtin.set_fact:
+    _gw_vars_file: >-
+      {{ instance_path }}/hosts/{{ _config_host_raw.content | b64decode | trim }}/vars.yaml
+
+- name: Read current vars
+  ansible.builtin.slurp:
+    src: "{{ _gw_vars_file }}"
+  register: _gw_vars_raw
+
+- name: Update wiki_url value
+  ansible.builtin.set_fact:
+    _gw_updated_vars: >-
+      {{ (_gw_vars_raw.content | b64decode | from_yaml)
+         | combine({'wiki_url_' + _gw_wiki.id: _gw_wiki.url}) }}
+
+- name: Write updated vars.yaml
+  ansible.builtin.copy:
+    content: "{{ _gw_updated_vars | to_nice_yaml(indent=2) }}"
+    dest: "{{ _gw_vars_file }}"
+    mode: "0644"
+
+- name: Stage updated vars.yaml
+  ansible.builtin.command:
+    cmd: "git add {{ _gw_vars_file }}"
+    chdir: "{{ instance_path }}"
+  changed_when: true

--- a/roles/config/tasks/set.yml
+++ b/roles/config/tasks/set.yml
@@ -72,6 +72,46 @@
         loop_var: _config_setting
         label: "{{ _config_setting.split('=', 1)[0] }}"
 
+    # MW_SITE_FQDN / HTTP_PORT / HTTPS_PORT / CADDY_AUTO_HTTPS re-derive
+    # MW_SITE_FQDN/MW_SITE_SERVER and rewrite wiki URLs in the rendered
+    # .env and config/wikis.yaml via _side_effects.yml. Those derived
+    # values are not in the typed settings, so the loop above never
+    # propagates them; without this block the next 'config regenerate' /
+    # 'gitops pull' re-renders them back to the pre-change domain.
+    - name: Propagate domain side effects to gitops vars
+      when: >-
+        settings.split() | map('regex_replace', '=.*$', '') | list
+        | intersect(['MW_SITE_FQDN', 'HTTP_PORT', 'HTTPS_PORT', 'CADDY_AUTO_HTTPS'])
+        | length > 0
+      block:
+        - name: Read final .env for derived domain keys
+          canasta_env:
+            path: "{{ instance_path }}/.env"
+            state: read_all
+          register: _config_env_final
+
+        - name: Propagate derived MW_SITE_FQDN/MW_SITE_SERVER to vars.yaml
+          ansible.builtin.include_tasks: _update_gitops_var.yml
+          loop:
+            - "MW_SITE_FQDN={{ _config_env_final.variables.MW_SITE_FQDN | default('') }}"
+            - "MW_SITE_SERVER={{ _config_env_final.variables.MW_SITE_SERVER | default('') }}"
+          loop_control:
+            loop_var: _config_setting
+            label: "{{ _config_setting.split('=', 1)[0] }}"
+
+        - name: Read final wikis.yaml for URL propagation
+          canasta_wikis_yaml:
+            instance_path: "{{ instance_path }}"
+            state: read
+          register: _config_wikis_final
+
+        - name: Propagate wiki URLs to vars.yaml
+          ansible.builtin.include_tasks: _update_gitops_wiki_url.yml
+          loop: "{{ _config_wikis_final.wikis }}"
+          loop_control:
+            loop_var: _gw_wiki
+            label: "wiki_url_{{ _gw_wiki.id }}"
+
 - name: Regenerate Caddyfile after config change
   ansible.builtin.include_role:
     name: orchestrator

--- a/roles/gitops/vars/main.yml
+++ b/roles/gitops/vars/main.yml
@@ -11,6 +11,7 @@ gitops_placeholder_keys:
   - MW_SITE_FQDN
   - HTTPS_PORT
   - HTTP_PORT
+  - CADDY_AUTO_HTTPS
 
 # Keys whose name starts with any of these prefixes are treated as
 # credentials and get placeholders in env.template.

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -1359,6 +1359,90 @@ def test_config_set_gitops(inst):
     )
 
 
+def test_config_set_gitops_domain(inst):
+    """config set MW_SITE_FQDN must survive config regenerate under gitops.
+
+    The side effects of a domain change derive MW_SITE_FQDN/MW_SITE_SERVER
+    and rewrite wiki URLs in the rendered .env/config/wikis.yaml. Those
+    derived values must also be propagated to hosts/<host>/vars.yaml, or
+    the next 'config regenerate' re-renders the files from the templates
+    and silently reverts the change.
+    """
+    if shutil.which("git-crypt") is None:
+        raise SkipTest("git-crypt not installed")
+
+    import yaml
+
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir,
+        "-e", inst.env_file,
+    )
+
+    print("Creating bare git repository...")
+    bare_repo = os.path.join(inst.work_dir, "gitops-remote.git")
+    subprocess.run(
+        ["git", "init", "--bare", bare_repo],
+        capture_output=True, check=True,
+    )
+
+    key_file = os.path.join(inst.work_dir, "gitops-test.key")
+
+    print("Initializing gitops...")
+    inst.run_ok(
+        "gitops", "init", "-i", inst.id,
+        "-n", "testhost",
+        "--repo", bare_repo,
+        "--key", key_file,
+    )
+
+    new_domain = "wiki3.example.com"
+    print("Changing primary domain via config set...")
+    inst.run_ok(
+        "config", "set", "-i", inst.id,
+        "MW_SITE_FQDN=%s" % new_domain, "--no-restart",
+    )
+
+    print("Regenerating config from gitops source of truth...")
+    inst.run_ok("config", "regenerate", "-i", inst.id)
+
+    # After regenerate the rendered files are re-derived from vars.yaml /
+    # templates. If the config set change reached the gitops source of
+    # truth the new domain survives; otherwise it reverts to localhost.
+    inst_path = inst.instance_path()
+
+    print("Verifying config/wikis.yaml kept the new domain...")
+    with open(os.path.join(inst_path, "config", "wikis.yaml")) as f:
+        wikis = yaml.safe_load(f)["wikis"]
+    primary_url = wikis[0]["url"]
+    assert primary_url.startswith(new_domain), (
+        "wikis.yaml primary url reverted after regenerate: %s" % primary_url
+    )
+
+    print("Verifying Caddyfile kept the new domain...")
+    with open(os.path.join(inst_path, "config", "Caddyfile")) as f:
+        caddyfile = f.read()
+    assert new_domain in caddyfile, (
+        "Caddyfile reverted after regenerate (no %s):\n%s"
+        % (new_domain, caddyfile)
+    )
+
+    print("Verifying vars.yaml recorded the new domain...")
+    vars_file = os.path.join(inst_path, "hosts", "testhost", "vars.yaml")
+    with open(vars_file) as f:
+        vars_data = yaml.safe_load(f)
+    assert vars_data.get("mw_site_fqdn") == new_domain, (
+        "mw_site_fqdn not propagated to vars.yaml: %s" % vars_data
+    )
+    assert new_domain in (vars_data.get("mw_site_server") or ""), (
+        "mw_site_server not propagated to vars.yaml: %s" % vars_data
+    )
+    assert new_domain in (vars_data.get("wiki_url_main") or ""), (
+        "wiki_url_main not propagated to vars.yaml: %s" % vars_data
+    )
+
+
 def test_gitops_push_shared_vars(inst):
     """Verify gitops push auto-migrates shared credential keys (#206)."""
     if shutil.which("git-crypt") is None:
@@ -1779,6 +1863,7 @@ ALL_TESTS = {
     "sitemap": test_sitemap,
     "maintenance": test_maintenance,
     "config-set-gitops": test_config_set_gitops,
+    "config-set-gitops-domain": test_config_set_gitops_domain,
     "gitops-push-shared": test_gitops_push_shared_vars,
     "gitops-push-reporting": test_gitops_push_reporting,
     "backup-restore-safety": test_backup_restore_excludes_safety,


### PR DESCRIPTION
## Summary

Under a gitops-managed Compose instance, `canasta config set` changes that rely on **side effects** were not durable. `config set` only propagates the keys the user typed to `hosts/<host>/vars.yaml`; the side-effect cascade additionally re-derives `MW_SITE_FQDN` / `MW_SITE_SERVER` and rewrites wiki URLs, and those derived values landed only in the *rendered* `.env` / `config/wikis.yaml`. The next `canasta config regenerate` (or `gitops pull`) re-rendered from the templates and silently reverted the change.

This affected every key whose side effects rewrite wiki URLs and/or derive `MW_SITE_*`: `MW_SITE_FQDN`, `HTTP_PORT`, `HTTPS_PORT`, and `CADDY_AUTO_HTTPS` (the latter was also not a placeholder key, so its own value reverted too).

Fixes #575.

## Changes

- `roles/config/tasks/set.yml` — when a domain/port/scheme key is set on a gitops instance, propagate the derived `MW_SITE_FQDN`/`MW_SITE_SERVER` (from the final `.env`) and each changed wiki URL to `hosts/<host>/vars.yaml`.
- `roles/config/tasks/_update_gitops_wiki_url.yml` (new) — helper that writes a single wiki's URL into `vars.yaml` under its `wiki_url_<id>` placeholder.
- `roles/gitops/vars/main.yml` — add `CADDY_AUTO_HTTPS` to `gitops_placeholder_keys` so its value is durable. This makes `CADDY_AUTO_HTTPS` a per-host var, which is the intended behavior (a dev host can be http-only while prod is https).
- `tests/integration/run_tests.py` — new `config-set-gitops-domain` test.

## Testing

- New `config-set-gitops-domain` test: fails on the pre-fix code (`wikis.yaml primary url reverted after regenerate: localhost:NNNN`) and passes after the fix.
- Regressions: `config-set-gitops`, `config-side-effects` pass; 814 unit tests pass; `make lint` and `make validate` clean.

## Follow-up

The canasta.wiki "Changing the domain name" instructions need a separate correction (the non-gitops farm steps omit `config regenerate`, and there is no documented gitops procedure).
