### PR TITLE
create: guide users to HTTP_PORT/HTTPS_PORT when --domain-name has a port

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -110,10 +110,27 @@ NESTED_SUBCOMMAND_GROUPS = {
     },
 }
 
+
+def _hostname_hint(value):
+    """Extra guidance when a rejected hostname carries a scheme or a port —
+    the most common reason --domain-name validation fails (users expect to
+    pass a URL or host:port). Ports/schemes are configured elsewhere."""
+    text = str(value)
+    if "://" in text or re.search(r":[0-9]+$", text):
+        return (
+            " Do not include a scheme or port here: pass --domain-name as a "
+            "bare hostname (e.g. 'example.com') and set HTTP_PORT/HTTPS_PORT "
+            "(and CADDY_AUTO_HTTPS=off for HTTP-only) in your .env file."
+        )
+    return ""
+
+
 # Named regex validators for parameters tagged with `validator: <name>`
-# in meta/command_definitions.yml. Each entry is (compiled_regex,
-# error_template). The error template is appended after the offending
-# value, e.g. "Error: --domain-name 'foo' is not a valid hostname …".
+# in meta/command_definitions.yml. Each entry is
+# (compiled_regex, error_template[, hint_fn]). The error template is
+# appended after the offending value, e.g.
+# "Error: --domain-name 'foo' is not a valid hostname …". The optional
+# hint_fn(value) returns extra, value-specific guidance to append.
 #
 # Validation runs after argparse but before any Ansible invocation, so
 # bad values fail in milliseconds instead of after Argo CD/helm/image
@@ -130,6 +147,7 @@ _VALIDATORS = {
         "is not a valid hostname. Expected lowercase letters, digits, "
         "'-' and '.' only, with each label starting and ending with an "
         "alphanumeric character (e.g. 'example.com').",
+        _hostname_hint,
     ),
 }
 
@@ -1357,14 +1375,17 @@ def main():
                 file=sys.stderr,
             )
             sys.exit(2)
-        regex, error_template = validator
+        regex, error_template = validator[0], validator[1]
+        hint_fn = validator[2] if len(validator) > 2 else None
         if not regex.match(str(value)):
+            hint = hint_fn(value) if hint_fn else ""
             print(
-                "Error: --%s %r %s"
+                "Error: --%s %r %s%s"
                 % (
                     param["name"].replace("_", "-"),
                     str(value),
                     error_template,
+                    hint,
                 ),
                 file=sys.stderr,
             )

--- a/tests/unit/test_domain_name_validation.py
+++ b/tests/unit/test_domain_name_validation.py
@@ -1,0 +1,51 @@
+"""Tests for --domain-name validation guidance (#667).
+
+The hostname validator rejects a value that carries a scheme or a port,
+but the bare "not a valid hostname" message left users (following older
+docs / the prior Go CLI) guessing. The validator now appends a hint that
+points them at HTTP_PORT/HTTPS_PORT for ports and a bare hostname for
+--domain-name.
+"""
+
+import os
+import sys
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+sys.path.insert(0, REPO_ROOT)
+
+import canasta  # noqa: E402
+
+
+class TestHostnameHint:
+    def test_hint_fires_on_scheme(self):
+        hint = canasta._hostname_hint("https://example.com")
+        assert "bare hostname" in hint
+        assert "HTTP_PORT/HTTPS_PORT" in hint
+
+    def test_hint_fires_on_port(self):
+        hint = canasta._hostname_hint("example.com:8443")
+        assert "HTTP_PORT/HTTPS_PORT" in hint
+        assert "CADDY_AUTO_HTTPS=off" in hint
+
+    def test_hint_fires_on_localhost_port(self):
+        assert canasta._hostname_hint("localhost:8443") != ""
+
+    def test_no_hint_for_plain_bad_hostname(self):
+        # A genuinely malformed hostname (uppercase, comma) is not a
+        # port/scheme problem, so no port hint should be appended.
+        assert canasta._hostname_hint("Example,com") == ""
+        assert canasta._hostname_hint("UPPER") == ""
+
+
+class TestHostnameValidatorWiring:
+    def test_hostname_validator_has_hint_fn(self):
+        validator = canasta._VALIDATORS["hostname"]
+        assert len(validator) == 3, (
+            "hostname validator must carry a hint function as its 3rd element"
+        )
+        assert callable(validator[2])
+        # A host:port value passes the regex check? It must NOT — the regex
+        # rejects ':' — and the hint must then describe where ports go.
+        regex, _template, hint_fn = validator
+        assert not regex.match("example.com:8443")
+        assert "HTTP_PORT/HTTPS_PORT" in hint_fn("example.com:8443")


### PR DESCRIPTION
## Summary

Closes #667.

`canasta create --domain-name` validates its value as a bare RFC-1123 hostname, so a URL or a `host:port` value is rejected with a bare "is not a valid hostname" message. Users following older docs — and the prior Go CLI, which accepted `host:port` — were left without a next step. This is the first half of the report in CanastaWiki/Canasta#639.

## Changes

- **`canasta.py`** — when a rejected `--domain-name` value contains a scheme (`://`) or a trailing `:port`, the validator now appends guidance:

  > Do not include a scheme or port here: pass --domain-name as a bare hostname (e.g. 'example.com') and set HTTP_PORT/HTTPS_PORT (and CADDY_AUTO_HTTPS=off for HTTP-only) in your .env file.

  Implemented as an optional `hint_fn` third element on the validator tuple, so the generic validation loop stays generic and other validators can opt in later. A genuinely malformed hostname (e.g. `Example,com`) still gets only the base message — no spurious port hint.
- **`tests/unit/test_domain_name_validation.py` (new)** — covers the hint firing on scheme / port / `localhost:port`, not firing on a malformed hostname, and the validator wiring.

The hostname regex itself is unchanged (it matches the k8s Ingress host rules); this is purely a message improvement.

## Testing

- `make test-unit` — 994 passed
- `make validate` — passed (77 commands, 59 playbooks)
- End-to-end: `canasta create -n example.com:8443` / `-n https://example.com` now print the hint; `-n Example,com` does not.
