### PR TITLE
crowdsec: rename `enroll` to `bouncer-enroll` for symmetry with console-enroll

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -80,7 +80,7 @@ SUBCOMMAND_GROUPS = {
     "extension": ["list", "enable", "disable"],
     "skin": ["list", "enable", "disable"],
     "maintenance": ["update", "script", "extension", "exec"],
-    "crowdsec": ["enroll", "console-enroll", "status", "ban", "unban"],
+    "crowdsec": ["bouncer-enroll", "console-enroll", "status", "ban", "unban"],
     "devmode": ["enable", "disable"],
     "sitemap": ["generate", "remove"],
     "backup": [

--- a/filter_plugins/canasta_crowdsec.py
+++ b/filter_plugins/canasta_crowdsec.py
@@ -48,8 +48,8 @@ def canasta_crowdsec_status_bouncers(bouncers, family_name="canasta-caddy"):
                 "  + %d stale auto-created duplicate registration(s) from past "
                 "container restarts (harmless — only the active bouncer above "
                 "pulls decisions). CrowdSec cannot delete these individually; "
-                "run 'canasta crowdsec enroll --force' to reset to a single "
-                "registration." % stale
+                "run 'canasta crowdsec bouncer-enroll --force' to reset to a "
+                "single registration." % stale
             )
 
     for b in others:

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -208,8 +208,8 @@ command_groups:
       same pattern as the other optional features); this group covers
       the steps that don't reduce to a single config value:
 
-      * `enroll` registers the Caddy bouncer with the CrowdSec engine,
-        captures the generated API key, stores it as
+      * `bouncer-enroll` registers the Caddy bouncer with the CrowdSec
+        engine, captures the generated API key, stores it as
         `CROWDSEC_BOUNCER_API_KEY`, and restarts so the bouncer starts
         enforcing decisions. This now happens automatically the first
         time the instance starts after CrowdSec is enabled; run it by
@@ -1309,8 +1309,8 @@ commands:
   # ---------------------------------------------------------------------------
   # CrowdSec
   # ---------------------------------------------------------------------------
-  - name: crowdsec_enroll
-    description: "Enroll the Caddy bouncer with CrowdSec"
+  - name: crowdsec_bouncer_enroll
+    description: "Register the Caddy bouncer with the CrowdSec engine"
     long_description: |
       Register the Caddy bouncer with the running CrowdSec engine,
       store the generated API key as CROWDSEC_BOUNCER_API_KEY, and
@@ -1321,13 +1321,15 @@ commands:
       bouncer automatically on the next start, so you rarely need to run
       this by hand. It is idempotent: if the bouncer is already enrolled
       and a key is stored, it reports success and does nothing. Use
-      `--force` to revoke the existing bouncer and issue a fresh key.
-      Compose only.
+      `--force` to revoke the existing bouncer and issue a fresh key
+      (e.g. to rotate a key, or recover one that drifted out of sync).
+      Distinct from `console-enroll`, which connects the engine to the
+      cloud CrowdSec Console. Compose only.
     examples:
-      - "canasta crowdsec enroll"
-      - "canasta crowdsec enroll -i mysite"
-      - "canasta crowdsec enroll -i mysite --force"
-    playbook: crowdsec_enroll.yml
+      - "canasta crowdsec bouncer-enroll"
+      - "canasta crowdsec bouncer-enroll -i mysite"
+      - "canasta crowdsec bouncer-enroll -i mysite --force"
+    playbook: crowdsec_bouncer_enroll.yml
     parameters:
       - name: id
         short: i
@@ -1354,8 +1356,8 @@ commands:
       Get an enrollment key from the Console (Security Engines → Enroll),
       run this command, then return to the Console to accept the pending
       engine and subscribe it to the blocklists you want. Distinct from
-      `canasta crowdsec enroll`, which registers the local Caddy bouncer
-      with the engine. Compose only.
+      `canasta crowdsec bouncer-enroll`, which registers the local Caddy
+      bouncer with the engine. Compose only.
     examples:
       - "canasta crowdsec console-enroll cssde-xxxxxxxxxxxx"
       - "canasta crowdsec console-enroll cssde-xxxxxxxxxxxx --name prod1"

--- a/playbooks/crowdsec_bouncer_enroll.yml
+++ b/playbooks/crowdsec_bouncer_enroll.yml
@@ -1,0 +1,7 @@
+---
+# canasta crowdsec bouncer-enroll
+
+- name: CrowdSec Bouncer Enroll
+  ansible.builtin.include_role:
+    name: crowdsec
+    tasks_from: bouncer_enroll.yml

--- a/playbooks/crowdsec_enroll.yml
+++ b/playbooks/crowdsec_enroll.yml
@@ -1,7 +1,0 @@
----
-# canasta crowdsec enroll
-
-- name: CrowdSec Enroll
-  ansible.builtin.include_role:
-    name: crowdsec
-    tasks_from: enroll.yml

--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -328,7 +328,7 @@
           when the instance starts.
           {{ '' if not (no_restart | default(false) | bool)
              else ("Because --no-restart was used, run 'canasta start -i "
-                   ~ instance_id ~ "' (or 'canasta crowdsec enroll -i "
+                   ~ instance_id ~ "' (or 'canasta crowdsec bouncer-enroll -i "
                    ~ instance_id ~ "') to activate enforcement.") }}
       when: _se_crowdsec_key.value | default('') | length == 0
 

--- a/roles/crowdsec/tasks/bouncer_enroll.yml
+++ b/roles/crowdsec/tasks/bouncer_enroll.yml
@@ -1,6 +1,6 @@
 ---
-# canasta crowdsec enroll - register the Caddy bouncer with the CrowdSec
-# engine, persist its API key, and restart so it starts enforcing.
+# canasta crowdsec bouncer-enroll - register the Caddy bouncer with the
+# CrowdSec engine, persist its API key, and restart so it starts enforcing.
 # Input: id (optional), force (bool)
 
 - name: Preflight (resolve, Compose-only, crowdsec running)

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -128,11 +128,11 @@
     # CrowdSec auto-enrollment. When the crowdsec profile is active but no
     # bouncer key is stored yet, register the Caddy bouncer with the
     # now-running engine so enabling CrowdSec "just works" — no separate
-    # `canasta crowdsec enroll` step. enroll.yml stores the key (via config
-    # set) BEFORE it restarts, so the restart's re-entrant start finds the
-    # key present and the guard below is false: self-terminating, not
-    # recursive. Gated on the key being absent, so it is a cheap no-op on
-    # every subsequent start.
+    # `canasta crowdsec bouncer-enroll` step. bouncer_enroll.yml stores the
+    # key (via config set) BEFORE it restarts, so the restart's re-entrant
+    # start finds the key present and the guard below is false:
+    # self-terminating, not recursive. Gated on the key being absent, so it
+    # is a cheap no-op on every subsequent start.
     - name: Read CrowdSec enablement and bouncer key for auto-enroll
       canasta_env:
         path: "{{ instance_path }}/.env"
@@ -142,7 +142,7 @@
     - name: Auto-enroll the CrowdSec bouncer when enabled but unenrolled
       ansible.builtin.include_role:
         name: crowdsec
-        tasks_from: enroll.yml
+        tasks_from: bouncer_enroll.yml
       when:
         - _start_crowdsec_env.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true'
         - (_start_crowdsec_env.variables.CROWDSEC_BOUNCER_API_KEY | default('') | length) == 0

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -2175,11 +2175,13 @@ def test_crowdsec(inst):
 
     _wait_for_crowdsec_lapi(inst)
 
-    print("Enrolling the Caddy bouncer...")
-    inst.run_ok("crowdsec", "enroll", "-i", inst.id)
+    # Enabling CrowdSec above auto-enrolls the bouncer on the restart, so the
+    # key is already stored; this exercises bouncer-enroll's idempotent path.
+    print("Re-running bouncer-enroll (idempotent)...")
+    inst.run_ok("crowdsec", "bouncer-enroll", "-i", inst.id)
     env = read_env(inst.env_path())
     assert env.get("CROWDSEC_BOUNCER_API_KEY", ""), (
-        "enroll must store CROWDSEC_BOUNCER_API_KEY"
+        "bouncer-enroll must store CROWDSEC_BOUNCER_API_KEY"
     )
 
     print("Checking status lists the bouncer...")

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -407,10 +407,10 @@ class TestCrowdsecCommands:
 
     def test_subcommand_group_registered(self):
         assert canasta_cli.SUBCOMMAND_GROUPS.get("crowdsec") == [
-            "enroll", "console-enroll", "status", "ban", "unban",
+            "bouncer-enroll", "console-enroll", "status", "ban", "unban",
         ], (
             "crowdsec subcommand group must expose "
-            "enroll/console-enroll/status/ban/unban"
+            "bouncer-enroll/console-enroll/status/ban/unban"
         )
 
     def test_group_umbrella_defined(self):
@@ -422,7 +422,7 @@ class TestCrowdsecCommands:
         )
 
     @pytest.mark.parametrize("cmd_name,playbook", [
-        ("crowdsec_enroll", "crowdsec_enroll.yml"),
+        ("crowdsec_bouncer_enroll", "crowdsec_bouncer_enroll.yml"),
         ("crowdsec_console_enroll", "crowdsec_console_enroll.yml"),
         ("crowdsec_status", "crowdsec_status.yml"),
         ("crowdsec_ban", "crowdsec_ban.yml"),
@@ -450,7 +450,7 @@ class TestCrowdsecCommands:
 class TestCrowdsecEnrollRole:
     def _enroll(self):
         return _read(os.path.join(
-            REPO_ROOT, "roles", "crowdsec", "tasks", "enroll.yml",
+            REPO_ROOT, "roles", "crowdsec", "tasks", "bouncer_enroll.yml",
         ))
 
     def test_registers_bouncer_and_captures_raw_key(self):
@@ -714,7 +714,7 @@ class TestCrowdsecAutoEnroll:
         content = _read(os.path.join(
             REPO_ROOT, "roles", "orchestrator", "tasks", "start.yml",
         ))
-        assert "tasks_from: enroll.yml" in content, (
+        assert "tasks_from: bouncer_enroll.yml" in content, (
             "start.yml must auto-enroll the bouncer via the crowdsec role"
         )
         assert "CANASTA_ENABLE_CROWDSEC" in content, (
@@ -729,7 +729,7 @@ class TestCrowdsecAutoEnroll:
         """Auto-enroll runs right after start, when the engine may still be
         booting, so enroll must poll the LAPI before issuing cscli calls."""
         content = _read(os.path.join(
-            REPO_ROOT, "roles", "crowdsec", "tasks", "enroll.yml",
+            REPO_ROOT, "roles", "crowdsec", "tasks", "bouncer_enroll.yml",
         ))
         assert "cscli lapi status" in content, (
             "enroll must wait for the LAPI to be ready before adding a bouncer"


### PR DESCRIPTION
## Summary

Closes #636. Follow-up to #633.

Now that #633 added `canasta crowdsec console-enroll`, the older `canasta crowdsec enroll` name is ambiguous — it registers the local Caddy bouncer with the engine, unrelated to the community blocklist / cloud Console. This renames it so the pair reads by **what each enrolls**:

| Command | Enrolls |
|---|---|
| `canasta crowdsec bouncer-enroll` | the **bouncer** with the local engine (mostly automatic now; manual only for `--force` key rotation/recovery) |
| `canasta crowdsec console-enroll` | the **engine** with the cloud CrowdSec Console (optional, full community blocklist) |

CrowdSec Compose is unreleased (slated for 4.1.0), so this breaks no published command.

## Changes
- Rename the user-facing command `crowdsec enroll` → `crowdsec bouncer-enroll` (`canasta.py`, `meta/command_definitions.yml`).
- Rename the playbook `crowdsec_enroll.yml` → `crowdsec_bouncer_enroll.yml` and role task `enroll.yml` → `bouncer_enroll.yml`.
- Update the auto-enroll include in `start.yml`, the `--no-restart` advice in `_side_effects.yml`, and the stale-registration hint in the status filter.
- Update unit + integration tests; cross-reference `console-enroll` in the command help.

## Testing
- `make validate` (73 commands / 55 playbooks)
- `make test-unit` (964 passed)
- `make lint` (clean)