### PR TITLE
crowdsec: fix literal \n in status console-blocklist breakdown

### DIFF
--- a/filter_plugins/canasta_crowdsec.py
+++ b/filter_plugins/canasta_crowdsec.py
@@ -71,8 +71,11 @@ def canasta_crowdsec_blocklist_breakdown(raw):
     ``reason`` is the subscribed blocklist's name (e.g. ``otx-webscanners``).
     Console-blocklist decisions number in the thousands and are excluded from
     the default ``cscli decisions list``, so this groups them by list and
-    returns aligned, indented ``name  count`` lines for the status message —
+    returns a ready-to-append block headed by ``Subscribed blocklists:`` —
     or ``""`` when there are none.
+
+    All newlines are produced here (Jinja string literals do not interpret
+    ``\\n``), so the caller can concatenate the result directly.
     """
     import csv
     import io
@@ -92,10 +95,9 @@ def canasta_crowdsec_blocklist_breakdown(raw):
         return ""
 
     width = max(len(name) for name in counts)
-    return "\n".join(
-        "    %-*s  %d" % (width, name, counts[name])
-        for name in sorted(counts)
-    )
+    lines = ["    %-*s  %d" % (width, name, counts[name])
+             for name in sorted(counts)]
+    return "\n  Subscribed blocklists:\n" + "\n".join(lines)
 
 
 class FilterModule(object):

--- a/roles/crowdsec/tasks/status.yml
+++ b/roles/crowdsec/tasks/status.yml
@@ -87,12 +87,10 @@
          if _crowdsec_capi.rc == 0
          else 'not registered (no community blocklist; auto-registers on the next start)' }}
     # `cscli console status -o raw` is CSV (option,enabled); an enrolled engine
-    # has at least one forward option set to true. List the subscribed
-    # blocklists with their IP counts when any have been pulled.
+    # has at least one forward option set to true. The breakdown filter returns
+    # a ready-to-append block (real newlines) or '' when no lists are pulled.
     _crowdsec_console_line: >-
-      {{ ('enrolled'
-          ~ (('\n  Subscribed blocklists:\n' ~ _crowdsec_blocklist_lines)
-             if (_crowdsec_blocklist_lines | length > 0) else ''))
+      {{ ('enrolled' ~ _crowdsec_blocklist_lines)
          if (_crowdsec_console.rc == 0 and ',true' in (_crowdsec_console.stdout | default('')))
          else 'not enrolled — run: canasta crowdsec console-enroll <key> (optional, for the full blocklist)' }}
 

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -672,19 +672,41 @@ class TestCrowdsecBlocklistBreakdown:
             "3,lists,Ip:3.3.3.3,firehol_dyndns_ponmocup,ban,,,0,1h,false,15",
         ])
         out = canasta_crowdsec_blocklist_breakdown(raw)
+        # leading newline + header, then one line per list (real newlines, not
+        # literal backslash-n — the caller can't add newlines in Jinja).
+        assert "\\n" not in out
+        assert out.startswith("\n  Subscribed blocklists:\n")
         lines = [ln for ln in out.splitlines() if ln.strip()]
-        assert len(lines) == 2
+        assert len(lines) == 3  # header + 2 lists
         # one line per list, sorted by name (firehol_... before otx-...)
-        assert ("firehol_dyndns_ponmocup" in lines[0]
-                and lines[0].rstrip().endswith("1"))
-        assert ("otx-webscanners" in lines[1]
-                and lines[1].rstrip().endswith("2"))
+        assert ("firehol_dyndns_ponmocup" in lines[1]
+                and lines[1].rstrip().endswith("1"))
+        assert ("otx-webscanners" in lines[2]
+                and lines[2].rstrip().endswith("2"))
 
     def test_empty_when_no_decisions(self):
         # cscli prints just the header (or nothing) when there are none.
         assert canasta_crowdsec_blocklist_breakdown(self._raw([])) == ""
         assert canasta_crowdsec_blocklist_breakdown("") == ""
         assert canasta_crowdsec_blocklist_breakdown(None) == ""
+
+    def test_renders_with_real_newlines_through_jinja(self):
+        """Regression for the literal-\\n bug: the console line concatenates
+        'enrolled' with the filter output in Jinja, so the result must contain
+        real newlines (not the backslash-n that a Jinja '\\n' literal yields)."""
+        import jinja2
+        raw = self._raw([
+            "1,lists,Ip:1.1.1.1,otx-webscanners,ban,,,0,1h,false,16",
+        ])
+        block = canasta_crowdsec_blocklist_breakdown(raw)
+        env = jinja2.Environment()
+        # Mirror status.yml: {{ 'enrolled' ~ _crowdsec_blocklist_lines }}
+        rendered = env.from_string(
+            "{{ 'enrolled' ~ block }}"
+        ).render(block=block)
+        assert "\\n" not in rendered
+        assert rendered.splitlines()[0] == "enrolled"
+        assert "  Subscribed blocklists:" in rendered.splitlines()[1]
 
 
 class TestCrowdsecStatusWiring:


### PR DESCRIPTION
## Summary

Closes #648. Follow-up to #647.

The per-list breakdown built its header with a Jinja `'\n'` literal, which Ansible/Jinja renders as a literal backslash-n (only the filter's Python `"\n".join` made real newlines), so status showed:

```
Console: enrolled\n  Subscribed blocklists:\n    firehol_dyndns_ponmocup  34
    otx-webscanners          2590
```

Fix: the `canasta_crowdsec_blocklist_breakdown` filter now returns the **whole** block (leading newline + `Subscribed blocklists:` header + per-list lines), all real newlines from Python. The console line just does `'enrolled' ~ <block>` — no Jinja newline literals. Renders as:

```
Console: enrolled
  Subscribed blocklists:
    firehol_dyndns_ponmocup  34
    otx-webscanners          2590
```

## Testing
- `make validate`, `make test-unit` (979 passed), `make lint` clean
- Added a **Jinja-render regression test** asserting the concatenated output has real newlines (no `\n`)
- Sanity-rendered with 3 lists → correct alignment + all three shown

Compose only.