### PR TITLE
Detect and harden against missing canasta-group membership (#610)

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -215,12 +215,21 @@ def self_update_cli():
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
             OSError) as e:
         # `e.stderr` is bytes/None on TimeoutExpired/OSError — guard.
-        detail = getattr(e, "stderr", "") or str(e)
-        print(
-            "Warning: could not fetch from origin (%s); "
-            "skipping self-update check." % detail.strip(),
-            file=sys.stderr,
+        detail = (getattr(e, "stderr", "") or str(e)).strip()
+        msg = (
+            "WARNING: self-update skipped — could not fetch from origin "
+            "(%s).\nThe CLI was NOT updated; this run uses the existing "
+            "version (%s, %s)." % (detail, current_version, current_commit)
         )
+        if "ermission denied" in detail:
+            msg += (
+                "\nThe install dir (%s) is not writable by you — you are "
+                "likely not in the 'canasta' group. Fix with:\n"
+                "  sudo usermod -aG canasta $(id -un)\n"
+                "then log out and back in (or run 'newgrp canasta') and "
+                "re-run." % repo
+            )
+        print(msg, file=sys.stderr)
         return
 
     pending = _git(["log", "HEAD..origin/main", "--oneline"], timeout=10)

--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -31,7 +31,8 @@ python3 -c "import os; mem=os.sysconf('SC_PAGE_SIZE')*os.sysconf('SC_PHYS_PAGES'
 df -h / | awk 'NR==2{print $4}' 2>/dev/null || echo unknown; echo "$D"
 cat /proc/sys/net/ipv4/ip_unprivileged_port_start 2>/dev/null || echo unknown; echo "$D"
 runtime="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"; _sock=""; for s in "$runtime/podman/podman.sock" "$runtime/docker.sock"; do if [ -S "$s" ]; then _sock="unix://$s"; break; fi; done; echo "$_sock"; echo "$D"
-command -v canasta >/dev/null 2>&1 && { canasta version >/dev/null 2>&1 && echo OK || echo BROKEN; } || echo MISSING
+command -v canasta >/dev/null 2>&1 && { canasta version >/dev/null 2>&1 && echo OK || echo BROKEN; } || echo MISSING; echo "$D"
+cdir="$(dirname "$(readlink -f "$(command -v canasta 2>/dev/null)" 2>/dev/null)" 2>/dev/null)"; if [ -n "$cdir" ] && [ -d "$cdir/.git" ]; then { [ -w "$cdir/.git" ] && echo WRITABLE || echo NOT_WRITABLE; } else echo NA; fi
 """
 
 
@@ -63,6 +64,9 @@ def _parse_doctor(stdout, hostname):
     # canasta probe is appended after rootless (index 18) so adding it
     # didn't shift the existing positional indices above.
     host_canasta = p(18) if len(parts) > 18 else "MISSING"
+    # Writability of the native install dir's .git — the precondition for
+    # `canasta upgrade`'s self-update (git fetch). NA on docker installs.
+    selfupdate = p(19) if len(parts) > 19 else "NA"
 
     lines = [
         "Canasta Dependency Check (%s)" % hostname,
@@ -168,12 +172,35 @@ def _parse_doctor(stdout, hostname):
                 "sudo usermod -aG www-data $USER (then log out and back in, "
                 "or start a new shell, for the change to take effect)"
             )
+        canasta_member = "canasta" in groups.split()
+        if canasta_member:
+            lines.append("  canasta group:   OK (member)")
+        else:
+            lines.append(
+                "  canasta group:   NOT A MEMBER — 'canasta upgrade' "
+                "self-updates by writing the install dir; without membership "
+                "the git fetch is skipped and the CLI silently stays on the "
+                "old version. Add with: sudo usermod -aG canasta $USER "
+                "(then log out and back in)"
+            )
     else:
         os_label = host_os if host_os and host_os != "unknown" else "this OS"
         lines.append(
             "  www-data group:  N/A (Docker Desktop handles UID mapping on %s)"
             % os_label
         )
+
+    # Direct self-update precondition: can the operator write the native
+    # install dir's .git? NA on docker installs / no native canasta.
+    if selfupdate == "NOT_WRITABLE":
+        lines.append(
+            "  Self-update:     BLOCKED — the canasta install dir's .git is "
+            "not writable by you, so 'canasta upgrade' silently skips the "
+            "self-update and the CLI stays on the old version (see "
+            "'canasta group' above)"
+        )
+    elif selfupdate == "WRITABLE":
+        lines.append("  Self-update:     OK (install dir writable)")
 
     return "\n".join(lines)
 

--- a/roles/install/tasks/canasta.yml
+++ b/roles/install/tasks/canasta.yml
@@ -150,6 +150,20 @@
         _operator_user: >-
           {{ ansible_user | default(_operator_user_cmd.stdout, true) }}
 
+    # Operator resolution should not normally fail (id -un above), but if
+    # it does, warn loudly instead of silently skipping — an empty
+    # 'canasta' group means 'canasta upgrade' self-update is skipped and
+    # the CLI silently stays on the old version.
+    - name: Warn loudly if the operator user could not be resolved
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: could not determine the operator (SSH) user, so nobody
+          was added to the 'canasta' group. Whoever runs 'canasta' on this
+          host MUST be a member, or 'canasta upgrade' self-update is
+          silently skipped. Add them manually: sudo usermod -aG canasta
+          <user> (then log out and back in, or run 'newgrp canasta').
+      when: _operator_user | length == 0
+
     - name: Add operator to the canasta group
       ansible.builtin.user:
         name: "{{ _operator_user }}"
@@ -162,12 +176,21 @@
       ansible.builtin.debug:
         msg: "canasta-native installed at /opt/canasta-ansible."
 
-    - name: Report operator group membership
+    # Always report the membership outcome (not only when changed), so a
+    # no-op never looks like a silent failure.
+    - name: Report operator added to canasta group
       ansible.builtin.debug:
         msg: >-
           Added '{{ _operator_user }}' to the 'canasta' group. New SSH
-          sessions on this host will pick this up automatically. If
-          you have an existing shell on this host, log out and back in
-          (or run 'newgrp canasta') before invoking 'canasta upgrade'
-          or 'canasta install'.
+          sessions on this host pick this up automatically. For an existing
+          shell, log out and back in (or run 'newgrp canasta') before
+          invoking 'canasta upgrade' or 'canasta install'.
       when: _operator_group_add is changed
+
+    - name: Report operator already in canasta group
+      ansible.builtin.debug:
+        msg: >-
+          Operator '{{ _operator_user }}' is already in the 'canasta' group.
+      when:
+        - _operator_user | length > 0
+        - _operator_group_add is not changed

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -1241,6 +1241,32 @@ class TestSelfUpdateCli:
         err = capsys.readouterr().err
         assert "could not fetch from origin" in err
 
+    def test_fetch_permission_denied_gives_remediation(
+        self, monkeypatch, tmp_path, capsys,
+    ):
+        """A permission-denied fetch (operator not in the canasta group)
+        surfaces loudly with the usermod remediation, not a quiet skip."""
+        self._patch_repo(monkeypatch, tmp_path)
+        first = [type("R", (), {
+            "returncode": 0, "stdout": "abc1234\n", "stderr": "",
+        })()]
+
+        def runner(argv, **kwargs):
+            if "fetch" in argv and kwargs.get("check"):
+                raise _subprocess.CalledProcessError(
+                    128, argv, output="",
+                    stderr="error: cannot open '.git/FETCH_HEAD': "
+                           "Permission denied",
+                )
+            return first.pop(0)
+
+        monkeypatch.setattr(_subprocess, "run", runner)
+        canasta_cli.self_update_cli()
+        err = capsys.readouterr().err
+        assert "self-update skipped" in err
+        assert "NOT updated" in err
+        assert "usermod -aG canasta" in err
+
 
 class TestCaBundleOverride:
     """_ca_bundle_override falls back to certifi only when the interpreter

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2264,6 +2264,34 @@ class TestDoctor:
             result = direct_commands._parse_doctor(stdout, "myhost")
             assert expected in result
 
+    # 20 parts: through the canasta probe (18) + self-update writability (19).
+    @staticmethod
+    def _doctor_parts(groups, writable):
+        return [
+            "Python 3.12.0", "Docker version 27.0.0",
+            "Docker Compose version v2.30.0", "OK",
+            groups, "OK", "v3.15.0", "k3s version v1.30.0",
+            "REACHABLE", "INSTALLED", "git version 2.45.0", "OK", "OK",
+            "Linux", "16 GB", "50G", "1024", "", "OK", writable,
+        ]
+
+    def test_parse_doctor_canasta_group_member(self):
+        d = direct_commands._SENTINEL
+        parts = self._doctor_parts("user docker www-data canasta", "WRITABLE")
+        result = direct_commands._parse_doctor(
+            ("\n" + d + "\n").join(parts) + "\n", "myhost")
+        assert "canasta group:   OK (member)" in result
+        assert "Self-update:     OK (install dir writable)" in result
+
+    def test_parse_doctor_not_in_canasta_group_flags_self_update(self):
+        d = direct_commands._SENTINEL
+        parts = self._doctor_parts("user docker www-data", "NOT_WRITABLE")
+        result = direct_commands._parse_doctor(
+            ("\n" + d + "\n").join(parts) + "\n", "myhost")
+        assert "canasta group:   NOT A MEMBER" in result
+        assert "usermod -aG canasta" in result
+        assert "Self-update:     BLOCKED" in result
+
     def test_parse_doctor_missing_deps(self):
         d = direct_commands._SENTINEL
         parts = [

--- a/tests/unit/test_install_group_membership.py
+++ b/tests/unit/test_install_group_membership.py
@@ -1,0 +1,59 @@
+"""Regression tests for the install canasta-group membership hardening.
+
+An empty operator resolution must not silently skip the group-add — that
+left a host's 'canasta' group with no members, so `canasta upgrade`'s
+self-update was silently skipped. install must warn when the operator
+can't be resolved, and must always report the membership outcome (not only
+when it changed).
+
+Pure YAML-structure parsing.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+INSTALL_CANASTA = os.path.join(
+    REPO_ROOT, "roles", "install", "tasks", "canasta.yml",
+)
+
+
+def _walk_tasks(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk_tasks(t[nested])
+
+
+def _tasks():
+    with open(INSTALL_CANASTA) as f:
+        return list(_walk_tasks(yaml.safe_load(f)))
+
+
+def _whens(task):
+    w = task.get("when")
+    if w is None:
+        return []
+    return w if isinstance(w, list) else [w]
+
+
+class TestInstallGroupHardening:
+    def test_warns_when_operator_unresolved(self):
+        # A task must fire specifically when the operator is empty — the
+        # group-add must not be the only handling of that case.
+        assert any(
+            any("_operator_user | length == 0" in str(c) for c in _whens(t))
+            for t in _tasks()
+        ), "install must warn (not silently skip) when operator is empty"
+
+    def test_reports_membership_even_when_unchanged(self):
+        # The membership outcome is reported even on a no-op, not only
+        # `when: _operator_group_add is changed`.
+        assert any(
+            any("is not changed" in str(c) for c in _whens(t))
+            for t in _tasks()
+        ), "install must report membership even when already a member"


### PR DESCRIPTION
Closes #610.

### Problem
A native install whose operator user isn't in the `canasta` group can't write the install dir, so `canasta upgrade`'s self-update silently skips (`git fetch` fails: `cannot open '.git/FETCH_HEAD': Permission denied`) while the run still prints success, leaving the CLI on the old version. The operator-resolution bug that produced empty membership was already fixed in #589; this adds detection and defense-in-depth.

### Fix
- **doctor:** report `canasta` group membership (alongside `www-data`) plus a direct self-update precondition check (install dir `.git` writability), with the `usermod -aG canasta` remediation.
- **install:** warn loudly instead of silently skipping the group-add when the operator can't be resolved, and always report the membership outcome (added / already a member).
- **self_update_cli:** when the fetch fails, say loudly the CLI was NOT updated and which version it stayed on; on a permission error, point at `canasta`-group membership with the `usermod` fix.

### Tests
- `test_direct_commands.py::TestDoctor` — the `canasta`-group + self-update lines in both states.
- `test_canasta_cli.py::TestSelfUpdateCli::test_fetch_permission_denied_gives_remediation`.
- `tests/unit/test_install_group_membership.py` — warn-on-empty and always-report invariants.

### Release
No version bump here — deferred until after the CrowdSec feature lands.
