### PR TITLE
upgrade: stop printing spurious error for ignored loop-item failures

### DIFF
--- a/callback_plugins/canasta_minimal.py
+++ b/callback_plugins/canasta_minimal.py
@@ -151,6 +151,16 @@ class CallbackModule(CallbackBase):
         return " (%s)" % "; ".join(parts)
 
     def v2_runner_item_on_failed(self, result, *args, **kwargs):
+        # Respect the task's ignore_errors. Unlike v2_runner_on_failed,
+        # item callbacks are not passed ignore_errors as a kwarg; Ansible
+        # instead stamps the task's value onto the item result as
+        # _ansible_ignore_errors (see task_executor). Without this check, a
+        # failed loop item in an ignore_errors task (e.g. the "OK if dir
+        # already moved" mv in the directory-structure migration) leaks a
+        # bare "Error: ..." into the upgrade output even though the failure
+        # is being ignored.
+        if result._result.get("_ansible_ignore_errors"):
+            return
         # Display the specific item's failure message (e.g., missing
         # required parameter in a loop over param definitions).
         msg = result._result.get("msg", "")

--- a/tests/unit/test_canasta_minimal_callback.py
+++ b/tests/unit/test_canasta_minimal_callback.py
@@ -160,3 +160,23 @@ class TestRunnerOnFailed:
         cb = _make_callback()
         cb.v2_runner_on_failed(_result(msg="One or more items failed"))
         assert cb._captured == []
+
+
+class TestRunnerItemOnFailed:
+    def test_item_failure_displayed_when_not_ignored(self):
+        cb = _make_callback()
+        cb.v2_runner_item_on_failed(_result(msg="missing required parameter"))
+        msgs = [m for (m, _, _) in cb._captured]
+        assert msgs == ["Error: missing required parameter"]
+
+    def test_item_failure_suppressed_when_ignore_errors(self):
+        """A failed loop item in an ignore_errors task carries the task's
+        ignore_errors via _ansible_ignore_errors. The callback must honor
+        it — otherwise the 'OK if dir already moved' mv in the upgrade
+        directory-structure migration leaks a bare 'Error: ...' line."""
+        cb = _make_callback()
+        cb.v2_runner_item_on_failed(_result(
+            msg="The command exited with a non-zero return code.",
+            _ansible_ignore_errors=True,
+        ))
+        assert cb._captured == []


### PR DESCRIPTION
Fixes #623.

## Problem

`canasta upgrade` printed an alarming `Error: The command exited with a non-zero return code.` even on a successful upgrade:

```
Checking directory structure...
Error: The command exited with a non-zero return code.
Checking default skin...
...
Upgraded 1 instance(s).
```

The upgrade actually succeeds — the line is cosmetic noise from an intentionally-ignored failure.

## Root cause

The directory-structure migration's "Move per-wiki directories" `mv` loop (`roles/upgrade/tasks/migrations/migrate_directory_structure.yml`) is marked `ignore_errors: true` ("OK if dir already moved"). On an already-migrated instance an item `mv` fails harmlessly and is meant to be ignored.

The `canasta_minimal` stdout callback honored `ignore_errors` in `v2_runner_on_failed` but not in `v2_runner_item_on_failed`. Ansible does not pass `ignore_errors` to item callbacks as a kwarg — it stamps the task's value onto each item result as `_ansible_ignore_errors` (`executor/task_executor.py`). The item handler never read it, so the ignored item failure leaked a bare `Error: ...`.

## Fix

`v2_runner_item_on_failed` now reads `_ansible_ignore_errors` from the item result and returns early when set, mirroring the task-level handler. Added tests for the suppressed and displayed item-failure cases.

All 948 unit tests pass.