### PR TITLE
gitops: add --ssh-key for git operations

### DIFF
--- a/direct_commands/__init__.py
+++ b/direct_commands/__init__.py
@@ -127,6 +127,7 @@ from .host import cmd_host_list, cmd_host_add, cmd_host_remove  # noqa: F401
 from .gitops import (  # noqa: F401
     cmd_gitops_status,
     cmd_gitops_diff,
+    _git_ssh_env_prefix,
     _gitops_argocd_status,
     _gitops_diff_script,
     _gitops_status_script,

--- a/direct_commands/gitops.py
+++ b/direct_commands/gitops.py
@@ -12,12 +12,31 @@ from . import _helpers
 from ._helpers import register
 
 
-def _gitops_status_script(path):
+def _git_ssh_env_prefix(ssh_key):
+    """Shell `export GIT_SSH_COMMAND=...; ` prefix for a given SSH key.
+
+    Mirrors the Ansible gitops_git_env convention (accept-new host keys,
+    explicit known_hosts). Returns an empty string when no key is given,
+    leaving git's ambient SSH config (agent forwarding / deploy key)
+    untouched.
+    """
+    if not ssh_key:
+        return ""
+    return (
+        'export GIT_SSH_COMMAND="ssh -i %s '
+        '-o StrictHostKeyChecking=accept-new '
+        '-o UserKnownHostsFile=~/.ssh/known_hosts"; '
+        % _helpers._shell_quote(ssh_key)
+    )
+
+
+def _gitops_status_script(path, ssh_key=None):
     """Build a batched shell script that gathers all gitops status info."""
     d = _helpers._SENTINEL
     qp = _helpers._shell_quote(path)
     return (
         "cd %(p)s; "
+        "%(ssh)s"
         "cat .gitops-host 2>/dev/null || echo MISSING; "
         "echo '%(d)s'; "
         "cat hosts/hosts.yaml 2>/dev/null || echo MISSING; "
@@ -32,7 +51,7 @@ def _gitops_status_script(path):
         "echo '%(d)s'; "
         "git fetch 2>/dev/null; "
         "git rev-list --left-right --count HEAD...@{upstream} 2>/dev/null || echo '0\t0'"
-    ) % {"p": qp, "d": d}
+    ) % {"p": qp, "d": d, "ssh": _git_ssh_env_prefix(ssh_key)}
 
 
 def _parse_gitops_status(stdout, instance_id):
@@ -185,7 +204,7 @@ def cmd_gitops_status(args):
     path = inst.get("path", "")
     orchestrator = inst.get("orchestrator", "compose")
 
-    script = _gitops_status_script(path)
+    script = _gitops_status_script(path, ssh_key=getattr(args, "ssh_key", None))
 
     if _helpers._is_localhost(host):
         try:

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1986,6 +1986,13 @@ commands:
           symmetric key for unlocking encrypted vars on other hosts.
           K8s does not use git-crypt; the parameter only affects
           the SSH key path there.
+      - name: ssh_key
+        type: path
+        description: >-
+          Path to an SSH private key for git network operations. When
+          set, git runs with GIT_SSH_COMMAND="ssh -i <ssh-key> ...".
+          Omit to keep the default: ssh-agent forwarding on Compose,
+          or the generated `<key>.ssh` deploy key on Kubernetes.
       - name: force
         type: bool
         default: false
@@ -2051,6 +2058,13 @@ commands:
           On Compose, `<key>` is the git-crypt symmetric key. On K8s,
           only `<key>.ssh` (the SSH deploy key) is used — git-crypt
           is not part of the K8s gitops flow.
+      - name: ssh_key
+        type: path
+        description: >-
+          Path to an SSH private key for git network operations. When
+          set, git runs with GIT_SSH_COMMAND="ssh -i <ssh-key> ...".
+          Omit to keep the default: ssh-agent forwarding on Compose,
+          or the generated `<key>.ssh` deploy key on Kubernetes.
       - name: reinit
         type: bool
         default: false
@@ -2125,6 +2139,13 @@ commands:
         short: m
         type: string
         description: "Commit message (defaults to 'Configuration update')"
+      - name: ssh_key
+        type: path
+        description: >-
+          Path to an SSH private key for git network operations. When
+          set, git runs with GIT_SSH_COMMAND="ssh -i <ssh-key> ...".
+          Omit to keep the default: ssh-agent forwarding on Compose,
+          or the staged deploy key on Kubernetes.
 
   - name: gitops_pull
     description: "Pull latest configuration from the git repository"
@@ -2141,6 +2162,13 @@ commands:
         short: i
         type: string
         description: "Canasta instance ID"
+      - name: ssh_key
+        type: path
+        description: >-
+          Path to an SSH private key for git network operations. When
+          set, git runs with GIT_SSH_COMMAND="ssh -i <ssh-key> ...".
+          Omit to keep the default: ssh-agent forwarding on Compose,
+          or the staged deploy key on Kubernetes.
 
   - name: gitops_status
     description: "Show gitops status for the instance"
@@ -2155,6 +2183,13 @@ commands:
         short: i
         type: string
         description: "Canasta instance ID"
+      - name: ssh_key
+        type: path
+        description: >-
+          Path to an SSH private key for the remote fetch. When set,
+          git runs with GIT_SSH_COMMAND="ssh -i <ssh-key> ...". Omit
+          to keep the default: ssh-agent forwarding on Compose, or
+          the staged deploy key on Kubernetes.
 
   - name: gitops_diff
     description: "Show local and remote changes since the branches diverged"

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -197,7 +197,10 @@
   ansible.builtin.command:
     cmd: "git ls-remote {{ repo }}"
   environment:
-    GIT_SSH_COMMAND: "ssh -i {{ ssh_key | default(_ssh_key_target_path, true) }} -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=~/.ssh/known_hosts"
+    GIT_SSH_COMMAND: >-
+      ssh -i {{ ssh_key | default(_ssh_key_target_path, true) }}
+      -o StrictHostKeyChecking=accept-new
+      -o UserKnownHostsFile=~/.ssh/known_hosts
   register: _gitops_remote
   changed_when: false
   ignore_errors: true
@@ -440,7 +443,10 @@
     cmd: "git push -u origin main {{ (force | default(false) | bool) | ternary('--force', '') }}"
     chdir: "{{ instance_path }}"
   environment:
-    GIT_SSH_COMMAND: "ssh -i {{ ssh_key | default(_ssh_key_target_path, true) }} -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=~/.ssh/known_hosts"
+    GIT_SSH_COMMAND: >-
+      ssh -i {{ ssh_key | default(_ssh_key_target_path, true) }}
+      -o StrictHostKeyChecking=accept-new
+      -o UserKnownHostsFile=~/.ssh/known_hosts
   changed_when: true
 
 # --- Create Argo CD repo credential Secret ---

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -94,8 +94,8 @@
     # to register a deploy key on the forge.
     _ssh_key_path: "{{ key }}.ssh"
     # Target-local path. git on the target reads this via
-    # GIT_SSH_COMMAND. .gitops-deploy-key is in .gitignore.default
-    # so it never gets committed.
+    # GIT_SSH_COMMAND unless --ssh-key overrides it. .gitops-deploy-key
+    # is in .gitignore.default so it never gets committed.
     _ssh_key_target_path: "{{ instance_path }}/.gitops-deploy-key"
 
 # Save/switch/restore the connection state around the controller-side
@@ -197,7 +197,7 @@
   ansible.builtin.command:
     cmd: "git ls-remote {{ repo }}"
   environment:
-    GIT_SSH_COMMAND: "ssh -i {{ _ssh_key_target_path }} -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=~/.ssh/known_hosts"
+    GIT_SSH_COMMAND: "ssh -i {{ ssh_key | default(_ssh_key_target_path, true) }} -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=~/.ssh/known_hosts"
   register: _gitops_remote
   changed_when: false
   ignore_errors: true
@@ -440,7 +440,7 @@
     cmd: "git push -u origin main {{ (force | default(false) | bool) | ternary('--force', '') }}"
     chdir: "{{ instance_path }}"
   environment:
-    GIT_SSH_COMMAND: "ssh -i {{ _ssh_key_target_path }} -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=~/.ssh/known_hosts"
+    GIT_SSH_COMMAND: "ssh -i {{ ssh_key | default(_ssh_key_target_path, true) }} -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=~/.ssh/known_hosts"
   changed_when: true
 
 # --- Create Argo CD repo credential Secret ---

--- a/roles/gitops/tasks/join_kubernetes.yml
+++ b/roles/gitops/tasks/join_kubernetes.yml
@@ -48,6 +48,8 @@
 # the public side they registered as a deploy key on the forge.
 # The private key gets mirrored to the target so git operations
 # there can authenticate against the forge.
+# --ssh-key, when passed, overrides _ssh_key_target_path in the
+# GIT_SSH_COMMAND below; otherwise the staged deploy key is used.
 - name: Set SSH key paths
   ansible.builtin.set_fact:
     _ssh_key_path: "{{ key }}.ssh"
@@ -82,7 +84,7 @@
     cmd: "git clone -b main {{ repo }} ."
     chdir: "{{ _join_tmpdir.path }}"
   environment:
-    GIT_SSH_COMMAND: "ssh -i {{ _ssh_key_target_path }} -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=~/.ssh/known_hosts"
+    GIT_SSH_COMMAND: "ssh -i {{ ssh_key | default(_ssh_key_target_path, true) }} -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=~/.ssh/known_hosts"
   changed_when: true
 
 # --- Validate host name not already in config ---
@@ -241,7 +243,7 @@
     cmd: "git push {{ (force | default(false) | bool) | ternary('--force', '') }}"
     chdir: "{{ instance_path }}"
   environment:
-    GIT_SSH_COMMAND: "ssh -i {{ _ssh_key_target_path }} -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=~/.ssh/known_hosts"
+    GIT_SSH_COMMAND: "ssh -i {{ ssh_key | default(_ssh_key_target_path, true) }} -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=~/.ssh/known_hosts"
   changed_when: true
 
 # --- Clean up ---

--- a/roles/gitops/tasks/join_kubernetes.yml
+++ b/roles/gitops/tasks/join_kubernetes.yml
@@ -84,7 +84,10 @@
     cmd: "git clone -b main {{ repo }} ."
     chdir: "{{ _join_tmpdir.path }}"
   environment:
-    GIT_SSH_COMMAND: "ssh -i {{ ssh_key | default(_ssh_key_target_path, true) }} -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=~/.ssh/known_hosts"
+    GIT_SSH_COMMAND: >-
+      ssh -i {{ ssh_key | default(_ssh_key_target_path, true) }}
+      -o StrictHostKeyChecking=accept-new
+      -o UserKnownHostsFile=~/.ssh/known_hosts
   changed_when: true
 
 # --- Validate host name not already in config ---
@@ -243,7 +246,10 @@
     cmd: "git push {{ (force | default(false) | bool) | ternary('--force', '') }}"
     chdir: "{{ instance_path }}"
   environment:
-    GIT_SSH_COMMAND: "ssh -i {{ ssh_key | default(_ssh_key_target_path, true) }} -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=~/.ssh/known_hosts"
+    GIT_SSH_COMMAND: >-
+      ssh -i {{ ssh_key | default(_ssh_key_target_path, true) }}
+      -o StrictHostKeyChecking=accept-new
+      -o UserKnownHostsFile=~/.ssh/known_hosts
   changed_when: true
 
 # --- Clean up ---

--- a/roles/gitops/vars/main.yml
+++ b/roles/gitops/vars/main.yml
@@ -58,6 +58,7 @@ gitops_shared_keys:
 # `-i <key>`, so this default doesn't apply there.
 gitops_git_env:
   GIT_SSH_COMMAND: >-
-    ssh{{ (ssh_key | default('') | length > 0) | ternary(' -i ' ~ (ssh_key | default('')), '') }}
+    ssh{{ (ssh_key | default('') | length > 0)
+    | ternary(' -i ' ~ (ssh_key | default('')), '') }}
     -o StrictHostKeyChecking=accept-new
     -o UserKnownHostsFile=~/.ssh/known_hosts

--- a/roles/gitops/vars/main.yml
+++ b/roles/gitops/vars/main.yml
@@ -47,14 +47,17 @@ gitops_shared_keys:
 # Environment applied to every git command in the Compose-side gitops
 # flows (init, push, pull, join). accept-new lets the first contact
 # with a forge (github.com etc.) silently add its host key instead of
-# failing with "Host key verification failed". Pair with
-# ForwardAgent=yes in ANSIBLE_SSH_ARGS (set by canasta.py) so the
-# operator's local ssh-agent reaches the target host and authenticates
-# against private repos without per-host deploy keys. The Kubernetes
-# gitops flows generate their own deploy key and override
-# GIT_SSH_COMMAND with `-i <key>`, so this default doesn't apply
-# there.
+# failing with "Host key verification failed".
+#
+# When the operator passes --ssh-key, git authenticates with that
+# private key (`-i <ssh_key>`). Otherwise, pair with ForwardAgent=yes
+# in ANSIBLE_SSH_ARGS (set by canasta.py) so the operator's local
+# ssh-agent reaches the target host and authenticates against private
+# repos without per-host deploy keys. The Kubernetes gitops flows
+# generate their own deploy key and override GIT_SSH_COMMAND with
+# `-i <key>`, so this default doesn't apply there.
 gitops_git_env:
   GIT_SSH_COMMAND: >-
-    ssh -o StrictHostKeyChecking=accept-new
+    ssh{{ (ssh_key | default('') | length > 0) | ternary(' -i ' ~ (ssh_key | default('')), '') }}
+    -o StrictHostKeyChecking=accept-new
     -o UserKnownHostsFile=~/.ssh/known_hosts

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1923,6 +1923,38 @@ class TestCmdGitopsStatus:
         )
 
 
+class TestGitopsSshKey:
+    """--ssh-key builds GIT_SSH_COMMAND for the status fetch."""
+
+    def test_prefix_empty_without_key(self):
+        assert direct_commands._git_ssh_env_prefix(None) == ""
+        assert direct_commands._git_ssh_env_prefix("") == ""
+
+    def test_prefix_sets_git_ssh_command(self):
+        prefix = direct_commands._git_ssh_env_prefix("/home/u/.ssh/id_ed25519")
+        assert prefix.startswith("export GIT_SSH_COMMAND=")
+        assert "ssh -i '/home/u/.ssh/id_ed25519' " in prefix
+        assert "StrictHostKeyChecking=accept-new" in prefix
+        assert prefix.endswith("; ")
+
+    def test_prefix_quotes_key_path(self):
+        prefix = direct_commands._git_ssh_env_prefix("/tmp/my key")
+        assert "'/tmp/my key'" in prefix
+
+    def test_status_script_omits_prefix_without_key(self):
+        script = direct_commands._gitops_status_script("/srv/mysite")
+        assert "GIT_SSH_COMMAND" not in script
+        assert "git fetch" in script
+
+    def test_status_script_includes_prefix_with_key(self):
+        script = direct_commands._gitops_status_script(
+            "/srv/mysite", ssh_key="/home/u/.ssh/deploy"
+        )
+        # Prefix is exported before the git commands that follow.
+        assert script.index("GIT_SSH_COMMAND") < script.index("git fetch")
+        assert "ssh -i '/home/u/.ssh/deploy' " in script
+
+
 class TestDirectCommandRegistry:
     """Module-wide invariants on the direct-command registry."""
 


### PR DESCRIPTION
## Summary

Adds an optional `--ssh-key <path>` parameter to the gitops commands that do git network I/O over SSH: `init`, `join`, `pull`, `push`, and `status`. When set, git runs with `GIT_SSH_COMMAND="ssh -i <ssh-key> -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=~/.ssh/known_hosts"`, matching the repo's existing host-key conventions.

This reimplements just the `--ssh-key` feature from #574 (the `--reinit` and callback-plugin changes there are already merged or superseded and are not included).

## `--ssh-key` is distinct from `--key`

The two keys serve unrelated purposes, so `--ssh-key` deliberately does **not** fall back to `--key`:

- `--key` is **not** an SSH key. On Compose it's the **git-crypt symmetric key**; on Kubernetes it's the **basename** the SSH deploy key is derived from (`<key>.ssh`).
- `--ssh-key` is an actual SSH private key passed to `ssh -i`.

When `--ssh-key` is omitted, behavior is unchanged:
- **Compose** — ssh-agent forwarding (no `-i`), via the shared `gitops_git_env`.
- **Kubernetes** — the generated/staged `<key>.ssh` deploy key. `--ssh-key` overrides this rather than clobbering it (`ssh_key | default(_ssh_key_target_path, true)`).
- **status** — honors `--ssh-key` for the remote fetch; no key fallback.

## Changes

- `meta/command_definitions.yml` — `ssh_key` (type `path`) param on the five commands.
- `roles/gitops/vars/main.yml` — `gitops_git_env.GIT_SSH_COMMAND` injects `-i <ssh_key>` when set; covers the Compose init/join/pull/push flows that share the var.
- `roles/gitops/tasks/init_kubernetes.yml`, `join_kubernetes.yml` — inline `GIT_SSH_COMMAND` prefers `--ssh-key`, falls back to the staged deploy key.
- `direct_commands/gitops.py` — new `_git_ssh_env_prefix()` exports `GIT_SSH_COMMAND` before the status fetch.
- Unit tests for the new helper and status-script wiring.

## Testing

- `make validate`, `make lint`, `make test-unit` (991 passed), `make docs` all pass.

Closes #664