### PR TITLE
backup + config: validate RESTIC on Compose; warn on quoted/CRLF .env (#568)

### DIFF
--- a/direct_commands/__init__.py
+++ b/direct_commands/__init__.py
@@ -61,6 +61,7 @@ from ._helpers import (  # noqa: F401
     _hosts_yml_path,
     _is_localhost,
     _k8s_get_pod,
+    _lint_env_content,
     _make_detail,
     _normalize_script_args,
     _parse_env_entries,

--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -83,6 +83,32 @@ def _read_env_content(path, host):
     return content if rc == 0 else ""
 
 
+def _lint_env_content(content):
+    """Find .env hygiene problems that survive read-time quote-stripping but
+    reach `docker --env-file` literally: quoted values and CRLF endings.
+    Mirrors canasta_env.lint_env_file() in the Ansible module. Returns
+    (quoted_keys, has_crlf).
+    """
+    has_crlf = "\r" in content
+    quoted_keys = []
+    for line in content.split("\n"):
+        # Tolerate a trailing CR so key detection works on CRLF files.
+        stripped = line.rstrip("\r").strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        parts = stripped.split("=", 1)
+        if len(parts) != 2:
+            continue
+        key = parts[0].strip()
+        value = parts[1].strip()
+        if len(value) >= 2 and (
+            (value.startswith('"') and value.endswith('"'))
+            or (value.startswith("'") and value.endswith("'"))
+        ):
+            quoted_keys.append(key)
+    return quoted_keys, has_crlf
+
+
 def _parse_env_entries(content):
     """Parse .env content into ordered (key, value, is_comment) tuples.
 

--- a/direct_commands/config.py
+++ b/direct_commands/config.py
@@ -6,6 +6,27 @@ from . import _helpers
 from ._helpers import register
 
 
+def _warn_env_hygiene(quoted_keys, has_crlf):
+    """Print a one-line .env hygiene advisory to stderr (never stdout, so
+    `V=$(canasta config get KEY)` stays clean). Quoted values and CRLF are
+    stripped on read — so the value printed above looks correct — but
+    containers (docker --env-file) receive them literally."""
+    parts = []
+    if quoted_keys:
+        parts.append("quoted values (%s)" % ", ".join(quoted_keys))
+    if has_crlf:
+        parts.append("CRLF line endings")
+    if not parts:
+        return
+    print(
+        "Warning: .env has %s. Containers (docker --env-file) receive these "
+        "literally — the quotes / trailing CR become part of the value, "
+        "unlike what's shown above. Remove the quotes and use LF line endings."
+        % " and ".join(parts),
+        file=sys.stderr,
+    )
+
+
 @register("config_get")
 def cmd_config_get(args):
     inst_id, inst = _helpers._resolve_instance(args)
@@ -17,6 +38,13 @@ def cmd_config_get(args):
         print("No configuration found.", file=sys.stderr)
         return 1
 
+    # Lint the raw file so we can warn (to stderr) when a value the user is
+    # reading is quoted or the file is CRLF — those look fine here (stripped
+    # on read) but reach containers literally.
+    quoted_keys, has_crlf = _helpers._lint_env_content(
+        _helpers._read_env_content(path, host)
+    )
+
     # Positional 'keys' comes from argparse as a list when run through
     # canasta.py. For each explicitly requested key, print KEY=value or
     # a not-found message. With no keys, dump every setting, sorted.
@@ -27,8 +55,12 @@ def cmd_config_get(args):
                 print("%s=%s" % (k, env_vars[k]))
             else:
                 print("Key '%s' not found." % k)
+        # Scope the quoted-value warning to the keys actually requested;
+        # CRLF is file-level so it always applies to the value(s) shown.
+        _warn_env_hygiene([k for k in keys if k in quoted_keys], has_crlf)
         return 0
 
     for k in sorted(env_vars.keys()):
         print("%s=%s" % (k, env_vars[k]))
+    _warn_env_hygiene(quoted_keys, has_crlf)
     return 0

--- a/roles/common/library/canasta_env.py
+++ b/roles/common/library/canasta_env.py
@@ -25,7 +25,7 @@ options:
   state:
     description: Action to perform.
     type: str
-    choices: [read, read_all, set, unset]
+    choices: [read, read_all, set, unset, lint]
     default: read_all
   key:
     description: Environment variable name.
@@ -69,6 +69,39 @@ def parse_env_file(content):
             # Malformed line, preserve as-is
             entries.append((None, line, True))
     return entries
+
+
+def lint_env_file(content):
+    """Find .env hygiene problems that survive read-time quote-stripping but
+    reach `docker --env-file` literally.
+
+    parse_env_file() strips surrounding quotes when reading, so a value like
+    RESTIC_PASSWORD="secret" looks correct via `canasta config get` — but
+    Docker's --env-file does NOT strip quotes, so the container sees the
+    quotes (and any trailing CR from CRLF endings) as part of the value. For
+    restic that surfaces as an opaque "wrong password" / auth failure.
+
+    Returns (quoted_keys, has_crlf): the keys whose values are wrapped in
+    matching quotes, and whether the file uses CRLF line endings.
+    """
+    has_crlf = "\r" in content
+    quoted_keys = []
+    for line in content.split("\n"):
+        # Tolerate a trailing CR so key detection still works on CRLF files.
+        stripped = line.rstrip("\r").strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        parts = stripped.split("=", 1)
+        if len(parts) != 2:
+            continue
+        key = parts[0].strip()
+        value = parts[1].strip()
+        if len(value) >= 2 and (
+            (value.startswith('"') and value.endswith('"'))
+            or (value.startswith("'") and value.endswith("'"))
+        ):
+            quoted_keys.append(key)
+    return quoted_keys, has_crlf
 
 
 def entries_to_dict(entries):
@@ -119,7 +152,7 @@ def unset_variable(entries, key):
 def run_module():
     module_args = dict(
         path=dict(type="str", required=True),
-        state=dict(type="str", default="read_all", choices=["read", "read_all", "set", "unset"]),
+        state=dict(type="str", default="read_all", choices=["read", "read_all", "set", "unset", "lint"]),
         key=dict(type="str", required=False),
         value=dict(type="str", required=False),
         keys=dict(type="list", elements="str", required=False),
@@ -150,6 +183,11 @@ def run_module():
 
     if state == "read_all":
         result["variables"] = env_dict
+
+    elif state == "lint":
+        quoted_keys, has_crlf = lint_env_file(content)
+        result["quoted_keys"] = quoted_keys
+        result["has_crlf"] = has_crlf
 
     elif state == "read":
         if not key:

--- a/roles/config/tasks/set.yml
+++ b/roles/config/tasks/set.yml
@@ -12,6 +12,34 @@
     loop_var: _setting
     label: "{{ _setting.split('=', 1)[0] }}"
 
+# Surface pre-existing .env hygiene problems while the user is here. Quoted
+# values and CRLF endings are stripped on read (so `config get` looks fine)
+# but reach containers via docker --env-file literally — a common cause of
+# restic "wrong password" and similar. canasta_env's `set` writes clean
+# lines, so this only flags lines the user hasn't fixed.
+- name: Check .env for quoted or CRLF values
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: lint
+  register: _set_env_lint
+
+- name: Build .env hygiene warning
+  ansible.builtin.set_fact:
+    _set_env_warn: >-
+      {{ ([] if _set_env_lint.quoted_keys | length == 0
+           else ['quoted values (' + (_set_env_lint.quoted_keys | join(', ')) + ')'])
+         + ([] if not _set_env_lint.has_crlf else ['CRLF line endings']) }}
+
+- name: Warn about quoted or CRLF .env values
+  ansible.builtin.debug:
+    msg: >-
+      Warning: {{ instance_path }}/.env has {{ _set_env_warn | join(' and ') }}.
+      Containers (docker --env-file) receive these literally, unlike
+      'canasta config get' which strips them — a common cause of restic
+      'wrong password' or backend auth failures. Remove surrounding quotes
+      and use LF line endings.
+  when: _set_env_warn | length > 0
+
 # If the instance is gitops-managed, update vars.yaml so the change
 # survives the next gitops pull (which re-renders .env from template).
 - name: Check for gitops instance

--- a/roles/orchestrator/tasks/run_backup.yml
+++ b/roles/orchestrator/tasks/run_backup.yml
@@ -60,6 +60,52 @@
               is match('^/'))
              | ternary(_backup_repo_env.value, '') }}
 
+    - name: Read RESTIC_PASSWORD from .env
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read
+        key: RESTIC_PASSWORD
+      register: _backup_pw_env
+      no_log: true
+
+    # Fail fast with a clear message instead of letting restic emit an
+    # opaque error. Mirrors the Kubernetes path (k8s_run_backup.yml), so
+    # both orchestrators behave the same way. backup has no -r override —
+    # the repo always comes from .env — so requiring both here is safe.
+    - name: Fail if restic repository or password is not configured
+      ansible.builtin.fail:
+        msg: "RESTIC_REPOSITORY and RESTIC_PASSWORD must be set in .env."
+      when: >-
+        (_backup_repo_env.value | default('')) == ''
+        or (_backup_pw_env.value | default('')) == ''
+
+    # Quoted values and CRLF endings are stripped by canasta_env on read
+    # (so `canasta config get` looks fine) but pass through Docker's
+    # --env-file literally, a common cause of restic "wrong password".
+    # Surface it as an advisory rather than failing.
+    - name: Check .env for quoted or CRLF values
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: lint
+      register: _backup_env_lint
+
+    - name: Build .env hygiene warning
+      ansible.builtin.set_fact:
+        _backup_env_warn: >-
+          {{ ([] if _backup_env_lint.quoted_keys | length == 0
+               else ['quoted values (' + (_backup_env_lint.quoted_keys | join(', ')) + ')'])
+             + ([] if not _backup_env_lint.has_crlf else ['CRLF line endings']) }}
+
+    - name: Warn about quoted or CRLF .env values
+      ansible.builtin.debug:
+        msg: >-
+          Warning: {{ instance_path }}/.env has {{ _backup_env_warn | join(' and ') }}.
+          Docker --env-file passes these to restic literally (unlike
+          'canasta config get', which strips them) — a common cause of restic
+          'wrong password' or backend auth failures. Remove surrounding quotes
+          and use LF line endings.
+      when: _backup_env_warn | length > 0
+
     - name: Run restic container
       ansible.builtin.shell:
         cmd: |

--- a/tests/unit/test_canasta_env.py
+++ b/tests/unit/test_canasta_env.py
@@ -196,3 +196,46 @@ class TestRunModuleUnset:
         })
         assert not failed
         assert not result["changed"]
+
+
+class TestLintEnvFile:
+    def test_clean_file_has_no_issues(self):
+        assert canasta_env.lint_env_file("A=1\nB=2\n# c\n") == ([], False)
+
+    def test_double_quoted_value_flagged(self):
+        assert canasta_env.lint_env_file('PW="secret"\n') == (["PW"], False)
+
+    def test_single_quoted_value_flagged(self):
+        assert canasta_env.lint_env_file("PW='secret'\n") == (["PW"], False)
+
+    def test_unquoted_value_not_flagged(self):
+        assert canasta_env.lint_env_file("PW=secret\n") == ([], False)
+
+    def test_crlf_detected(self):
+        quoted, crlf = canasta_env.lint_env_file("A=1\r\nB=2\r\n")
+        assert quoted == [] and crlf is True
+
+    def test_quoted_and_crlf_together(self):
+        # The trailing CR must not defeat quote detection.
+        quoted, crlf = canasta_env.lint_env_file('PW="x"\r\nA=1\r\n')
+        assert quoted == ["PW"] and crlf is True
+
+    def test_comments_and_blanks_ignored(self):
+        assert canasta_env.lint_env_file('# PW="x"\n\nA=1\n') == ([], False)
+
+    def test_multiple_quoted_keys(self):
+        assert canasta_env.lint_env_file('A="1"\nB=2\nC=\'3\'\n') == (
+            ["A", "C"], False
+        )
+
+
+class TestRunModuleLint:
+    def test_lint_flags_quoted_values(self, sample_env_file):
+        result, failed, _ = run_module_with_params(canasta_env, {
+            "path": sample_env_file, "state": "lint",
+            "key": None, "value": None, "keys": None,
+        })
+        assert not failed
+        assert "QUOTED_VALUE" in result["quoted_keys"]
+        assert "MW_SITE_NAME" in result["quoted_keys"]
+        assert result["has_crlf"] is False

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -3203,3 +3203,41 @@ class TestDockerHostPropagation:
             "remote cmd should be unmodified when DOCKER_HOST unset; "
             "got %r" % remote_cmd
         )
+
+
+class TestLintEnvContent:
+    """_lint_env_content flags quoted values / CRLF that survive read-time
+    stripping but reach docker --env-file literally."""
+
+    def test_clean(self):
+        assert direct_commands._lint_env_content("A=1\nB=2\n# c\n") == (
+            [], False
+        )
+
+    def test_double_quoted(self):
+        assert direct_commands._lint_env_content('PW="x"\n') == (["PW"], False)
+
+    def test_single_quoted(self):
+        assert direct_commands._lint_env_content("PW='x'\n") == (["PW"], False)
+
+    def test_unquoted_not_flagged(self):
+        assert direct_commands._lint_env_content("PW=x\n") == ([], False)
+
+    def test_crlf(self):
+        assert direct_commands._lint_env_content("A=1\r\n") == ([], True)
+
+    def test_quoted_and_crlf(self):
+        # Trailing CR must not defeat quote detection.
+        assert direct_commands._lint_env_content('PW="x"\r\nA=1\r\n') == (
+            ["PW"], True
+        )
+
+    def test_comments_and_blanks_ignored(self):
+        assert direct_commands._lint_env_content('# PW="x"\n\nA=1\n') == (
+            [], False
+        )
+
+    def test_multiple_quoted_keys(self):
+        assert direct_commands._lint_env_content('A="1"\nB=2\nC=\'3\'\n') == (
+            ["A", "C"], False
+        )


### PR DESCRIPTION
Fixes #568

## 1. Fail-fast RESTIC validation on Compose

The Compose backup path ran `restic` without checking that `RESTIC_REPOSITORY` / `RESTIC_PASSWORD` are set, so a misconfigured `.env` surfaced only as an opaque restic error. The Kubernetes path already fails fast (`k8s_run_backup.yml`). Add the same check to the Compose branch of `run_backup.yml` — the single exec point for *every* restic op (create/check/list/restore/purge/init) — failing with the same message:

```
RESTIC_REPOSITORY and RESTIC_PASSWORD must be set in .env.
```

Backup has no `-r` override (the repo always comes from `.env`), so requiring both is safe.

## 2. Warn on quoted / CRLF .env values — at backup *and* config

`canasta_env` strips surrounding quotes and tolerates CRLF on read, so `canasta config get RESTIC_PASSWORD` looks correct — but Docker's `--env-file` passes the quotes and any trailing `\r` to restic **literally**, a common cause of `Fatal: wrong password or no key found`. This is invisible to normal debugging.

Detection lives in two mirrored helpers (the Ansible module and the direct-command path each have their own `.env` parsing):
- `canasta_env` `state: lint` / `lint_env_file()`
- `direct_commands._lint_env_content()`

Consumers:
- **Compose backup** (`run_backup.yml`): advisory via `debug` before restic runs (the only channel the `canasta_minimal` callback surfaces — `module.warn()` would be swallowed).
- **`config get`** (direct Python): prints the value to **stdout** and the advisory to **stderr**, so `V=$(canasta config get KEY)` stays clean. The quoted-value warning is **scoped to the keys requested**; CRLF is file-level.
- **`config set`** (`set.yml`): advisory via `debug` after the set loop.

`doctor` was considered and rejected — it's host-dependency scoped (`-H`, tooling presence), with no instance `.env`. The quote-stripping on *read* is intentional and unchanged.

## Testing

- `lint_env_file` / `_lint_env_content` unit tests (quoted single/double, unquoted, CRLF, quoted+CRLF, comments/blanks, multiple keys) + a `state: lint` module test. `make test-unit` → 845 passed; `make validate` + YAML lint clean.
- End-to-end check of `config get`: value on stdout, advisory on stderr, and no warning when the requested key is clean.
