### PR TITLE
List subcommands for bare nested groups instead of erroring

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -785,6 +785,44 @@ def print_subcommand_help(group, data):
     print("Run 'canasta %s <subcommand> --help' for details." % group)
 
 
+def nested_group_for(command_name):
+    """If command_name names a bare nested group (e.g. 'backup_schedule' or
+    'storage_setup'), return (group, nested_group); otherwise None.
+
+    Lets the dispatcher treat a nested group invoked without a leaf
+    subcommand the same way it treats a bare top-level group — by listing
+    its subcommands rather than erroring with "Unknown command".
+    """
+    for group, nested_map in NESTED_SUBCOMMAND_GROUPS.items():
+        for nested_group in nested_map:
+            if command_name == "%s_%s" % (group, internal_name(nested_group)):
+                return (group, nested_group)
+    return None
+
+
+def print_nested_subcommand_help(group, nested_group, data):
+    """Print the subcommands of a nested group (e.g. 'backup schedule')."""
+    cmd_index = {c["name"]: c for c in data["commands"]}
+    subcmds = NESTED_SUBCOMMAND_GROUPS.get(group, {}).get(nested_group, [])
+    rows = []
+    for sub in subcmds:
+        internal = "%s_%s_%s" % (
+            group, internal_name(nested_group), internal_name(sub)
+        )
+        desc = cmd_index.get(internal, {}).get("description", "") or ""
+        rows.append((sub, desc))
+
+    width = max((len(r[0]) for r in rows), default=0)
+    print("Available '%s %s' subcommands:" % (group, nested_group))
+    for name, desc in rows:
+        print("  %-*s  %s" % (width, name, desc))
+    print("")
+    print(
+        "Run 'canasta %s %s <subcommand> --help' for details."
+        % (group, nested_group)
+    )
+
+
 def resolve_command_name(args):
     """Resolve the internal command name from parsed args."""
     cmd = args.command
@@ -1111,6 +1149,12 @@ def main():
         # list the subcommands with descriptions instead of erroring.
         if command_name in SUBCOMMAND_GROUPS:
             print_subcommand_help(command_name, data)
+            sys.exit(2)
+        # Same for a bare nested group (e.g. 'canasta backup schedule',
+        # 'canasta storage setup'): list its leaf subcommands.
+        nested = nested_group_for(command_name)
+        if nested:
+            print_nested_subcommand_help(nested[0], nested[1], data)
             sys.exit(2)
         print("Unknown command: %s" % command_name, file=sys.stderr)
         sys.exit(1)

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -1248,3 +1248,32 @@ class TestCaBundleOverride:
             lambda: "/certifi/cacert.pem",
         )
         assert result == "/certifi/cacert.pem"
+
+
+class TestNestedGroupHelp:
+    """A bare nested group (e.g. 'canasta backup schedule') lists its
+    subcommands instead of erroring with 'Unknown command'."""
+
+    def test_nested_group_for_backup_schedule(self):
+        assert canasta_cli.nested_group_for("backup_schedule") == (
+            "backup", "schedule"
+        )
+
+    def test_nested_group_for_storage_setup(self):
+        assert canasta_cli.nested_group_for("storage_setup") == (
+            "storage", "setup"
+        )
+
+    def test_nested_group_for_leaf_command_is_none(self):
+        # A real leaf command, not a nested group.
+        assert canasta_cli.nested_group_for("backup_list") is None
+
+    def test_nested_group_for_unknown_is_none(self):
+        assert canasta_cli.nested_group_for("not_a_group") is None
+
+    def test_print_nested_help_lists_subcommands(self, data, capsys):
+        canasta_cli.print_nested_subcommand_help("backup", "schedule", data)
+        out = capsys.readouterr().out
+        assert "backup schedule" in out
+        for sub in ("set", "list", "remove"):
+            assert sub in out


### PR DESCRIPTION
Fixes #585

## Problem

A nested subcommand group invoked without a leaf subcommand errored instead of listing its subcommands:

```
$ canasta backup schedule
Unknown command: backup_schedule
$ canasta storage setup
Unknown command: storage_setup
```

Bare top-level groups (`canasta gitops`, `canasta host`) already print their subcommands; the two nested groups (`backup schedule`, `storage setup`) didn't, because the group-help fallback only checked `SUBCOMMAND_GROUPS`.

## Change

- `nested_group_for(command_name)` — maps a bare nested-group name (`backup_schedule`, `storage_setup`) back to `(group, nested_group)`.
- `print_nested_subcommand_help(group, nested_group, data)` — lists the leaf subcommands with descriptions.
- Dispatcher: when a resolved command isn't a leaf and isn't a top-level group, check for a nested group and print its subcommands (exit 2), mirroring top-level behavior.

Now:

```
$ canasta backup schedule
Available 'backup schedule' subcommands:
  set     Set a recurring backup schedule
  list    Show the backup schedule
  remove  Remove a scheduled backup

Run 'canasta backup schedule <subcommand> --help' for details.

$ canasta storage setup
Available 'storage setup' subcommands:
  nfs  Set up NFS shared storage for Kubernetes
  efs  Set up AWS EFS shared storage for Kubernetes
```

## Testing

- New unit tests for `nested_group_for` (both nested groups, a leaf, an unknown) and `print_nested_subcommand_help`. `make test-unit` → 828 passed; `make validate` clean.
- Verified functionally for both nested groups.
