### PR TITLE
ci: retry ansible-galaxy collection install to survive Galaxy CDN timeouts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,16 @@ jobs:
           python -m venv .venv
           .venv/bin/pip install -r requirements.txt
           .venv/bin/pip install kubernetes
-          .venv/bin/ansible-galaxy collection install kubernetes.core
+          # Retry to ride out transient Ansible Galaxy CDN timeouts.
+          for attempt in 1 2 3 4; do
+            .venv/bin/ansible-galaxy collection install kubernetes.core && break
+            if [ "$attempt" -eq 4 ]; then
+              echo "ansible-galaxy install failed after 4 attempts" >&2
+              exit 1
+            fi
+            echo "ansible-galaxy install attempt $attempt failed; retrying in $((attempt * 10))s..." >&2
+            sleep $((attempt * 10))
+          done
           git config --global user.name "CI"
           git config --global user.email "ci@canasta.wiki"
       - name: Run core tests
@@ -122,7 +131,16 @@ jobs:
           python -m venv .venv
           .venv/bin/pip install -r requirements.txt
           .venv/bin/pip install kubernetes
-          .venv/bin/ansible-galaxy collection install kubernetes.core
+          # Retry to ride out transient Ansible Galaxy CDN timeouts.
+          for attempt in 1 2 3 4; do
+            .venv/bin/ansible-galaxy collection install kubernetes.core && break
+            if [ "$attempt" -eq 4 ]; then
+              echo "ansible-galaxy install failed after 4 attempts" >&2
+              exit 1
+            fi
+            echo "ansible-galaxy install attempt $attempt failed; retrying in $((attempt * 10))s..." >&2
+            sleep $((attempt * 10))
+          done
           git config --global user.name "CI"
           git config --global user.email "ci@canasta.wiki"
       - name: Run feature tests
@@ -150,7 +168,16 @@ jobs:
           python -m venv .venv
           .venv/bin/pip install -r requirements.txt
           .venv/bin/pip install kubernetes
-          .venv/bin/ansible-galaxy collection install kubernetes.core
+          # Retry to ride out transient Ansible Galaxy CDN timeouts.
+          for attempt in 1 2 3 4; do
+            .venv/bin/ansible-galaxy collection install kubernetes.core && break
+            if [ "$attempt" -eq 4 ]; then
+              echo "ansible-galaxy install failed after 4 attempts" >&2
+              exit 1
+            fi
+            echo "ansible-galaxy install attempt $attempt failed; retrying in $((attempt * 10))s..." >&2
+            sleep $((attempt * 10))
+          done
           git config --global user.name "CI"
           git config --global user.email "ci@canasta.wiki"
       - name: Run gitops tests
@@ -189,7 +216,16 @@ jobs:
           python -m venv .venv
           .venv/bin/pip install -r requirements.txt
           .venv/bin/pip install kubernetes
-          .venv/bin/ansible-galaxy collection install kubernetes.core
+          # Retry to ride out transient Ansible Galaxy CDN timeouts.
+          for attempt in 1 2 3 4; do
+            .venv/bin/ansible-galaxy collection install kubernetes.core && break
+            if [ "$attempt" -eq 4 ]; then
+              echo "ansible-galaxy install failed after 4 attempts" >&2
+              exit 1
+            fi
+            echo "ansible-galaxy install attempt $attempt failed; retrying in $((attempt * 10))s..." >&2
+            sleep $((attempt * 10))
+          done
           git config --global user.name "CI"
           git config --global user.email "ci@canasta.wiki"
       - name: Run K8s tests
@@ -216,7 +252,16 @@ jobs:
           python -m venv .venv
           .venv/bin/pip install -r requirements.txt
           .venv/bin/pip install kubernetes
-          .venv/bin/ansible-galaxy collection install kubernetes.core
+          # Retry to ride out transient Ansible Galaxy CDN timeouts.
+          for attempt in 1 2 3 4; do
+            .venv/bin/ansible-galaxy collection install kubernetes.core && break
+            if [ "$attempt" -eq 4 ]; then
+              echo "ansible-galaxy install failed after 4 attempts" >&2
+              exit 1
+            fi
+            echo "ansible-galaxy install attempt $attempt failed; retrying in $((attempt * 10))s..." >&2
+            sleep $((attempt * 10))
+          done
 
       - name: Run remote integration tests
         run: tests/integration/remote/run_tests.sh


### PR DESCRIPTION
## Summary

The integration jobs install the `kubernetes.core` Ansible collection during their "Install dependencies" step. Ansible Galaxy's CDN intermittently times out mid-download, failing the whole job with `The read operation timed out`. There was no retry around the install, so a single slow download breaks CI.

This wraps every `ansible-galaxy collection install` invocation in `.github/workflows/tests.yml` in a small bash retry loop — 4 attempts with linear backoff (10s/20s/30s) — applied consistently across all five integration jobs (Core, Features, GitOps, Kubernetes, Remote). An explicit `exit 1` on the final attempt ensures a genuine failure still fails the step (a bare `for` loop would otherwise swallow the error and exit 0).

Example failing run: https://github.com/CanastaWiki/Canasta-CLI/actions/runs/27368550735

## Changes

- `.github/workflows/tests.yml`: retry loop around all 5 `ansible-galaxy collection install kubernetes.core` calls.

## Verification

- `yamllint -c .yamllint.yml .github/workflows/tests.yml` passes (note: `make lint` does not cover `.github/workflows/`, so the file was linted directly).
- `bash -n` confirms the retry loop syntax.

Fixes #634
