### PR TITLE
crowdsec: switch caddy to the plugin image when enabling on K8s

### DIFF
--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -437,8 +437,21 @@
 
     - name: Compute desired caddy image and managed state
       vars:
-        _crowdsec_on: "{{ _k8s_img_env.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true' }}"
-        _tp_mode: "{{ _k8s_img_env.variables.CADDY_TRUSTED_PROXIES | default('') | trim | lower }}"
+        # Side effects run BEFORE the .env write (see _set_single.yml), so the
+        # key currently being set is not yet in _k8s_img_env. Overlay
+        # _config_value for it — otherwise a fresh
+        # `config set CANASTA_ENABLE_CROWDSEC=true` reads the stale 'false',
+        # leaves the stock caddy image, and the pod crashloops on the crowdsec
+        # Caddyfile directive. (Compose self-heals via the start-time profile
+        # re-sync; the K8s start path has no equivalent, so fix it at source.)
+        _eff_crowdsec: >-
+          {{ _config_value if _config_key == 'CANASTA_ENABLE_CROWDSEC'
+             else (_k8s_img_env.variables.CANASTA_ENABLE_CROWDSEC | default('false')) }}
+        _eff_tp: >-
+          {{ _config_value if _config_key == 'CADDY_TRUSTED_PROXIES'
+             else (_k8s_img_env.variables.CADDY_TRUSTED_PROXIES | default('')) }}
+        _crowdsec_on: "{{ _eff_crowdsec | lower == 'true' }}"
+        _tp_mode: "{{ _eff_tp | trim | lower }}"
         _plugin_needed: "{{ _crowdsec_on or (_tp_mode in ['cloudflare', 'imperva']) }}"
       ansible.builtin.set_fact:
         _k8s_img_values: "{{ _k8s_img_values_raw.content | b64decode | from_yaml }}"

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -1221,6 +1221,30 @@ class TestCrowdsecPreflightK8sReadiness:
         assert jp[0].endswith("{end}"), "the full jsonpath (incl. {end}) must be one token"
 
 
+class TestCrowdsecK8sCaddyImageReconcile:
+    """A fresh `config set CANASTA_ENABLE_CROWDSEC=true` on K8s must switch the
+    caddy image to the plugin build. The reconcile runs in _side_effects BEFORE
+    .env is written (_set_single.yml: validate -> side effects -> set), so it
+    must overlay _config_value for the key being set rather than read the stale
+    .env — otherwise caddy keeps the stock image and crashloops on the crowdsec
+    Caddyfile directive. (K8s, unlike Compose, has no start-time image re-sync.)"""
+
+    def _side_effects(self):
+        return _read(os.path.join(
+            REPO_ROOT, "roles", "config", "tasks", "_side_effects.yml"))
+
+    def test_reconcile_overlays_config_value_for_the_key_being_set(self):
+        content = self._side_effects()
+        assert "_config_value if _config_key == 'CANASTA_ENABLE_CROWDSEC'" in content, (
+            "K8s caddy-image reconcile must overlay _config_value for "
+            "CANASTA_ENABLE_CROWDSEC — .env is written after side effects, so "
+            "reading .env alone yields the stale value"
+        )
+        assert "_config_value if _config_key == 'CADDY_TRUSTED_PROXIES'" in content, (
+            "the trusted-proxy branch must overlay _config_value too"
+        )
+
+
 class TestCrowdsecK8sChart:
     def test_values_has_crowdsec_block(self):
         values = yaml.safe_load(_read(os.path.join(HELM_DIR, "values.yaml")))


### PR DESCRIPTION
Fixes #681.

Enabling CrowdSec on Kubernetes (`config set CANASTA_ENABLE_CROWDSEC=true`) left the caddy container on the **stock image** while the Caddyfile gained the `crowdsec` directive → `CrashLoopBackOff` (`crowdsec is not a registered directive`) and the enabling `helm upgrade --wait` timed out. Found during live K8s e2e.

## Cause

`_set_single.yml` runs **validate → side effects → write `.env`**. The K8s caddy-image reconcile reads feature flags from `.env`, which on a fresh enable still says `CANASTA_ENABLE_CROWDSEC=false` → "plugin not needed" → stock image kept. The `crowdsec.enabled` propagation uses `_config_value` directly, so the sidecar/directive turned on anyway → mismatch → crash. Compose self-heals (its `start.yml` re-runs `sync_compose_profiles` after the `.env` write); the K8s start path has no equivalent re-sync.

## Fix

Overlay `_config_value` for the key being set when computing whether the plugin image is needed, so the reconcile is correct without depending on `.env` already being written. Handles both enable (→ plugin) and disable (→ stock). Regression test (`TestCrowdsecK8sCaddyImageReconcile`) asserts the overlay. `make test-unit` green (1041).

## Verification

Confirmed live: manually setting `caddy.image` to the plugin build + `canasta restart` brought the caddy pod up `2/2` and the bouncer enrolled cleanly — i.e. the only missing piece was the plugin image, which this reconcile now sets automatically.

## Notes

- K8s only; release blocker for K8s CrowdSec.
- Worth a follow-up to verify the **create-time** path (`canasta create -e` with crowdsec enabled) also selects the plugin image.
- The CI gap that let this through (K8s integration never *enables* CrowdSec) is the same one tracked for #677 — a K8s-enable integration test would have caught this and the jsonpath bug.