### PR TITLE
crowdsec: auto-enroll bouncer on enable; add console-enroll for full community blocklist

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -80,7 +80,7 @@ SUBCOMMAND_GROUPS = {
     "extension": ["list", "enable", "disable"],
     "skin": ["list", "enable", "disable"],
     "maintenance": ["update", "script", "extension", "exec"],
-    "crowdsec": ["enroll", "status", "ban", "unban"],
+    "crowdsec": ["enroll", "console-enroll", "status", "ban", "unban"],
     "devmode": ["enable", "disable"],
     "sitemap": ["generate", "remove"],
     "backup": [

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -211,7 +211,13 @@ command_groups:
       * `enroll` registers the Caddy bouncer with the CrowdSec engine,
         captures the generated API key, stores it as
         `CROWDSEC_BOUNCER_API_KEY`, and restarts so the bouncer starts
-        enforcing decisions.
+        enforcing decisions. This now happens automatically the first
+        time the instance starts after CrowdSec is enabled; run it by
+        hand only to force a fresh key (`--force`).
+      * `console-enroll` connects the engine to the CrowdSec Console
+        (app.crowdsec.net) for the full community blocklist. Optional —
+        the engine already pulls the smaller "Lite" community blocklist
+        via the Central API by default.
       * `status` shows the registered bouncers and the currently active
         IP decisions.
       * `ban` / `unban` add or remove a manual decision for an IP,
@@ -1310,11 +1316,13 @@ commands:
       store the generated API key as CROWDSEC_BOUNCER_API_KEY, and
       restart so the bouncer begins enforcing decisions.
 
-      Run this once after enabling CrowdSec
-      (`canasta config set CANASTA_ENABLE_CROWDSEC=true`). It is
-      idempotent: if the bouncer is already enrolled and a key is
-      stored, it reports success and does nothing. Use `--force` to
-      revoke the existing bouncer and issue a fresh key. Compose only.
+      Enabling CrowdSec
+      (`canasta config set CANASTA_ENABLE_CROWDSEC=true`) now enrolls the
+      bouncer automatically on the next start, so you rarely need to run
+      this by hand. It is idempotent: if the bouncer is already enrolled
+      and a key is stored, it reports success and does nothing. Use
+      `--force` to revoke the existing bouncer and issue a fresh key.
+      Compose only.
     examples:
       - "canasta crowdsec enroll"
       - "canasta crowdsec enroll -i mysite"
@@ -1330,6 +1338,42 @@ commands:
         type: bool
         default: false
         description: "Revoke the existing bouncer and issue a fresh key"
+
+  - name: crowdsec_console_enroll
+    description: "Connect CrowdSec to the Console for the full community blocklist"
+    long_description: |
+      Enroll this instance's CrowdSec engine in the CrowdSec Console
+      (https://app.crowdsec.net) to unlock the full community blocklist
+      plus any console-managed third-party blocklists.
+
+      This is optional. Without it, the engine still pulls the smaller
+      "Lite" community blocklist automatically via the Central API — so
+      CrowdSec already blocks crowd-sourced IPs out of the box; console
+      enrollment just upgrades that to the full list.
+
+      Get an enrollment key from the Console (Security Engines → Enroll),
+      run this command, then return to the Console to accept the pending
+      engine and subscribe it to the blocklists you want. Distinct from
+      `canasta crowdsec enroll`, which registers the local Caddy bouncer
+      with the engine. Compose only.
+    examples:
+      - "canasta crowdsec console-enroll cssde-xxxxxxxxxxxx"
+      - "canasta crowdsec console-enroll cssde-xxxxxxxxxxxx --name prod1"
+      - "canasta crowdsec console-enroll cssde-xxxxxxxxxxxx -i mysite"
+    playbook: crowdsec_console_enroll.yml
+    parameters:
+      - name: key
+        type: string
+        positional: true
+        required: true
+        description: "Console enrollment key from app.crowdsec.net"
+      - name: name
+        type: string
+        description: "Instance name to show in the Console"
+      - name: id
+        short: i
+        type: string
+        description: "Canasta instance ID"
 
   - name: crowdsec_status
     description: "Show CrowdSec bouncers and active decisions"

--- a/playbooks/crowdsec_console_enroll.yml
+++ b/playbooks/crowdsec_console_enroll.yml
@@ -1,0 +1,7 @@
+---
+# canasta crowdsec console-enroll
+
+- name: CrowdSec Console Enroll
+  ansible.builtin.include_role:
+    name: crowdsec
+    tasks_from: console_enroll.yml

--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -304,10 +304,11 @@
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/orchestrator/tasks/sync_compose_profiles.yml
 
-# CrowdSec without a bouncer key starts cleanly but enforces nothing.
-# Point the operator at the one-time enrollment step rather than letting
-# them assume protection is active.
-- name: Warn when CrowdSec is enabled without a bouncer key
+# CrowdSec without a bouncer key enforces nothing until the bouncer is
+# registered. The restart this config-set triggers auto-enrolls the bouncer
+# (orchestrator start.yml), so the normal case just works; only flag the
+# manual fallback for --no-restart, where no start runs to enroll it.
+- name: Note bouncer enrollment when CrowdSec is enabled without a key
   when:
     - instance_orchestrator | default('compose') == 'compose'
     - _config_key == 'CANASTA_ENABLE_CROWDSEC'
@@ -320,12 +321,15 @@
         key: CROWDSEC_BOUNCER_API_KEY
       register: _se_crowdsec_key
 
-    - name: Advise enrolling a bouncer
+    - name: Advise on bouncer enrollment
       ansible.builtin.debug:
         msg: >-
-          CrowdSec is enabled but CROWDSEC_BOUNCER_API_KEY is unset, so
-          Caddy starts without enforcing any decisions. Enroll a bouncer
-          with 'canasta crowdsec enroll -i {{ instance_id }}'.
+          CrowdSec is enabled. The Caddy bouncer is enrolled automatically
+          when the instance starts.
+          {{ '' if not (no_restart | default(false) | bool)
+             else ("Because --no-restart was used, run 'canasta start -i "
+                   ~ instance_id ~ "' (or 'canasta crowdsec enroll -i "
+                   ~ instance_id ~ "') to activate enforcement.") }}
       when: _se_crowdsec_key.value | default('') | length == 0
 
 - name: Apply CANASTA_ENABLE_OBSERVABILITY side effects

--- a/roles/crowdsec/tasks/console_enroll.yml
+++ b/roles/crowdsec/tasks/console_enroll.yml
@@ -1,0 +1,58 @@
+---
+# canasta crowdsec console-enroll - connect this instance's CrowdSec engine
+# to the CrowdSec Console (app.crowdsec.net), which unlocks the full
+# community blocklist plus any console-managed third-party blocklists.
+#
+# Optional. Without it the engine still pulls the smaller "Lite" community
+# blocklist via the Central API by default, so CrowdSec already blocks
+# crowd-sourced IPs out of the box; this just upgrades that to the full list.
+# Input: id (optional), key (str, required), name (str, optional)
+
+- name: Preflight (resolve, Compose-only, crowdsec running)
+  ansible.builtin.include_tasks: _preflight.yml
+
+- name: Require an enrollment key
+  ansible.builtin.fail:
+    msg: >-
+      An enrollment key is required. Get one from
+      https://app.crowdsec.net (Security Engines -> Enroll), then run:
+      canasta crowdsec console-enroll <key>
+  when: key is not defined or (key | string | length) == 0
+
+# argv (not a shell string) so the key and optional --name are passed
+# without quoting. no_log keeps the enrollment key out of Ansible output.
+- name: Build cscli console enroll argv
+  ansible.builtin.set_fact:
+    _crowdsec_console_argv: >-
+      {{ ['docker', 'compose', 'exec', '-T', 'crowdsec',
+          'cscli', 'console', 'enroll']
+         + (['--name', name | string] if (name | default('') | string | length > 0) else [])
+         + [key | string] }}
+
+- name: Enroll the engine with the CrowdSec Console
+  ansible.builtin.command:
+    argv: "{{ _crowdsec_console_argv }}"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+  no_log: true
+
+# cscli writes the console credentials into the persisted /etc/crowdsec
+# volume; a restart makes the engine pick them up and begin syncing
+# console-pushed blocklists (mirrors `systemctl reload crowdsec` on a
+# host install).
+- name: Restart the CrowdSec engine to apply the enrollment
+  ansible.builtin.command:
+    cmd: "docker compose restart crowdsec"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+
+- name: Report next steps
+  ansible.builtin.debug:
+    msg: |-
+      CrowdSec engine for instance '{{ instance_id }}' is enrolled with the
+      Console. Finish in the Console UI at https://app.crowdsec.net:
+        1. Accept the pending enrollment for this engine.
+        2. Under Blocklists, subscribe the engine to the CrowdSec
+           Community Blocklist (and any others you want).
+      Subscribed blocklists are pulled on CrowdSec's Central API schedule
+      (about every 2 hours) and enforced by the Caddy bouncer.

--- a/roles/crowdsec/tasks/enroll.yml
+++ b/roles/crowdsec/tasks/enroll.yml
@@ -13,6 +13,19 @@
     key: CROWDSEC_BOUNCER_API_KEY
   register: _crowdsec_key
 
+# The engine's LAPI may still be coming up when this runs straight after a
+# start (auto-enroll) — `cscli bouncers` calls fail until it answers. Poll
+# until ready so both the manual command and auto-enroll are race-free.
+- name: Wait for the CrowdSec LAPI to be ready
+  ansible.builtin.command:
+    cmd: "docker compose exec -T crowdsec cscli lapi status"
+    chdir: "{{ instance_path }}"
+  register: _crowdsec_lapi
+  until: _crowdsec_lapi.rc == 0
+  retries: 30
+  delay: 2
+  changed_when: false
+
 - name: List registered bouncers
   ansible.builtin.command:
     cmd: "docker compose exec -T crowdsec cscli bouncers list -o json"

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -125,6 +125,28 @@
         - _start_web_cid.stdout | trim != ''
         - _start_web_has_health.stdout | default('') | trim == 'has'
 
+    # CrowdSec auto-enrollment. When the crowdsec profile is active but no
+    # bouncer key is stored yet, register the Caddy bouncer with the
+    # now-running engine so enabling CrowdSec "just works" — no separate
+    # `canasta crowdsec enroll` step. enroll.yml stores the key (via config
+    # set) BEFORE it restarts, so the restart's re-entrant start finds the
+    # key present and the guard below is false: self-terminating, not
+    # recursive. Gated on the key being absent, so it is a cheap no-op on
+    # every subsequent start.
+    - name: Read CrowdSec enablement and bouncer key for auto-enroll
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read_all
+      register: _start_crowdsec_env
+
+    - name: Auto-enroll the CrowdSec bouncer when enabled but unenrolled
+      ansible.builtin.include_role:
+        name: crowdsec
+        tasks_from: enroll.yml
+      when:
+        - _start_crowdsec_env.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true'
+        - (_start_crowdsec_env.variables.CROWDSEC_BOUNCER_API_KEY | default('') | length) == 0
+
 - name: Start (Kubernetes)
   when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
   block:

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -407,8 +407,11 @@ class TestCrowdsecCommands:
 
     def test_subcommand_group_registered(self):
         assert canasta_cli.SUBCOMMAND_GROUPS.get("crowdsec") == [
-            "enroll", "status", "ban", "unban",
-        ], "crowdsec subcommand group must expose enroll/status/ban/unban"
+            "enroll", "console-enroll", "status", "ban", "unban",
+        ], (
+            "crowdsec subcommand group must expose "
+            "enroll/console-enroll/status/ban/unban"
+        )
 
     def test_group_umbrella_defined(self):
         defs = self._defs()
@@ -420,6 +423,7 @@ class TestCrowdsecCommands:
 
     @pytest.mark.parametrize("cmd_name,playbook", [
         ("crowdsec_enroll", "crowdsec_enroll.yml"),
+        ("crowdsec_console_enroll", "crowdsec_console_enroll.yml"),
         ("crowdsec_status", "crowdsec_status.yml"),
         ("crowdsec_ban", "crowdsec_ban.yml"),
         ("crowdsec_unban", "crowdsec_unban.yml"),
@@ -668,4 +672,65 @@ class TestCrowdsecStatusWiring:
             "the filter_plugins path must be registered so the status filter "
             "loads at runtime (role-local plugins don't auto-discover under "
             "include_role)"
+        )
+
+
+class TestCrowdsecConsoleEnrollRole:
+    def _console(self):
+        return _read(os.path.join(
+            REPO_ROOT, "roles", "crowdsec", "tasks", "console_enroll.yml",
+        ))
+
+    def test_runs_cscli_console_enroll(self):
+        content = self._console()
+        assert "'cscli', 'console', 'enroll'" in content, (
+            "console-enroll must call `cscli console enroll`"
+        )
+
+    def test_requires_a_key(self):
+        content = self._console()
+        assert "key is not defined" in content, (
+            "console-enroll must fail clearly when no enrollment key is given"
+        )
+
+    def test_key_handling_is_no_log(self):
+        content = self._console()
+        assert "no_log: true" in content, (
+            "the enroll step must be no_log so the key never lands in output"
+        )
+
+    def test_restarts_engine_to_apply(self):
+        content = self._console()
+        assert "docker compose restart crowdsec" in content, (
+            "the engine must restart so it picks up the console credentials"
+        )
+
+
+class TestCrowdsecAutoEnroll:
+    def test_start_auto_enrolls_when_enabled_without_key(self):
+        """Enabling CrowdSec should enroll the bouncer on the next start,
+        with no separate manual step — gated on the key being absent so it
+        is a no-op once enrolled."""
+        content = _read(os.path.join(
+            REPO_ROOT, "roles", "orchestrator", "tasks", "start.yml",
+        ))
+        assert "tasks_from: enroll.yml" in content, (
+            "start.yml must auto-enroll the bouncer via the crowdsec role"
+        )
+        assert "CANASTA_ENABLE_CROWDSEC" in content, (
+            "auto-enroll must be gated on CrowdSec being enabled"
+        )
+        assert "CROWDSEC_BOUNCER_API_KEY" in content, (
+            "auto-enroll must be gated on the bouncer key being absent so it "
+            "is idempotent and does not recurse through the restart"
+        )
+
+    def test_enroll_waits_for_lapi_ready(self):
+        """Auto-enroll runs right after start, when the engine may still be
+        booting, so enroll must poll the LAPI before issuing cscli calls."""
+        content = _read(os.path.join(
+            REPO_ROOT, "roles", "crowdsec", "tasks", "enroll.yml",
+        ))
+        assert "cscli lapi status" in content, (
+            "enroll must wait for the LAPI to be ready before adding a bouncer"
         )


### PR DESCRIPTION
## Summary

Closes #632.

Two improvements to the Compose CrowdSec integration.

### 1. Auto-enroll the Caddy bouncer when CrowdSec is enabled
Enabling CrowdSec (`canasta config set CANASTA_ENABLE_CROWDSEC=true`) now registers the Caddy bouncer with the engine automatically on the next start, so it begins enforcing without a separate manual `canasta crowdsec enroll` step.

- Hooked into the end of the Compose `start.yml`, gated on the crowdsec profile being active and `CROWDSEC_BOUNCER_API_KEY` being absent.
- Reuses the existing `enroll.yml`, which stores the key (via `config set`) **before** its restart — so the restart's re-entrant start finds the key present and skips. Self-terminating, not recursive.
- `enroll.yml` now waits for the LAPI to be ready before issuing cscli calls (auto-enroll can run while the engine is still booting).
- `canasta crowdsec enroll` stays for forcing a fresh key (`--force`).

### 2. New optional `canasta crowdsec console-enroll <key>`
Connects the engine to the CrowdSec Console (app.crowdsec.net) for the full community blocklist plus console-managed blocklists.

- Optional: the engine already pulls the smaller "Lite" community blocklist via the Central API by default, so CrowdSec blocks crowd-sourced IPs out of the box; this upgrades to the full list.
- Runs `cscli console enroll`, restarts the engine, and prints the console-side steps (accept the engine, subscribe to blocklists).

## Files
- `roles/crowdsec/tasks/console_enroll.yml` (new), `playbooks/crowdsec_console_enroll.yml` (new)
- `roles/orchestrator/tasks/start.yml` — auto-enroll block
- `roles/crowdsec/tasks/enroll.yml` — LAPI readiness wait
- `roles/config/tasks/_side_effects.yml` — enable-without-key advice reflects auto-enroll
- `meta/command_definitions.yml`, `canasta.py` — register the command + group help
- `tests/unit/test_crowdsec.py` — tests for console-enroll, auto-enroll wiring, LAPI wait

## Testing
- `make validate` (73 commands / 55 playbooks)
- `make test-unit` (964 passed)
- `make lint` (clean)
- Integration `test_crowdsec` remains valid: enabling now auto-enrolls during the restart, so the test's explicit `crowdsec enroll` hits the idempotent no-op path.

Compose-only (K8s CrowdSec tracked separately).