### PR TITLE
backup: scheduled purge on Compose uses --older-than, not --keep-within

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1530,10 +1530,11 @@ commands:
     long_description: |
       Remove backup snapshots that exceed the specified retention
       policy and reclaim disk space. At least one retention flag
-      (`--older-than` or `--keep-last`) is required.
+      (e.g. `--keep-within` or `--keep-last`) is required. The
+      retention flags mirror restic's `forget` options.
     examples:
       - "canasta backup purge --keep-last 5"
-      - "canasta backup purge --older-than 30d"
+      - "canasta backup purge --keep-within 30d"
     playbook: backup_purge.yml
     parameters:
       - name: id
@@ -1549,12 +1550,21 @@ commands:
       - name: keep_daily
         type: string
         description: "Number of daily backups to keep"
+      - name: keep_weekly
+        type: string
+        description: "Number of weekly backups to keep"
       - name: keep_monthly
         type: string
         description: "Number of monthly backups to keep"
-      - name: older_than
+      - name: keep_yearly
         type: string
-        description: "Purge backups older than this (e.g. 30d, 6m)"
+        description: "Number of yearly backups to keep"
+      - name: keep_within
+        type: string
+        description: "Keep all backups made within this duration (e.g. 30d, 6m)"
+      - name: keep_tag
+        type: string
+        description: "Keep backups that have this tag"
 
   - name: backup_schedule_set
     description: "Set a recurring backup schedule"

--- a/roles/backup/tasks/purge.yml
+++ b/roles/backup/tasks/purge.yml
@@ -27,17 +27,35 @@
       {{ _purge_list + ['--keep-daily', keep_daily] }}
   when: keep_daily is defined and keep_daily != ''
 
+- name: Add keep-weekly
+  ansible.builtin.set_fact:
+    _purge_list: >-
+      {{ _purge_list + ['--keep-weekly', keep_weekly] }}
+  when: keep_weekly is defined and keep_weekly != ''
+
 - name: Add keep-monthly
   ansible.builtin.set_fact:
     _purge_list: >-
       {{ _purge_list + ['--keep-monthly', keep_monthly] }}
   when: keep_monthly is defined and keep_monthly != ''
 
+- name: Add keep-yearly
+  ansible.builtin.set_fact:
+    _purge_list: >-
+      {{ _purge_list + ['--keep-yearly', keep_yearly] }}
+  when: keep_yearly is defined and keep_yearly != ''
+
 - name: Add keep-within
   ansible.builtin.set_fact:
     _purge_list: >-
-      {{ _purge_list + ['--keep-within', older_than] }}
-  when: older_than is defined and older_than != ''
+      {{ _purge_list + ['--keep-within', keep_within] }}
+  when: keep_within is defined and keep_within != ''
+
+- name: Add keep-tag
+  ansible.builtin.set_fact:
+    _purge_list: >-
+      {{ _purge_list + ['--keep-tag', keep_tag] }}
+  when: keep_tag is defined and keep_tag != ''
 
 - name: Purge old backups
   ansible.builtin.include_tasks: >-

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -873,7 +873,7 @@ def test_backup_advanced(inst):
     print("Purging older snapshots (keep last 1)...")
     inst.run_ok(
         "backup", "purge", "-i", inst.id,
-        "--older-than", "1h",
+        "--keep-within", "1h",
     )
 
     print("Verifying at least one snapshot remains after purge...")

--- a/tests/unit/test_backup_schedule_compose.py
+++ b/tests/unit/test_backup_schedule_compose.py
@@ -1,0 +1,75 @@
+"""Regression test for the Compose backup-schedule purge flag.
+
+The original bug: schedule_set.yml generated a host cron calling
+`canasta backup purge --keep-within <dur>`, but `canasta backup purge`
+did not accept `--keep-within` (it had a canasta-specific `--older-than`
+instead). Every scheduled purge failed and snapshots accumulated even
+though `create` succeeded.
+
+The fix made `canasta backup purge` mirror restic's `forget` flags
+(including `--keep-within`). These tests guard the invariant directly:
+the flag the schedule generates must be one the purge command accepts.
+
+Pure YAML-structure parsing, mirroring test_backup_schedule_k8s.py.
+"""
+
+import os
+import re
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+SCHEDULE_SET = os.path.join(
+    REPO_ROOT, "roles", "backup", "tasks", "schedule_set.yml",
+)
+COMMAND_DEFS = os.path.join(REPO_ROOT, "meta", "command_definitions.yml")
+
+
+def _walk_tasks(tasks):
+    """Yield every task dict, descending into block/rescue/always."""
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk_tasks(t[nested])
+
+
+def _compose_purge_flag():
+    """The retention flag in the Compose `_cron_purge` template."""
+    with open(SCHEDULE_SET) as f:
+        tasks = yaml.safe_load(f)
+    for task in _walk_tasks(tasks):
+        sf = task.get("ansible.builtin.set_fact") or task.get("set_fact")
+        if isinstance(sf, dict) and "_cron_purge" in sf:
+            m = re.search(r"backup purge\b.*?(--[a-z-]+)", sf["_cron_purge"])
+            assert m, "no purge flag found in _cron_purge template"
+            return m.group(1)
+    raise AssertionError("schedule_set.yml has no _cron_purge set_fact")
+
+
+def _purge_accepted_flags():
+    """Flags accepted by `canasta backup purge`, per command_definitions."""
+    with open(COMMAND_DEFS) as f:
+        defs = yaml.safe_load(f)
+    for cmd in defs.get("commands", []):
+        if cmd.get("name") == "backup_purge":
+            return {
+                "--" + p["name"].replace("_", "-")
+                for p in cmd.get("parameters", [])
+            }
+    raise AssertionError("backup_purge not found in command_definitions.yml")
+
+
+class TestComposeSchedulePurgeFlag:
+    def test_schedule_purge_flag_is_accepted_by_purge(self):
+        flag = _compose_purge_flag()
+        accepted = _purge_accepted_flags()
+        assert flag in accepted, (
+            f"schedule generates `canasta backup purge {flag}` but purge "
+            f"only accepts {sorted(accepted)}"
+        )
+
+    def test_schedule_uses_restic_native_keep_within(self):
+        assert _compose_purge_flag() == "--keep-within"


### PR DESCRIPTION
## Problem

`canasta backup schedule set --purge-older-than <dur>` generates, on **Compose**, a host cron that runs `canasta backup purge --keep-within <dur>`. But `canasta backup purge` did **not** accept `--keep-within` — it exposed a canasta-specific `--older-than` instead (restic's flag, renamed). So every scheduled purge failed (`unrecognized arguments: --keep-within`) and snapshots accumulated indefinitely, even though `create` succeeded. (K8s was unaffected — it chains `restic forget --keep-within` directly.)

## Fix

Make `canasta backup purge` **mirror restic's `forget` retention flags** instead of inventing its own:

- **Add** `--keep-within`, `--keep-weekly`, `--keep-yearly`, `--keep-tag` (joining the existing `--keep-last` / `--keep-hourly` / `--keep-daily` / `--keep-monthly`, which already match restic).
- **Remove** the canasta-specific `--older-than` (superseded by `--keep-within`).

This fixes the bug at the root — the Compose schedule already generated `--keep-within`, which `purge` now accepts — and unifies the Compose and K8s purge paths on restic's native flag. `schedule set --purge-older-than` is unchanged (it stays the schedule-level convenience flag and generates `--keep-within`).

Adds `tests/unit/test_backup_schedule_compose.py`, which cross-checks that the flag the schedule generates is one `purge` actually accepts (the exact bug class). Updates the integration test. **853 unit tests pass.**

Fixes #600
