### PR TITLE
crowdsec: fix infinite restart loop on `config set CANASTA_ENABLE_CROWDSEC=true`

### DIFF
--- a/roles/config/tasks/set.yml
+++ b/roles/config/tasks/set.yml
@@ -5,9 +5,20 @@
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
+# Internal callers (crowdsec bouncer_enroll storing the API key) run during
+# a config-set-triggered restart, where `settings` is an Ansible extra-var
+# and so cannot be overridden by include_role vars (extra-vars outrank them).
+# They pass config_settings_override instead; everything below reads this
+# resolved value rather than `settings` directly. Without it, the nested
+# config set re-applies the outer setting (e.g. CANASTA_ENABLE_CROWDSEC),
+# never stores the key, and the auto-enroll restart loops forever.
+- name: Resolve settings string (allow internal override of the extra-var)
+  ansible.builtin.set_fact:
+    _config_settings: "{{ config_settings_override | default(settings) }}"
+
 - name: Validate, apply side effects, and set each key
   ansible.builtin.include_tasks: _set_single.yml
-  loop: "{{ settings.split() }}"
+  loop: "{{ _config_settings.split() }}"
   loop_control:
     loop_var: _setting
     label: "{{ _setting.split('=', 1)[0] }}"
@@ -67,7 +78,7 @@
     # below picks it up and the propagation to vars.yaml fires.
     - name: Ensure env.template has placeholders for new credential keys
       ansible.builtin.include_tasks: _ensure_env_template_placeholder.yml
-      loop: "{{ settings.split() }}"
+      loop: "{{ _config_settings.split() }}"
       loop_control:
         loop_var: _ep_setting
         label: "{{ _ep_setting.split('=', 1)[0] }}"
@@ -95,7 +106,7 @@
 
     - name: Update vars.yaml for each changed key
       ansible.builtin.include_tasks: _update_gitops_var.yml
-      loop: "{{ settings.split() }}"
+      loop: "{{ _config_settings.split() }}"
       loop_control:
         loop_var: _config_setting
         label: "{{ _config_setting.split('=', 1)[0] }}"
@@ -108,7 +119,7 @@
     # 'gitops pull' re-renders them back to the pre-change domain.
     - name: Propagate domain side effects to gitops vars
       when: >-
-        settings.split() | map('regex_replace', '=.*$', '') | list
+        _config_settings.split() | map('regex_replace', '=.*$', '') | list
         | intersect(['MW_SITE_FQDN', 'HTTP_PORT', 'HTTPS_PORT', 'CADDY_AUTO_HTTPS'])
         | length > 0
       block:

--- a/roles/crowdsec/tasks/bouncer_enroll.yml
+++ b/roles/crowdsec/tasks/bouncer_enroll.yml
@@ -90,12 +90,18 @@
     # are no_log'd at the task level on a secret-key match. no_log here would
     # not propagate into the included role anyway, and would also hide the
     # restart output we want to surface.
+    #
+    # Pass the key via config_settings_override, NOT settings: this enroll
+    # runs inside the restart that the original `config set` triggered, where
+    # `settings` is an extra-var that include_role vars cannot override. Using
+    # `settings` here would silently re-apply the outer setting, never store
+    # the key, and loop the restart/auto-enroll cycle forever.
     - name: Store the key, re-render the Caddyfile, and restart
       ansible.builtin.include_role:
         name: config
         tasks_from: set.yml
       vars:
-        settings: "CROWDSEC_BOUNCER_API_KEY={{ _crowdsec_add.stdout | trim }}"
+        config_settings_override: "CROWDSEC_BOUNCER_API_KEY={{ _crowdsec_add.stdout | trim }}"
 
     - name: Report success
       ansible.builtin.debug:

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -478,6 +478,28 @@ class TestCrowdsecEnrollRole:
         assert "CROWDSEC_BOUNCER_API_KEY=" in content
         assert "tasks_from: set.yml" in content
 
+    def test_key_store_uses_override_not_settings_extra_var(self):
+        """Regression: auto-enroll runs inside a config-set-triggered
+        restart, where `settings` is an Ansible extra-var that
+        include_role vars cannot override. Passing the key as `settings:`
+        silently re-applied the OUTER setting, never stored the key, and
+        looped the restart/auto-enroll cycle forever. The nested call must
+        use config_settings_override, which set.yml honors over `settings`.
+        """
+        content = self._enroll()
+        assert "config_settings_override: \"CROWDSEC_BOUNCER_API_KEY=" in content, (
+            "enroll must pass the key via config_settings_override so it "
+            "survives the extra-var precedence of `settings`"
+        )
+        # set.yml must resolve the override ahead of the extra-var.
+        set_yml = _read(os.path.join(
+            REPO_ROOT, "roles", "config", "tasks", "set.yml",
+        ))
+        assert "config_settings_override | default(settings)" in set_yml, (
+            "set.yml must read config_settings_override (falling back to the "
+            "settings extra-var) so internal callers can substitute the key"
+        )
+
     def test_key_handling_is_no_log(self):
         # The cscli-add step captures the raw key under no_log.
         content = self._enroll()


### PR DESCRIPTION
## Problem

On a Compose instance, `canasta config set CANASTA_ENABLE_CROWDSEC=true` loops forever, repeating:

```
CrowdSec is enabled. The Caddy bouncer is enrolled automatically when the instance starts.
Starting containers...
Registered bouncer 'canasta-caddy'. Storing its key and restarting to activate it...
```

…until Ctrl+C, and the bouncer key is never persisted. Running `canasta crowdsec bouncer-enroll` manually works fine.

## Root cause

An Ansible variable-precedence collision:

1. `config set` triggers a restart → `roles/orchestrator/tasks/start.yml` auto-enrolls the bouncer because `CROWDSEC_BOUNCER_API_KEY` is still empty.
2. `roles/crowdsec/tasks/bouncer_enroll.yml` stored the freshly issued key by calling `config set` again via `include_role` with `vars: settings: "CROWDSEC_BOUNCER_API_KEY=…"` (routing through config set keeps the Caddyfile re-render and gitops-vars durability — `CROWDSEC_BOUNCER_API_KEY` is a gitops placeholder key).
3. But `settings` arrives from `canasta.py` as an Ansible **extra-var** (`-e @file`) — the highest precedence. `include_role` `vars:` cannot override it, so the nested config set re-processed the **outer** `settings` (`CANASTA_ENABLE_CROWDSEC=true`) instead of the key.
4. The key was never stored → the key-absent auto-enroll guard stayed true → restart → enroll → restart → … forever.

Manual `crowdsec bouncer-enroll` is unaffected because that command has no `settings` extra-var, so the override takes effect.

## Fix

Let an internal caller substitute the settings string without colliding with the extra-var:

- `set.yml` reads `config_settings_override | default(settings)` everywhere it previously read `settings`.
- `bouncer_enroll.yml` passes the key via `config_settings_override` instead of `settings`.

All of `config set`'s gitops / Caddyfile / restart logic is reused unchanged.

## Tests

- Added regression test `test_key_store_uses_override_not_settings_extra_var` asserting the nested store uses the override var and that `set.yml` honors it over the extra-var.
- Full unit suite: 980 passed. `make validate` and `make lint` clean.

Fixes #652