### PR TITLE
crowdsec: correct reload/console-enroll blocklist-pull wording

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -218,9 +218,9 @@ command_groups:
         (app.crowdsec.net) for the full community blocklist. Optional —
         the engine already pulls the smaller "Lite" community blocklist
         via the Central API by default.
-      * `reload` restarts just the engine to apply changes (accepted
-        console enrollment, whitelist edits) or force a blocklist pull,
-        without restarting the whole instance.
+      * `reload` restarts just the engine to apply changes (an accepted
+        console enrollment, whitelist edits) without restarting the whole
+        instance.
       * `status` shows the registered bouncers and the currently active
         IP decisions.
       * `ban` / `unban` add or remove a manual decision for an IP,
@@ -1385,9 +1385,11 @@ commands:
     long_description: |
       Restart just the CrowdSec engine container to apply pending changes
       without restarting the whole instance. Use it after accepting a
-      console enrollment, after editing `config/crowdsec/whitelists.yaml`,
-      or to force a fresh blocklist pull. The Caddy bouncer keeps enforcing
-      its cached decisions during the brief restart. Compose only.
+      console enrollment or after editing `config/crowdsec/whitelists.yaml`.
+      The Caddy bouncer keeps enforcing its cached decisions during the
+      brief restart. Note that community and console blocklists arrive on
+      CrowdSec's own pull cycle (about every 2 hours), which a restart does
+      not force. Compose only.
     examples:
       - "canasta crowdsec reload"
       - "canasta crowdsec reload -i mysite"

--- a/roles/crowdsec/tasks/console_enroll.yml
+++ b/roles/crowdsec/tasks/console_enroll.yml
@@ -36,9 +36,7 @@
   no_log: true
 
 # cscli writes the console credentials into the persisted /etc/crowdsec
-# volume; a restart makes the engine pick them up and begin syncing
-# console-pushed blocklists (mirrors `systemctl reload crowdsec` on a
-# host install).
+# volume; restart so the engine picks them up.
 - name: Restart the CrowdSec engine to apply the enrollment
   ansible.builtin.command:
     cmd: "docker compose restart crowdsec"
@@ -53,5 +51,5 @@
         1. Accept the pending enrollment for this engine.
         2. Under Blocklists, subscribe the engine to the CrowdSec
            Community Blocklist (and any others you want).
-      Then run 'canasta crowdsec reload' to apply the acceptance and pull
-      the blocklists now (otherwise they arrive on CrowdSec's ~2h schedule).
+      Then run 'canasta crowdsec reload' to apply the acceptance. Subscribed
+      blocklists arrive on CrowdSec's own pull cycle (about every 2 hours).

--- a/roles/crowdsec/tasks/reload.yml
+++ b/roles/crowdsec/tasks/reload.yml
@@ -1,7 +1,8 @@
 ---
 # canasta crowdsec reload - restart just the CrowdSec engine to apply pending
-# changes (accepted console enrollment, whitelist edits) and pull the latest
-# blocklists, without bouncing the rest of the instance.
+# changes (accepted console enrollment, whitelist edits) without bouncing the
+# rest of the instance. Blocklists arrive on CrowdSec's own ~2h pull cycle,
+# which a restart does not force.
 # Input: id (optional)
 
 - name: Preflight (resolve, Compose-only, crowdsec running)


### PR DESCRIPTION
## Summary

Closes #645. Follow-up to #643.

`canasta crowdsec reload` and `console-enroll`'s next-steps message claimed a restart **forces a fresh blocklist pull**. It doesn't — CrowdSec skips the CAPI pull on startup when the last one was under ~90 minutes old:

```
level=info msg="last CAPI pull is newer than 1h30, skip."
```

So restarts don't reliably pull blocklists; they arrive on CrowdSec's own ~2h cycle (confirmed on a live v1.6.11 engine). This rewords the `reload` command help, the group help, `reload.yml`, and `console_enroll.yml` to say so. Reload still correctly applies an accepted console enrollment and whitelist edits.

## Testing
- `make validate` (74 commands / 56 playbooks)
- `make test-unit` (975 passed)
- `make lint` (clean)

Compose only.