### PR TITLE
Report runnable canasta on the host in canasta doctor

### DIFF
--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -30,7 +30,8 @@ uname -s 2>/dev/null || echo unknown; echo "$D"
 python3 -c "import os; mem=os.sysconf('SC_PAGE_SIZE')*os.sysconf('SC_PHYS_PAGES')//(1024**3); print(str(mem)+' GB')" 2>/dev/null || echo unknown; echo "$D"
 df -h / | awk 'NR==2{print $4}' 2>/dev/null || echo unknown; echo "$D"
 cat /proc/sys/net/ipv4/ip_unprivileged_port_start 2>/dev/null || echo unknown; echo "$D"
-runtime="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"; for sock in "$runtime/podman/podman.sock" "$runtime/docker.sock"; do if [ -S "$sock" ]; then echo "unix://$sock"; exit 0; fi; done; echo ""
+runtime="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"; _sock=""; for s in "$runtime/podman/podman.sock" "$runtime/docker.sock"; do if [ -S "$s" ]; then _sock="unix://$s"; break; fi; done; echo "$_sock"; echo "$D"
+command -v canasta >/dev/null 2>&1 && { canasta version >/dev/null 2>&1 && echo OK || echo BROKEN; } || echo MISSING
 """
 
 
@@ -59,6 +60,9 @@ def _parse_doctor(stdout, hostname):
     disk = p(15) if len(parts) > 15 else "unknown"
     unpriv_port_start = p(16) if len(parts) > 16 else "unknown"
     rootless_sock = p(17) if len(parts) > 17 else ""
+    # canasta probe is appended after rootless (index 18) so adding it
+    # didn't shift the existing positional indices above.
+    host_canasta = p(18) if len(parts) > 18 else "MISSING"
 
     lines = [
         "Canasta Dependency Check (%s)" % hostname,
@@ -135,6 +139,15 @@ def _parse_doctor(stdout, hostname):
         "OK" if crontab == "OK"
         else "not installed (install cron to use canasta backup schedule "
              "on Compose; K8s uses an in-cluster CronJob instead)"))
+    # Scheduled backups run `canasta backup create` on the host via the
+    # crontab, so a runnable canasta must exist there (any flavor —
+    # native or docker). BROKEN = the command exists but doesn't run.
+    lines.append("  canasta on host: %s" % (
+        "OK" if host_canasta == "OK"
+        else "installed but not runnable" if host_canasta == "BROKEN"
+        else "not installed (scheduled backups run 'canasta backup create' "
+             "on the host; install with 'canasta install canasta -H <host>' "
+             "or canasta-docker)"))
 
     lines.append("")
     lines.append("System:")

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2244,6 +2244,26 @@ class TestDoctor:
         assert "crontab:         OK" in result
         assert "www-data group:  OK (member)" in result
 
+    def test_parse_doctor_reports_host_canasta(self):
+        d = direct_commands._SENTINEL
+        # 18 base parts (through the rootless socket at index 17); the
+        # canasta probe is appended at index 18.
+        base = [
+            "Python 3.12.0", "Docker version 27.0.0",
+            "Docker Compose version v2.30.0", "OK",
+            "user docker www-data", "OK", "v3.15.0", "k3s version v1.30.0",
+            "REACHABLE", "INSTALLED", "git version 2.45.0", "OK", "OK",
+            "Linux", "16 GB", "50G", "1024", "",
+        ]
+        for value, expected in [
+            ("OK", "canasta on host: OK"),
+            ("BROKEN", "canasta on host: installed but not runnable"),
+            ("MISSING", "canasta on host: not installed"),
+        ]:
+            stdout = ("\n" + d + "\n").join(base + [value]) + "\n"
+            result = direct_commands._parse_doctor(stdout, "myhost")
+            assert expected in result
+
     def test_parse_doctor_missing_deps(self):
         d = direct_commands._SENTINEL
         parts = [


### PR DESCRIPTION
Fixes #592. Follow-up to #591.

`canasta doctor` now reports whether canasta is runnable on the host, in the "Scheduled backups, Compose only" section — relevant because scheduled backups on Compose run `canasta backup create` on the host. The check is functional (`command -v canasta` + `canasta version`), so any flavor (canasta-native or canasta-docker) counts; it reports OK / installed-but-not-runnable / not-installed.

The probe is appended after the rootless-socket probe so the existing positional parser indices are unchanged. The rootless probe's early `exit 0` is replaced with a break + variable so the appended canasta probe still runs when a rootless socket is present.

## Testing
- New `test_parse_doctor_reports_host_canasta` covers OK / BROKEN / MISSING.
- `make test-unit` (846 passed), `make lint`, `make validate` all pass.
