### PR TITLE
crowdsec: add `reload` to restart just the engine

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -80,7 +80,7 @@ SUBCOMMAND_GROUPS = {
     "extension": ["list", "enable", "disable"],
     "skin": ["list", "enable", "disable"],
     "maintenance": ["update", "script", "extension", "exec"],
-    "crowdsec": ["bouncer-enroll", "console-enroll", "status", "ban", "unban"],
+    "crowdsec": ["bouncer-enroll", "console-enroll", "reload", "status", "ban", "unban"],
     "devmode": ["enable", "disable"],
     "sitemap": ["generate", "remove"],
     "backup": [

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -218,6 +218,9 @@ command_groups:
         (app.crowdsec.net) for the full community blocklist. Optional —
         the engine already pulls the smaller "Lite" community blocklist
         via the Central API by default.
+      * `reload` restarts just the engine to apply changes (accepted
+        console enrollment, whitelist edits) or force a blocklist pull,
+        without restarting the whole instance.
       * `status` shows the registered bouncers and the currently active
         IP decisions.
       * `ban` / `unban` add or remove a manual decision for an IP,
@@ -1372,6 +1375,24 @@ commands:
       - name: name
         type: string
         description: "Instance name to show in the Console"
+      - name: id
+        short: i
+        type: string
+        description: "Canasta instance ID"
+
+  - name: crowdsec_reload
+    description: "Restart the CrowdSec engine to apply changes"
+    long_description: |
+      Restart just the CrowdSec engine container to apply pending changes
+      without restarting the whole instance. Use it after accepting a
+      console enrollment, after editing `config/crowdsec/whitelists.yaml`,
+      or to force a fresh blocklist pull. The Caddy bouncer keeps enforcing
+      its cached decisions during the brief restart. Compose only.
+    examples:
+      - "canasta crowdsec reload"
+      - "canasta crowdsec reload -i mysite"
+    playbook: crowdsec_reload.yml
+    parameters:
       - name: id
         short: i
         type: string

--- a/playbooks/crowdsec_reload.yml
+++ b/playbooks/crowdsec_reload.yml
@@ -1,0 +1,7 @@
+---
+# canasta crowdsec reload
+
+- name: CrowdSec Reload
+  ansible.builtin.include_role:
+    name: crowdsec
+    tasks_from: reload.yml

--- a/roles/crowdsec/tasks/console_enroll.yml
+++ b/roles/crowdsec/tasks/console_enroll.yml
@@ -54,5 +54,5 @@
         1. Accept the pending enrollment for this engine.
         2. Under Blocklists, subscribe the engine to the CrowdSec
            Community Blocklist (and any others you want).
-      Subscribed blocklists are pulled on CrowdSec's Central API schedule
-      (about every 2 hours) and enforced by the Caddy bouncer.
+      Then run 'canasta crowdsec reload' to apply the acceptance and pull
+      the blocklists now (otherwise they arrive on CrowdSec's ~2h schedule).

--- a/roles/crowdsec/tasks/reload.yml
+++ b/roles/crowdsec/tasks/reload.yml
@@ -1,0 +1,20 @@
+---
+# canasta crowdsec reload - restart just the CrowdSec engine to apply pending
+# changes (accepted console enrollment, whitelist edits) and pull the latest
+# blocklists, without bouncing the rest of the instance.
+# Input: id (optional)
+
+- name: Preflight (resolve, Compose-only, crowdsec running)
+  ansible.builtin.include_tasks: _preflight.yml
+
+- name: Restart the CrowdSec engine
+  ansible.builtin.command:
+    cmd: "docker compose restart crowdsec"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+
+- name: Report
+  ansible.builtin.debug:
+    msg: >-
+      Reloaded the CrowdSec engine for instance '{{ instance_id }}'. The
+      Caddy bouncer keeps enforcing cached decisions during the restart.

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -407,10 +407,11 @@ class TestCrowdsecCommands:
 
     def test_subcommand_group_registered(self):
         assert canasta_cli.SUBCOMMAND_GROUPS.get("crowdsec") == [
-            "bouncer-enroll", "console-enroll", "status", "ban", "unban",
+            "bouncer-enroll", "console-enroll", "reload",
+            "status", "ban", "unban",
         ], (
             "crowdsec subcommand group must expose "
-            "bouncer-enroll/console-enroll/status/ban/unban"
+            "bouncer-enroll/console-enroll/reload/status/ban/unban"
         )
 
     def test_group_umbrella_defined(self):
@@ -424,6 +425,7 @@ class TestCrowdsecCommands:
     @pytest.mark.parametrize("cmd_name,playbook", [
         ("crowdsec_bouncer_enroll", "crowdsec_bouncer_enroll.yml"),
         ("crowdsec_console_enroll", "crowdsec_console_enroll.yml"),
+        ("crowdsec_reload", "crowdsec_reload.yml"),
         ("crowdsec_status", "crowdsec_status.yml"),
         ("crowdsec_ban", "crowdsec_ban.yml"),
         ("crowdsec_unban", "crowdsec_unban.yml"),
@@ -717,6 +719,28 @@ class TestCrowdsecConsoleEnrollRole:
         content = self._console()
         assert "docker compose restart crowdsec" in content, (
             "the engine must restart so it picks up the console credentials"
+        )
+
+
+class TestCrowdsecReloadRole:
+    def _reload(self):
+        return _read(os.path.join(
+            REPO_ROOT, "roles", "crowdsec", "tasks", "reload.yml",
+        ))
+
+    def test_restarts_only_the_engine(self):
+        """reload must bounce just the crowdsec container, not the whole
+        instance."""
+        content = self._reload()
+        assert "docker compose restart crowdsec" in content, (
+            "reload must restart only the crowdsec engine container"
+        )
+
+    def test_preflight_gated(self):
+        content = self._reload()
+        assert "_preflight.yml" in content, (
+            "reload must run the shared crowdsec preflight (Compose-only, "
+            "engine running)"
         )
 
 


### PR DESCRIPTION
## Summary

Closes #642.

After accepting a console enrollment (or editing `whitelists.yaml`, or to force a fresh blocklist pull), the only documented way to make the engine pick up the change was `canasta restart` — which bounces the whole instance just to reload the engine.

`canasta crowdsec reload` restarts only the crowdsec container (`docker compose restart crowdsec`). The Caddy bouncer keeps enforcing its cached decisions during the brief bounce, so the wiki isn't disrupted.

## Changes
- `roles/crowdsec/tasks/reload.yml` (new) + `playbooks/crowdsec_reload.yml` (new)
- `canasta.py`, `meta/command_definitions.yml` — register the command + group help
- `console_enroll.yml` — its next-steps message now points at `canasta crowdsec reload` instead of implying a restart
- tests

## Testing
- `make validate` (74 commands / 56 playbooks)
- `make test-unit` (973 passed)
- `make lint` (clean)

Compose only. Help:CrowdSec on canasta.wiki will be updated to use `reload` in the console-accept and whitelist flows.