### PR TITLE
Point "already ahead" upgrade message to the installer, not a manual git checkout

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -321,10 +321,10 @@ def self_update_cli(dev=False):
                     "Canasta CLI is already ahead of the latest release "
                     "(%s); keeping the current build (version %s, commit %s) "
                     "rather than moving backward.\nUse 'canasta upgrade --dev' "
-                    "to keep tracking development builds, or run "
-                    "'git checkout %s' in %s to pin the release exactly."
-                    % (target_ref, current_version, current_commit,
-                       target_ref, repo)
+                    "to keep tracking development builds, or re-run the "
+                    "installer to return to the latest release:\n"
+                    "  curl -fsSL https://get.canasta.wiki | bash"
+                    % (target_ref, current_version, current_commit)
                 )
             return
         # HEAD is behind the latest release (or on a divergent line that


### PR DESCRIPTION
Closes #628.

## Summary

Follow-up to #627. When `canasta upgrade` declines to downgrade a development build that is ahead of the latest release, the message suggested running `git checkout <tag>` directly in the install dir. On a Linux native install that dir is `root:canasta` (group-writable, set up by the installer's `chgrp`/`chmod` pass); a manual checkout writes user-owned files into it, eroding the shared-group ownership model and possibly breaking later upgrades — and may fail depending on group membership.

The message now points to re-running the installer, which does its git work under `sudo` and re-applies group ownership — the documented, ownership-safe way back to the latest release:

```
Use 'canasta upgrade --dev' to keep tracking development builds, or re-run
the installer to return to the latest release:
  curl -fsSL https://get.canasta.wiki | bash
```

## Changes

- **`canasta.py`** — reword the "already ahead of the latest release" branch of `self_update_cli`.
- **Docs** — Help:Upgrading: drop the parallel "check out its tag manually" note (published separately).

## Testing

- `make test-unit` — 957 passed (the existing no-downgrade test still asserts the "already ahead" wording).