### PR TITLE
Fall back to certifi when the interpreter has no system CA store

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -26,6 +26,54 @@ ANSIBLE_CFG = os.path.join(SCRIPT_DIR, "ansible.cfg")
 # Ensure Ansible uses the repo's config regardless of working directory
 os.environ.setdefault("ANSIBLE_CONFIG", ANSIBLE_CFG)
 
+
+def _ca_bundle_override(environ, verify_paths, path_exists, certifi_where):
+    """Decide whether to point SSL_CERT_FILE at certifi's CA bundle.
+
+    Returns the certifi bundle path when the interpreter has no usable
+    system CA store, or None to leave the environment untouched.
+
+    python.org's macOS Python ships without a working CA store, so the
+    venv's `ansible-galaxy` fails to verify TLS to galaxy.ansible.com with
+    CERTIFICATE_VERIFY_FAILED. We fall back to certifi, but only when:
+      * the user hasn't set SSL_CERT_FILE themselves (corporate CA / custom
+        trust store wins), and
+      * the interpreter has no usable system CA store — so Linux and
+        Homebrew Python, which verify against the OS trust store, are left
+        alone (avoids overriding a system store that trusts internal CAs).
+
+    `certifi_where` is passed in as a callable so the policy stays pure and
+    import-free for unit tests.
+    """
+    if environ.get("SSL_CERT_FILE"):
+        return None
+    cafile = verify_paths.cafile
+    capath = verify_paths.capath
+    if ( cafile and path_exists( cafile ) ) or ( capath and path_exists( capath ) ):
+        return None
+    return certifi_where()
+
+
+def _ensure_ca_bundle():
+    """Export SSL_CERT_FILE/REQUESTS_CA_BUNDLE for interpreters lacking a
+    system CA store (see _ca_bundle_override). No-op on Linux / when the
+    user configured their own bundle, and silently skipped if certifi isn't
+    installed yet (e.g. before the first dependency refresh)."""
+    try:
+        import ssl
+        import certifi
+    except ImportError:
+        return
+    override = _ca_bundle_override(
+        os.environ, ssl.get_default_verify_paths(), os.path.exists, certifi.where
+    )
+    if override:
+        os.environ["SSL_CERT_FILE"] = override
+        os.environ.setdefault("REQUESTS_CA_BUNDLE", override)
+
+
+_ensure_ca_bundle()
+
 # Commands that have subcommands (e.g., "config get" -> "config_get")
 SUBCOMMAND_GROUPS = {
     "config": ["get", "set", "unset", "regenerate"],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ansible-core>=2.15
 bcrypt>=4.0
+certifi>=2024.0
 kubernetes>=28.1.0
 pytest>=7.0
 pytest-mock>=3.0

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import types
 
 import pytest
 
@@ -1200,3 +1201,50 @@ class TestSelfUpdateCli:
         canasta_cli.self_update_cli()
         err = capsys.readouterr().err
         assert "could not fetch from origin" in err
+
+
+class TestCaBundleOverride:
+    """_ca_bundle_override falls back to certifi only when the interpreter
+    has no usable system CA store and the user hasn't set SSL_CERT_FILE."""
+
+    @staticmethod
+    def _paths(cafile=None, capath=None):
+        return types.SimpleNamespace(cafile=cafile, capath=capath)
+
+    def test_respects_user_set_ssl_cert_file(self):
+        # An explicit user value is never overridden, even with no system store.
+        result = canasta_cli._ca_bundle_override(
+            {"SSL_CERT_FILE": "/my/ca.pem"},
+            self._paths(cafile="/missing", capath="/missing"),
+            lambda p: False,
+            lambda: "/certifi/cacert.pem",
+        )
+        assert result is None
+
+    def test_skips_when_system_cafile_exists(self):
+        result = canasta_cli._ca_bundle_override(
+            {},
+            self._paths(cafile="/etc/ssl/cert.pem"),
+            lambda p: p == "/etc/ssl/cert.pem",
+            lambda: "/certifi/cacert.pem",
+        )
+        assert result is None
+
+    def test_skips_when_system_capath_exists(self):
+        result = canasta_cli._ca_bundle_override(
+            {},
+            self._paths(capath="/etc/ssl/certs"),
+            lambda p: p == "/etc/ssl/certs",
+            lambda: "/certifi/cacert.pem",
+        )
+        assert result is None
+
+    def test_falls_back_to_certifi_when_no_system_store(self):
+        # python.org macOS: verify paths point at files that don't exist.
+        result = canasta_cli._ca_bundle_override(
+            {},
+            self._paths(cafile="/missing/cert.pem", capath="/missing/certs"),
+            lambda p: False,
+            lambda: "/certifi/cacert.pem",
+        )
+        assert result == "/certifi/cacert.pem"


### PR DESCRIPTION
Fixes #583

## Problem

On macOS with python.org's Python, `canasta upgrade` fails the `ansible-galaxy` collection refresh with `CERTIFICATE_VERIFY_FAILED` — that interpreter ships no usable CA bundle, and `ansible-galaxy` verifies TLS via Python's `ssl` module (pip succeeds in the same flow because it uses its own vendored certs).

## Change

- Add `certifi` to `requirements.txt`.
- At CLI startup (`canasta.py` module load), default `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` to `certifi.where()` via the pure helper `_ca_bundle_override`, which only returns a bundle when:
  - the user hasn't set `SSL_CERT_FILE` (corporate CA / custom trust store wins), **and**
  - the interpreter has no usable system CA store (so Linux and Homebrew Python, which verify against the OS trust store, are left untouched — avoids overriding a system store that trusts internal CAs).
- Silently skipped if `certifi` isn't installed yet (before the first dependency refresh).

## Testing

- Unit tests for all four `_ca_bundle_override` branches (user-set wins; system cafile exists; system capath exists; no system store → certifi). `make test-unit` → 823 passed.

## Notes

- This is a macOS-dev-machine robustness fix; Linux controllers are unaffected (CI installs collections fine).
- Bootstrap caveat: the first `canasta upgrade` that pulls this still runs the *old* code for its own galaxy step, so the fix takes effect from the next invocation onward (and `certifi` lands via the same refresh's pip step).
