### PR TITLE
orchestrator: progress messages during the K8s start/restart

### DIFF
--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -186,6 +186,10 @@
       changed_when: false
       ignore_errors: true  # OK if deployment doesn't exist yet
 
+    - name: Report applying Helm release
+      ansible.builtin.debug:
+        msg: "Applying Helm release (pulling images and rolling out pods; this may take a few minutes)..."
+
     - name: Apply values and upgrade Helm release
       ansible.builtin.include_tasks: helm_deploy.yml
 
@@ -240,6 +244,10 @@
       ansible.builtin.set_fact:
         _db_enabled: "{{ _start_values.get('db', {}).get('enabled', true) }}"
 
+    - name: Report waiting for rollout
+      ansible.builtin.debug:
+        msg: "Waiting for pods to become ready..."
+
     - name: Wait for DB readiness
       ansible.builtin.command:
         cmd: >-
@@ -274,6 +282,12 @@
           kubectl rollout status deployment/canasta-{{ instance_id }}-caddy
           -n {{ _k8s_namespace }} --timeout=300s
       changed_when: false
+      when:
+        - _start_crowdsec_env.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true'
+
+    - name: Report enrolling CrowdSec
+      ansible.builtin.debug:
+        msg: "CrowdSec is enabled — registering with the Central API and enrolling the Caddy bouncer..."
       when:
         - _start_crowdsec_env.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true'
 

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -976,3 +976,24 @@ class TestRequirementsCollectionsHelm4Compat:
                 "%r which lets pip install pre-Helm-4 versions; "
                 "must be >=6.4.0 (#525)" % pin
             )
+
+
+class TestK8sStartProgressMessages:
+    """The K8s start path runs a Helm upgrade + rollout waits that can take
+    minutes; without progress output `config set`/restart looks hung — a user
+    reported a long silent wait before an error when enabling CrowdSec on K8s.
+    Assert the curated progress lines are present, mirroring the Compose path's
+    'Starting containers...'."""
+
+    def _start(self):
+        with open(os.path.join(ORCHESTRATOR_TASKS, "start.yml")) as f:
+            return f.read()
+
+    def test_helm_upgrade_has_progress_message(self):
+        assert "Applying Helm release" in self._start()
+
+    def test_rollout_wait_has_progress_message(self):
+        assert "Waiting for pods to become ready" in self._start()
+
+    def test_crowdsec_enroll_has_progress_message(self):
+        assert "enrolling the Caddy bouncer" in self._start()


### PR DESCRIPTION
Fixes #679.

On Kubernetes, `canasta config set` / restart runs a Helm upgrade + rollout waits that can take minutes with **no output**, so it looks hung. (Hit live when enabling CrowdSec on K8s.) The Compose path already prints "Starting containers..."; the K8s path had no equivalent.

## Change

Curated progress lines added to the K8s path in `roles/orchestrator/tasks/start.yml`, mirroring Compose:
- **"Applying Helm release (pulling images and rolling out pods; this may take a few minutes)..."** — before the Helm upgrade
- **"Waiting for pods to become ready..."** — before the rollout-status waits
- **"CrowdSec is enabled — registering with the Central API and enrolling the Caddy bouncer..."** — before auto-enroll (only when CrowdSec is on)

UX only — no behavior change. Tests assert the three lines are present (`TestK8sStartProgressMessages`). `make test-unit` green (1043).

Independent of the preflight jsonpath bugfix (#678 / #677).