### PR TITLE
upgrade: don't abort when db is stopped during MySQL-to-MariaDB probe

### DIFF
--- a/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
+++ b/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
@@ -12,17 +12,37 @@
 - name: Check for MySQL 8.0 data
   when: instance_orchestrator | default('compose') == 'compose'
   block:
-    - name: Check if MySQL data volume has read-only flag (MySQL 8.0 indicator)
-      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
-      vars:
-        exec_service: db
-        exec_command: "test -f /var/lib/mysql/.rocksdb && echo mysql8 || echo mariadb"
-      register: _mysql_check
+    # Detection (and the migration itself) requires a live db container to
+    # exec into. A stopped instance has no db service, so skip rather than
+    # abort the upgrade. ignore_errors on the include_tasks below would not
+    # help: it does not propagate to the shell task inside exec.yml, so the
+    # running-state is guarded explicitly here instead.
+    - name: Default MySQL 8 detection flag
+      ansible.builtin.set_fact:
+        _is_mysql8: false
+
+    - name: Check whether the db service is running
+      ansible.builtin.command:
+        cmd: "docker compose ps -q db"
+        chdir: "{{ instance_path }}"
+      register: _db_ps
+      changed_when: false
       ignore_errors: true  # OK if db container not running
 
-    - name: Set MySQL 8 detection flag
-      ansible.builtin.set_fact:
-        _is_mysql8: "{{ exec_result.stdout | default('') | trim == 'mysql8' }}"
+    - name: Detect MySQL 8.0 data (db running only)
+      when:
+        - _db_ps.rc == 0
+        - _db_ps.stdout | default('') | trim | length > 0
+      block:
+        - name: Check if MySQL data volume has read-only flag (MySQL 8.0 indicator)
+          ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+          vars:
+            exec_service: db
+            exec_command: "test -f /var/lib/mysql/.rocksdb && echo mysql8 || echo mariadb"
+
+        - name: Set MySQL 8 detection flag
+          ansible.builtin.set_fact:
+            _is_mysql8: "{{ exec_result.stdout | default('') | trim == 'mysql8' }}"
 
     - name: Migrate MySQL 8.0 to MariaDB
       when: _is_mysql8 | bool


### PR DESCRIPTION
Fixes #654.

## Problem
Running `canasta upgrade` against a **stopped** Docker Compose instance fails at the MySQL-to-MariaDB migration:

```
service "db" is not running
```

The `mysql_to_mariadb` migration probes the db container with `docker compose exec -T db ...` to detect MySQL-8-on-disk. On a stopped instance the db service is not running, so the command exits non-zero and aborts the whole upgrade.

The task carried `ignore_errors: true` to tolerate exactly this case, but the flag was on the `include_tasks` — and `ignore_errors` does not propagate to the `shell` task inside `roles/orchestrator/tasks/exec.yml`, so the failure escaped and killed the run.

## Fix
Guard the probe behind an explicit `docker compose ps -q db` running-check (a `command` task that genuinely honors `ignore_errors`) and default `_is_mysql8` to false. A stopped instance now skips MySQL detection and the upgrade continues — which matches the migration intent, since it cannot dump/re-import a stopped database anyway.

## Testing
- `make lint` — passes (only pre-existing line-length warnings)
- `make test-unit` — 980 passed