### PR TITLE
crowdsec: make `crowdsec status` clear about blocklists and console state

### DIFF
--- a/roles/crowdsec/tasks/bouncer_enroll.yml
+++ b/roles/crowdsec/tasks/bouncer_enroll.yml
@@ -13,9 +13,8 @@
     key: CROWDSEC_BOUNCER_API_KEY
   register: _crowdsec_key
 
-# The engine's LAPI may still be coming up when this runs straight after a
-# start (auto-enroll) — `cscli bouncers` calls fail until it answers. Poll
-# until ready so both the manual command and auto-enroll are race-free.
+# Poll until the LAPI answers; `cscli bouncers` calls fail until the engine
+# is up (it may still be booting straight after a start).
 - name: Wait for the CrowdSec LAPI to be ready
   ansible.builtin.command:
     cmd: "docker compose exec -T crowdsec cscli lapi status"

--- a/roles/crowdsec/tasks/console_enroll.yml
+++ b/roles/crowdsec/tasks/console_enroll.yml
@@ -3,9 +3,8 @@
 # to the CrowdSec Console (app.crowdsec.net), which unlocks the full
 # community blocklist plus any console-managed third-party blocklists.
 #
-# Optional. Without it the engine still pulls the smaller "Lite" community
-# blocklist via the Central API by default, so CrowdSec already blocks
-# crowd-sourced IPs out of the box; this just upgrades that to the full list.
+# Optional: without it the engine still pulls the smaller "Lite" community
+# blocklist via the Central API. This upgrades that to the full list.
 # Input: id (optional), key (str, required), name (str, optional)
 
 - name: Preflight (resolve, Compose-only, crowdsec running)

--- a/roles/crowdsec/tasks/ensure_capi.yml
+++ b/roles/crowdsec/tasks/ensure_capi.yml
@@ -1,15 +1,8 @@
 ---
-# Ensure the CrowdSec engine is registered with the Central API (CAPI).
-#
-# CAPI registration is what enables the crowd-sourced community blocklist,
-# and it is a prerequisite for console enrollment (`console-enroll`). The
-# upstream image only auto-registers on first boot when its config has no
-# online_client configured; with our persistent /etc/crowdsec volume the
-# stock config already points at an (empty) credentials file, so the
-# entrypoint skips registration and CAPI never gets set up. We register it
-# explicitly here so the community blocklist works out of the box.
-#
-# Idempotent: skips entirely once `cscli capi status` succeeds.
+# Register the CrowdSec engine with the Central API (CAPI), which enables the
+# community blocklist and is a prerequisite for console-enroll. With a
+# persistent /etc/crowdsec volume the image does not self-register, so we do.
+# Idempotent: skips once `cscli capi status` succeeds.
 # Input: instance_path (the crowdsec engine must already be running)
 
 - name: Check whether CrowdSec is registered with the Central API
@@ -29,11 +22,8 @@
           Registering the CrowdSec engine with the Central API so the
           community blocklist is active...
 
-    # `cscli capi register` writes the machine credentials (url/login/
-    # password) to stdout; redirect them into the credentials file inside
-    # the persisted /etc/crowdsec volume, exactly as the image entrypoint
-    # does on first boot. no_log so the credentials never reach Ansible
-    # output. The double slash in the engine's own log line is cosmetic.
+    # cscli writes the credentials to stdout; redirect them into the
+    # credentials file. no_log so they never reach Ansible output.
     - name: Register CAPI and write the credentials file
       ansible.builtin.command:
         cmd: >-

--- a/roles/crowdsec/tasks/status.yml
+++ b/roles/crowdsec/tasks/status.yml
@@ -30,10 +30,8 @@
   register: _crowdsec_decisions
   changed_when: false
 
-# Central API registration is what enables the crowd-sourced community
-# blocklist; a non-zero rc means it never registered (the silent failure
-# mode this surfaces). Console status reflects whether the engine is wired
-# to the cloud Console for the full blocklist. Both are read-only probes.
+# Read-only probes: CAPI registration gates the community blocklist;
+# console status reflects whether the engine is wired to the Console.
 - name: Get Central API (community blocklist) status
   ansible.builtin.command:
     cmd: "docker compose exec -T crowdsec cscli capi status"
@@ -50,12 +48,32 @@
   changed_when: false
   failed_when: false
 
-- name: Summarize Central API state
+# `cscli decisions list` excludes CAPI blocklist decisions, so count them by
+# origin. -o raw keeps the payload to one integer; tail drops the CSV header.
+- name: Count community-blocklist (CAPI) decisions
+  ansible.builtin.command:
+    cmd: >-
+      docker compose exec -T crowdsec sh -c
+      'cscli decisions list --origin CAPI -o raw 2>/dev/null | tail -n +2 | wc -l'
+    chdir: "{{ instance_path }}"
+  register: _crowdsec_capi_count
+  changed_when: false
+  failed_when: false
+
+- name: Summarize Central API and console state
   ansible.builtin.set_fact:
+    # Show the loaded-IP count when registered.
     _crowdsec_capi_line: >-
-      {{ 'registered — community blocklist active'
+      {{ ('registered — community blocklist active'
+          ~ ((' (' ~ (_crowdsec_capi_count.stdout | trim) ~ ' IPs loaded)')
+             if (_crowdsec_capi_count.stdout | trim | int) > 0 else ''))
          if _crowdsec_capi.rc == 0
          else 'not registered (no community blocklist; auto-registers on the next start)' }}
+    # An enrolled engine has at least one forward option activated (✅).
+    _crowdsec_console_line: >-
+      {{ 'enrolled'
+         if (_crowdsec_console.rc == 0 and '✅' in (_crowdsec_console.stdout | default('')))
+         else 'not enrolled — run: canasta crowdsec console-enroll <key> (optional, for the full blocklist)' }}
 
 - name: Show CrowdSec status
   ansible.builtin.debug:
@@ -66,10 +84,7 @@
       {{ _crowdsec_bouncer_list | canasta_crowdsec_status_bouncers }}
 
       Central API (community blocklist): {{ _crowdsec_capi_line }}
+      Console: {{ _crowdsec_console_line }}
 
-      Console:
-      {{ (_crowdsec_console.stdout | default('') | trim)
-         or 'not enrolled — run: canasta crowdsec console-enroll <key> (optional, for the full blocklist)' }}
-
-      Decisions:
+      Local decisions (manual bans + scenario detections):
       {{ _crowdsec_decisions.stdout | default('(none)') }}

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -125,24 +125,17 @@
         - _start_web_cid.stdout | trim != ''
         - _start_web_has_health.stdout | default('') | trim == 'has'
 
-    # CrowdSec auto-enrollment. When the crowdsec profile is active but no
-    # bouncer key is stored yet, register the Caddy bouncer with the
-    # now-running engine so enabling CrowdSec "just works" — no separate
-    # `canasta crowdsec bouncer-enroll` step. bouncer_enroll.yml stores the
-    # key (via config set) BEFORE it restarts, so the restart's re-entrant
-    # start finds the key present and the guard below is false:
-    # self-terminating, not recursive. Gated on the key being absent, so it
-    # is a cheap no-op on every subsequent start.
+    # Auto-enroll the bouncer when CrowdSec is on but no key is stored yet.
+    # bouncer_enroll stores the key before its restart, so the re-entrant
+    # start sees the key and skips — gated on key-absent, no recursion.
     - name: Read CrowdSec enablement and bouncer key for auto-enroll
       canasta_env:
         path: "{{ instance_path }}/.env"
         state: read_all
       register: _start_crowdsec_env
 
-    # Register the engine with the Central API first, so the community
-    # blocklist is active and console enrollment is possible. Idempotent
-    # (skips once registered); its restart is of the crowdsec container
-    # only, so it does not re-enter this start.
+    # Register CAPI before bouncer auto-enroll (console enrollment depends on
+    # it). Idempotent; restarts only the crowdsec container.
     - name: Ensure CrowdSec is registered with the Central API
       ansible.builtin.include_role:
         name: crowdsec

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -688,6 +688,34 @@ class TestCrowdsecStatusWiring:
             "status must probe console enrollment state"
         )
 
+    def test_status_counts_blocklist_decisions(self):
+        """Community-blocklist decisions are hidden from `cscli decisions
+        list`, so status must count them by origin — otherwise a loaded
+        blocklist reads as 'no decisions'."""
+        content = _read(os.path.join(
+            REPO_ROOT, "roles", "crowdsec", "tasks", "status.yml",
+        ))
+        assert "--origin CAPI" in content, (
+            "status must count community-blocklist (CAPI) decisions, which are "
+            "excluded from the default decisions list"
+        )
+
+    def test_status_summarizes_console_without_raw_table(self):
+        """The raw `cscli console status` table includes an unrelated
+        `console_management` row that reads as a problem; status must show a
+        one-line enrolled/not-enrolled summary instead of dumping it."""
+        content = _read(os.path.join(
+            REPO_ROOT, "roles", "crowdsec", "tasks", "status.yml",
+        ))
+        assert "_crowdsec_console_line" in content, (
+            "status must derive a one-line console summary"
+        )
+        assert "Console: {{ _crowdsec_console_line }}" in content, (
+            "status must display the one-line console summary, not dump the "
+            "raw cscli console table (which shows the misleading "
+            "console_management row)"
+        )
+
 
 class TestCrowdsecConsoleEnrollRole:
     def _console(self):


### PR DESCRIPTION
## Summary

Closes #640. Follow-up to #639.

The `canasta crowdsec status` output added in #639 misled a real user — confirmed in the field. Two fixes:

### 1. Console: one-line summary instead of the raw table
The old output dumped the full `cscli console status` table, including a `console_management ❌` row. That option is an unrelated opt-in (let the Console *push* decisions to the engine), off by default — but the red ❌ read as "broken" and sent the user chasing a non-problem while enrollment was actually fine. Now: `Console: enrolled` / `Console: not enrolled — run: …`.

### 2. Decisions: count the community blocklist (it was hidden)
`cscli decisions list` deliberately excludes community/CAPI blocklist decisions, so an engine enforcing ~15,000 blocklist bans showed *"No active decisions"*. Now the Central API line shows the loaded count inline, e.g.:

```
Central API (community blocklist): registered — community blocklist active (15000 IPs loaded)
Console: enrolled

Local decisions (manual bans + scenario detections):
…
```

The count is gathered cheaply (`cscli decisions list --origin CAPI -o raw | wc -l` inside the container — only the integer crosses the boundary, not the list).

## Testing

- `make validate` (73 commands / 55 playbooks)
- `make test-unit` (972 passed)
- `make lint` (clean)

Compose only.