### PR TITLE
upgrade: actually suppress ignored loop-item errors (read ignore_errors off the task)

### DIFF
--- a/callback_plugins/canasta_minimal.py
+++ b/callback_plugins/canasta_minimal.py
@@ -152,14 +152,17 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_item_on_failed(self, result, *args, **kwargs):
         # Respect the task's ignore_errors. Unlike v2_runner_on_failed,
-        # item callbacks are not passed ignore_errors as a kwarg; Ansible
-        # instead stamps the task's value onto the item result as
-        # _ansible_ignore_errors (see task_executor). Without this check, a
-        # failed loop item in an ignore_errors task (e.g. the "OK if dir
-        # already moved" mv in the directory-structure migration) leaks a
-        # bare "Error: ..." into the upgrade output even though the failure
-        # is being ignored.
-        if result._result.get("_ansible_ignore_errors"):
+        # item callbacks are not handed ignore_errors as a kwarg, and the
+        # per-item _ansible_ignore_errors marker is consumed during loop
+        # aggregation before the callback runs (it is absent from the item
+        # result). The reliable signal across ansible-core versions is the
+        # task's own ignore_errors. Without this check, a failed loop item
+        # in an ignore_errors task (e.g. the "OK if dir already moved" mv
+        # in the directory-structure migration) leaks a bare "Error: ..."
+        # into the upgrade output even though the failure is being ignored.
+        if (kwargs.get("ignore_errors")
+                or result._result.get("_ansible_ignore_errors")
+                or getattr(getattr(result, "_task", None), "ignore_errors", None)):
             return
         # Display the specific item's failure message (e.g., missing
         # required parameter in a loop over param definitions).

--- a/tests/unit/test_canasta_minimal_callback.py
+++ b/tests/unit/test_canasta_minimal_callback.py
@@ -30,6 +30,17 @@ def _result(**fields):
     return SimpleNamespace(_result=dict(fields))
 
 
+def _item_result(ignore_errors=None, **fields):
+    """A loop-item result as Ansible delivers it to v2_runner_item_on_failed:
+    the per-item _ansible_ignore_errors marker has already been consumed by
+    loop aggregation, so the only reliable ignore_errors signal is the task
+    object's own ignore_errors field."""
+    return SimpleNamespace(
+        _result=dict(fields),
+        _task=SimpleNamespace(ignore_errors=ignore_errors),
+    )
+
+
 class TestFormatCmdDiagnostics:
     def test_empty(self):
         assert canasta_minimal.CallbackModule._format_cmd_diagnostics("", "") == ""
@@ -165,18 +176,39 @@ class TestRunnerOnFailed:
 class TestRunnerItemOnFailed:
     def test_item_failure_displayed_when_not_ignored(self):
         cb = _make_callback()
+        cb.v2_runner_item_on_failed(
+            _item_result(ignore_errors=None, msg="missing required parameter")
+        )
+        msgs = [m for (m, _, _) in cb._captured]
+        assert msgs == ["Error: missing required parameter"]
+
+    def test_item_failure_displayed_when_no_task_attached(self):
+        """Defensive: a result without a _task object (e.g. some param
+        validation loops) must still surface its message."""
+        cb = _make_callback()
         cb.v2_runner_item_on_failed(_result(msg="missing required parameter"))
         msgs = [m for (m, _, _) in cb._captured]
         assert msgs == ["Error: missing required parameter"]
 
-    def test_item_failure_suppressed_when_ignore_errors(self):
-        """A failed loop item in an ignore_errors task carries the task's
-        ignore_errors via _ansible_ignore_errors. The callback must honor
-        it — otherwise the 'OK if dir already moved' mv in the upgrade
-        directory-structure migration leaks a bare 'Error: ...' line."""
+    def test_item_failure_suppressed_via_task_ignore_errors(self):
+        """How Ansible actually delivers it: the per-item
+        _ansible_ignore_errors marker is consumed during loop aggregation
+        and is absent from the item result, so the callback must read
+        ignore_errors off the task. Otherwise the 'OK if dir already moved'
+        mv in the upgrade directory-structure migration leaks a bare
+        'Error: ...' line into the output."""
         cb = _make_callback()
-        cb.v2_runner_item_on_failed(_result(
-            msg="The command exited with a non-zero return code.",
-            _ansible_ignore_errors=True,
+        cb.v2_runner_item_on_failed(_item_result(
+            ignore_errors=True,
+            msg="non-zero return code",
         ))
+        assert cb._captured == []
+
+    def test_item_failure_suppressed_via_ignore_errors_kwarg(self):
+        """Belt-and-suspenders for any ansible-core version that passes
+        ignore_errors as a kwarg to the item callback."""
+        cb = _make_callback()
+        cb.v2_runner_item_on_failed(
+            _result(msg="non-zero return code"), ignore_errors=True
+        )
         assert cb._captured == []


### PR DESCRIPTION
Fixes #623. Follow-up to #624, which did not work.

## Why #624 failed

#624 checked `result._result["_ansible_ignore_errors"]` in `v2_runner_item_on_failed`. ansible-core consumes that per-item marker during loop aggregation (`executor/task_executor.py` pops it), so the key is **absent** from the item result by the time the callback runs — the guard was a no-op. The unit test passed only because it fabricated a key Ansible never delivers, so `canasta upgrade` still printed:

```
Checking directory structure...
Error: The command exited with a non-zero return code.
Checking default skin...
```

## Fix

Read `ignore_errors` directly off `result._task`, which is reliably set across ansible-core versions. The kwarg and `_ansible_ignore_errors` checks remain as fallbacks.

Verified end-to-end with a real `ansible-playbook` run reproducing the failing scenario (an `ignore_errors: true` mv loop whose item fails):

- before: leaks `Error: non-zero return code`
- after: suppressed
- control: a non-ignored loop-item failure still surfaces its message and aborts the play

Tests updated to mirror how Ansible actually delivers the item result (task-attached `ignore_errors`, no `_ansible_ignore_errors` key) plus coverage for the no-`_task` and kwarg paths. Full unit suite (949 tests) passes.