### PR TITLE
status/doctor: detect the instance from any subdirectory

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -507,8 +507,10 @@ def resolve_instance(instance_id=None):
         inst["id"] = instance_id
         return inst
 
-    # Walk up from cwd to find a matching instance path
-    search = os.path.abspath(os.getcwd())
+    # Walk up from cwd to find a matching instance path. Honor
+    # CANASTA_HOST_PWD (the dockerized CLI passes the host's working
+    # directory there) before falling back to the process cwd.
+    search = os.path.abspath(os.environ.get("CANASTA_HOST_PWD") or os.getcwd())
     while True:
         for iid, inst in instances.items():
             if os.path.abspath(inst.get("path", "")) == search:

--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -70,6 +70,34 @@ def _resolve_instance(args):
     return inst["id"], inst
 
 
+def _resolve_instance_by_cwd(args):
+    """Resolve (id, inst) from --id, else by walking UP from the working
+    directory to a registered instance path.
+
+    Honors CANASTA_HOST_PWD (the dockerized CLI passes the host's working
+    directory there) before os.getcwd(), and walks up parent directories so
+    the instance is detected from any subdirectory — not just its top level.
+    Returns (None, None) on no match so callers can emit their own error
+    message, unlike canasta.resolve_instance() which exits. Shared by
+    `status`, `doctor`, and `version` so they detect instances identically.
+    """
+    inst_id = getattr(args, "id", None)
+    conf_path = os.path.join(_get_config_dir(), "conf.json")
+    instances = _read_registry(conf_path)
+    if inst_id:
+        return (inst_id, instances.get(inst_id))
+    search = os.path.abspath(os.environ.get("CANASTA_HOST_PWD") or os.getcwd())
+    while True:
+        for iid, inst in instances.items():
+            if os.path.abspath(inst.get("path", "")) == search:
+                return (iid, inst)
+        parent = os.path.dirname(search)
+        if parent == search:
+            break
+        search = parent
+    return (None, None)
+
+
 def _read_env_content(path, host):
     """Read raw .env file content. Returns '' if missing or unreadable."""
     env_path = os.path.join(path, ".env")

--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -199,14 +199,9 @@ def cmd_doctor(args):
                 return 1
             host = instances[inst_id].get("host") or "localhost"
         else:
-            cwd = os.path.abspath(
-                os.environ.get("CANASTA_HOST_PWD") or os.getcwd()
-            )
-            for inst in instances.values():
-                p = inst.get("path", "")
-                if p and os.path.abspath(p) == cwd:
-                    host = inst.get("host") or "localhost"
-                    break
+            _, inst = _helpers._resolve_instance_by_cwd(args)
+            if inst:
+                host = inst.get("host") or "localhost"
     script = _DOCTOR_SCRIPT % {"delim": _helpers._SENTINEL}
 
     if not host or host == "localhost":

--- a/direct_commands/info.py
+++ b/direct_commands/info.py
@@ -254,20 +254,15 @@ def cmd_version(args):
 
     # No -i: try cwd resolution. If inside an instance directory,
     # give the same full-fidelity report as -i.
+    iid, inst = _helpers._resolve_instance_by_cwd(args)
+    if inst:
+        image, running = _read_instance_image(iid, inst)
+        print("Instance '%s': %s (running: %s)" % (iid, image, running))
+        return 0
+
     config_dir = _helpers._get_config_dir()
     conf_path = os.path.join(config_dir, "conf.json")
     instances = _helpers._read_registry(conf_path)
-    cwd = os.path.abspath(os.getcwd())
-    while True:
-        for iid, inst in instances.items():
-            if os.path.abspath(inst.get("path", "")) == cwd:
-                image, running = _read_instance_image(iid, inst)
-                print("Instance '%s': %s (running: %s)" % (iid, image, running))
-                return 0
-        parent = os.path.dirname(cwd)
-        if parent == cwd:
-            break
-        cwd = parent
 
     # Outside any instance directory: list every registered instance
     # with its pinned CANASTA_IMAGE tag only (no docker-compose-exec
@@ -287,22 +282,12 @@ def cmd_version(args):
     return 0
 
 def _resolve_status_instance(args):
-    """Pick the instance the user wants status for.
-
-    Same dispatch as `canasta delete`: --id wins; if absent, look up
-    by current working directory against the registry's `path` field.
-    Returns (id, instance_dict) or (None, None) on no match.
+    """Pick the instance the user wants status for: --id wins, otherwise
+    detect it from the working directory, walking up parent dirs so it
+    works from any subdirectory. Returns (id, instance_dict) or
+    (None, None) on no match. See _helpers._resolve_instance_by_cwd.
     """
-    inst_id = getattr(args, "id", None)
-    conf_path = os.path.join(_helpers._get_config_dir(), "conf.json")
-    instances = _helpers._read_registry(conf_path)
-    if inst_id:
-        return (inst_id, instances.get(inst_id))
-    cwd = os.environ.get("CANASTA_HOST_PWD") or os.getcwd()
-    for k, v in instances.items():
-        if v.get("path") == cwd:
-            return (k, v)
-    return (None, None)
+    return _helpers._resolve_instance_by_cwd(args)
 
 
 def _kubectl_section(host, ns, cmd_args, label):

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -3261,3 +3261,52 @@ class TestLintEnvContent:
         assert direct_commands._lint_env_content('A="1"\nB=2\nC=\'3\'\n') == (
             ["A", "C"], False
         )
+
+
+class TestResolveInstanceByCwd:
+    """#596: status/doctor/version must detect the instance from any
+    subdirectory (walking up parent dirs), honoring CANASTA_HOST_PWD."""
+
+    @staticmethod
+    def _args(instance_id=None):
+        import types
+        return types.SimpleNamespace(id=instance_id)
+
+    def test_top_level_dir(self, registry, monkeypatch):
+        _, data = registry
+        path = data["Instances"]["siteA"]["path"]
+        monkeypatch.setenv("CANASTA_HOST_PWD", path)
+        iid, inst = direct_commands._helpers._resolve_instance_by_cwd(self._args())
+        assert iid == "siteA"
+        assert inst["path"] == path
+
+    def test_subdirectory_walks_up(self, registry, monkeypatch):
+        _, data = registry
+        sub = os.path.join(data["Instances"]["siteA"]["path"], "config")
+        monkeypatch.setenv("CANASTA_HOST_PWD", sub)
+        iid, _inst = direct_commands._helpers._resolve_instance_by_cwd(self._args())
+        assert iid == "siteA"
+
+    def test_deeper_subdirectory_walks_up(self, registry, monkeypatch):
+        _, data = registry
+        deep = os.path.join(
+            data["Instances"]["siteB"]["path"], "config", "settings"
+        )
+        os.makedirs(deep, exist_ok=True)
+        monkeypatch.setenv("CANASTA_HOST_PWD", deep)
+        iid, _inst = direct_commands._helpers._resolve_instance_by_cwd(self._args())
+        assert iid == "siteB"
+
+    def test_no_match_returns_none(self, registry, monkeypatch):
+        monkeypatch.setenv("CANASTA_HOST_PWD", "/")
+        assert direct_commands._helpers._resolve_instance_by_cwd(
+            self._args()
+        ) == (None, None)
+
+    def test_explicit_id_wins(self, registry, monkeypatch):
+        monkeypatch.setenv("CANASTA_HOST_PWD", "/nowhere")
+        iid, inst = direct_commands._helpers._resolve_instance_by_cwd(
+            self._args("siteB")
+        )
+        assert iid == "siteB"
+        assert inst is not None


### PR DESCRIPTION
## Problem

`canasta status` and `canasta doctor` only detected the current instance when run from its **top-level directory**. From a subdirectory they failed (`status` prints *"no instance found for the current directory; pass --id explicitly."*) while other instance-aware commands worked fine — because they matched the working directory against registry paths with an **exact comparison and no parent-directory walk-up**. `version` worked, but via its own duplicate walk-up loop.

Full analysis in #596.

## Fix

Consolidate the three onto one shared resolver, `_helpers._resolve_instance_by_cwd()`, which:
- honors `CANASTA_HOST_PWD` (the dockerized CLI's host working dir) then falls back to `os.getcwd()`,
- **walks up parent directories**, so the instance is detected from any subdirectory, and
- returns `(None, None)` on no match so callers keep their own error handling (unlike `canasta.resolve_instance()`, which exits).

`status`, `doctor`, and `version` now share it. `canasta.resolve_instance()` also learns to honor `CANASTA_HOST_PWD`, so the shared walk-up works under the Docker CLI too.

## Tests

- New `TestResolveInstanceByCwd`: top-level dir, subdirectory walk-up, deeper subdirectory, no-match, and explicit `--id` wins.
- `make test-unit`: **851 passed**. `make validate`: passed.

Fixes #596
