### PR TITLE
crowdsec: show console-subscribed blocklist count in status

### DIFF
--- a/filter_plugins/canasta_crowdsec.py
+++ b/filter_plugins/canasta_crowdsec.py
@@ -64,8 +64,44 @@ def canasta_crowdsec_status_bouncers(bouncers, family_name="canasta-caddy"):
     return "\n".join(lines) if lines else "  (none)"
 
 
+def canasta_crowdsec_blocklist_breakdown(raw):
+    """Per-blocklist IP counts from ``cscli decisions list --origin lists -o raw``.
+
+    The raw output is CSV with columns ``id,source,ip,reason,...`` where
+    ``reason`` is the subscribed blocklist's name (e.g. ``otx-webscanners``).
+    Console-blocklist decisions number in the thousands and are excluded from
+    the default ``cscli decisions list``, so this groups them by list and
+    returns aligned, indented ``name  count`` lines for the status message —
+    or ``""`` when there are none.
+    """
+    import csv
+    import io
+
+    text = (raw or "").strip()
+    if not text:
+        return ""
+    rows = list(csv.reader(io.StringIO(text)))
+    if rows and rows[0][:4] == ["id", "source", "ip", "reason"]:
+        rows = rows[1:]  # drop the header
+
+    counts = {}
+    for row in rows:
+        if len(row) >= 4:
+            counts[row[3]] = counts.get(row[3], 0) + 1
+    if not counts:
+        return ""
+
+    width = max(len(name) for name in counts)
+    return "\n".join(
+        "    %-*s  %d" % (width, name, counts[name])
+        for name in sorted(counts)
+    )
+
+
 class FilterModule(object):
     def filters(self):
         return {
             "canasta_crowdsec_status_bouncers": canasta_crowdsec_status_bouncers,
+            "canasta_crowdsec_blocklist_breakdown":
+                canasta_crowdsec_blocklist_breakdown,
         }

--- a/roles/crowdsec/tasks/status.yml
+++ b/roles/crowdsec/tasks/status.yml
@@ -42,7 +42,7 @@
 
 - name: Get console enrollment status
   ansible.builtin.command:
-    cmd: "docker compose exec -T crowdsec cscli console status"
+    cmd: "docker compose exec -T crowdsec cscli console status -o raw"
     chdir: "{{ instance_path }}"
   register: _crowdsec_console
   changed_when: false
@@ -60,6 +60,23 @@
   changed_when: false
   failed_when: false
 
+# Console-subscribed blocklists carry origin 'lists' and are excluded from the
+# default decisions list; fetch them (raw CSV) and break them down per list.
+- name: List console-blocklist (lists) decisions
+  ansible.builtin.command:
+    cmd: >-
+      docker compose exec -T crowdsec
+      cscli decisions list --origin lists -o raw
+    chdir: "{{ instance_path }}"
+  register: _crowdsec_lists_raw
+  changed_when: false
+  failed_when: false
+
+- name: Break down console blocklists by list
+  ansible.builtin.set_fact:
+    _crowdsec_blocklist_lines: >-
+      {{ _crowdsec_lists_raw.stdout | default('') | canasta_crowdsec_blocklist_breakdown }}
+
 - name: Summarize Central API and console state
   ansible.builtin.set_fact:
     # Show the loaded-IP count when registered.
@@ -69,10 +86,14 @@
              if (_crowdsec_capi_count.stdout | trim | int) > 0 else ''))
          if _crowdsec_capi.rc == 0
          else 'not registered (no community blocklist; auto-registers on the next start)' }}
-    # An enrolled engine has at least one forward option activated (✅).
+    # `cscli console status -o raw` is CSV (option,enabled); an enrolled engine
+    # has at least one forward option set to true. List the subscribed
+    # blocklists with their IP counts when any have been pulled.
     _crowdsec_console_line: >-
-      {{ 'enrolled'
-         if (_crowdsec_console.rc == 0 and '✅' in (_crowdsec_console.stdout | default('')))
+      {{ ('enrolled'
+          ~ (('\n  Subscribed blocklists:\n' ~ _crowdsec_blocklist_lines)
+             if (_crowdsec_blocklist_lines | length > 0) else ''))
+         if (_crowdsec_console.rc == 0 and ',true' in (_crowdsec_console.stdout | default('')))
          else 'not enrolled — run: canasta crowdsec console-enroll <key> (optional, for the full blocklist)' }}
 
 - name: Show CrowdSec status

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -30,7 +30,10 @@ import canasta as canasta_cli  # noqa: E402 (the canasta.py module)
 sys.path.insert(
     0, os.path.join(os.path.dirname(__file__), "..", "..", "filter_plugins")
 )
-from canasta_crowdsec import canasta_crowdsec_status_bouncers  # noqa: E402
+from canasta_crowdsec import (  # noqa: E402
+    canasta_crowdsec_status_bouncers,
+    canasta_crowdsec_blocklist_breakdown,
+)
 
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
@@ -655,6 +658,35 @@ class TestCrowdsecStatusBouncersDisplay:
         assert "stale" not in out2
 
 
+class TestCrowdsecBlocklistBreakdown:
+    HEADER = ("id,source,ip,reason,action,country,as,events_count,"
+              "expiration,simulated,alert_id")
+
+    def _raw(self, rows):
+        return "\n".join([self.HEADER] + rows)
+
+    def test_groups_and_counts_by_list(self):
+        raw = self._raw([
+            "1,lists,Ip:1.1.1.1,otx-webscanners,ban,,,0,1h,false,16",
+            "2,lists,Ip:2.2.2.2,otx-webscanners,ban,,,0,1h,false,16",
+            "3,lists,Ip:3.3.3.3,firehol_dyndns_ponmocup,ban,,,0,1h,false,15",
+        ])
+        out = canasta_crowdsec_blocklist_breakdown(raw)
+        lines = [ln for ln in out.splitlines() if ln.strip()]
+        assert len(lines) == 2
+        # one line per list, sorted by name (firehol_... before otx-...)
+        assert ("firehol_dyndns_ponmocup" in lines[0]
+                and lines[0].rstrip().endswith("1"))
+        assert ("otx-webscanners" in lines[1]
+                and lines[1].rstrip().endswith("2"))
+
+    def test_empty_when_no_decisions(self):
+        # cscli prints just the header (or nothing) when there are none.
+        assert canasta_crowdsec_blocklist_breakdown(self._raw([])) == ""
+        assert canasta_crowdsec_blocklist_breakdown("") == ""
+        assert canasta_crowdsec_blocklist_breakdown(None) == ""
+
+
 class TestCrowdsecStatusWiring:
     def test_status_lists_bouncers_as_json_and_uses_filter(self):
         content = _read(os.path.join(
@@ -701,6 +733,10 @@ class TestCrowdsecStatusWiring:
             "status must count community-blocklist (CAPI) decisions, which are "
             "excluded from the default decisions list"
         )
+        assert "--origin lists" in content, (
+            "status must also count console-subscribed blocklist (lists) "
+            "decisions, which are likewise excluded from the default list"
+        )
 
     def test_status_summarizes_console_without_raw_table(self):
         """The raw `cscli console status` table includes an unrelated
@@ -716,6 +752,20 @@ class TestCrowdsecStatusWiring:
             "status must display the one-line console summary, not dump the "
             "raw cscli console table (which shows the misleading "
             "console_management row)"
+        )
+
+    def test_console_enrolled_detection_is_glyph_free(self):
+        """Enrolled-detection must read the stable `-o raw` CSV (option,enabled)
+        rather than scraping the human table's ✅ glyph, which is fragile to
+        cscli formatting/locale/color changes."""
+        content = _read(os.path.join(
+            REPO_ROOT, "roles", "crowdsec", "tasks", "status.yml",
+        ))
+        assert "cscli console status -o raw" in content, (
+            "console status must be read as raw CSV, not the human table"
+        )
+        assert "✅" not in content, (
+            "enrolled-detection must not depend on the ✅ glyph"
         )
 
 


### PR DESCRIPTION
## Summary

Closes #644.

Console-subscribed blocklists carry origin `lists` (e.g. `otx-webscanners`, `firehol_dyndns_ponmocup`) and, like the CAPI community blocklist, are **excluded from `cscli decisions list`** — so an engine pulling thousands of console-blocklist IPs read as `Console: enrolled` / `No active decisions`, looking empty when it wasn't.

This breaks them out **per list** under the Console line:

```
Central API (community blocklist): registered — community blocklist active (15259 IPs loaded)
Console: enrolled
  Subscribed blocklists:
    firehol_dyndns_ponmocup  34
    otx-webscanners          2600
```

## How

- `status.yml` fetches `cscli decisions list --origin lists -o raw`; grouping is done in a new `canasta_crowdsec_blocklist_breakdown` filter (Python `csv`), keyed on the **`reason`** column — verified from cscli's raw header (`id,source,ip,reason,…`) in the CrowdSec source, so column order/quoting are handled robustly.
- Omitted when there are no console blocklists.

## Also: hardened enrolled-detection (no more glyph scraping)

The console enrolled/not-enrolled check previously scraped the human `cscli console status` table for the `✅` glyph — fragile to cscli formatting/locale/color. It now reads `cscli console status -o raw` (stable CSV `option,enabled`) and tests for an enabled option. Source-confirmed format.

## Testing

- `make validate` (74 commands / 56 playbooks)
- `make test-unit` (978 passed; filter grouping/empty-input + glyph-free assertions)
- `make lint` (clean)
- Filter sanity-checked against 2,634 synthetic rows.

Compose only. Follow-up to #641.