### PR TITLE
create: derive MW_SITE_SERVER scheme from CADDY_AUTO_HTTPS

### DIFF
--- a/roles/create/tasks/_env_update.yml
+++ b/roles/create/tasks/_env_update.yml
@@ -43,7 +43,13 @@
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   loop:
-    - { key: "MW_SITE_SERVER", value: "https://{{ _wiki_domain }}" }
+    # Scheme mirrors CADDY_AUTO_HTTPS: an HTTP-only instance must get an
+    # http:// server URL, otherwise MediaWiki canonical-redirects to https
+    # on a stack that serves no TLS (SSL_PROTOCOL_ERROR). _http_only is set
+    # in _envfile.yml, which runs earlier in create. Mirrors the scheme
+    # derivation in the config-set path (_side_effects.yml _active_scheme).
+    - { key: "MW_SITE_SERVER",
+        value: "{{ (_http_only | default(false) | bool) | ternary('http', 'https') }}://{{ _wiki_domain }}" }
     - { key: "MW_SITE_FQDN", value: "{{ _wiki_domain }}" }
     - { key: "MYSQL_PASSWORD", value: "{{ _rootdbpass }}" }
     - { key: "CANASTA_IMAGE", value: "{{ _base_image }}" }

--- a/tests/unit/test_create_site_server_scheme.py
+++ b/tests/unit/test_create_site_server_scheme.py
@@ -1,0 +1,70 @@
+"""Guards against the HTTP-only redirect bug in #666.
+
+`canasta create` must derive the MW_SITE_SERVER scheme from
+CADDY_AUTO_HTTPS (via the _http_only fact), not hardcode https://.
+A hardcoded https:// gives an HTTP-only instance an https $wgServer,
+so MediaWiki canonical-redirects login/Special pages to https on a
+stack that serves no TLS -> SSL_PROTOCOL_ERROR.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+ENV_UPDATE = os.path.join(
+    REPO_ROOT, "roles", "create", "tasks", "_env_update.yml"
+)
+ENVFILE = os.path.join(
+    REPO_ROOT, "roles", "create", "tasks", "_envfile.yml"
+)
+CREATE_MAIN = os.path.join(REPO_ROOT, "roles", "create", "tasks", "main.yml")
+
+
+def _load_tasks(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _read(path):
+    with open(path) as f:
+        return f.read()
+
+
+def _site_server_value():
+    """Return the MW_SITE_SERVER value templated in the core .env loop."""
+    for task in _load_tasks(ENV_UPDATE):
+        for item in task.get("loop", []) or []:
+            if isinstance(item, dict) and item.get("key") == "MW_SITE_SERVER":
+                return item["value"]
+    raise AssertionError("MW_SITE_SERVER not set in _env_update.yml core loop")
+
+
+class TestSiteServerScheme:
+    def test_scheme_is_not_hardcoded_https(self):
+        value = _site_server_value()
+        assert not value.lstrip().startswith("https://"), (
+            "MW_SITE_SERVER must not hardcode https:// at create time; an "
+            "HTTP-only instance would then redirect to https with no cert"
+        )
+
+    def test_scheme_derives_from_http_only(self):
+        value = _site_server_value()
+        assert "_http_only" in value, (
+            "MW_SITE_SERVER scheme must derive from the _http_only fact"
+        )
+        assert "http" in value and "https" in value, (
+            "MW_SITE_SERVER must choose between http and https schemes"
+        )
+
+    def test_http_only_is_set_before_env_update(self):
+        """_env_update.yml relies on the _http_only fact; _envfile.yml must
+        set it and run first in create's main.yml."""
+        assert "_http_only" in _read(ENVFILE), (
+            "_envfile.yml must set the _http_only fact"
+        )
+        main = _read(CREATE_MAIN)
+        assert main.index("_envfile.yml") < main.index("_env_update.yml"), (
+            "_envfile.yml must be included before _env_update.yml so "
+            "_http_only is defined when MW_SITE_SERVER is built"
+        )


### PR DESCRIPTION
## Summary

Closes #666.

When an instance is created **HTTP-only** (`CADDY_AUTO_HTTPS=off`), `canasta create` still wrote an **`https://`** `MW_SITE_SERVER` into `.env`. MediaWiki then set `$wgServer` to `https://…` and canonical-redirected login, `Special:Random`, etc. to HTTPS — but the stack serves no TLS, so the browser hit `ERR_SSL_PROTOCOL_ERROR`. This is the redirect half of the report in CanastaWiki/Canasta#639.

It is **not** port-specific — every HTTP-only instance created via the CLI was affected; a non-standard port just made it more visible.

## Changes

- **`roles/create/tasks/_env_update.yml`** — derive the `MW_SITE_SERVER` scheme from the `_http_only` fact (set earlier in `_envfile.yml` from `CADDY_AUTO_HTTPS`) instead of hardcoding `https://`. This mirrors the existing config-set path, which already derives the scheme via `_active_scheme` in `roles/config/tasks/_side_effects.yml`. `MW_SITE_FQDN` is unchanged (schemeless, already correct).
- **`tests/unit/test_create_site_server_scheme.py` (new)** — regression test: `MW_SITE_SERVER` must not hardcode `https://`, must derive the scheme from `_http_only`, and `_envfile.yml` must set `_http_only` and run before `_env_update.yml`.

## Testing

- `make test-unit` — 989 passed
- `make validate` — passed (77 commands, 59 playbooks)
- `make lint` — clean (no errors)

Compose only. The Caddy site address in `rewrite_caddy.yml` was already correct for HTTP-only, so no change was needed there.
