### PR TITLE
Fix canasta install crash resolving operator user without gather_facts

### DIFF
--- a/roles/install/tasks/canasta.yml
+++ b/roles/install/tasks/canasta.yml
@@ -131,13 +131,24 @@
         dest: /usr/local/bin/canasta
         state: link
 
-    # ansible_user is the SSH user we connected as; ansible_user_id is
-    # the local-run fallback. Either way, this is the user who will be
-    # invoking 'canasta upgrade' / 'canasta install' on the target, so
-    # they're the one who needs canasta-group membership.
-    - name: Determine operator user
+    # Determine the operator (SSH) user who will invoke canasta on the
+    # target — they're the one who needs canasta-group membership.
+    # ansible_user (if set in inventory) wins; otherwise read it with
+    # `id -un` run WITHOUT become, so we capture the connecting SSH user
+    # rather than root. The dispatcher play is gather_facts: false (so
+    # ansible_user_id is unavailable here) and this block is become: true
+    # (so the fact would resolve to 'root' anyway) — hence the explicit
+    # pre-become lookup.
+    - name: Determine operator (SSH) user
+      ansible.builtin.command: id -un
+      become: false
+      changed_when: false
+      register: _operator_user_cmd
+
+    - name: Set operator user fact
       ansible.builtin.set_fact:
-        _operator_user: "{{ ansible_user | default(ansible_user_id) }}"
+        _operator_user: >-
+          {{ ansible_user | default(_operator_user_cmd.stdout, true) }}
 
     - name: Add operator to the canasta group
       ansible.builtin.user:

--- a/roles/install/tasks/docker.yml
+++ b/roles/install/tasks/docker.yml
@@ -3,9 +3,20 @@
 # Supports Debian/Ubuntu (apt) and RHEL/CentOS/Fedora (dnf).
 # Idempotent — skips if Docker is already installed and running.
 
-- name: Capture real username before become
+# Capture the operator (SSH) user who will run docker — read with
+# `id -un` WITHOUT become so we get the connecting user on the target,
+# not root and not the controller's `$USER` (which would be wrong for a
+# remote `-H` install). ansible_user wins if set in inventory.
+- name: Determine operator (SSH) user
+  ansible.builtin.command: id -un
+  become: false
+  changed_when: false
+  register: _install_user_cmd
+
+- name: Set install user fact
   ansible.builtin.set_fact:
-    _install_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+    _install_user: >-
+      {{ ansible_user | default(_install_user_cmd.stdout, true) }}
 
 - name: Warn on unsupported platforms
   ansible.builtin.fail:


### PR DESCRIPTION
Fixes #588.

The install tasks determined the operator/install user from `ansible_user_id`, a gathered fact. The dispatcher play runs with `gather_facts: false`, so the fact is undefined and `canasta install` crashed with `'ansible_user_id' is undefined` whenever `ansible_user` was not set in inventory (e.g. the SSH user comes from SSH-config `User`). The install block is also `become: true`, so the fact would resolve to `root` rather than the operator user who needs `canasta`-group membership.

This reads the operator (SSH) user with `id -un` run with `become: false`, in both `canasta.yml` and `docker.yml`. `docker.yml` previously fell back to `lookup('env', 'USER')` — the **controller's** username — which is wrong for a remote `-H` install (it would add/create the controller's user on the target).

## Testing
- `make lint` and `make validate` pass (68 commands, 50 playbooks).
- Confirmed `id -un` over an SSH connection returns the operator user (not `root`) when run without become.
- Not re-run end-to-end on a fresh host (available targets already had canasta installed); the change is a direct swap of the user-detection source within the existing tasks.
