### PR TITLE
Capture custom Dockerfile and build context in backups

### DIFF
--- a/roles/backup/tasks/create.yml
+++ b/roles/backup/tasks/create.yml
@@ -101,6 +101,13 @@
   loop_control:
     label: "{{ item.item }}"
 
+- name: Discover custom Docker build inputs
+  ansible.builtin.include_tasks: discover_build_paths.yml
+
+- name: Add custom build inputs to staging
+  ansible.builtin.set_fact:
+    _backup_volumes: "{{ _backup_volumes | combine(_build_staging_map) }}"
+
 # --host pins restic's host to the instance id, so every snapshot of this
 # instance shares a stable host. Without it, restic records the host as the
 # ephemeral restic container's random id (different every run), so it never

--- a/roles/backup/tasks/discover_build_paths.yml
+++ b/roles/backup/tasks/discover_build_paths.yml
@@ -17,6 +17,14 @@
 #     (the rest of the context is already covered by the standard dirs).
 #   - context is a subdirectory          -> stage that whole directory; the
 #     Dockerfile lives inside it, so it is captured too.
+#
+# Limitation: with an instance-directory context, only the Dockerfile is
+# captured. A Dockerfile that COPYs additional files from the instance root
+# (e.g. COPY scripts/foo.sh ...) will not have those sources backed up unless
+# they already live under a standard dir. Staging the whole instance directory
+# is not an option - it is the entire instance (.git, generated compose files,
+# logs), which the allowlist exists to exclude. Builds that COPY files should
+# use a dedicated subdirectory as the build context, which is captured in full.
 
 - name: Initialize build staging map
   ansible.builtin.set_fact:

--- a/roles/backup/tasks/discover_build_paths.yml
+++ b/roles/backup/tasks/discover_build_paths.yml
@@ -1,0 +1,60 @@
+---
+# Discover the custom Docker build inputs (Dockerfile + build context)
+# referenced by docker-compose.override.yml, so a backup captures everything
+# needed to rebuild a custom image on restore. Without this, a backup keeps
+# the override that declares `build:` but not the Dockerfile/context it points
+# at, and a restore onto a fresh host fails to start.
+#
+# Compose-only: K8s custom images are pushed to the in-cluster registry rather
+# than built from a local context, so there is nothing on disk to capture.
+#
+# Output: _build_staging_map - dict of {host_path: '/currentsnapshot/<rel>'},
+#         ready to combine into a backup volume map. Empty when the instance
+#         has no buildable services.
+#
+# For each buildable service:
+#   - context is the instance directory  -> stage the Dockerfile file itself
+#     (the rest of the context is already covered by the standard dirs).
+#   - context is a subdirectory          -> stage that whole directory; the
+#     Dockerfile lives inside it, so it is captured too.
+
+- name: Initialize build staging map
+  ansible.builtin.set_fact:
+    _build_staging_map: {}
+
+- name: Discover custom build inputs (Compose)
+  when: instance_orchestrator | default('compose') == 'compose'
+  block:
+    - name: Render merged compose config as JSON
+      ansible.builtin.command:
+        cmd: "docker compose config --format json"
+        chdir: "{{ instance_path }}"
+      register: _build_compose_config
+      changed_when: false
+
+    # `docker compose config` resolves build.context to an absolute path and
+    # leaves build.dockerfile as a filename relative to that context.
+    - name: Collect build context and Dockerfile paths
+      ansible.builtin.set_fact:
+        _build_staging_paths: >-
+          {{ _build_staging_paths | default([])
+             + [ (_ctx == _instance_dir)
+                 | ternary(
+                     _instance_dir ~ '/' ~ (item.value.build.dockerfile | default('Dockerfile')),
+                     _ctx) ] }}
+      vars:
+        _instance_dir: "{{ instance_path | regex_replace('/$', '') }}"
+        _ctx: "{{ item.value.build.context | regex_replace('/$', '') }}"
+      loop: "{{ (_build_compose_config.stdout | from_json).services | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
+      when: item.value.build is defined
+
+    - name: Build staging map from discovered paths
+      ansible.builtin.set_fact:
+        _build_staging_map: >-
+          {{ _build_staging_map | combine(
+               {item: '/currentsnapshot/' ~ (item | relpath(instance_path))}) }}
+      loop: "{{ _build_staging_paths | default([]) | unique }}"
+      loop_control:
+        label: "{{ item }}"

--- a/roles/backup/tasks/discover_build_paths.yml
+++ b/roles/backup/tasks/discover_build_paths.yml
@@ -12,11 +12,15 @@
 #         ready to combine into a backup volume map. Empty when the instance
 #         has no buildable services.
 #
-# For each buildable service:
-#   - context is the instance directory  -> stage the Dockerfile file itself
-#     (the rest of the context is already covered by the standard dirs).
-#   - context is a subdirectory          -> stage that whole directory; the
-#     Dockerfile lives inside it, so it is captured too.
+# Each build input is reduced to its TOP-LEVEL component under the instance
+# directory before staging, so a backup stages and a restore replaces at the
+# same granularity (a whole top-level entry):
+#   - context is the instance directory      -> the Dockerfile's top-level
+#     component (the Dockerfile itself when it sits at the instance root).
+#   - context is, or sits under, a subdir    -> that top-level directory.
+# Staging a nested path on its own would put a partial directory in the
+# snapshot, and the wholesale restore would then delete that directory's
+# unstaged siblings.
 #
 # Limitation: with an instance-directory context, only the Dockerfile is
 # captured. A Dockerfile that COPYs additional files from the instance root
@@ -26,43 +30,88 @@
 # logs), which the allowlist exists to exclude. Builds that COPY files should
 # use a dedicated subdirectory as the build context, which is captured in full.
 
-- name: Initialize build staging map
+- name: Initialize build staging facts
   ansible.builtin.set_fact:
     _build_staging_map: {}
+    _build_staging_paths: []
 
 - name: Discover custom build inputs (Compose)
   when: instance_orchestrator | default('compose') == 'compose'
   block:
+    # `docker compose config` reports build.context as a physical path (symlinks
+    # resolved). Resolve the instance dir the same way so the two are comparable
+    # - otherwise a symlinked instance path makes every context look "outside"
+    # the instance and the build inputs silently miss the snapshot.
+    - name: Resolve physical instance directory
+      ansible.builtin.command:
+        cmd: "realpath {{ instance_path }}"
+      register: _build_instance_realpath
+      changed_when: false
+
+    - name: Set physical instance directory
+      ansible.builtin.set_fact:
+        _build_instance_dir: "{{ _build_instance_realpath.stdout }}"
+
     - name: Render merged compose config as JSON
       ansible.builtin.command:
         cmd: "docker compose config --format json"
         chdir: "{{ instance_path }}"
       register: _build_compose_config
       changed_when: false
+      # The rendered config interpolates .env values (including
+      # MYSQL_PASSWORD); keep it out of task logs. The variable is still
+      # usable below - only its display is suppressed.
+      no_log: true
+
+    # Pull out just the build sections. The secret-bearing remainder of the
+    # rendered config is dropped here, so every task below operates on
+    # secret-free data and needs no no_log of its own.
+    - name: Extract build sections
+      ansible.builtin.set_fact:
+        _build_specs: >-
+          {{ (_build_compose_config.stdout | from_json).services | dict2items
+             | map(attribute='value.build') | select('defined') | list }}
 
     # `docker compose config` resolves build.context to an absolute path and
-    # leaves build.dockerfile as a filename relative to that context.
-    - name: Collect build context and Dockerfile paths
+    # leaves build.dockerfile as a filename relative to that context. Reduce
+    # each build input to its top-level component under the instance dir.
+    - name: Compute top-level build input paths
       ansible.builtin.set_fact:
-        _build_staging_paths: >-
-          {{ _build_staging_paths | default([])
-             + [ (_ctx == _instance_dir)
-                 | ternary(
-                     _instance_dir ~ '/' ~ (item.value.build.dockerfile | default('Dockerfile')),
-                     _ctx) ] }}
+        _build_staging_paths: "{{ _build_staging_paths + [_top] }}"
       vars:
-        _instance_dir: "{{ instance_path | regex_replace('/$', '') }}"
-        _ctx: "{{ item.value.build.context | regex_replace('/$', '') }}"
-      loop: "{{ (_build_compose_config.stdout | from_json).services | dict2items }}"
+        _instance_dir: "{{ _build_instance_dir | regex_replace('/$', '') }}"
+        _ctx: "{{ item.context | regex_replace('/$', '') }}"
+        _target: >-
+          {{ (_ctx == _instance_dir)
+             | ternary(_instance_dir ~ '/' ~ (item.dockerfile | default('Dockerfile')), _ctx) }}
+        _rel: "{{ _target | relpath(_instance_dir) }}"
+        _top: "{{ _instance_dir ~ '/' ~ (_rel.split('/') | first) }}"
+      loop: "{{ _build_specs }}"
       loop_control:
-        label: "{{ item.key }}"
-      when: item.value.build is defined
+        label: "{{ item.context }}"
+      # Skip anything that resolves outside the instance directory (e.g. an
+      # unexpected symlinked context); the restore only handles paths within it.
+      when: not _rel.startswith('..')
 
-    - name: Build staging map from discovered paths
+    - name: Stat discovered build inputs
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      register: _build_stat
+      loop: "{{ _build_staging_paths | unique }}"
+      loop_control:
+        label: "{{ item }}"
+
+    # Only stage inputs that actually exist on disk. A declared-but-missing
+    # build input (an override that references a Dockerfile not yet created)
+    # would otherwise be bind-mounted by the staging container, which on Linux
+    # creates a junk directory at that path - the same broken state this task
+    # exists to prevent.
+    - name: Stage existing build inputs
       ansible.builtin.set_fact:
         _build_staging_map: >-
           {{ _build_staging_map | combine(
-               {item: '/currentsnapshot/' ~ (item | relpath(instance_path))}) }}
-      loop: "{{ _build_staging_paths | default([]) | unique }}"
+               {item.item: '/currentsnapshot/' ~ (item.item | relpath(_build_instance_dir))}) }}
+      loop: "{{ _build_stat.results }}"
+      when: item.stat.exists
       loop_control:
-        label: "{{ item }}"
+        label: "{{ item.item }}"

--- a/roles/backup/tasks/restore.yml
+++ b/roles/backup/tasks/restore.yml
@@ -123,6 +123,13 @@
       loop_control:
         label: "{{ item.item }}"
 
+    - name: Discover custom Docker build inputs for safety backup
+      ansible.builtin.include_tasks: discover_build_paths.yml
+
+    - name: Add custom build inputs to safety staging
+      ansible.builtin.set_fact:
+        _safety_volumes: "{{ _safety_volumes | combine(_build_staging_map) }}"
+
     - name: Run safety backup with staged files
       ansible.builtin.include_tasks: >-
         {{ canasta_root }}/roles/orchestrator/tasks/run_backup.yml
@@ -162,26 +169,35 @@
       - "/"
   when: instance_orchestrator | default('compose') == 'compose'
 
+# The standard MediaWiki dirs are replaced wholesale (rm -rf then copy) so a
+# restore doesn't leave stale files behind. Everything else the snapshot holds
+# - .env, docker-compose.override.yml, my.cnf, and any custom build inputs
+# (Dockerfile, build context dirs) staged by discover_build_paths.yml - is
+# copied back generically, so the restore round-trips whatever was captured.
 - name: Copy files from volume to host
   ansible.builtin.shell:
     cmd: |
       docker run --rm \
         -v "canasta-backup-{{ instance_path | basename }}:/currentsnapshot:ro" \
         -v "{{ instance_path }}:/install" \
-        alpine sh -c "
-        for d in config extensions images skins public_assets; do
-          if [ -d /currentsnapshot/\$d ]; then
-            mkdir -p /install/\$d &&
-            rm -rf /install/\$d/* \
-              /install/\$d/.[!.]* 2>/dev/null;
-            cp -a /currentsnapshot/\$d/. /install/\$d/;
+        alpine sh -c '
+        std="config extensions images skins public_assets";
+        for d in $std; do
+          if [ -d /currentsnapshot/$d ]; then
+            mkdir -p /install/$d &&
+            rm -rf /install/$d/* /install/$d/.[!.]* 2>/dev/null;
+            cp -a /currentsnapshot/$d/. /install/$d/;
           fi;
         done;
-        for f in .env docker-compose.override.yml my.cnf; do
-          if [ -f /currentsnapshot/\$f ]; then
-            cp -a /currentsnapshot/\$f /install/\$f;
-          fi;
-        done"
+        for e in /currentsnapshot/* /currentsnapshot/.[!.]*; do
+          [ -e "$e" ] || continue;
+          name=$(basename "$e");
+          skip=0;
+          for d in $std; do [ "$name" = "$d" ] && skip=1; done;
+          [ "$skip" = "1" ] && continue;
+          [ -d "$e" ] && rm -rf "/install/$name";
+          cp -a "$e" "/install/$name";
+        done'
   changed_when: true
   when: instance_orchestrator | default('compose') == 'compose'
 

--- a/roles/orchestrator/tasks/run_backup.yml
+++ b/roles/orchestrator/tasks/run_backup.yml
@@ -41,7 +41,7 @@
                 alpine sh -c \
                 "rm -rf /currentsnapshot/* && \
               {% for src, dst in backup_volumes.items() %}
-                mkdir -p $(dirname {{ dst }}) && cp -a /src{{ loop.index0 }} {{ dst }}{{ ' && ' if not loop.last else '' }} \
+                cp -a /src{{ loop.index0 }} {{ dst }}{{ ' && ' if not loop.last else '' }} \
               {% endfor %}
                 "
           changed_when: true

--- a/roles/orchestrator/tasks/run_backup.yml
+++ b/roles/orchestrator/tasks/run_backup.yml
@@ -41,7 +41,7 @@
                 alpine sh -c \
                 "rm -rf /currentsnapshot/* && \
               {% for src, dst in backup_volumes.items() %}
-                cp -a /src{{ loop.index0 }} {{ dst }}{{ ' && ' if not loop.last else '' }} \
+                mkdir -p $(dirname {{ dst }}) && cp -a /src{{ loop.index0 }} {{ dst }}{{ ' && ' if not loop.last else '' }} \
               {% endfor %}
                 "
           changed_when: true

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -461,6 +461,106 @@ def test_backup(inst):
     shutil.rmtree(backup_dir, ignore_errors=True)
 
 
+def test_backup_custom_dockerfile(inst):
+    """A custom Dockerfile + override are captured by backup and restored.
+
+    Regression: backup staged docker-compose.override.yml but not the
+    Dockerfile / build context it references, so a restore onto a fresh host
+    had an override pointing at a missing build and could not start.
+    """
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir,
+        "-e", inst.env_file,
+    )
+    time.sleep(10)  # Brief wait for containers to stabilize
+
+    inst_path = inst.instance_path()
+    override_path = os.path.join(inst_path, "docker-compose.override.yml")
+    dockerfile_path = os.path.join(inst_path, "Dockerfile.custom")
+
+    # Reuse the instance's own base image so the build is a no-op single FROM
+    # layer (instant, no network) rather than pulling a fresh image.
+    canasta_image = "ghcr.io/canastawiki/canasta:latest"
+    with open(inst.env_path()) as f:
+        for line in f:
+            if line.startswith("CANASTA_IMAGE="):
+                canasta_image = line.split("=", 1)[1].strip()
+                break
+
+    print("Adding a custom web build (override + Dockerfile.custom)...")
+    with open(override_path, "w") as f:
+        f.write(
+            "services:\n"
+            "  web:\n"
+            "    image: %s:custom\n"
+            "    build:\n"
+            "      context: .\n"
+            "      dockerfile: Dockerfile.custom\n"
+            % inst.id
+        )
+    with open(dockerfile_path, "w") as f:
+        f.write("FROM %s\n" % canasta_image)
+
+    print("Configuring backup repository...")
+    backup_dir = tempfile.mkdtemp(prefix="canasta-int-backup-")
+    inst.run_ok(
+        "config", "set", "-i", inst.id,
+        "RESTIC_REPOSITORY=%s" % backup_dir, "--no-restart",
+    )
+    inst.run_ok(
+        "config", "set", "-i", inst.id,
+        "RESTIC_PASSWORD=testpass", "--no-restart",
+    )
+
+    print("Initializing backup repository...")
+    inst.run_ok("backup", "init", "-i", inst.id)
+
+    print("Creating backup snapshot...")
+    inst.run_ok("backup", "create", "-i", inst.id, "-t", "custom-build")
+
+    print("Verifying the Dockerfile is inside the snapshot...")
+    output = inst.run_quiet("backup", "list", "-i", inst.id)
+    snapshot_id = None
+    for line in output.split("\n"):
+        if "custom-build" in line:
+            match = re.search(r'\b([0-9a-f]{8,})\b', line)
+            if match:
+                snapshot_id = match.group(1)
+                break
+    assert snapshot_id, "Could not extract snapshot ID from:\n%s" % output
+    files = inst.run_quiet(
+        "backup", "files", "-i", inst.id, "-s", snapshot_id,
+    )
+    assert "Dockerfile.custom" in files, (
+        "Dockerfile.custom not captured in snapshot:\n%s" % files
+    )
+
+    print("Deleting build inputs to simulate loss...")
+    os.remove(override_path)
+    os.remove(dockerfile_path)
+
+    print("Restoring from backup...")
+    inst.run_ok(
+        "backup", "restore", "-i", inst.id,
+        "-s", snapshot_id, "--skip-safety-backup",
+    )
+
+    print("Verifying build inputs are back on disk...")
+    assert os.path.isfile(dockerfile_path), "Dockerfile.custom was not restored"
+    assert os.path.isfile(override_path), (
+        "docker-compose.override.yml was not restored"
+    )
+
+    print("Restarting after restore...")
+    inst.run_ok("restart", "-i", inst.id)
+
+    print("Verifying wiki accessible after restore...")
+    wait_for_wiki(inst.http_port, timeout=300)
+    shutil.rmtree(backup_dir, ignore_errors=True)
+
+
 def test_gitops(inst):
     """Init gitops, verify templates, push, verify remote."""
     # Check prerequisites
@@ -1946,6 +2046,7 @@ ALL_TESTS = {
     "upgrade-backfill-hosts-yaml": test_upgrade_backfill_hosts_yaml,
     "backup": test_backup,
     "backup-advanced": test_backup_advanced,
+    "backup-custom-dockerfile": test_backup_custom_dockerfile,
     "gitops": test_gitops,
     "gitops-pull-diff": test_gitops_pull_diff,
     "extension-skin": test_extension_skin,

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -561,6 +561,67 @@ def test_backup_custom_dockerfile(inst):
     shutil.rmtree(backup_dir, ignore_errors=True)
 
 
+def test_backup_missing_dockerfile(inst):
+    """A backup of an override that references a missing Dockerfile is clean.
+
+    Regression: discovery trusts `docker compose config`, which emits the
+    build: section even when the Dockerfile is absent. Staging that missing
+    path would bind-mount it, and on Linux Docker creates a root-owned junk
+    directory there. Discovery must stat each path and stage only existing
+    ones, so the backup leaves the instance directory untouched.
+    """
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir,
+        "-e", inst.env_file,
+    )
+    time.sleep(10)  # Brief wait for containers to stabilize
+
+    inst_path = inst.instance_path()
+    override_path = os.path.join(inst_path, "docker-compose.override.yml")
+    dockerfile_path = os.path.join(inst_path, "Dockerfile.custom")
+
+    print("Adding an override that references a NON-EXISTENT Dockerfile...")
+    with open(override_path, "w") as f:
+        f.write(
+            "services:\n"
+            "  web:\n"
+            "    image: %s:custom\n"
+            "    build:\n"
+            "      context: .\n"
+            "      dockerfile: Dockerfile.custom\n"
+            % inst.id
+        )
+    assert not os.path.exists(dockerfile_path), "precondition: Dockerfile absent"
+
+    print("Configuring backup repository...")
+    backup_dir = tempfile.mkdtemp(prefix="canasta-int-backup-")
+    inst.run_ok(
+        "config", "set", "-i", inst.id,
+        "RESTIC_REPOSITORY=%s" % backup_dir, "--no-restart",
+    )
+    inst.run_ok(
+        "config", "set", "-i", inst.id,
+        "RESTIC_PASSWORD=testpass", "--no-restart",
+    )
+
+    print("Initializing backup repository...")
+    inst.run_ok("backup", "init", "-i", inst.id)
+
+    print("Creating backup snapshot (must not create a junk Dockerfile dir)...")
+    inst.run_ok("backup", "create", "-i", inst.id, "-t", "missing-df")
+
+    print("Verifying no junk Dockerfile.custom was created...")
+    assert not os.path.isdir(dockerfile_path), (
+        "backup created a junk directory at Dockerfile.custom"
+    )
+    assert not os.path.exists(dockerfile_path), (
+        "backup created an unexpected Dockerfile.custom entry"
+    )
+    shutil.rmtree(backup_dir, ignore_errors=True)
+
+
 def test_gitops(inst):
     """Init gitops, verify templates, push, verify remote."""
     # Check prerequisites
@@ -2047,6 +2108,7 @@ ALL_TESTS = {
     "backup": test_backup,
     "backup-advanced": test_backup_advanced,
     "backup-custom-dockerfile": test_backup_custom_dockerfile,
+    "backup-missing-dockerfile": test_backup_missing_dockerfile,
     "gitops": test_gitops,
     "gitops-pull-diff": test_gitops_pull_diff,
     "extension-skin": test_extension_skin,


### PR DESCRIPTION
## What

Makes `canasta backup` capture the custom `Dockerfile` and build context that a `docker-compose.override.yml` references, so a backup is self-sufficient and a restore onto a fresh host can rebuild the custom image.

Closes #616.

## Why

Previously the Compose backup staged an explicit allowlist (`config/`, `extensions/`, `images/`, `skins/`, `public_assets/`, `.env`, optionally `docker-compose.override.yml` and `my.cnf`) but nothing for the `build:` the override points at. A restored instance therefore had an override declaring a `build:` whose Dockerfile/context was missing, and `docker compose up -d` failed to build it — the instance would not start.

## How

- **`roles/backup/tasks/discover_build_paths.yml`** (new): reads `docker compose config --format json` and, for each service with a `build:` section, produces a staging map. When the build context is the instance directory, it stages the referenced Dockerfile; when the context is a subdirectory, it stages that whole directory (the Dockerfile inside it is captured too). No-op when there are no buildable services.
- **`create.yml`**: combines the discovered build inputs into the backup staging map.
- **`restore.yml`**: applies the same discovery to the pre-restore safety snapshot, and makes the copy-to-host step content-agnostic — standard MediaWiki dirs are replaced wholesale (so no stale files linger), and every other top-level entry the snapshot holds (`.env`, override, `my.cnf`, Dockerfile, build context dirs) is copied back. This restores whatever was captured instead of a hard-coded list.
- **`run_backup.yml`**: the staging container creates the destination's parent dir before copying, so a build input nested below the instance root is staged correctly.

Compose orchestrator only. On Kubernetes, custom images are pushed to the in-cluster registry rather than built from a local context, so there is no on-disk build input to capture.

## Testing

- `make test-unit` — 871 passed.
- `make validate` — passes.
- New integration test `backup-custom-dockerfile`: adds a custom `web` build (override + `Dockerfile.custom`), backs up, asserts the Dockerfile is inside the snapshot, deletes the build inputs, restores, asserts they are back on disk, and confirms the wiki comes up after the post-restore rebuild.
- The restore copy loop and the discovery transform were validated in isolation (real `alpine` container for the copy semantics; Ansible templating for the path discovery against actual `docker compose config` JSON output).
