### PR TITLE
Preflight host canasta + absolute path in scheduled-backup cron

### DIFF
--- a/roles/backup/tasks/schedule_set.yml
+++ b/roles/backup/tasks/schedule_set.yml
@@ -11,12 +11,35 @@
 - name: Set backup schedule (Compose)
   when: instance_orchestrator | default('compose') == 'compose'
   block:
+    # The host crontab runs 'canasta backup create' on this host, so a
+    # runnable 'canasta' must exist here. Any flavor satisfies it
+    # (canasta-native or canasta-docker) — we only check that the command
+    # runs. Also, cron's PATH is minimal (typically /usr/bin:/bin) and
+    # usually excludes /usr/local/bin where canasta lives, so we resolve
+    # the absolute path now and bake it into the crontab.
+    - name: Resolve canasta executable on the host
+      ansible.builtin.shell: command -v canasta
+      register: _host_canasta
+      changed_when: false
+      failed_when: false
+
+    - name: Require a runnable canasta on the host for scheduled backups
+      ansible.builtin.fail:
+        msg: >-
+          Scheduled backups run 'canasta backup create' on this host via
+          crontab, but no 'canasta' executable was found here. Install it
+          first — 'canasta install canasta -H <host>' (or install
+          canasta-docker) — then re-run 'canasta backup schedule set'.
+      when: _host_canasta.rc != 0 or (_host_canasta.stdout | trim) == ''
+
     - name: Build backup command for cron
       ansible.builtin.set_fact:
-        _cron_base: "canasta backup create -i {{ instance_id }} --tag scheduled"
+        _cron_base: >-
+          {{ _host_canasta.stdout | trim }} backup create
+          -i {{ instance_id }} --tag scheduled
         _cron_purge: >-
           {{ (purge_older_than is defined and purge_older_than != '')
-             | ternary('&& canasta backup purge -i ' + instance_id + ' --keep-within ' + (purge_older_than | default('')), '') }}
+             | ternary('&& ' + (_host_canasta.stdout | trim) + ' backup purge -i ' + instance_id + ' --keep-within ' + (purge_older_than | default('')), '') }}
         _cron_log: '>> "{{ instance_path }}/backup.log" 2>&1'
 
     - name: Assemble cron command


### PR DESCRIPTION
Fixes #590.

`canasta backup schedule set` (Compose) writes a host crontab running `canasta backup create` on the host, but didn't verify canasta exists there and called it by bare name — so scheduled backups could silently fail (no canasta on the host, or cron's minimal PATH not finding `/usr/local/bin/canasta`).

This resolves a runnable `canasta` on the host with `command -v` (any flavor — canasta-native or canasta-docker), fails with actionable guidance if none is found, and bakes the resolved absolute path into the crontab for both the create and purge commands. Kubernetes is unaffected (its scheduled backups run as an in-cluster CronJob with no host dependency).

## Testing
- `make lint` and `make validate` pass.
- Confirmed `command -v canasta` on a host with canasta installed returns its absolute path; `command -v` exits non-zero when absent, which drives the new fail-with-guidance task.
- `schedule list`/`remove` unaffected — they match the substring `canasta backup create -i <id> `, still present in the absolute-path command.
