### PR TITLE
upgrade: deliver managed docker-compose.yml changes to existing instances

### DIFF
--- a/roles/orchestrator/tasks/write_stack_files.yml
+++ b/roles/orchestrator/tasks/write_stack_files.yml
@@ -1,8 +1,11 @@
 ---
 # Copy stack files to the instance directory.
 # Dispatches to Compose or Kubernetes based on instance_orchestrator.
-# No-clobber: only creates files that don't already exist.
-# Input: instance_path, instance_orchestrator
+# The managed docker-compose.yml is force-refreshed when stack_files_force
+# is set (upgrade), so compose changes (e.g. a new crowdsec service) reach
+# instances created on an older version. All other files are no-clobber to
+# preserve operator-owned content (override, scripts, logstash configs).
+# Input: instance_path, instance_orchestrator, stack_files_force (bool)
 
 - name: Write Compose stack files
   when: instance_orchestrator | default('compose') == 'compose'
@@ -15,8 +18,9 @@
       ansible.builtin.copy:
         src: "{{ role_path }}/files/compose/docker-compose.yml"
         dest: "{{ instance_path }}/docker-compose.yml"
-        force: false
+        force: "{{ stack_files_force | default(false) | bool }}"
         mode: "0644"
+      register: _compose_stack_copy
 
     - name: Copy docker-compose.override.yml.example
       ansible.builtin.copy:

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -84,10 +84,15 @@
         - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
 
 # --- Refresh config ---
-- name: Refresh stack files (no-clobber)
+# Force-refresh the managed docker-compose.yml so compose changes (e.g. a
+# newly added crowdsec service) reach instances created on an older
+# version. User-adjacent files stay no-clobber inside write_stack_files.
+- name: Refresh stack files (force-refresh managed compose)
   ansible.builtin.include_role:
     name: orchestrator
     tasks_from: write_stack_files.yml
+  vars:
+    stack_files_force: true
 
 - name: Initialize orchestrator config
   ansible.builtin.include_role:
@@ -273,8 +278,16 @@
     - _images_updated | bool
     - (_buildable_services | default([]) | length) > 0
 
+# A compose-only change (e.g. gaining the crowdsec service) must also
+# trigger a recreate, not just an image bump.
+- name: Decide whether a restart is needed
+  ansible.builtin.set_fact:
+    _restart_needed: >-
+      {{ (_images_updated | bool)
+         or (_compose_stack_copy is defined and _compose_stack_copy is changed) }}
+
 - name: Restart containers
-  when: _images_updated | bool
+  when: _restart_needed | bool
   block:
     - name: Report restarting
       ansible.builtin.debug:
@@ -304,4 +317,4 @@
 - name: Report already up to date
   ansible.builtin.debug:
     msg: "Already up to date — no restart needed."
-  when: not (_images_updated | bool)
+  when: not (_restart_needed | bool)

--- a/tests/unit/test_upgrade_refresh_compose.py
+++ b/tests/unit/test_upgrade_refresh_compose.py
@@ -1,0 +1,104 @@
+"""Guards for canasta upgrade refreshing the managed compose on existing
+instances and recreating when only the compose changed.
+
+write_stack_files is otherwise no-clobber, so a pre-existing instance never
+received compose changes (e.g. a new crowdsec service behind a profile) on
+upgrade, and the recreate only fired on an image bump. The fix makes the
+managed docker-compose.yml force-refreshable via stack_files_force (upgrade
+passes true) and registered, and makes upgrade recreate when the compose
+changed, not just on an image change.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+WRITE_STACK = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "write_stack_files.yml"
+)
+UPGRADE_MAIN = os.path.join(
+    REPO_ROOT, "roles", "upgrade", "tasks", "main.yml"
+)
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _iter_tasks(tasks):
+    """Yield every task, descending into block: wrappers."""
+    for t in tasks:
+        yield t
+        if isinstance(t, dict) and "block" in t:
+            yield from _iter_tasks(t["block"])
+
+
+def _find(tasks, name_substring):
+    for t in _iter_tasks(tasks):
+        if isinstance(t, dict) and name_substring in t.get("name", ""):
+            return t
+    return None
+
+
+class TestWriteStackFilesForceRefresh:
+    def test_compose_copy_force_is_parameterized(self):
+        copy = _find(_load(WRITE_STACK), "Copy docker-compose.yml")
+        assert copy is not None
+        force = copy["ansible.builtin.copy"]["force"]
+        assert "stack_files_force" in str(force), (
+            "docker-compose.yml must be force-refreshable via "
+            "stack_files_force so upgrade can deliver compose changes to "
+            "existing instances, not hardcoded force: false"
+        )
+
+    def test_compose_copy_is_registered(self):
+        copy = _find(_load(WRITE_STACK), "Copy docker-compose.yml")
+        assert copy.get("register") == "_compose_stack_copy", (
+            "the docker-compose.yml copy must register its result so "
+            "upgrade can detect a compose change and recreate"
+        )
+
+    def test_operator_adjacent_files_stay_no_clobber(self):
+        override = _find(
+            _load(WRITE_STACK), "Copy docker-compose.override.yml.example"
+        )
+        assert override["ansible.builtin.copy"]["force"] in (False, "false"), (
+            "override example must stay no-clobber to preserve operator content"
+        )
+
+
+class TestUpgradeRefreshesAndRecreatesOnComposeChange:
+    def test_upgrade_passes_stack_files_force_true(self):
+        refresh = _find(_load(UPGRADE_MAIN), "Refresh stack files")
+        assert refresh is not None
+        assert refresh.get("vars", {}).get("stack_files_force") is True, (
+            "upgrade must pass stack_files_force: true so the managed "
+            "docker-compose.yml is refreshed on existing instances"
+        )
+
+    def test_restart_decision_accounts_for_compose_change(self):
+        decide = _find(_load(UPGRADE_MAIN), "Decide whether a restart is needed")
+        assert decide is not None, (
+            "upgrade must compute a restart decision covering a compose-only "
+            "change, not only an image bump"
+        )
+        expr = str(decide["ansible.builtin.set_fact"]["_restart_needed"])
+        assert "_images_updated" in expr and "_compose_stack_copy" in expr, (
+            "_restart_needed must be true on an image bump OR a compose change"
+        )
+
+    def test_restart_gated_on_restart_needed(self):
+        restart = _find(_load(UPGRADE_MAIN), "Restart containers")
+        assert "_restart_needed" in str(restart.get("when", "")), (
+            "Restart must fire on _restart_needed so a compose-only change "
+            "recreates the containers"
+        )
+
+    def test_already_up_to_date_gated_on_restart_needed(self):
+        uptodate = _find(_load(UPGRADE_MAIN), "Report already up to date")
+        assert "_restart_needed" in str(uptodate.get("when", "")), (
+            "'Already up to date' must key off _restart_needed so a compose "
+            "change isn't reported as a no-op"
+        )


### PR DESCRIPTION
Fixes #614.

## Summary

`canasta upgrade` never delivered managed `docker-compose.yml` changes to existing instances: `write_stack_files` copied it `force: false` (no-clobber), and upgrade only recreated containers on an image bump. So a managed-compose change (e.g. a new service behind a profile) reached new instances but never existing ones.

## Changes

- `write_stack_files.yml`: the managed `docker-compose.yml` copy is now force-refreshable via `stack_files_force` (default `false`, so create stays no-clobber) and registers its result. The override example stays no-clobber.
- `upgrade/tasks/main.yml`: passes `stack_files_force: true` when refreshing stack files, and recreates containers when the image updated **or** the compose changed (`_restart_needed`), reporting "already up to date" only when neither did.
- `tests/unit/test_upgrade_refresh_compose.py`: covers the force parameterization, registration, the restart decision, and that operator-adjacent files stay no-clobber.

## Testing

`make test-unit` — full suite green. `make lint` clean.
