### PR TITLE
crowdsec: collapse duplicate Caddy bouncer registrations in status output

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -12,6 +12,9 @@ gathering = explicit
 # Overridden at runtime by canasta.py to canasta_minimal (non-verbose mode)
 stdout_callback = default
 callback_plugins = callback_plugins
+# Role-local filter plugins do not auto-discover under include_role (same
+# reason as module_utils above), so the filter dir is registered here.
+filter_plugins = filter_plugins
 # Suppressed to keep CLI output clean
 deprecation_warnings = False
 nocows = True

--- a/filter_plugins/canasta_crowdsec.py
+++ b/filter_plugins/canasta_crowdsec.py
@@ -1,0 +1,71 @@
+# Jinja filters for the CrowdSec Compose integration.
+#
+# Loaded via the `filter_plugins` path in ansible.cfg (role-local plugin
+# auto-discovery does not fire because Canasta drives everything through
+# include_role / include_tasks rather than the play-level `roles:` keyword).
+
+
+def _is_caddy_family(bouncer, family_name):
+    name = str(bouncer.get("name", "")) if isinstance(bouncer, dict) else ""
+    return name == family_name or name.startswith(family_name + "@")
+
+
+def canasta_crowdsec_status_bouncers(bouncers, family_name="canasta-caddy"):
+    """Render a de-duplicated 'Bouncers' summary for ``crowdsec status``.
+
+    Every time the caddy container reconnects from a new container IP,
+    CrowdSec auto-creates a ``canasta-caddy@<ip>`` child registration, so the
+    raw ``cscli bouncers list`` accumulates stale rows that all report
+    ``valid`` even though only the newest one pulls. These children are
+    undeletable in CrowdSec (deleting the parent cascades and revokes the
+    shared key), so the status command instead collapses the family for
+    display: show the single live registration (most-recent ``last_pull``)
+    plus a count of the harmless duplicates. Any non-caddy bouncers are listed
+    verbatim.
+
+    Returns a pre-formatted, indented block of lines (or ``(none)``) so the
+    status playbook can drop it straight into its message.
+    """
+    bouncers = [b for b in (bouncers or []) if isinstance(b, dict)]
+    family = [b for b in bouncers if _is_caddy_family(b, family_name)]
+    others = [b for b in bouncers if not _is_caddy_family(b, family_name)]
+
+    lines = []
+    if family:
+        # last_pull is an RFC3339 UTC timestamp; lexicographic max == latest.
+        # A never-pulled row sorts oldest, so a live puller always wins.
+        live = max(family, key=lambda b: b.get("last_pull") or "")
+        lines.append(
+            "  %s — active (IP %s, last pull %s)" % (
+                live.get("name", "?"),
+                live.get("ip_address") or "?",
+                live.get("last_pull") or "never",
+            )
+        )
+        stale = len(family) - 1
+        if stale > 0:
+            lines.append(
+                "  + %d stale auto-created duplicate registration(s) from past "
+                "container restarts (harmless — only the active bouncer above "
+                "pulls decisions). CrowdSec cannot delete these individually; "
+                "run 'canasta crowdsec enroll --force' to reset to a single "
+                "registration." % stale
+            )
+
+    for b in others:
+        lines.append(
+            "  %s — IP %s, last pull %s" % (
+                b.get("name", "?"),
+                b.get("ip_address") or "?",
+                b.get("last_pull") or "never",
+            )
+        )
+
+    return "\n".join(lines) if lines else "  (none)"
+
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            "canasta_crowdsec_status_bouncers": canasta_crowdsec_status_bouncers,
+        }

--- a/roles/crowdsec/tasks/status.yml
+++ b/roles/crowdsec/tasks/status.yml
@@ -6,12 +6,22 @@
 - name: Preflight (resolve, Compose-only, crowdsec running)
   ansible.builtin.include_tasks: _preflight.yml
 
+# JSON (not the table) so we can collapse the caddy bouncer family. CrowdSec
+# auto-creates an undeletable 'canasta-caddy@<ip>' child every time the caddy
+# container reconnects from a new IP, so the raw list grows a trail of stale
+# 'valid' rows that confuse the output (issue #619).
 - name: List registered bouncers
   ansible.builtin.command:
-    cmd: "docker compose exec -T crowdsec cscli bouncers list"
+    cmd: "docker compose exec -T crowdsec cscli bouncers list -o json"
     chdir: "{{ instance_path }}"
   register: _crowdsec_bouncers
   changed_when: false
+
+# cscli prints "null" (not "[]") when no bouncers exist, so coalesce to an
+# empty list before parsing.
+- name: Parse bouncer list
+  ansible.builtin.set_fact:
+    _crowdsec_bouncer_list: "{{ ((_crowdsec_bouncers.stdout | trim) or '[]') | from_json }}"
 
 - name: List active decisions
   ansible.builtin.command:
@@ -26,7 +36,7 @@
       CrowdSec status for instance '{{ instance_id }}'
 
       Bouncers:
-      {{ _crowdsec_bouncers.stdout | default('(none)') }}
+      {{ _crowdsec_bouncer_list | canasta_crowdsec_status_bouncers }}
 
       Decisions:
       {{ _crowdsec_decisions.stdout | default('(none)') }}

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -2119,6 +2119,21 @@ def _wait_for_crowdsec_lapi(inst, timeout=120):
     )
 
 
+def _cscli(inst, *args):
+    """Run a cscli command inside the instance's crowdsec container."""
+    result = subprocess.run(
+        ["docker", "compose", "exec", "-T", "crowdsec", "cscli"] + list(args),
+        capture_output=True, text=True, cwd=inst.instance_path(),
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            "cscli %s failed (rc=%d): %s"
+            % (" ".join(args), result.returncode,
+               (result.stderr or result.stdout).strip())
+        )
+    return result.stdout
+
+
 def test_crowdsec(inst):
     """Enable CrowdSec on an instance created BEFORE the feature existed,
     verify the acquisition/whitelist files are backfilled (not left as empty
@@ -2170,6 +2185,7 @@ def test_crowdsec(inst):
     print("Checking status lists the bouncer...")
     out = inst.run_quiet("crowdsec", "status", "-i", inst.id)
     assert "canasta-caddy" in out, "status should list the canasta-caddy bouncer"
+    assert "active" in out, "status should mark the live bouncer active"
 
     # 203.0.113.0/24 is TEST-NET-3 (documentation range) — safe to ban.
     print("Banning a test IP and verifying the decision appears...")
@@ -2181,6 +2197,29 @@ def test_crowdsec(inst):
     inst.run_ok("crowdsec", "unban", "203.0.113.7", "-i", inst.id)
     out = inst.run_quiet("crowdsec", "status", "-i", inst.id)
     assert "203.0.113.7" not in out, "unbanned IP should be gone from decisions"
+
+    # Recreating the caddy container makes CrowdSec auto-create an undeletable
+    # 'canasta-caddy@<ip>' child each time it reconnects from a new IP,
+    # accumulating stale 'valid' rows (issue #619). They cannot be pruned
+    # (deleting the parent cascades and revokes the shared key), so status
+    # collapses the family for display instead. Simulate two duplicates and
+    # verify status shows one active bouncer plus a stale-count note rather
+    # than listing each row.
+    print("Simulating stale IP-suffixed bouncer duplicates...")
+    for ip in ("172.18.0.250", "172.18.0.251"):
+        _cscli(inst, "bouncers", "add", "canasta-caddy@%s" % ip, "-o", "raw")
+
+    print("Verifying status collapses the duplicates for display...")
+    out = inst.run_quiet("crowdsec", "status", "-i", inst.id)
+    assert out.count("— active") == 1, (
+        "status should show exactly one active canasta-caddy registration"
+    )
+    assert "2 stale auto-created duplicate" in out, (
+        "status should summarize the two duplicates as a stale count"
+    )
+    assert "172.18.0.250" not in out and "172.18.0.251" not in out, (
+        "individual stale duplicate rows must not be listed"
+    )
 
 
 # --- Test runner ---

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -27,6 +27,11 @@ import yaml
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 import canasta as canasta_cli  # noqa: E402 (the canasta.py module)
 
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "..", "..", "filter_plugins")
+)
+from canasta_crowdsec import canasta_crowdsec_status_bouncers  # noqa: E402
+
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 COMPOSE_PATH = os.path.join(
@@ -562,4 +567,105 @@ class TestCrowdsecWhitelist:
         ), (
             "whitelists.yaml must mount into /etc/crowdsec/parsers/"
             "s02-enrich/ so CrowdSec loads it"
+        )
+
+
+def _bouncer(name, last_pull=None, ip_address=None):
+    """A minimal `cscli bouncers list -o json` entry."""
+    return {
+        "name": name, "last_pull": last_pull,
+        "ip_address": ip_address, "valid": True,
+    }
+
+
+class TestCrowdsecStatusBouncersDisplay:
+    """`crowdsec status` collapses the canasta-caddy bouncer family for
+    display: CrowdSec auto-creates an undeletable 'canasta-caddy@<ip>' child
+    each time the caddy container reconnects from a new IP, so the raw list
+    accumulates harmless stale 'valid' rows (issue #619). The status filter
+    shows the single live registration plus a count of the duplicates rather
+    than listing each one."""
+
+    def test_empty_and_none_render_none(self):
+        assert canasta_crowdsec_status_bouncers([]) == "  (none)"
+        assert canasta_crowdsec_status_bouncers(None) == "  (none)"
+
+    def test_single_bouncer_no_stale_note(self):
+        out = canasta_crowdsec_status_bouncers([
+            _bouncer("canasta-caddy", "2026-06-11T12:00:00Z", "172.18.0.3"),
+        ])
+        assert "canasta-caddy — active" in out
+        assert "172.18.0.3" in out
+        assert "2026-06-11T12:00:00Z" in out
+        assert "stale" not in out  # no duplicates -> no note
+
+    def test_duplicates_collapse_to_live_plus_count(self):
+        # The real aic shape: stale base + stale child + live child.
+        out = canasta_crowdsec_status_bouncers([
+            _bouncer("canasta-caddy", "2026-06-11T02:54:46Z", "172.18.0.4"),
+            _bouncer("canasta-caddy@172.18.0.5", "2026-06-11T03:44:44Z", "172.18.0.5"),
+            _bouncer("canasta-caddy@172.18.0.3", "2026-06-11T10:42:33Z", "172.18.0.3"),
+        ])
+        # The live (most-recently-pulled) registration is shown as active.
+        assert "canasta-caddy@172.18.0.3 — active" in out
+        assert "172.18.0.3" in out
+        # The two stale duplicates are summarized, not listed individually.
+        assert "2 stale auto-created duplicate" in out
+        assert "enroll --force" in out
+        assert "canasta-caddy@172.18.0.5" not in out
+        # Exactly one active line (the note also contains the word "active").
+        assert out.count("— active") == 1
+
+    def test_live_base_with_stale_children(self):
+        out = canasta_crowdsec_status_bouncers([
+            _bouncer("canasta-caddy", "2026-06-11T12:00:00Z", "172.18.0.3"),
+            _bouncer("canasta-caddy@172.18.0.9", "2026-06-11T09:00:00Z", "172.18.0.9"),
+        ])
+        assert "canasta-caddy — active" in out
+        assert "1 stale auto-created duplicate" in out
+
+    def test_never_pulled_renders_never(self):
+        out = canasta_crowdsec_status_bouncers([
+            _bouncer("canasta-caddy", None, None),
+        ])
+        assert "active" in out
+        assert "never" in out
+        assert "IP ?" in out
+
+    def test_other_bouncers_listed_verbatim(self):
+        out = canasta_crowdsec_status_bouncers([
+            _bouncer("canasta-caddy", "2026-06-11T12:00:00Z", "172.18.0.3"),
+            _bouncer("some-firewall-bouncer", "2026-06-11T11:00:00Z", "10.0.0.2"),
+        ])
+        assert "canasta-caddy — active" in out
+        assert "some-firewall-bouncer" in out
+        assert "10.0.0.2" in out
+        # A non-family name (no '@') is not folded into the caddy family.
+        out2 = canasta_crowdsec_status_bouncers([
+            _bouncer("canasta-caddy", "2026-06-11T12:00:00Z", "172.18.0.3"),
+            _bouncer("canasta-caddy-extra", "2026-06-11T11:00:00Z", "10.0.0.2"),
+        ])
+        assert "canasta-caddy-extra" in out2
+        assert "stale" not in out2
+
+
+class TestCrowdsecStatusWiring:
+    def test_status_lists_bouncers_as_json_and_uses_filter(self):
+        content = _read(os.path.join(
+            REPO_ROOT, "roles", "crowdsec", "tasks", "status.yml",
+        ))
+        assert "cscli bouncers list -o json" in content, (
+            "status must read the bouncer list as JSON so the family can be "
+            "collapsed"
+        )
+        assert "canasta_crowdsec_status_bouncers" in content, (
+            "status must render bouncers through the de-duplicating filter"
+        )
+
+    def test_status_filter_registered_in_ansible_cfg(self):
+        cfg = _read(os.path.join(REPO_ROOT, "ansible.cfg"))
+        assert "filter_plugins = filter_plugins" in cfg, (
+            "the filter_plugins path must be registered so the status filter "
+            "loads at runtime (role-local plugins don't auto-discover under "
+            "include_role)"
         )


### PR DESCRIPTION
## Summary

`canasta crowdsec status` accumulated stale Caddy bouncer registrations. Each time the `caddy` container is recreated (restart / upgrade / config-set), it reconnects to the CrowdSec LAPI from a new container IP, and CrowdSec **auto-creates** a `canasta-caddy@<ip>` child registration. The raw `cscli bouncers list` therefore grows a trail of rows that all report `valid` even though only the newest one pulls — harmless, but cluttered and confusing.

These duplicates **cannot be pruned**: `cscli` refuses to delete an auto-created bouncer (_"delete parent bouncer instead"_), and deleting the parent `canasta-caddy` cascades and revokes the shared API key. So rather than touch the bouncer database, this collapses the family for **display only**.

## Changes

- **`roles/crowdsec/tasks/status.yml`** — read the bouncer list as JSON and render it through a new filter that shows the single live registration (most-recent `last_pull`) plus a count of the stale auto-created duplicates; non-caddy bouncers are listed verbatim. Read-only.
- **`filter_plugins/canasta_crowdsec.py`** — new `canasta_crowdsec_status_bouncers` filter.
- **`ansible.cfg`** — register the `filter_plugins` path (role-local plugins don't auto-discover under `include_role`, same as `module_utils`).
- Unit tests for the filter + status wiring; integration test asserts the display collapses simulated duplicates.

`enroll` and the bouncer database are unchanged.

## Example

```
Bouncers:
  canasta-caddy@172.18.0.3 — active (IP 172.18.0.3, last pull 2026-06-11T10:42:33Z)
  + 2 stale auto-created duplicate registration(s) from past container restarts
    (harmless — only the active bouncer above pulls decisions). CrowdSec cannot
    delete these individually; run 'canasta crowdsec enroll --force' to reset.
```

## Testing

- `make test-unit` (945 pass), `make validate`, `make lint` — all green
- `python tests/integration/run_tests.py crowdsec` — passes; status collapses simulated duplicates
- Verified on a live instance

Closes #619