### PR TITLE
crowdsec: add reload --purge-blocklist(s) and clarify cached-blocklist status

### DIFF
--- a/filter_plugins/canasta_crowdsec.py
+++ b/filter_plugins/canasta_crowdsec.py
@@ -71,8 +71,11 @@ def canasta_crowdsec_blocklist_breakdown(raw):
     ``reason`` is the subscribed blocklist's name (e.g. ``otx-webscanners``).
     Console-blocklist decisions number in the thousands and are excluded from
     the default ``cscli decisions list``, so this groups them by list and
-    returns a ready-to-append block headed by ``Subscribed blocklists:`` —
-    or ``""`` when there are none.
+    returns a ready-to-append block headed by ``Console blocklists in effect
+    (cached locally):`` and tailed by a note on how to clear them — or ``""``
+    when there are none. The header avoids "subscribed" because, from inside
+    the engine, a still-subscribed list and one left over after a Console
+    unsubscribe/engine-deletion look identical.
 
     All newlines are produced here (Jinja string literals do not interpret
     ``\\n``), so the caller can concatenate the result directly.
@@ -97,7 +100,14 @@ def canasta_crowdsec_blocklist_breakdown(raw):
     width = max(len(name) for name in counts)
     lines = ["    %-*s  %d" % (width, name, counts[name])
              for name in sorted(counts)]
-    return "\n  Subscribed blocklists:\n" + "\n".join(lines)
+    note = (
+        "\n\n  These stay enforced even after you unsubscribe or remove the"
+        "\n  engine in the Console. Clear them with:"
+        "\n    canasta crowdsec reload --purge-blocklist <name>   (one list)"
+        "\n    canasta crowdsec reload --purge-blocklists         (all)"
+    )
+    return ("\n  Console blocklists in effect (cached locally):\n"
+            + "\n".join(lines) + note)
 
 
 class FilterModule(object):

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1396,15 +1396,35 @@ commands:
       brief restart. Note that community and console blocklists arrive on
       CrowdSec's own pull cycle (about every 2 hours), which a restart does
       not force. Compose only.
+
+      After you unsubscribe a list — or delete the engine — in the Console,
+      the engine keeps enforcing the IPs it already pulled from that list:
+      they stay in its local decision DB and the Caddy bouncer keeps blocking
+      them. It just stops receiving updates (a free-tier engine gets no
+      reconcile, since that is a paid PAPI order). That frozen snapshot is
+      usually fine to leave in place. Purge it only when you actually want to
+      STOP blocking those IPs: add `--purge-blocklist <name>` (one list, by the
+      name shown under "Console blocklists in effect" in `canasta crowdsec
+      status`) or `--purge-blocklists` (all). Lists you are still subscribed to
+      refill on the next pull cycle.
     examples:
       - "canasta crowdsec reload"
       - "canasta crowdsec reload -i mysite"
+      - "canasta crowdsec reload --purge-blocklist firehol_cruzit_web_attacks"
+      - "canasta crowdsec reload --purge-blocklists"
     playbook: crowdsec_reload.yml
     parameters:
       - name: id
         short: i
         type: string
         description: "Canasta instance ID"
+      - name: purge_blocklist
+        type: string
+        description: "Stop blocking one console blocklist's cached IPs, by the name shown in status"
+      - name: purge_blocklists
+        type: bool
+        default: false
+        description: "Stop blocking all cached console-blocklist IPs"
 
   - name: crowdsec_status
     description: "Show CrowdSec bouncers and active decisions"

--- a/roles/crowdsec/tasks/reload.yml
+++ b/roles/crowdsec/tasks/reload.yml
@@ -3,7 +3,26 @@
 # changes (accepted console enrollment, whitelist edits) without bouncing the
 # rest of the instance. Blocklists arrive on CrowdSec's own ~2h pull cycle,
 # which a restart does not force.
-# Input: id (optional)
+#
+# --purge-blocklist <name> / --purge-blocklists drop the console-blocklist
+# decisions (origin=lists) the engine has cached locally. After you unsubscribe
+# a list (or delete the engine) in the Console, the engine keeps enforcing the
+# IPs it already pulled — they stay in the local decision DB and the bouncer
+# keeps blocking them; it just stops getting updates (a free-tier engine gets
+# no reconcile, since that is a paid PAPI order). That frozen snapshot is
+# usually fine to leave; purge only when you want to STOP blocking those IPs.
+# The delete touches only the local DB — the Console subscription is untouched,
+# so lists you are still subscribed to refill on the next pull cycle.
+# Input: id (optional), purge_blocklist (str), purge_blocklists (bool)
+
+- name: Reject conflicting purge options
+  ansible.builtin.fail:
+    msg: >-
+      Pass either --purge-blocklist <name> (one list) or --purge-blocklists
+      (all), not both.
+  when:
+    - purge_blocklists | default(false) | bool
+    - purge_blocklist is defined and (purge_blocklist | string | length) > 0
 
 - name: Preflight (resolve, Compose-only, crowdsec running)
   ansible.builtin.include_tasks: _preflight.yml
@@ -14,8 +33,37 @@
     chdir: "{{ instance_path }}"
   changed_when: true
 
+# --origin lists scopes the delete to console blocklists (never manual bans or
+# the CAPI community list); --scenario narrows it to one list by the name shown
+# under "Console blocklists in effect" in status. argv (not a shell string) so a
+# user-supplied list name needs no quoting and is not word-split.
+- name: Purge cached console-blocklist decisions
+  when: >-
+    (purge_blocklists | default(false) | bool)
+    or (purge_blocklist is defined and (purge_blocklist | string | length) > 0)
+  block:
+    - name: Delete the decisions
+      ansible.builtin.command:
+        argv: >-
+          {{ ['docker', 'compose', 'exec', '-T', 'crowdsec',
+              'cscli', 'decisions', 'delete', '--origin', 'lists']
+             + (['--scenario', purge_blocklist | string]
+                if (purge_blocklist is defined and (purge_blocklist | string | length) > 0)
+                else []) }}
+        chdir: "{{ instance_path }}"
+      changed_when: true
+
+    - name: Note what was purged
+      ansible.builtin.set_fact:
+        _crowdsec_purge_line: >-
+          Purged {{ ("console blocklist '" ~ purge_blocklist ~ "'")
+                     if (purge_blocklist is defined and (purge_blocklist | string | length) > 0)
+                     else 'all console blocklists' }} from the local engine;
+          lists you are still subscribed to refill on the next pull cycle.
+
 - name: Report
   ansible.builtin.debug:
     msg: >-
       Reloaded the CrowdSec engine for instance '{{ instance_id }}'. The
       Caddy bouncer keeps enforcing cached decisions during the restart.
+      {{ _crowdsec_purge_line | default('') }}

--- a/roles/crowdsec/tasks/status.yml
+++ b/roles/crowdsec/tasks/status.yml
@@ -87,10 +87,13 @@
          if _crowdsec_capi.rc == 0
          else 'not registered (no community blocklist; auto-registers on the next start)' }}
     # `cscli console status -o raw` is CSV (option,enabled); an enrolled engine
-    # has at least one forward option set to true. The breakdown filter returns
-    # a ready-to-append block (real newlines) or '' when no lists are pulled.
+    # has at least one forward option set to true. This is the engine's local
+    # view — it cannot confirm the Console still recognizes the engine (that
+    # needs PAPI, a paid feature), so we say "per local config" rather than
+    # imply a verified live link. The breakdown filter returns a ready-to-append
+    # block (real newlines) or '' when no lists are pulled.
     _crowdsec_console_line: >-
-      {{ ('enrolled' ~ _crowdsec_blocklist_lines)
+      {{ ('enrolled (per local config)' ~ _crowdsec_blocklist_lines)
          if (_crowdsec_console.rc == 0 and ',true' in (_crowdsec_console.stdout | default('')))
          else 'not enrolled — run: canasta crowdsec console-enroll <key> (optional, for the full blocklist)' }}
 

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -746,14 +746,20 @@ class TestCrowdsecBlocklistBreakdown:
         # leading newline + header, then one line per list (real newlines, not
         # literal backslash-n — the caller can't add newlines in Jinja).
         assert "\\n" not in out
-        assert out.startswith("\n  Subscribed blocklists:\n")
+        assert out.startswith(
+            "\n  Console blocklists in effect (cached locally):\n")
         lines = [ln for ln in out.splitlines() if ln.strip()]
-        assert len(lines) == 3  # header + 2 lists
-        # one line per list, sorted by name (firehol_... before otx-...)
+        # header, then one line per list sorted by name (firehol_... before
+        # otx-...), then the "clear them" note.
+        assert "Console blocklists in effect" in lines[0]
         assert ("firehol_dyndns_ponmocup" in lines[1]
                 and lines[1].rstrip().endswith("1"))
         assert ("otx-webscanners" in lines[2]
                 and lines[2].rstrip().endswith("2"))
+        # the note points at the purge flags so status is self-explanatory
+        assert "Clear them with:" in out
+        assert "--purge-blocklist <name>" in out
+        assert "--purge-blocklists" in out
 
     def test_empty_when_no_decisions(self):
         # cscli prints just the header (or nothing) when there are none.
@@ -777,7 +783,8 @@ class TestCrowdsecBlocklistBreakdown:
         ).render(block=block)
         assert "\\n" not in rendered
         assert rendered.splitlines()[0] == "enrolled"
-        assert "  Subscribed blocklists:" in rendered.splitlines()[1]
+        assert ("  Console blocklists in effect (cached locally):"
+                in rendered.splitlines()[1])
 
 
 class TestCrowdsecStatusWiring:


### PR DESCRIPTION
Closes #661.

## Problem
Unsubscribing a console blocklist — or deleting the engine — in the CrowdSec Console leaves the IPs it already pulled in the engine's **local** decision DB (`origin=lists`), where the Caddy bouncer keeps enforcing them. The Console never tells a free-tier engine to drop them: that reconcile is a PAPI order, and PAPI is a paid feature (free engines get `402`). A plain `reload` only restarts the engine, so the cached decisions linger and don't time out promptly.

## Change
**`canasta crowdsec reload` gains an opt-in purge** (default `reload` is unchanged — still just a safe restart):
- `--purge-blocklist <name>` — drop one console blocklist's cached decisions (`--scenario`, by the name shown in `status`). The common case (you unsubscribed one list); never touches lists you're still on.
- `--purge-blocklists` — drop all console-blocklist decisions. For the delete-engine case.

Both run `cscli decisions delete --origin lists [--scenario <name>]` after the restart, touching only the local decision DB — manual bans and the CAPI community list are never affected, and lists still subscribed in the Console refill on the next pull cycle. The two flags are mutually exclusive.

**`crowdsec status` is now honest about what it can know from inside the engine.** It cannot distinguish a still-subscribed list from one left over after a Console unsubscribe/deletion (that needs PAPI), so:
- the breakdown header is now `Console blocklists in effect (cached locally):` with a note on how to clear them, and
- the Console line reads `enrolled (per local config)`.

```
Console: enrolled (per local config)
  Console blocklists in effect (cached locally):
    firehol_dyndns   1
    otx-webscanners  2

  These stay enforced even after you unsubscribe or remove the
  engine in the Console. Clear them with:
    canasta crowdsec reload --purge-blocklist <name>   (one list)
    canasta crowdsec reload --purge-blocklists         (all)
```

## Testing
- `make test-unit` (986 passed), `make validate`, `make docs`, yamllint — all clean.
- Unit assertions updated for the new wording + note.

> [!WARNING]
> The "lists you're still subscribed to refill on the next pull cycle" behavior is reasoned from PAPI being paid + the periodic free-tier pull, but has **not** been verified empirically against a live engine. Worth a live check before relying on `--purge-blocklists` against an engine with subscriptions you want to keep.