### PR TITLE
crowdsec: fix spurious blank line in ban/reload report messages

### DIFF
--- a/roles/crowdsec/tasks/ban.yml
+++ b/roles/crowdsec/tasks/ban.yml
@@ -29,5 +29,5 @@
   ansible.builtin.debug:
     msg: >-
       Blocked {{ ip }}{{ (' for ' ~ duration)
-        if (duration | default('') | string | length > 0) else '' }}
+      if (duration | default('') | string | length > 0) else '' }}
       on instance '{{ instance_id }}'.

--- a/roles/crowdsec/tasks/reload.yml
+++ b/roles/crowdsec/tasks/reload.yml
@@ -61,8 +61,8 @@
       ansible.builtin.set_fact:
         _crowdsec_purge_line: >-
           Purged {{ ("console blocklist '" ~ purge_blocklist ~ "'")
-                     if (purge_blocklist is defined and (purge_blocklist | string | length) > 0)
-                     else 'all console blocklists' }} from the local engine;
+          if (purge_blocklist is defined and (purge_blocklist | string | length) > 0)
+          else 'all console blocklists' }} from the local engine;
           lists you are still subscribed to refill on the next pull cycle.
 
 # On Compose only the crowdsec service bounces, so Caddy keeps enforcing
@@ -73,6 +73,6 @@
     msg: >-
       Reloaded the CrowdSec engine for instance '{{ instance_id }}'.
       {{ 'The Caddy bouncer keeps enforcing cached decisions during the restart.'
-         if (instance_orchestrator | default('compose') == 'compose')
-         else 'The caddy pod rolls with it, so expect a brief blip; the bouncer resumes once the engine is back.' }}
+      if (instance_orchestrator | default('compose') == 'compose')
+      else 'The caddy pod rolls with it, so expect a brief blip; the bouncer resumes once the engine is back.' }}
       {{ _crowdsec_purge_line | default('') }}

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -989,6 +989,56 @@ class TestCrowdsecReloadRole:
         )
 
 
+class TestCrowdsecReportFormatting:
+    """Folded (>-) display messages must collapse to a single logical line.
+    A continuation line indented deeper than the first makes YAML preserve
+    the line break instead of folding it to a space, which prints as a
+    spurious blank line in the command output (regression: ban report)."""
+
+    def _strings(self, name):
+        tasks = yaml.safe_load(_read(os.path.join(
+            REPO_ROOT, "roles", "crowdsec", "tasks", name)))
+        found = []
+
+        def walk(n):
+            if isinstance(n, dict):
+                for v in n.values():
+                    walk(v)
+            elif isinstance(n, list):
+                for v in n:
+                    walk(v)
+            elif isinstance(n, str):
+                found.append(n)
+        walk(tasks)
+        return found
+
+    def _stray_newlines(self, s):
+        # Newlines that survive YAML folding OUTSIDE a {{ }} expression are the
+        # ones that reach the rendered output as blank lines.
+        return re.sub(r"\{\{.*?\}\}", "", s, flags=re.S).count("\n")
+
+    def test_ban_report_renders_on_one_line(self):
+        msg = next(s for s in self._strings("ban.yml")
+                   if s.startswith("Blocked {{ ip }}"))
+        assert self._stray_newlines(msg) == 0, (
+            "ban report must fold to one line — no stray newline before "
+            "'on instance'"
+        )
+        # Render both branches to prove the visible output is single-line.
+        for dur in ("10m", ""):
+            out = jinja2.Environment().from_string(msg).render(
+                ip="203.0.113.5", duration=dur, instance_id="mysite")
+            assert "\n" not in out, f"ban report wrapped (duration={dur!r}): {out!r}"
+
+    def test_reload_report_and_purge_line_render_on_one_line(self):
+        strings = self._strings("reload.yml")
+        report = next(s for s in strings
+                      if s.startswith("Reloaded the CrowdSec engine"))
+        purge = next(s for s in strings if s.startswith("Purged {{"))
+        assert self._stray_newlines(report) == 0, "reload report must fold to one line"
+        assert self._stray_newlines(purge) == 0, "purge note must fold to one line"
+
+
 class TestCrowdsecAutoEnroll:
     def test_start_auto_enrolls_when_enabled_without_key(self):
         """Enabling CrowdSec should enroll the bouncer on the next start,


### PR DESCRIPTION
Fixes #675.

`canasta crowdsec ban` (and `reload`) printed their confirmation across two lines with a spurious blank break:

```
Blocked 2.25.190.83 for 10m
on instance 'wikifarm'.
```

## Cause

The report strings use a folded YAML scalar (`>-`) whose conditional continuation line is indented *deeper* than the first content line. YAML treats a more-indented line as a literal block and preserves the line breaks around it instead of folding them to spaces, so a newline survives into the rendered output as a blank line.

## Fix

De-indent the conditional continuations to the base indentation so each scalar folds to a single logical line:
- `roles/crowdsec/tasks/ban.yml` — report
- `roles/crowdsec/tasks/reload.yml` — report + the `--purge-blocklist(s)` note

The `|-` literal-block messages (status / metrics / scenarios / alerts / console-enroll) are intentional multi-line output and are left unchanged.

## Test

Adds `TestCrowdsecReportFormatting`, which strips `{{ }}` expressions and asserts no stray newline survives folding, and renders the ban message in both the with-duration and without-duration branches to prove single-line output. Full suite green (1040 passing).

## Scope

Released Docker Compose behavior; cosmetic (output formatting only). Independent of the K8s work in #604/#659.