### PR TITLE
Default canasta upgrade to the latest release; add --dev for development builds

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -43,8 +43,11 @@ fi
 
 # CANASTA_CLI_IMAGE is the post-rename name; CANASTA_ANSIBLE_IMAGE
 # remains a backwards-compatible fallback for users who already
-# set the old name in their environment.
-IMAGE="${CANASTA_CLI_IMAGE:-${CANASTA_ANSIBLE_IMAGE:-ghcr.io/canastawiki/canasta-ansible:latest}}"
+# set the old name in their environment. When either is set the user has
+# pinned the image explicitly and 'canasta upgrade' leaves it alone.
+ENV_IMAGE_OVERRIDE=false
+[[ -n "${CANASTA_CLI_IMAGE:-}" || -n "${CANASTA_ANSIBLE_IMAGE:-}" ]] \
+    && ENV_IMAGE_OVERRIDE=true
 
 # Determine config directory (same logic as canasta_registry.py)
 if [[ -n "${CANASTA_CONFIG_DIR:-}" ]]; then
@@ -59,6 +62,18 @@ fi
 
 # Ensure config directory exists
 mkdir -p "$CONFIG_DIR"
+
+# Select the canasta-ansible image. The channel (release vs dev) is pinned
+# by 'canasta upgrade' in $CONFIG_DIR/cli_image_tag and applies to every
+# command; an explicit CANASTA_CLI_IMAGE/CANASTA_ANSIBLE_IMAGE env var wins
+# over it. Default to the floating 'latest' tag when nothing is pinned.
+PINNED_TAG_FILE="$CONFIG_DIR/cli_image_tag"
+DEFAULT_TAG="latest"
+if [[ -f "$PINNED_TAG_FILE" ]]; then
+    PINNED_TAG="$(tr -d '[:space:]' < "$PINNED_TAG_FILE")"
+    [[ -n "$PINNED_TAG" ]] && DEFAULT_TAG="$PINNED_TAG"
+fi
+IMAGE="${CANASTA_CLI_IMAGE:-${CANASTA_ANSIBLE_IMAGE:-ghcr.io/canastawiki/canasta-ansible:$DEFAULT_TAG}}"
 
 # Base mounts: Docker socket + registry + current directory + $HOME.
 # The container runs as the invoking user's UID/GID so that any files
@@ -530,16 +545,52 @@ if [[ "$SSH_FWD_OK" == "true" ]]; then
     )
 fi
 
-# When the user runs 'canasta upgrade', pull the latest image and update
-# this wrapper script from the main branch, matching the Go CLI's
-# self-update behavior.
+# When the user runs 'canasta upgrade', pull the canasta-ansible image for
+# the selected channel and update this wrapper script to match. Default is
+# the latest released version; 'canasta upgrade --dev' tracks head of main.
+# The chosen channel is persisted to $PINNED_TAG_FILE so every later command
+# runs the same image.
 WRAPPER_PATH="$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")"
-WRAPPER_URL="https://raw.githubusercontent.com/CanastaWiki/Canasta-CLI/main/canasta-docker"
+
+# Resolve the highest vX.Y.Z release tag via the GitHub tags API (no jq/git
+# dependency). Echoes the bare version (e.g. 4.0.4), or nothing on failure.
+latest_release_tag() {
+    curl -fsSL "https://api.github.com/repos/CanastaWiki/Canasta-CLI/tags" 2>/dev/null \
+        | grep -oE '"name": *"v[0-9]+\.[0-9]+\.[0-9]+"' \
+        | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' \
+        | sort -V | tail -1 | sed 's/^v//'
+}
+
+DEV_CHANNEL=false
+for arg in "$@"; do
+    [[ "$arg" == "--dev" ]] && DEV_CHANNEL=true
+done
+
 for arg in "$@"; do
     case "$arg" in
         -*) continue ;;
         upgrade)
-            echo "Pulling latest canasta-ansible image..."
+            if [[ "$ENV_IMAGE_OVERRIDE" == "true" ]]; then
+                # User pinned the image explicitly; just refresh it.
+                WRAPPER_REF="main"
+            elif [[ "$DEV_CHANNEL" == "true" ]]; then
+                echo "latest" > "$PINNED_TAG_FILE"
+                IMAGE="ghcr.io/canastawiki/canasta-ansible:latest"
+                WRAPPER_REF="main"
+            else
+                TAG="$(latest_release_tag)"
+                if [[ -z "$TAG" ]]; then
+                    echo "Warning: could not determine the latest release; keeping current image ($IMAGE)." >&2
+                    WRAPPER_REF="main"
+                else
+                    echo "$TAG" > "$PINNED_TAG_FILE"
+                    IMAGE="ghcr.io/canastawiki/canasta-ansible:$TAG"
+                    WRAPPER_REF="v$TAG"
+                fi
+            fi
+            WRAPPER_URL="https://raw.githubusercontent.com/CanastaWiki/Canasta-CLI/${WRAPPER_REF}/canasta-docker"
+
+            echo "Pulling canasta-ansible image ($IMAGE)..."
             docker pull "$IMAGE"
 
             # Update the wrapper script itself if the upstream differs.
@@ -617,8 +668,11 @@ if [[ -t 0 ]]; then
 fi
 
 # Tell canasta.py it's running under the docker wrapper, so
-# 'canasta version' reports the correct run mode.
+# 'canasta version' reports the correct run mode. Pass the resolved image
+# tag too (the part after the last colon) so 'canasta version' can tell a
+# release (semver tag) from a dev build (':latest').
 DOCKER_RUN_FLAGS+=(-e CANASTA_RUN_MODE=docker)
+DOCKER_RUN_FLAGS+=(-e "CANASTA_CLI_IMAGE_TAG=${IMAGE##*:}")
 
 # Detect if `docker` is actually a podman shim (e.g. the podman-docker
 # package on Debian/Fedora installs /usr/bin/docker as a wrapper that

--- a/canasta.py
+++ b/canasta.py
@@ -161,16 +161,45 @@ def find_ansible_playbook():
     sys.exit(1)
 
 
-def self_update_cli():
-    """Pull latest CLI code from origin/main before invoking ansible-playbook.
+_RELEASE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+
+def _pick_latest_release_tag(tags):
+    """Return the highest strict vX.Y.Z tag from `tags`, or None.
+
+    Pre-releases (e.g. v5.0.0-rc1) and non-version tags are ignored so we
+    only ever move to a real release. Comparison is by numeric (major,
+    minor, patch) tuple, not lexical, so v4.0.10 sorts above v4.0.9.
+    """
+    best = None
+    best_key = None
+    for tag in tags:
+        m = _RELEASE_TAG_RE.match(tag.strip())
+        if not m:
+            continue
+        key = tuple(int(p) for p in m.groups())
+        if best_key is None or key > best_key:
+            best, best_key = tag.strip(), key
+    return best
+
+
+def self_update_cli(dev=False):
+    """Update the CLI code before invoking ansible-playbook.
+
+    By default the CLI moves to the latest released version — the highest
+    vX.Y.Z git tag, via a detached checkout. Pass ``dev=True`` to instead
+    track the head of main (``git checkout main && git pull --ff-only``).
+    Release tags are used rather than the GitHub Releases API because the
+    Releases API deliberately keeps v3.7.0 as 'latest' for legacy clients
+    (see .github/workflows/docker.yml).
 
     Runs in the canasta.py process (i.e. before os.execvp swaps in
-    ansible-playbook), so any changes the pull lands on disk —
+    ansible-playbook), so any changes the move lands on disk —
     ansible.cfg, module_utils, modules, playbook tasks — are visible
     to the ansible-playbook process from its very first config load.
     Used to live as the first task of upgrade.yml itself, but loading
     ansible.cfg at startup means an in-flight cfg change between
-    pre-pull and post-pull state would silently make ansible-playbook
+    pre- and post-move state would silently make ansible-playbook
     keep using stale values (#489).
 
     Docker installs (no .git in the script dir) are no-ops here: the
@@ -212,7 +241,7 @@ def self_update_cli():
         current_version = "unknown"
 
     try:
-        _git(["fetch", "origin"], check=True)
+        _git(["fetch", "--tags", "origin"], check=True)
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
             OSError) as e:
         # `e.stderr` is bytes/None on TimeoutExpired/OSError — guard.
@@ -233,20 +262,58 @@ def self_update_cli():
         print(msg, file=sys.stderr)
         return
 
-    pending = _git(["log", "HEAD..origin/main", "--oneline"], timeout=10)
-    if pending.returncode != 0 or not pending.stdout.strip():
+    # Resolve the ref this run should move to: head of main for --dev, or
+    # the latest release tag otherwise.
+    if dev:
+        target_ref = "origin/main"
+    else:
+        tags = _git(["tag", "-l", "v*"], timeout=10).stdout.split()
+        target_ref = _pick_latest_release_tag(tags)
+        if target_ref is None:
+            print(
+                "WARNING: self-update skipped — no release tags found.\n"
+                "Use 'canasta upgrade --dev' to track the development "
+                "branch (head of main) instead.",
+                file=sys.stderr,
+            )
+            return
+
+    target_commit = _git(
+        ["rev-parse", "--short", target_ref], timeout=5,
+    ).stdout.strip()
+    on_main = _git(
+        ["rev-parse", "--abbrev-ref", "HEAD"], timeout=5,
+    ).stdout.strip() == "main"
+
+    # Already at the target? For --dev we also require being on the main
+    # branch, so a prior release upgrade's detached HEAD still switches back.
+    if target_commit and target_commit == current_commit \
+            and (not dev or on_main):
+        channel = "dev (main)" if dev else "release %s" % target_ref
         print(
             "Canasta CLI is already up to date "
-            "(version %s, commit %s)." % (current_version, current_commit)
+            "(version %s, commit %s, %s)."
+            % (current_version, current_commit, channel)
         )
         return
 
-    pull = _git(["pull", "--ff-only", "origin", "main"], timeout=60)
-    if pull.returncode != 0:
+    if dev:
+        # Restore the main branch first — a previous release upgrade may
+        # have left a detached HEAD at a tag — then fast-forward.
+        co = _git(["checkout", "main"], timeout=30)
+        pull = _git(["pull", "--ff-only", "origin", "main"], timeout=60)
+        move_failed = co.returncode != 0 or pull.returncode != 0
+    else:
+        # Detached checkout of the latest release tag.
+        co = _git(["checkout", target_ref], timeout=60)
+        move_failed = co.returncode != 0
+
+    if move_failed:
         print(
-            "Could not fast-forward to latest main "
-            "(local branch may have diverged).\n"
-            "Run 'git pull origin main' manually in %s." % repo,
+            "Could not move to %s "
+            "(local checkout may have uncommitted changes or have "
+            "diverged).\nResolve manually in %s (e.g. check 'git status')."
+            % (target_ref, repo),
             file=sys.stderr,
         )
         return
@@ -1344,7 +1411,7 @@ def main():
     # but running it inside the playbook means ansible-playbook's
     # in-memory config goes stale on cfg changes — see #489.
     if command_name == "upgrade":
-        self_update_cli()
+        self_update_cli(dev=getattr(args, "dev", False))
 
     os.execvp(ansible_args[0], ansible_args)
 

--- a/canasta.py
+++ b/canasta.py
@@ -281,30 +281,54 @@ def self_update_cli(dev=False):
     target_commit = _git(
         ["rev-parse", "--short", target_ref], timeout=5,
     ).stdout.strip()
-    on_main = _git(
-        ["rev-parse", "--abbrev-ref", "HEAD"], timeout=5,
-    ).stdout.strip() == "main"
-
-    # Already at the target? For --dev we also require being on the main
-    # branch, so a prior release upgrade's detached HEAD still switches back.
-    if target_commit and target_commit == current_commit \
-            and (not dev or on_main):
-        channel = "dev (main)" if dev else "release %s" % target_ref
-        print(
-            "Canasta CLI is already up to date "
-            "(version %s, commit %s, %s)."
-            % (current_version, current_commit, channel)
-        )
-        return
 
     if dev:
+        on_main = _git(
+            ["rev-parse", "--abbrev-ref", "HEAD"], timeout=5,
+        ).stdout.strip() == "main"
+        # Already on main at origin/main? Nothing to do. (Require being on
+        # the main branch so a prior release upgrade's detached HEAD still
+        # switches back.)
+        if target_commit and target_commit == current_commit and on_main:
+            print(
+                "Canasta CLI is already up to date "
+                "(version %s, commit %s, dev (main))."
+                % (current_version, current_commit)
+            )
+            return
         # Restore the main branch first — a previous release upgrade may
         # have left a detached HEAD at a tag — then fast-forward.
         co = _git(["checkout", "main"], timeout=30)
         pull = _git(["pull", "--ff-only", "origin", "main"], timeout=60)
         move_failed = co.returncode != 0 or pull.returncode != 0
     else:
-        # Detached checkout of the latest release tag.
+        # Release channel: only ever move forward. If the latest release
+        # tag is already contained in HEAD — we're sitting on it, or on a
+        # newer development build — checking it out would be a downgrade,
+        # so stay put. 'canasta upgrade' must never travel backward in time.
+        contained = _git(
+            ["merge-base", "--is-ancestor", target_ref, "HEAD"], timeout=5,
+        ).returncode == 0
+        if contained:
+            if target_commit == current_commit:
+                print(
+                    "Canasta CLI is already up to date "
+                    "(version %s, commit %s, release %s)."
+                    % (current_version, current_commit, target_ref)
+                )
+            else:
+                print(
+                    "Canasta CLI is already ahead of the latest release "
+                    "(%s); keeping the current build (version %s, commit %s) "
+                    "rather than moving backward.\nUse 'canasta upgrade --dev' "
+                    "to keep tracking development builds, or run "
+                    "'git checkout %s' in %s to pin the release exactly."
+                    % (target_ref, current_version, current_commit,
+                       target_ref, repo)
+                )
+            return
+        # HEAD is behind the latest release (or on a divergent line that
+        # doesn't contain it) — move to the release tag.
         co = _git(["checkout", target_ref], timeout=60)
         move_failed = co.returncode != 0
 

--- a/direct_commands/info.py
+++ b/direct_commands/info.py
@@ -180,6 +180,39 @@ def _read_instance_image(inst_id, inst):
     return image, running
 
 
+def _detect_dev_build(script_dir, mode):
+    """Whether this CLI is a development build rather than a tagged release.
+
+    Returns True for a dev build, False for an exact release, or None when
+    it can't be determined (callers then fall back to the VERSION file).
+
+    The VERSION file is unreliable on a dev checkout — it commonly still
+    holds the last release's number until the next bump — so 'canasta
+    version' shows 'dev' instead of a possibly-wrong number in that case.
+    """
+    if mode == "docker":
+        # The canasta-docker wrapper passes the resolved image tag: a bare
+        # semver is a release, 'latest' (or any other tag) is a dev build.
+        tag = os.environ.get("CANASTA_CLI_IMAGE_TAG")
+        if not tag:
+            return None
+        return not re.match(r"^\d+\.\d+\.\d+$", tag)
+    # Native install: a release is a detached checkout whose HEAD carries a
+    # vX.Y.Z tag (done by 'canasta upgrade'); anything else is a dev build.
+    try:
+        result = subprocess.run(
+            ["git", "tag", "--points-at", "HEAD"],
+            cwd=script_dir, capture_output=True, text=True, timeout=5,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return not any(
+        re.match(r"^v\d+\.\d+\.\d+$", t) for t in result.stdout.split()
+    )
+
+
 @register("version")
 def cmd_version(args):
     script_dir = _helpers._get_script_dir()
@@ -236,7 +269,12 @@ def cmd_version(args):
         except (subprocess.TimeoutExpired, OSError):
             date = "unknown"
 
-    print("Canasta CLI v%s (%s, commit %s, built %s)" % (version, mode, commit, date))
+    # On a dev build the VERSION number may not yet match the eventual
+    # release, so show 'dev' instead of a potentially-misleading version.
+    dev_build = _detect_dev_build(script_dir, mode)
+    version_label = "dev" if dev_build else "v%s" % version
+    print("Canasta CLI %s (%s, commit %s, built %s)"
+          % (version_label, mode, commit, date))
     print("Target Canasta version: %s" % target_canasta_version)
 
     # --cli-only: stop after the two-line header; no instance reads.

--- a/get-canasta.sh
+++ b/get-canasta.sh
@@ -1,16 +1,24 @@
 #!/usr/bin/env bash
 # get-canasta.sh — Install or upgrade to the Ansible-based Canasta CLI.
 #
+# By default this installs the latest released version of the CLI (the
+# highest vX.Y.Z tag); pass --dev to track the development branch (the
+# head of main) instead. This mirrors 'canasta upgrade', which also
+# defaults to the latest release and takes --dev for development builds.
+#
 # Usage:
 #   curl -fsSL https://get.canasta.wiki | bash
 #   curl -fsSL https://get.canasta.wiki | bash -s -- --native
 #   curl -fsSL https://get.canasta.wiki | bash -s -- --docker
+#   curl -fsSL https://get.canasta.wiki | bash -s -- --dev
 #
 # Documentation: https://canasta.wiki/wiki/Help:Installation
 #
 # Flags:
 #   --native    Install canasta-native (requires Python 3.10+, git)
 #   --docker    Install canasta-docker (requires Docker only, default)
+#   --dev       Track the development branch (head of main) instead of
+#               the latest released version
 #   --prefix    Installation prefix (default: /opt/canasta-ansible for native)
 #
 # Linux native installs create a 'canasta' system group. Add users with:
@@ -27,10 +35,10 @@
 set -euo pipefail
 
 REPO_URL="https://github.com/CanastaWiki/Canasta-CLI.git"
-DOCKER_WRAPPER_URL="https://raw.githubusercontent.com/CanastaWiki/Canasta-CLI/main/canasta-docker"
 BIN_DIR="/usr/local/bin"
 MODE=""
 PREFIX=""
+DEV=false
 
 # --- Helpers -----------------------------------------------------------------
 
@@ -42,6 +50,86 @@ need_cmd() {
     if ! command -v "$1" >/dev/null 2>&1; then
         error "Required command not found: $1"
     fi
+}
+
+# Highest vX.Y.Z release tag on the repo (e.g. v4.0.4); empty on failure.
+# Prefers git ls-remote (no API rate limits); falls back to the GitHub
+# tags API via curl. The Releases API is intentionally not used — it pins
+# v3.7.0 as 'latest' for legacy clients. Mirrors the resolver in canasta.py
+# and the canasta-docker wrapper.
+latest_release_tag() {
+    local tag=""
+    if command -v git >/dev/null 2>&1; then
+        tag="$(git ls-remote --tags --refs "$REPO_URL" 'v*' 2>/dev/null \
+            | sed 's#.*refs/tags/##' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V | tail -1 || true)"
+    fi
+    if [[ -z "$tag" ]] && command -v curl >/dev/null 2>&1; then
+        tag="$(curl -fsSL "https://api.github.com/repos/CanastaWiki/Canasta-CLI/tags" 2>/dev/null \
+            | grep -oE '"name": *"v[0-9]+\.[0-9]+\.[0-9]+"' \
+            | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' \
+            | sort -V | tail -1 || true)"
+    fi
+    printf '%s' "$tag"
+}
+
+# Point a freshly cloned/updated native checkout at the selected channel:
+# the latest release tag by default (detached checkout), or the head of
+# main with --dev. $1 = install dir; $2 = sudo prefix ("$SUDO" or "").
+set_native_channel() {
+    local install_dir="$1"
+    local sudo_cmd="${2:-}"
+    if [[ "$DEV" == true ]]; then
+        info "Tracking development branch (head of main)..."
+        $sudo_cmd git -C "$install_dir" checkout --quiet main
+        $sudo_cmd git -C "$install_dir" pull --ff-only --quiet
+        return
+    fi
+    local tag
+    tag="$(latest_release_tag)"
+    if [[ -z "$tag" ]]; then
+        warn "Could not determine the latest release tag; staying on the default branch (development)."
+        return
+    fi
+    info "Checking out latest release ${tag}..."
+    $sudo_cmd git -C "$install_dir" fetch --tags --quiet origin || true
+    $sudo_cmd git -C "$install_dir" checkout --quiet "$tag"
+}
+
+# The user who will actually run 'canasta' (not necessarily root, when the
+# installer is invoked via sudo). Used to place the Docker-mode channel pin
+# in that user's config dir.
+target_user() { echo "${SUDO_USER:-$(id -un)}"; }
+
+# Resolve the config dir the canasta-docker wrapper will use for the target
+# user, mirroring the wrapper's own logic (minus the root /etc/canasta case,
+# since the pin is for the non-root user who runs canasta).
+canasta_config_dir() {
+    local u h
+    u="$(target_user)"
+    h="$(getent passwd "$u" 2>/dev/null | cut -d: -f6)"
+    [[ -z "$h" ]] && h="$(eval echo "~$u" 2>/dev/null)"
+    [[ -z "$h" ]] && return 0
+    if [[ "$(uname)" == "Darwin" ]]; then
+        echo "$h/Library/Application Support/canasta"
+    elif [[ "$u" == "$(id -un)" && -n "${XDG_CONFIG_HOME:-}" ]]; then
+        echo "$XDG_CONFIG_HOME/canasta"
+    else
+        echo "$h/.config/canasta"
+    fi
+}
+
+# Best-effort: pin the Docker-mode image channel so the first command runs
+# the right image before any 'canasta upgrade'. A later upgrade rewrites
+# this, so a miss here is harmless. $1 = tag to pin ('latest' or a version).
+pin_docker_channel() {
+    local tag="$1" cfg
+    cfg="$(canasta_config_dir)" || return 0
+    [[ -z "$cfg" ]] && return 0
+    $SUDO mkdir -p "$cfg" 2>/dev/null || return 0
+    printf '%s\n' "$tag" | $SUDO tee "$cfg/cli_image_tag" >/dev/null 2>&1 || return 0
+    $SUDO chown -R "$(target_user)" "$cfg" 2>/dev/null || true
 }
 
 install_native_deps() {
@@ -180,10 +268,11 @@ parse_args() {
         case "$1" in
             --native) MODE="native" ;;
             --docker) MODE="docker" ;;
+            --dev) DEV=true ;;
             --prefix) PREFIX="$2"; shift ;;
             --prefix=*) PREFIX="${1#*=}" ;;
             -h|--help)
-                echo "Usage: get-canasta.sh [--native|--docker] [--prefix PATH]"
+                echo "Usage: get-canasta.sh [--native|--docker] [--dev] [--prefix PATH]"
                 exit 0
                 ;;
             *) error "Unknown option: $1" ;;
@@ -205,10 +294,29 @@ install_docker_mode() {
     need_cmd curl
     need_sudo
 
-    info "Downloading canasta-docker wrapper..."
+    # Select the channel: the latest released wrapper + image tag by
+    # default, or the head of main with --dev.
+    local wrapper_ref="main"
+    local pin_tag="latest"
+    if [[ "$DEV" != true ]]; then
+        local tag
+        tag="$(latest_release_tag)"
+        if [[ -n "$tag" ]]; then
+            wrapper_ref="$tag"
+            pin_tag="${tag#v}"
+        else
+            warn "Could not determine the latest release; using main (development)."
+        fi
+    fi
+    local wrapper_url="https://raw.githubusercontent.com/CanastaWiki/Canasta-CLI/${wrapper_ref}/canasta-docker"
+
+    info "Downloading canasta-docker wrapper (${wrapper_ref})..."
     $SUDO curl -fsSL --retry 3 --retry-delay 5 \
-        -o "${BIN_DIR}/canasta-docker" "$DOCKER_WRAPPER_URL"
+        -o "${BIN_DIR}/canasta-docker" "$wrapper_url"
     $SUDO chmod +x "${BIN_DIR}/canasta-docker"
+
+    # Pin the image channel so the first command runs the chosen image.
+    pin_docker_channel "$pin_tag"
 
     info "Creating canasta symlink..."
     $SUDO ln -sf "${BIN_DIR}/canasta-docker" "${BIN_DIR}/canasta"
@@ -245,14 +353,14 @@ install_native_linux() {
         $SUDO groupadd --system canasta
     fi
 
-    # Clone or update the repo
+    # Clone or update the repo, then move to the selected channel.
     if [[ -d "${install_dir}/.git" ]]; then
         info "Updating existing installation at ${install_dir}..."
-        $SUDO git -C "$install_dir" pull --ff-only
     else
         info "Cloning Canasta CLI to ${install_dir}..."
         $SUDO git clone "$REPO_URL" "$install_dir"
     fi
+    set_native_channel "$install_dir" "$SUDO"
 
     # Mark as safe directory for git (so non-root users can run git
     # commands against the root-owned repo during e.g. 'canasta upgrade')
@@ -310,14 +418,15 @@ install_native_macos() {
 
     info "Installing Canasta (native mode, macOS)..."
 
-    # Clone or update the repo (user-owned, no sudo needed for the repo)
+    # Clone or update the repo (user-owned, no sudo needed for the repo),
+    # then move to the selected channel.
     if [[ -d "${install_dir}/.git" ]]; then
         info "Updating existing installation at ${install_dir}..."
-        git -C "$install_dir" pull --ff-only
     else
         info "Cloning Canasta CLI to ${install_dir}..."
         git clone "$REPO_URL" "$install_dir"
     fi
+    set_native_channel "$install_dir" ""
 
     # Create venv and install deps
     info "Creating Python virtual environment..."
@@ -426,7 +535,13 @@ post_install_upgrade() {
     info "Running 'canasta upgrade' to apply config migrations and"
     info "pull current container images for registered instances..."
     info "========================================"
-    if ! "${BIN_DIR}/canasta" upgrade; then
+    local rc=0
+    if [[ "$DEV" == true ]]; then
+        "${BIN_DIR}/canasta" upgrade --dev || rc=$?
+    else
+        "${BIN_DIR}/canasta" upgrade || rc=$?
+    fi
+    if [[ "$rc" -ne 0 ]]; then
         warn ""
         warn "'canasta upgrade' reported issues; review the output above."
         warn "The Canasta CLI itself is installed and ready. Re-run"

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -749,8 +749,13 @@ commands:
     long_description: |
       Upgrade all registered Canasta instances by refreshing configs,
       pulling latest images, running migrations, and restarting containers.
+
+      By default the CLI itself updates to the latest released version
+      (the highest vX.Y.Z tag). Pass --dev to track the development branch
+      (head of main) instead.
     examples:
       - "canasta upgrade"
+      - "canasta upgrade --dev"
       - "canasta upgrade --dry-run"
     playbook: upgrade.yml
     parameters:
@@ -758,6 +763,10 @@ commands:
         type: bool
         default: false
         description: "Preview changes without applying"
+      - name: dev
+        type: bool
+        default: false
+        description: "Track the development branch (head of main) instead of the latest release"
 
   # ---------------------------------------------------------------------------
   # Wiki management

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -1038,6 +1038,15 @@ class TestSelfUpdateCli:
 
         return fake_run, calls
 
+    def test_pick_latest_release_tag(self):
+        tags = ("v3.7.0 v4.0.0 v4.0.2 v4.0.10 v5.0.0-rc1 main "
+                "not-a-tag").split()
+        # Numeric (not lexical) ordering: v4.0.10 > v4.0.2; pre-release and
+        # non-version refs are ignored.
+        assert canasta_cli._pick_latest_release_tag(tags) == "v4.0.10"
+        assert canasta_cli._pick_latest_release_tag([]) is None
+        assert canasta_cli._pick_latest_release_tag(["v5.0.0-rc1"]) is None
+
     def test_no_op_when_not_a_git_repo(
         self, monkeypatch, tmp_path, capsys,
     ):
@@ -1071,34 +1080,56 @@ class TestSelfUpdateCli:
         assert out.err == ""
 
     def test_already_up_to_date(self, monkeypatch, tmp_path, capsys):
+        # Default (released) channel: latest tag's commit already == HEAD.
         self._patch_repo(monkeypatch, tmp_path)
         runner, calls = self._make_runner([
-            {"stdout": "abc1234\n"},   # rev-parse current
-            {"stdout": ""},             # fetch
-            {"stdout": ""},             # log HEAD..origin/main → empty
+            {"stdout": "abc1234\n"},        # rev-parse current HEAD
+            {"stdout": ""},                  # fetch --tags
+            {"stdout": "v3.7.0\nv4.0.0\n"},  # tag -l v* → latest is v4.0.0
+            {"stdout": "abc1234\n"},         # rev-parse v4.0.0 == HEAD
+            {"stdout": "main\n"},            # rev-parse --abbrev-ref HEAD
         ])
         monkeypatch.setattr(_subprocess, "run", runner)
         canasta_cli.self_update_cli()
         out = capsys.readouterr().out
         assert "already up to date" in out
+        assert "release v4.0.0" in out
         assert "4.0.0" in out
         assert "abc1234" in out
+
+    def test_dev_already_up_to_date(self, monkeypatch, tmp_path, capsys):
+        # --dev tracks origin/main; up to date only when on main and at HEAD.
+        self._patch_repo(monkeypatch, tmp_path)
+        runner, calls = self._make_runner([
+            {"stdout": "abc1234\n"},   # rev-parse current HEAD
+            {"stdout": ""},             # fetch --tags
+            {"stdout": "abc1234\n"},    # rev-parse origin/main == HEAD
+            {"stdout": "main\n"},       # rev-parse --abbrev-ref HEAD
+        ])
+        monkeypatch.setattr(_subprocess, "run", runner)
+        canasta_cli.self_update_cli(dev=True)
+        out = capsys.readouterr().out
+        assert "already up to date" in out
+        assert "dev (main)" in out
 
     def test_pulls_and_updates_build_files(
         self, monkeypatch, tmp_path, capsys,
     ):
         self._patch_repo(monkeypatch, tmp_path, version="4.0.0")
-        # Sequence: rev-parse current, fetch, log (has updates),
-        # pull, rev-parse new, log -1 date, pip install, galaxy install.
+        # Default (released) channel sequence: rev-parse current, fetch,
+        # tag -l, rev-parse target, rev-parse abbrev-ref, checkout tag,
+        # rev-parse new, log -1 date, pip install, galaxy install.
         runner, calls = self._make_runner([
-            {"stdout": "old1234\n"},
-            {"stdout": ""},
-            {"stdout": "new1234 some change\n"},   # pending updates
-            {"stdout": ""},                         # pull succeeded
-            {"stdout": "new1234\n"},
-            {"stdout": "2026-05-05 10:00:00\n"},
-            {"stdout": ""},                         # pip install
-            {"stdout": ""},                         # ansible-galaxy install
+            {"stdout": "old1234\n"},                # rev-parse HEAD
+            {"stdout": ""},                          # fetch --tags
+            {"stdout": "v4.0.0\nv4.1.0\n"},          # tag -l → latest v4.1.0
+            {"stdout": "new1234\n"},                 # rev-parse v4.1.0
+            {"stdout": "main\n"},                    # rev-parse --abbrev-ref
+            {"stdout": ""},                          # checkout v4.1.0
+            {"stdout": "new1234\n"},                 # rev-parse new HEAD
+            {"stdout": "2026-05-05 10:00:00\n"},     # log -1 date
+            {"stdout": ""},                          # pip install
+            {"stdout": ""},                          # ansible-galaxy install
         ])
         monkeypatch.setattr(_subprocess, "run", runner)
 
@@ -1145,12 +1176,12 @@ class TestSelfUpdateCli:
         )
 
         # pip + ansible-galaxy ran with the right arguments.
-        pip_call = calls[6]
+        pip_call = calls[8]
         assert pip_call[1:] == [
             "-m", "pip", "install", "--quiet",
             "-r", str(tmp_path / "requirements.txt"),
         ]
-        galaxy_call = calls[7]
+        galaxy_call = calls[9]
         assert galaxy_call[-5:] == [
             "collection", "install", "--upgrade",
             "-r", str(tmp_path / "requirements.yml"),
@@ -1165,12 +1196,14 @@ class TestSelfUpdateCli:
         deps are on disk."""
         self._patch_repo(monkeypatch, tmp_path, version="4.0.0")
         runner, calls = self._make_runner([
-            {"stdout": "old1234\n"},
-            {"stdout": ""},
-            {"stdout": "new1234 some change\n"},
-            {"stdout": ""},
-            {"stdout": "new1234\n"},
-            {"stdout": "2026-05-05 10:00:00\n"},
+            {"stdout": "old1234\n"},                # rev-parse HEAD
+            {"stdout": ""},                          # fetch --tags
+            {"stdout": "v4.0.0\nv4.1.0\n"},          # tag -l → latest v4.1.0
+            {"stdout": "new1234\n"},                 # rev-parse v4.1.0
+            {"stdout": "main\n"},                    # rev-parse --abbrev-ref
+            {"stdout": ""},                          # checkout v4.1.0
+            {"stdout": "new1234\n"},                 # rev-parse new HEAD
+            {"stdout": "2026-05-05 10:00:00\n"},     # log -1 date
             {"stdout": "", "returncode": 1},        # pip fails
             {"stdout": "", "returncode": 1},        # galaxy fails
         ])
@@ -1197,20 +1230,40 @@ class TestSelfUpdateCli:
         assert "ansible-galaxy collection install failed" in captured.err
         assert "dependency refresh incomplete" in captured.err
 
-    def test_pull_failure_warns_and_continues(
+    def test_move_failure_warns_and_continues(
         self, monkeypatch, tmp_path, capsys,
     ):
+        # A failed checkout of the release tag (dirty/divergent tree) warns
+        # but does not abort the rest of the upgrade.
         self._patch_repo(monkeypatch, tmp_path)
         runner, calls = self._make_runner([
-            {"stdout": "abc1234\n"},
-            {"stdout": ""},
-            {"stdout": "ff00 some change\n"},
-            {"stdout": "", "returncode": 1, "stderr": "diverged\n"},
+            {"stdout": "abc1234\n"},                # rev-parse HEAD
+            {"stdout": ""},                          # fetch --tags
+            {"stdout": "v4.0.0\nv4.1.0\n"},          # tag -l → latest v4.1.0
+            {"stdout": "def5678\n"},                 # rev-parse v4.1.0 != HEAD
+            {"stdout": "main\n"},                    # rev-parse --abbrev-ref
+            {"stdout": "", "returncode": 1, "stderr": "diverged\n"},  # checkout
         ])
         monkeypatch.setattr(_subprocess, "run", runner)
         canasta_cli.self_update_cli()
         err = capsys.readouterr().err
-        assert "Could not fast-forward" in err
+        assert "Could not move to v4.1.0" in err
+
+    def test_no_release_tags_warns_and_returns(
+        self, monkeypatch, tmp_path, capsys,
+    ):
+        # Released channel with no vX.Y.Z tags: skip, pointing at --dev.
+        self._patch_repo(monkeypatch, tmp_path)
+        runner, calls = self._make_runner([
+            {"stdout": "abc1234\n"},   # rev-parse HEAD
+            {"stdout": ""},             # fetch --tags
+            {"stdout": "\n"},           # tag -l → none
+        ])
+        monkeypatch.setattr(_subprocess, "run", runner)
+        canasta_cli.self_update_cli()
+        err = capsys.readouterr().err
+        assert "no release tags found" in err
+        assert "--dev" in err
 
     def test_fetch_failure_warns_and_returns(
         self, monkeypatch, tmp_path, capsys,

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -1087,7 +1087,7 @@ class TestSelfUpdateCli:
             {"stdout": ""},                  # fetch --tags
             {"stdout": "v3.7.0\nv4.0.0\n"},  # tag -l v* → latest is v4.0.0
             {"stdout": "abc1234\n"},         # rev-parse v4.0.0 == HEAD
-            {"stdout": "main\n"},            # rev-parse --abbrev-ref HEAD
+            {"returncode": 0},               # merge-base --is-ancestor (contained)
         ])
         monkeypatch.setattr(_subprocess, "run", runner)
         canasta_cli.self_update_cli()
@@ -1096,6 +1096,33 @@ class TestSelfUpdateCli:
         assert "release v4.0.0" in out
         assert "4.0.0" in out
         assert "abc1234" in out
+
+    def test_release_ahead_does_not_downgrade(
+        self, monkeypatch, tmp_path, capsys,
+    ):
+        # On a development build ahead of the latest release tag: the
+        # release tag is contained in HEAD, so 'canasta upgrade' must NOT
+        # check it out (no travelling backward in time).
+        self._patch_repo(monkeypatch, tmp_path)
+        execv_calls = []
+        monkeypatch.setattr(
+            canasta_cli.os, "execv", lambda *a: execv_calls.append(a),
+        )
+        runner, calls = self._make_runner([
+            {"stdout": "newbuild\n"},        # rev-parse current HEAD (ahead)
+            {"stdout": ""},                   # fetch --tags
+            {"stdout": "v4.0.0\nv4.0.4\n"},   # tag -l v* → latest is v4.0.4
+            {"stdout": "old4044\n"},          # rev-parse v4.0.4 (behind HEAD)
+            {"returncode": 0},                # merge-base: tag IS ancestor of HEAD
+        ])
+        monkeypatch.setattr(_subprocess, "run", runner)
+        canasta_cli.self_update_cli()
+        out = capsys.readouterr().out
+        assert "already ahead of the latest release" in out
+        assert "v4.0.4" in out
+        # No checkout, no re-exec — we stayed on the current build.
+        assert not any("checkout" in c for c in calls)
+        assert execv_calls == []
 
     def test_dev_already_up_to_date(self, monkeypatch, tmp_path, capsys):
         # --dev tracks origin/main; up to date only when on main and at HEAD.
@@ -1124,7 +1151,7 @@ class TestSelfUpdateCli:
             {"stdout": ""},                          # fetch --tags
             {"stdout": "v4.0.0\nv4.1.0\n"},          # tag -l → latest v4.1.0
             {"stdout": "new1234\n"},                 # rev-parse v4.1.0
-            {"stdout": "main\n"},                    # rev-parse --abbrev-ref
+            {"returncode": 1},                       # merge-base: not contained → move
             {"stdout": ""},                          # checkout v4.1.0
             {"stdout": "new1234\n"},                 # rev-parse new HEAD
             {"stdout": "2026-05-05 10:00:00\n"},     # log -1 date
@@ -1200,7 +1227,7 @@ class TestSelfUpdateCli:
             {"stdout": ""},                          # fetch --tags
             {"stdout": "v4.0.0\nv4.1.0\n"},          # tag -l → latest v4.1.0
             {"stdout": "new1234\n"},                 # rev-parse v4.1.0
-            {"stdout": "main\n"},                    # rev-parse --abbrev-ref
+            {"returncode": 1},                       # merge-base: not contained → move
             {"stdout": ""},                          # checkout v4.1.0
             {"stdout": "new1234\n"},                 # rev-parse new HEAD
             {"stdout": "2026-05-05 10:00:00\n"},     # log -1 date
@@ -1241,7 +1268,7 @@ class TestSelfUpdateCli:
             {"stdout": ""},                          # fetch --tags
             {"stdout": "v4.0.0\nv4.1.0\n"},          # tag -l → latest v4.1.0
             {"stdout": "def5678\n"},                 # rev-parse v4.1.0 != HEAD
-            {"stdout": "main\n"},                    # rev-parse --abbrev-ref
+            {"returncode": 1},                       # merge-base: not contained → move
             {"stdout": "", "returncode": 1, "stderr": "diverged\n"},  # checkout
         ])
         monkeypatch.setattr(_subprocess, "run", runner)

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -822,22 +822,76 @@ class TestCmdVersion:
         assert direct_commands.is_direct_command("version")
 
     def test_native_checkout(self, tmp_path, monkeypatch, capsys):
+        # Release checkout: HEAD carries a vX.Y.Z tag, so the version shows.
         (tmp_path / "VERSION").write_text("4.0.0\n")
         monkeypatch.delenv("CANASTA_RUN_MODE", raising=False)
         monkeypatch.setattr(direct_commands._helpers, "_get_script_dir", lambda: str(tmp_path))
-        monkeypatch.setattr(
-            subprocess, "run",
-            lambda *a, **kw: type("R", (), {
-                "returncode": 0,
-                "stdout": "abc1234\n" if "rev-parse" in a[0] else "2026-04-18 12:00:00\n",
-            })(),
-        )
+
+        def fake_run(*a, **kw):
+            if "tag" in a[0]:
+                stdout = "v4.0.0\n"            # release tag points at HEAD
+            elif "rev-parse" in a[0]:
+                stdout = "abc1234\n"
+            else:
+                stdout = "2026-04-18 12:00:00\n"
+            return type("R", (), {"returncode": 0, "stdout": stdout})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
         rc = direct_commands.cmd_version(None)
         assert rc == 0
         out = capsys.readouterr().out
         assert "v4.0.0" in out
         assert "native" in out
         assert "abc1234" in out
+
+    def test_native_dev_checkout_shows_dev(self, tmp_path, monkeypatch, capsys):
+        # Dev checkout: no release tag at HEAD, so 'dev' replaces the number
+        # (the VERSION file may not match the eventual release).
+        (tmp_path / "VERSION").write_text("4.0.0\n")
+        monkeypatch.delenv("CANASTA_RUN_MODE", raising=False)
+        monkeypatch.setattr(direct_commands._helpers, "_get_script_dir", lambda: str(tmp_path))
+
+        def fake_run(*a, **kw):
+            if "tag" in a[0]:
+                stdout = ""                    # no tag points at HEAD
+            elif "rev-parse" in a[0]:
+                stdout = "abc1234\n"
+            else:
+                stdout = "2026-04-18 12:00:00\n"
+            return type("R", (), {"returncode": 0, "stdout": stdout})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        rc = direct_commands.cmd_version(None)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Canasta CLI dev (" in out
+        assert "v4.0.0" not in out
+        assert "native" in out
+
+    def test_docker_release_tag_shows_version(self, tmp_path, monkeypatch, capsys):
+        (tmp_path / "VERSION").write_text("4.0.0\n")
+        (tmp_path / "BUILD_COMMIT").write_text("def5678\n")
+        (tmp_path / "BUILD_DATE").write_text("2026-04-18 10:00:00\n")
+        monkeypatch.setenv("CANASTA_RUN_MODE", "docker")
+        monkeypatch.setenv("CANASTA_CLI_IMAGE_TAG", "4.0.0")
+        monkeypatch.setattr(direct_commands._helpers, "_get_script_dir", lambda: str(tmp_path))
+        rc = direct_commands.cmd_version(None)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "v4.0.0" in out
+
+    def test_docker_latest_tag_shows_dev(self, tmp_path, monkeypatch, capsys):
+        (tmp_path / "VERSION").write_text("4.0.0\n")
+        (tmp_path / "BUILD_COMMIT").write_text("def5678\n")
+        (tmp_path / "BUILD_DATE").write_text("2026-04-18 10:00:00\n")
+        monkeypatch.setenv("CANASTA_RUN_MODE", "docker")
+        monkeypatch.setenv("CANASTA_CLI_IMAGE_TAG", "latest")
+        monkeypatch.setattr(direct_commands._helpers, "_get_script_dir", lambda: str(tmp_path))
+        rc = direct_commands.cmd_version(None)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Canasta CLI dev (" in out
+        assert "v4.0.0" not in out
 
     def test_docker_mode(self, tmp_path, monkeypatch, capsys):
         (tmp_path / "VERSION").write_text("4.0.0\n")


### PR DESCRIPTION
Closes #626.

## Summary

`canasta upgrade` (and `get-canasta.sh`) now track the **latest released version** by default instead of always following the head of `main`. A new `--dev` flag preserves the previous behavior.

"Latest release" is the highest `vX.Y.Z` git tag — resolved from tags, not the GitHub Releases API, which intentionally pins `v3.7.0` as latest for legacy clients. The CI workflow that creates those tags and version-tags the image on a `VERSION` bump already exists in `.github/workflows/docker.yml`.

## Changes

- **`canasta.py`** — `self_update_cli(dev=False)`: detached-checkout of the latest release tag by default; `--dev` restores `main` and fast-forwards. Adds `_pick_latest_release_tag()` (numeric semver sort, skips pre-releases). The release path is **forward-only** — if the latest tag is already contained in HEAD (you're on it, or on a newer dev build), it stays put rather than checking out the older tag, so `canasta upgrade` never moves backward in time (`git merge-base --is-ancestor`).
- **`canasta-docker`** — pins the channel in `$CONFIG_DIR/cli_image_tag` so every command runs the matching image (released tag by default, `:latest` for `--dev`); resolves the release via the GitHub tags API; self-updates the wrapper from the matching ref. Passes the resolved image tag into the container for `canasta version`.
- **`direct_commands/info.py`** — `canasta version` reports `dev` (no number) on a development build and `vX.Y.Z` on a release checkout, since the `VERSION` file may not match the eventual release on `main`.
- **`get-canasta.sh`** — installs the latest release by default, adds `--dev`, and best-effort pins the Docker channel so a fresh install and the CLI's own upgrade agree.
- **`meta/command_definitions.yml`** — adds the `--dev` flag to the `upgrade` command.
- **Tests** — updated `self_update_cli` and `cmd_version` unit tests; added coverage for the dev/release channels, the no-tags fallback, and the tag picker.

## Behavior notes

- `canasta upgrade` (release channel) is forward-only: it advances to a newer release when one is tagged, but never downgrades a development build that is ahead of the latest release. `--dev` is forward-only too (`git pull --ff-only`).
- `get-canasta.sh` is deliberately a "set to this version" action, not forward-only — re-running it (default) checks out the latest release tag even from a newer dev build. This is intentional: it's the way to return to the last supported release from a dev build when no newer release has been tagged yet.

## Docs

canasta.wiki Help: pages updated (Upgrading, CLI overview, Development mode, Installation) to describe the released/development channels, including a note distinguishing `canasta upgrade --dev` from `canasta devmode`.

## Testing

- `make test-unit` — 956 passed
- `make validate` — passed
- `bash -n get-canasta.sh` — clean; release resolver verified to return the highest tag
