### PR TITLE
crowdsec: quote the K8s caddy-readiness jsonpath in preflight

### DIFF
--- a/roles/crowdsec/tasks/_preflight.yml
+++ b/roles/crowdsec/tasks/_preflight.yml
@@ -40,7 +40,7 @@
           kubectl get pods -n canasta-{{ instance_id }}
           -l app.kubernetes.io/component=caddy
           --field-selector=status.phase=Running
-          -o jsonpath={range .items[0].status.containerStatuses[*]}{.name}={.ready} {end}
+          -o "jsonpath={range .items[0].status.containerStatuses[*]}{.name}={.ready} {end}"
       register: _crowdsec_k8s_ready
       changed_when: false
 

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -1183,6 +1183,44 @@ class TestCrowdsecResolveCscli:
         assert "_resolve_cscli.yml" in preflight
 
 
+class TestCrowdsecPreflightK8sReadiness:
+    """The K8s caddy-pod readiness probe in _preflight.yml uses a jsonpath
+    that contains a space (the 'name=ready ' separator). It must be quoted so
+    Ansible's command parser keeps it as one argument — otherwise the trailing
+    ' {end}' splits into its own token and kubectl reads it as a pod name,
+    failing with 'name cannot be provided when a selector is specified'."""
+
+    def _readiness_cmd(self):
+        tasks = yaml.safe_load(_read(os.path.join(
+            REPO_ROOT, "roles", "crowdsec", "tasks", "_preflight.yml")))
+        found = []
+
+        def walk(n):
+            if isinstance(n, dict):
+                cmd = n.get("ansible.builtin.command")
+                if isinstance(cmd, dict) and "containerStatuses" in str(cmd.get("cmd", "")):
+                    found.append(cmd["cmd"])
+                for v in n.values():
+                    walk(v)
+            elif isinstance(n, list):
+                for v in n:
+                    walk(v)
+        walk(tasks)
+        assert found, "expected the jsonpath readiness command in _preflight.yml"
+        return found[0]
+
+    def test_readiness_jsonpath_is_a_single_argument(self):
+        import shlex
+        tokens = shlex.split(self._readiness_cmd().replace("{{ instance_id }}", "big"))
+        assert "{end}" not in tokens, (
+            "jsonpath must be quoted — an unquoted ' {end}' splits into its own "
+            "token and kubectl reads it as a pod name"
+        )
+        jp = [t for t in tokens if t.startswith("jsonpath=")]
+        assert len(jp) == 1, f"expected exactly one jsonpath token, got {jp}"
+        assert jp[0].endswith("{end}"), "the full jsonpath (incl. {end}) must be one token"
+
+
 class TestCrowdsecK8sChart:
     def test_values_has_crowdsec_block(self):
         values = yaml.safe_load(_read(os.path.join(HELM_DIR, "values.yaml")))

--- a/tests/unit/test_kubectl_commands.py
+++ b/tests/unit/test_kubectl_commands.py
@@ -1,0 +1,72 @@
+"""Repo-wide guard against malformed kubectl command construction.
+
+The crowdsec K8s preflight once passed an unquoted kubectl jsonpath that
+contained a space ("name=ready " separator). Ansible's command parser split
+the trailing " {end}" into its own token, and kubectl read it as a positional
+pod name — failing with "name cannot be provided when a selector is
+specified". That broke every K8s crowdsec command.
+
+This is a class of bug (a jsonpath fragment leaking into its own argument)
+that string-grep unit tests miss because it only manifests when the command
+is actually tokenized. Scan every kubectl command in roles/ and assert each
+jsonpath expression survives shlex tokenization as a single argument.
+"""
+
+import glob
+import os
+import re
+import shlex
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+_CMD_KEYS = ("ansible.builtin.command", "ansible.builtin.shell", "command", "shell")
+
+
+def _kubectl_cmds():
+    """Yield (file, cmd-string) for every command/shell task cmd in roles/."""
+    found = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if k in _CMD_KEYS and isinstance(v, dict) and isinstance(v.get("cmd"), str):
+                    found.append(v["cmd"])
+                walk(v)
+        elif isinstance(node, list):
+            for v in node:
+                walk(v)
+
+    out = []
+    for f in glob.glob(os.path.join(REPO_ROOT, "roles", "**", "*.yml"), recursive=True):
+        try:
+            doc = yaml.safe_load(open(f))
+        except yaml.YAMLError:
+            continue
+        found.clear()
+        walk(doc)
+        for c in found:
+            if "kubectl" in c:
+                out.append((os.path.relpath(f, REPO_ROOT), c))
+    return out
+
+
+def test_kubectl_jsonpath_is_always_a_single_token():
+    """Every `-o jsonpath=...` must tokenize as one argument. A jsonpath with a
+    space (e.g. a {range ...} {end} template) must be quoted, or it splits and
+    kubectl mistakes the trailing fragment for a resource name."""
+    offenders = []
+    for f, cmd in _kubectl_cmds():
+        if "jsonpath" not in cmd:
+            continue
+        # {{ jinja }} expressions contain spaces; collapse to a placeholder so
+        # tokenization reflects the real argument structure, not the template.
+        tokens = shlex.split(re.sub(r"\{\{.*?\}\}", "X", cmd, flags=re.S))
+        leaked = [t for t in tokens if t.startswith("{")]
+        jsonpath_tokens = [t for t in tokens if "jsonpath" in t]
+        if leaked or len(jsonpath_tokens) != 1:
+            offenders.append(
+                f"{f}: jsonpath split into {jsonpath_tokens!r} with leaked "
+                f"fragment(s) {leaked!r} — quote the jsonpath"
+            )
+    assert not offenders, "Malformed kubectl jsonpath argument(s):\n" + "\n".join(offenders)


### PR DESCRIPTION
Fixes #677.

On Kubernetes, every `canasta crowdsec` command failed at preflight with `error: name cannot be provided when a selector is specified` — surfaced live when enabling CrowdSec on a K8s instance.

## Cause
`_preflight.yml`'s caddy-readiness check used an **unquoted** kubectl jsonpath containing a space (the `name=ready ` separator), so Ansible's command parser split the trailing ` {end}` into its own token and kubectl read it as a positional pod name. Preflight runs for every K8s crowdsec subcommand, so all of them broke.

## Fix
- Quote the jsonpath so it's passed as a single argument.
- Regression test: shlex-splits the command and asserts the jsonpath stays one token.
- **Repo-wide guard** (`tests/unit/test_kubectl_commands.py`): scans every kubectl command in `roles/` and fails if any jsonpath splits — guards the whole class, not just this line. Verified clean across all 9 jsonpath commands in the repo today.

## Verification
`make test-unit` green (1042). The fix was also validated by hand against a live k3s cluster.

## Scope
K8s only (#604); Compose unaffected. The CI gap that let this reach `main` (K8s integration never enables CrowdSec) is tracked separately.