### PR TITLE
crowdsec: auto-register CAPI so the community blocklist works out of the box

### DIFF
--- a/roles/crowdsec/tasks/ensure_capi.yml
+++ b/roles/crowdsec/tasks/ensure_capi.yml
@@ -1,0 +1,50 @@
+---
+# Ensure the CrowdSec engine is registered with the Central API (CAPI).
+#
+# CAPI registration is what enables the crowd-sourced community blocklist,
+# and it is a prerequisite for console enrollment (`console-enroll`). The
+# upstream image only auto-registers on first boot when its config has no
+# online_client configured; with our persistent /etc/crowdsec volume the
+# stock config already points at an (empty) credentials file, so the
+# entrypoint skips registration and CAPI never gets set up. We register it
+# explicitly here so the community blocklist works out of the box.
+#
+# Idempotent: skips entirely once `cscli capi status` succeeds.
+# Input: instance_path (the crowdsec engine must already be running)
+
+- name: Check whether CrowdSec is registered with the Central API
+  ansible.builtin.command:
+    cmd: "docker compose exec -T crowdsec cscli capi status"
+    chdir: "{{ instance_path }}"
+  register: _crowdsec_capi_status
+  changed_when: false
+  failed_when: false
+
+- name: Register the engine with the Central API
+  when: _crowdsec_capi_status.rc != 0
+  block:
+    - name: Announce CAPI registration
+      ansible.builtin.debug:
+        msg: >-
+          Registering the CrowdSec engine with the Central API so the
+          community blocklist is active...
+
+    # `cscli capi register` writes the machine credentials (url/login/
+    # password) to stdout; redirect them into the credentials file inside
+    # the persisted /etc/crowdsec volume, exactly as the image entrypoint
+    # does on first boot. no_log so the credentials never reach Ansible
+    # output. The double slash in the engine's own log line is cosmetic.
+    - name: Register CAPI and write the credentials file
+      ansible.builtin.command:
+        cmd: >-
+          docker compose exec -T crowdsec
+          sh -c 'cscli capi register > /etc/crowdsec/online_api_credentials.yaml'
+        chdir: "{{ instance_path }}"
+      changed_when: true
+      no_log: true
+
+    - name: Restart the engine so it loads the CAPI credentials
+      ansible.builtin.command:
+        cmd: "docker compose restart crowdsec"
+        chdir: "{{ instance_path }}"
+      changed_when: true

--- a/roles/crowdsec/tasks/status.yml
+++ b/roles/crowdsec/tasks/status.yml
@@ -30,6 +30,33 @@
   register: _crowdsec_decisions
   changed_when: false
 
+# Central API registration is what enables the crowd-sourced community
+# blocklist; a non-zero rc means it never registered (the silent failure
+# mode this surfaces). Console status reflects whether the engine is wired
+# to the cloud Console for the full blocklist. Both are read-only probes.
+- name: Get Central API (community blocklist) status
+  ansible.builtin.command:
+    cmd: "docker compose exec -T crowdsec cscli capi status"
+    chdir: "{{ instance_path }}"
+  register: _crowdsec_capi
+  changed_when: false
+  failed_when: false
+
+- name: Get console enrollment status
+  ansible.builtin.command:
+    cmd: "docker compose exec -T crowdsec cscli console status"
+    chdir: "{{ instance_path }}"
+  register: _crowdsec_console
+  changed_when: false
+  failed_when: false
+
+- name: Summarize Central API state
+  ansible.builtin.set_fact:
+    _crowdsec_capi_line: >-
+      {{ 'registered — community blocklist active'
+         if _crowdsec_capi.rc == 0
+         else 'not registered (no community blocklist; auto-registers on the next start)' }}
+
 - name: Show CrowdSec status
   ansible.builtin.debug:
     msg: |-
@@ -37,6 +64,12 @@
 
       Bouncers:
       {{ _crowdsec_bouncer_list | canasta_crowdsec_status_bouncers }}
+
+      Central API (community blocklist): {{ _crowdsec_capi_line }}
+
+      Console:
+      {{ (_crowdsec_console.stdout | default('') | trim)
+         or 'not enrolled — run: canasta crowdsec console-enroll <key> (optional, for the full blocklist)' }}
 
       Decisions:
       {{ _crowdsec_decisions.stdout | default('(none)') }}

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -139,6 +139,17 @@
         state: read_all
       register: _start_crowdsec_env
 
+    # Register the engine with the Central API first, so the community
+    # blocklist is active and console enrollment is possible. Idempotent
+    # (skips once registered); its restart is of the crowdsec container
+    # only, so it does not re-enter this start.
+    - name: Ensure CrowdSec is registered with the Central API
+      ansible.builtin.include_role:
+        name: crowdsec
+        tasks_from: ensure_capi.yml
+      when:
+        - _start_crowdsec_env.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true'
+
     - name: Auto-enroll the CrowdSec bouncer when enabled but unenrolled
       ansible.builtin.include_role:
         name: crowdsec

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -674,6 +674,20 @@ class TestCrowdsecStatusWiring:
             "include_role)"
         )
 
+    def test_status_reports_capi_and_console(self):
+        """status must surface Central API registration (the community
+        blocklist) and console enrollment, so an un-registered engine is no
+        longer a silent failure."""
+        content = _read(os.path.join(
+            REPO_ROOT, "roles", "crowdsec", "tasks", "status.yml",
+        ))
+        assert "cscli capi status" in content, (
+            "status must probe Central API registration (community blocklist)"
+        )
+        assert "cscli console status" in content, (
+            "status must probe console enrollment state"
+        )
+
 
 class TestCrowdsecConsoleEnrollRole:
     def _console(self):
@@ -734,3 +748,57 @@ class TestCrowdsecAutoEnroll:
         assert "cscli lapi status" in content, (
             "enroll must wait for the LAPI to be ready before adding a bouncer"
         )
+
+
+class TestCrowdsecCapiRegistration:
+    def _capi(self):
+        return _read(os.path.join(
+            REPO_ROOT, "roles", "crowdsec", "tasks", "ensure_capi.yml",
+        ))
+
+    def test_registers_capi_to_enable_community_blocklist(self):
+        """Without CAPI registration there is no community blocklist and
+        console enrollment is impossible; ensure_capi must register it."""
+        content = self._capi()
+        assert "cscli capi register" in content, (
+            "ensure_capi must register the engine with the Central API"
+        )
+        assert "online_api_credentials.yaml" in content, (
+            "the registration must write the CAPI credentials file"
+        )
+
+    def test_registration_is_idempotent(self):
+        """It must skip once registered, so it is a cheap no-op on every
+        subsequent start (gated on `cscli capi status` failing)."""
+        content = self._capi()
+        assert "cscli capi status" in content, (
+            "ensure_capi must check capi status to stay idempotent"
+        )
+        assert "_crowdsec_capi_status.rc != 0" in content, (
+            "registration must be gated on capi status failing"
+        )
+
+    def test_credentials_are_no_log(self):
+        content = self._capi()
+        assert "no_log: true" in content, (
+            "the register step must be no_log so CAPI credentials never leak"
+        )
+
+    def test_restarts_engine_to_load_credentials(self):
+        content = self._capi()
+        assert "docker compose restart crowdsec" in content, (
+            "the engine must restart to pick up the new CAPI credentials"
+        )
+
+    def test_start_ensures_capi_when_enabled(self):
+        """start.yml must register CAPI when CrowdSec is enabled, before the
+        bouncer auto-enroll (console enrollment depends on CAPI)."""
+        content = _read(os.path.join(
+            REPO_ROOT, "roles", "orchestrator", "tasks", "start.yml",
+        ))
+        assert "tasks_from: ensure_capi.yml" in content, (
+            "start.yml must ensure CAPI registration via the crowdsec role"
+        )
+        assert content.index("tasks_from: ensure_capi.yml") < content.index(
+            "tasks_from: bouncer_enroll.yml"
+        ), "CAPI registration must run before bouncer auto-enroll"


### PR DESCRIPTION
## Summary

Closes #638.

Enabling CrowdSec never registered the engine with the **Central API (CAPI)**. With our persistent `/etc/crowdsec` volume, the upstream image's stock config already points `online_client` at an empty credentials file, so the entrypoint skips first-boot registration. The result, confirmed on a live instance:

- the crowd-sourced **community blocklist was inactive** (not even the Lite tier), and
- `canasta crowdsec console-enroll` **failed** — the Console sits on top of CAPI:
  `Error: the Central API (CAPI) must be configured with 'cscli capi register'`

…and `canasta crowdsec status` gave no hint, so it was a silent failure.

## Changes

- **`roles/crowdsec/tasks/ensure_capi.yml` (new)** — registers the engine with CAPI (`cscli capi register` → credentials file, then restart the engine). Idempotent: skips once `cscli capi status` succeeds; `no_log` so credentials never leak.
- **`start.yml`** — includes `ensure_capi.yml` when CrowdSec is enabled, *before* the bouncer auto-enroll (console enrollment depends on CAPI). Its restart is of the crowdsec container only, so it does not re-enter start.
- **`status.yml`** — `canasta crowdsec status` now reports Central API (community blocklist) registration and console enrollment state.

## Why it's safe / idempotent

On a fresh enable: engine comes up → `ensure_capi` registers + restarts the crowdsec container → bouncer auto-enroll runs. On every later start, `cscli capi status` already succeeds, so `ensure_capi` is a no-op.

## Testing

- `make validate` (73 commands / 55 playbooks)
- `make test-unit` (970 passed)
- `make lint` (clean)
- Manually confirmed the underlying sequence on a live instance: `cscli capi register` → restart → `cscli capi status` succeeds → `console enroll` works.

Compose only (K8s CrowdSec tracked separately). Follow-up to #633 / #637.