### PR TITLE
gitops diff: show actual patches instead of file-name lists

### DIFF
--- a/direct_commands/gitops.py
+++ b/direct_commands/gitops.py
@@ -210,47 +210,62 @@ def cmd_gitops_status(args):
         print(_parse_gitops_status(stdout, inst_id))
     return 0
 
-def _gitops_diff_script(path):
+def _gitops_diff_script(path, stat=False):
+    # For each of the three boundaries we emit two sections: a
+    # --name-only list (for the file count and the restart/update
+    # heuristics) followed by the actual patch the user asked to see.
+    # Uncommitted uses `HEAD` so staged *and* unstaged changes both
+    # show up (plain `git diff` would miss staged files). Local and
+    # remote use three-dot ranges so each side shows what its own
+    # commits introduced since the branches diverged, rather than the
+    # symmetric two-dot file set.
     d = _helpers._SENTINEL
     qp = _helpers._shell_quote(path)
+    fmt = "--stat" if stat else "-p"
     return (
         "cd %(p)s; "
-        "git diff --name-only 2>/dev/null; "
+        "git diff --name-only HEAD 2>/dev/null; "
         "echo '%(d)s'; "
-        "git diff --name-only HEAD @{upstream} 2>/dev/null; "
+        "git diff %(f)s HEAD 2>/dev/null; "
         "echo '%(d)s'; "
-        "git diff --name-only @{upstream} HEAD 2>/dev/null; "
+        "git diff --name-only @{upstream}...HEAD 2>/dev/null; "
+        "echo '%(d)s'; "
+        "git diff %(f)s @{upstream}...HEAD 2>/dev/null; "
+        "echo '%(d)s'; "
+        "git diff --name-only HEAD...@{upstream} 2>/dev/null; "
+        "echo '%(d)s'; "
+        "git diff %(f)s HEAD...@{upstream} 2>/dev/null; "
         "echo '%(d)s'; "
         "git submodule status 2>/dev/null"
-    ) % {"p": qp, "d": d}
+    ) % {"p": qp, "d": d, "f": fmt}
 
 
 def _parse_gitops_diff(stdout):
     parts = stdout.split(_helpers._SENTINEL + "\n")
 
-    uncommitted = parts[0].strip() if len(parts) > 0 else ""
-    local = parts[1].strip() if len(parts) > 1 else ""
-    remote = parts[2].strip() if len(parts) > 2 else ""
-    submodules_raw = parts[3].strip() if len(parts) > 3 else ""
+    def _names(i):
+        raw = parts[i].strip() if len(parts) > i else ""
+        return sorted(raw.split("\n")) if raw else []
 
-    uc_files = sorted(uncommitted.split("\n")) if uncommitted else []
-    lc_files = sorted(local.split("\n")) if local else []
-    rc_files = sorted(remote.split("\n")) if remote else []
+    def _patch(i):
+        return parts[i].strip("\n") if len(parts) > i else ""
 
-    lines = ["Uncommitted changes: %d file(s)" % len(uc_files)]
-    for f in uc_files:
-        lines.append("  %s" % f)
-    lines.append("")
+    uc_files, uc_patch = _names(0), _patch(1)
+    lc_files, lc_patch = _names(2), _patch(3)
+    rc_files, rc_patch = _names(4), _patch(5)
+    submodules_raw = parts[6].strip() if len(parts) > 6 else ""
 
-    lines.append("Local changes (not yet pushed): %d file(s)" % len(lc_files))
-    for f in lc_files:
-        lines.append("  %s" % f)
-    lines.append("")
+    lines = []
 
-    lines.append("Remote changes (would be applied on pull): %d file(s)" % len(rc_files))
-    for f in rc_files:
-        lines.append("  %s" % f)
-    lines.append("")
+    def _section(title, files, patch):
+        lines.append("%s: %d file(s)" % (title, len(files)))
+        if patch:
+            lines.append(patch)
+        lines.append("")
+
+    _section("Uncommitted changes", uc_files, uc_patch)
+    _section("Local changes (not yet pushed)", lc_files, lc_patch)
+    _section("Remote changes (would be applied on pull)", rc_files, rc_patch)
 
     subs = [
         s.split()[1] for s in submodules_raw.split("\n")
@@ -285,7 +300,7 @@ def cmd_gitops_diff(args):
 
     host = inst.get("host") or "localhost"
     path = inst.get("path", "")
-    script = _gitops_diff_script(path)
+    script = _gitops_diff_script(path, stat=bool(getattr(args, "stat", False)))
 
     if _helpers._is_localhost(host):
         try:

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1991,18 +1991,24 @@ commands:
   - name: gitops_diff
     description: "Show local and remote changes since the branches diverged"
     long_description: |
-      Show uncommitted working tree changes, then fetch the latest
-      from the remote and show what files have changed locally, what
-      files have changed on the remote, and which files have changed
-      in both (potential merge conflicts).
+      Show the actual patch for uncommitted working tree changes, for
+      local commits not yet pushed, and for remote commits that would
+      be applied on the next pull. Each section is headed by its file
+      count. Use --stat to show a diffstat summary instead of the full
+      patch.
     examples:
       - "canasta gitops diff"
+      - "canasta gitops diff --stat"
     playbook: gitops_diff.yml
     parameters:
       - name: id
         short: i
         type: string
         description: "Canasta instance ID"
+      - name: stat
+        type: bool
+        default: false
+        description: "Show a diffstat summary instead of the full patch"
 
   - name: gitops_fix_submodules
     description: "Convert extensions and skins to proper git submodules"

--- a/roles/gitops/tasks/diff_compose.yml
+++ b/roles/gitops/tasks/diff_compose.yml
@@ -1,30 +1,59 @@
 ---
-# GitOps diff (Compose). Matches Go CLI categorized output.
+# GitOps diff (Compose). Matches the direct command in
+# direct_commands/gitops.py — shows the actual patch for each
+# boundary, headed by its file count.
 # Requires: instance_path (set by dispatcher)
 
-# Uncommitted changes (working tree vs index)
-- name: Get uncommitted changes
+- name: Set diff format
+  ansible.builtin.set_fact:
+    _gdiff_fmt: "{{ '--stat' if (stat is defined and stat | bool) else '-p' }}"
+
+# Uncommitted changes (working tree vs HEAD: staged + unstaged)
+- name: Get uncommitted file list
   ansible.builtin.command:
-    cmd: git diff --name-only
+    cmd: git diff --name-only HEAD
     chdir: "{{ instance_path }}"
   register: _gdiff_uncommitted
   changed_when: false
 
-# Local changes (committed but not pushed)
-- name: Get local unpushed changes
+- name: Get uncommitted patch
   ansible.builtin.command:
-    cmd: git diff --name-only HEAD @{upstream}
+    cmd: "git diff {{ _gdiff_fmt }} HEAD"
+    chdir: "{{ instance_path }}"
+  register: _gdiff_uncommitted_patch
+  changed_when: false
+
+# Local changes (committed but not pushed)
+- name: Get local unpushed file list
+  ansible.builtin.command:
+    cmd: git diff --name-only @{upstream}...HEAD
     chdir: "{{ instance_path }}"
   register: _gdiff_local
   changed_when: false
   ignore_errors: true  # OK if no upstream configured
 
-# Remote changes (on remote but not pulled)
-- name: Get remote changes
+- name: Get local unpushed patch
   ansible.builtin.command:
-    cmd: git diff --name-only @{upstream} HEAD
+    cmd: "git diff {{ _gdiff_fmt }} @{upstream}...HEAD"
+    chdir: "{{ instance_path }}"
+  register: _gdiff_local_patch
+  changed_when: false
+  ignore_errors: true  # OK if no upstream configured
+
+# Remote changes (on remote but not pulled)
+- name: Get remote file list
+  ansible.builtin.command:
+    cmd: git diff --name-only HEAD...@{upstream}
     chdir: "{{ instance_path }}"
   register: _gdiff_remote
+  changed_when: false
+  ignore_errors: true  # OK if no upstream configured
+
+- name: Get remote patch
+  ansible.builtin.command:
+    cmd: "git diff {{ _gdiff_fmt }} HEAD...@{upstream}"
+    chdir: "{{ instance_path }}"
+  register: _gdiff_remote_patch
   changed_when: false
   ignore_errors: true  # OK if no upstream configured
 
@@ -53,19 +82,13 @@
       {% set rc_files = rc.split('\n')
          if rc else [] %}
       Uncommitted changes: {{ uc_files | length }} file(s)
-      {% for f in uc_files | sort %}
-        {{ f }}
-      {% endfor %}
+      {{ _gdiff_uncommitted_patch.stdout | default('') }}
 
       Local changes (not yet pushed): {{ lc_files | length }} file(s)
-      {% for f in lc_files | sort %}
-        {{ f }}
-      {% endfor %}
+      {{ _gdiff_local_patch.stdout | default('') }}
 
       Remote changes (would be applied on pull): {{ rc_files | length }} file(s)
-      {% for f in rc_files | sort %}
-        {{ f }}
-      {% endfor %}
+      {{ _gdiff_remote_patch.stdout | default('') }}
 
       {% set subs = _gdiff_submodules.stdout_lines
          | default([])

--- a/roles/gitops/tasks/diff_kubernetes.yml
+++ b/roles/gitops/tasks/diff_kubernetes.yml
@@ -4,24 +4,51 @@
 # Requires: instance_path, instance_id (set by dispatcher)
 
 # --- Git diffs ---
+- name: Set diff format
+  ansible.builtin.set_fact:
+    _kdiff_fmt: "{{ '--stat' if (stat is defined and stat | bool) else '-p' }}"
+
+- name: Get uncommitted file list
+  ansible.builtin.command:
+    cmd: "git diff --name-only HEAD"
+    chdir: "{{ instance_path }}"
+  register: _kdiff_uncommitted_names
+  changed_when: false
+
 - name: Get uncommitted changes
   ansible.builtin.command:
-    cmd: "git diff --stat"
+    cmd: "git diff {{ _kdiff_fmt }} HEAD"
     chdir: "{{ instance_path }}"
   register: _kdiff_uncommitted
   changed_when: false
 
+- name: Get local unpushed file list
+  ansible.builtin.command:
+    cmd: "git diff --name-only @{upstream}...HEAD"
+    chdir: "{{ instance_path }}"
+  register: _kdiff_local_names
+  changed_when: false
+  ignore_errors: true  # OK if no upstream configured
+
 - name: Get local unpushed changes
   ansible.builtin.command:
-    cmd: "git diff --stat HEAD @{upstream}"
+    cmd: "git diff {{ _kdiff_fmt }} @{upstream}...HEAD"
     chdir: "{{ instance_path }}"
   register: _kdiff_local
   changed_when: false
   ignore_errors: true  # OK if no upstream configured
 
+- name: Get remote unpulled file list
+  ansible.builtin.command:
+    cmd: "git diff --name-only HEAD...@{upstream}"
+    chdir: "{{ instance_path }}"
+  register: _kdiff_remote_names
+  changed_when: false
+  ignore_errors: true  # OK if no upstream configured
+
 - name: Get remote unpulled changes
   ansible.builtin.command:
-    cmd: "git diff --stat @{upstream} HEAD"
+    cmd: "git diff {{ _kdiff_fmt }} HEAD...@{upstream}"
     chdir: "{{ instance_path }}"
   register: _kdiff_remote
   changed_when: false
@@ -62,13 +89,13 @@
 - name: Display diff
   ansible.builtin.debug:
     msg: |-
-      Uncommitted changes: {{ _kdiff_uncommitted.stdout_lines | default([]) | length }} file(s)
+      Uncommitted changes: {{ _kdiff_uncommitted_names.stdout_lines | default([]) | length }} file(s)
       {{ _kdiff_uncommitted.stdout | default('') }}
 
-      Local changes (not yet pushed): {{ _kdiff_local.stdout_lines | default([]) | length }} file(s)
+      Local changes (not yet pushed): {{ _kdiff_local_names.stdout_lines | default([]) | length }} file(s)
       {{ _kdiff_local.stdout | default('') }}
 
-      Remote changes (would be applied on pull): {{ _kdiff_remote.stdout_lines | default([]) | length }} file(s)
+      Remote changes (would be applied on pull): {{ _kdiff_remote_names.stdout_lines | default([]) | length }} file(s)
       {{ _kdiff_remote.stdout | default('') }}
       {% if _kdiff_cluster is defined and _kdiff_cluster.stdout | default('') | trim | length > 0 %}
 

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2170,12 +2170,19 @@ class TestExtensionSkinList:
 # ---------------------------------------------------------------------------
 
 class TestParseGitopsDiff:
-    def _make_output(self, uncommitted="", local="", remote="", submodules=""):
+    def _make_output(self, uncommitted="", uncommitted_patch="",
+                     local="", local_patch="", remote="", remote_patch="",
+                     submodules=""):
+        # Seven sentinel-separated sections: for each boundary a
+        # --name-only list followed by the patch, then submodule status.
         d = direct_commands._SENTINEL
         return (
             uncommitted + "\n" + d + "\n"
+            + uncommitted_patch + "\n" + d + "\n"
             + local + "\n" + d + "\n"
+            + local_patch + "\n" + d + "\n"
             + remote + "\n" + d + "\n"
+            + remote_patch + "\n" + d + "\n"
             + submodules + "\n"
         )
 
@@ -2190,7 +2197,18 @@ class TestParseGitopsDiff:
         out = self._make_output(uncommitted="config/.env\nconfig/wikis.yaml")
         result = direct_commands._parse_gitops_diff(out)
         assert "Uncommitted changes: 2 file(s)" in result
-        assert "config/.env" in result
+
+    def test_patch_content_shown(self):
+        patch = (
+            "diff --git a/config/.env b/config/.env\n"
+            "@@ -1 +1 @@\n-FOO=old\n+FOO=new"
+        )
+        out = self._make_output(uncommitted="config/.env",
+                                uncommitted_patch=patch)
+        result = direct_commands._parse_gitops_diff(out)
+        assert "Uncommitted changes: 1 file(s)" in result
+        assert "+FOO=new" in result
+        assert "-FOO=old" in result
 
     def test_local_and_remote(self):
         out = self._make_output(local="config/.env", remote="config/settings.php")
@@ -2233,6 +2251,9 @@ class TestCmdGitopsDiff:
         d = direct_commands._SENTINEL
         ssh_output = (
             "config/.env\n" + d + "\n"
+            + "diff --git a/config/.env b/config/.env\n" + d + "\n"
+            + "\n" + d + "\n"
+            + "\n" + d + "\n"
             + "\n" + d + "\n"
             + "\n" + d + "\n"
             + "\n"


### PR DESCRIPTION
Closes #621.

## Problem

`canasta gitops diff` printed only categorized file-name lists, which largely duplicated `canasta gitops status` and never showed the actual changes — leaving little reason to have both commands.

```
$ canasta gitops diff
Uncommitted changes: 1 file(s)
  env.template

Local changes (not yet pushed): 0 file(s)

Remote changes (would be applied on pull): 0 file(s)
```

## Changes

`gitops diff` now shows the **actual patch** for each boundary, headed by its file count, with a `--stat` flag for a diffstat summary. `gitops status` stays the concise "am I in sync" snapshot.

Also fixes two latent correctness bugs:

1. **Staged files were invisible.** The "Uncommitted changes" bucket ran `git diff` (unstaged only). A staged-but-uncommitted file appeared in neither "Uncommitted" nor "Local changes (not yet pushed)" — it fell between the two buckets, even though `gitops status` reported it under "Staged for push". Now uses `git diff HEAD` (staged + unstaged).
2. **Local and remote buckets were symmetric.** Two-dot ranges produced the same file set in both directions. Now three-dot: `@{upstream}...HEAD` for local commits, `HEAD...@{upstream}` for what a pull would bring.

## Scope

- `direct_commands/gitops.py` — the Compose path (`_gitops_diff_script` / `_parse_gitops_diff`)
- `roles/gitops/tasks/diff_compose.yml` — Ansible fallback, kept consistent
- `roles/gitops/tasks/diff_kubernetes.yml` — now defaults to full patch instead of hardcoded `--stat`; honors the flag; counts derived from `--name-only`
- `meta/command_definitions.yml` — added `--stat`, rewrote the description
- `tests/unit/test_direct_commands.py` — updated for the new layout + patch-content test

## Testing

- 946 unit tests pass
- `make validate` passes (72 commands, 54 playbooks)
- `canasta gitops diff --help` shows the new `--stat` flag