### PR TITLE
Stub canasta on the remote integration test host (fixes #591 CI regression)

### DIFF
--- a/tests/integration/remote/Dockerfile
+++ b/tests/integration/remote/Dockerfile
@@ -41,6 +41,15 @@ RUN mkdir /run/sshd \
 RUN mkdir -p /etc/canasta \
     && chown testuser:testuser /etc/canasta
 
+# Stub 'canasta' on PATH. 'canasta backup schedule set' preflights that a
+# runnable canasta exists on the host (scheduled backups run 'canasta
+# backup create' there via crontab) and bakes its absolute path into the
+# cron entry. The schedule tests only verify the crontab is written and
+# read back, not that a backup runs, so a no-op stub satisfies the
+# preflight without installing the full CLI on the test host.
+RUN printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/canasta \
+    && chmod 0755 /usr/local/bin/canasta
+
 EXPOSE 22
 
 CMD ["/usr/sbin/sshd", "-D", "-e"]


### PR DESCRIPTION
Fixes #594. Regression from #591.

#591's `canasta backup schedule set` preflight requires a runnable `canasta` on the host. The remote integration test's sshd container has cron but no canasta, so Tests 4 & 5 fail. Those tests only verify the crontab is written and read back (no backup is run), so this adds a no-op `canasta` stub on the test container's PATH.

## Testing
- Built the test image and confirmed `command -v canasta` resolves `/usr/local/bin/canasta` in a non-interactive sh context (both root and testuser) — matching how the Ansible preflight probes it.
