### PR TITLE
Point "already ahead" upgrade hint at the installer URL (not a Docker-defaulting command)

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -322,10 +322,9 @@ def self_update_cli(dev=False):
                     "(%s); keeping the current build (version %s, commit %s) "
                     "rather than moving backward.\nUse 'canasta upgrade --dev' "
                     "to keep tracking development builds, or re-run the "
-                    "installer to return to the latest release:\n"
-                    "  curl -fsSL https://get.canasta.wiki | bash -s -- "
-                    "--native --prefix %s"
-                    % (target_ref, current_version, current_commit, repo)
+                    "installer at https://get.canasta.wiki to return to the "
+                    "latest release."
+                    % (target_ref, current_version, current_commit)
                 )
             return
         # HEAD is behind the latest release (or on a divergent line that

--- a/canasta.py
+++ b/canasta.py
@@ -323,8 +323,9 @@ def self_update_cli(dev=False):
                     "rather than moving backward.\nUse 'canasta upgrade --dev' "
                     "to keep tracking development builds, or re-run the "
                     "installer to return to the latest release:\n"
-                    "  curl -fsSL https://get.canasta.wiki | bash"
-                    % (target_ref, current_version, current_commit)
+                    "  curl -fsSL https://get.canasta.wiki | bash -s -- "
+                    "--native --prefix %s"
+                    % (target_ref, current_version, current_commit, repo)
                 )
             return
         # HEAD is behind the latest release (or on a divergent line that

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -1120,6 +1120,9 @@ class TestSelfUpdateCli:
         out = capsys.readouterr().out
         assert "already ahead of the latest release" in out
         assert "v4.0.4" in out
+        # The return-to-release hint must keep native users on native — the
+        # bare installer one-liner defaults to Docker mode.
+        assert "--native" in out
         # No checkout, no re-exec — we stayed on the current build.
         assert not any("checkout" in c for c in calls)
         assert execv_calls == []

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -1120,9 +1120,9 @@ class TestSelfUpdateCli:
         out = capsys.readouterr().out
         assert "already ahead of the latest release" in out
         assert "v4.0.4" in out
-        # The return-to-release hint must keep native users on native — the
-        # bare installer one-liner defaults to Docker mode.
-        assert "--native" in out
+        # The hint points to the installer URL (operators pick their own
+        # options) rather than a bare command that would default to Docker.
+        assert "get.canasta.wiki" in out
         # No checkout, no re-exec — we stayed on the current build.
         assert not any("checkout" in c for c in calls)
         assert execv_calls == []


### PR DESCRIPTION
Closes #630.

## Summary

Follow-up to #629. The "already ahead of the latest release" message is only ever shown on native installs (`self_update_cli` returns early when the install dir has no `.git`), but its installer hint used the bare `curl … | bash`, which defaults to **Docker mode** — following it would switch a native install to Docker.

Rather than prescribe a specific command (which would have to encode the mode and prefix), the message now just points at the installer URL and lets the operator choose options matching how they originally installed:

```
Use 'canasta upgrade --dev' to keep tracking development builds, or re-run
the installer at https://get.canasta.wiki to return to the latest release.
```

## Changes

- **`canasta.py`** — point the "already ahead" hint at https://get.canasta.wiki instead of a bare `curl … | bash` command.
- **Tests** — assert the hint references the installer URL (regression guard).
- **Docs** — Help:Upgrading escape hatch shows both Docker and native installer commands (published separately).

## Testing

- `make test-unit` — 957 passed