### PR TITLE
lint: honor committed .yamllint and make the gate strict

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test: test-unit
 # --- Linting -----------------------------------------------------------------
 
 lint: venv
-	$(YAMLLINT) -d relaxed meta/ roles/ playbooks/ inventory/ canasta.yml || true
+	$(YAMLLINT) --strict meta/ roles/ playbooks/ inventory/ canasta.yml
 	$(PYTHON) scripts/validate_definitions.py
 
 # --- Documentation -----------------------------------------------------------

--- a/playbooks/export.yml
+++ b/playbooks/export.yml
@@ -24,7 +24,10 @@
 
 - name: Resolve output path
   ansible.builtin.set_fact:
-    _export_file: "{{ _export_raw if _export_raw.startswith('/') else (lookup('env', 'CANASTA_HOST_PWD') | default(lookup('env', 'PWD'), true)) + '/' + _export_raw }}"
+    _export_file: >-
+      {{ _export_raw if _export_raw.startswith('/')
+      else (lookup('env', 'CANASTA_HOST_PWD')
+      | default(lookup('env', 'PWD'), true)) + '/' + _export_raw }}
 
 - name: Check if gzip requested
   ansible.builtin.set_fact:

--- a/roles/backup/tasks/schedule_set.yml
+++ b/roles/backup/tasks/schedule_set.yml
@@ -39,7 +39,8 @@
           -i {{ instance_id }} --tag scheduled
         _cron_purge: >-
           {{ (purge_older_than is defined and purge_older_than != '')
-             | ternary('&& ' + (_host_canasta.stdout | trim) + ' backup purge -i ' + instance_id + ' --keep-within ' + (purge_older_than | default('')), '') }}
+             | ternary('&& ' + (_host_canasta.stdout | trim)
+             + ' backup purge -i ' + instance_id + ' --keep-within ' + (purge_older_than | default('')), '') }}
         _cron_log: '>> "{{ instance_path }}/backup.log" 2>&1'
 
     - name: Assemble cron command

--- a/roles/create/tasks/_register.yml
+++ b/roles/create/tasks/_register.yml
@@ -9,7 +9,10 @@
 
 - name: Build registry host string
   ansible.builtin.set_fact:
-    _registry_host: "{{ (ansible_user | default('') + '@') if (ansible_user | default('')) else '' }}{{ ansible_host | default(inventory_hostname) }}"
+    _registry_host: >-
+      {{ (ansible_user | default('') + '@')
+      if (ansible_user | default('')) else '' }}{{
+      ansible_host | default(inventory_hostname) }}
 
 - name: Register instance in controller config
   canasta_registry:

--- a/roles/mediawiki/tasks/import_database.yml
+++ b/roles/mediawiki/tasks/import_database.yml
@@ -50,7 +50,10 @@
 
     - name: Copy dump via kubectl cp
       ansible.builtin.command:
-        cmd: "kubectl cp /tmp/canasta-import{{ _is_gzipped | bool | ternary('.sql.gz', '.sql') }} canasta-{{ instance_id }}/{{ _k8s_pod_name }}:{{ _import_container_file }}"
+        cmd: >-
+          kubectl cp /tmp/canasta-import{{ _is_gzipped | bool
+          | ternary('.sql.gz', '.sql') }} canasta-{{ instance_id
+          }}/{{ _k8s_pod_name }}:{{ _import_container_file }}
       changed_when: true
 
 - name: Import gzipped database


### PR DESCRIPTION
## Summary

Closes #672.

`make lint` ran `yamllint -d relaxed meta/ roles/ playbooks/ inventory/ canasta.yml || true`. The `-d relaxed` flag makes yamllint use the built-in *relaxed* config and **ignore the committed `.yamllint`**, discarding its `ignore:` list (Helm / Kubernetes / Compose templates) and `max: 140`. Consequences:

- the Helm Go-template files (`{{ }}`, not valid YAML) produced spurious "syntax error" lines;
- the line-length threshold reverted to the relaxed default of 80, producing a wall of warnings;
- the trailing `|| true` swallowed all of it — including any *real* errors — so lint could never fail.

## Changes

- **`Makefile`** — `yamllint -d relaxed … || true` → `yamllint --strict …`. Dropping `-d relaxed` lets yamllint auto-discover the committed `.yamllint` (which already `extends: relaxed`, sets `max: 140`, and ignores the template dirs). Dropping `|| true` and adding `--strict` makes lint a real gate that fails on errors and warnings.
- **Wrapped the 4 remaining >140-char Jinja lines** that surfaced under the proper config (`playbooks/export.yml`, `roles/create/tasks/_register.yml`, `roles/mediawiki/tasks/import_database.yml`, `roles/backup/tasks/schedule_set.yml`). Each is reflowed without changing the rendered value — break points fall inside `{{ }}` expressions, so no concatenation (`}}{{`) or literal spacing changes. Verified by whitespace-normalized comparison against `main`.

## Testing

- `make lint` — clean, exit 0 (now `--strict`, no Helm syntax-error noise)
- `make test-unit` — 989 passed
- `make validate` — passed (77 commands, 59 playbooks)
- Each wrapped scalar confirmed functionally identical to its original value
