### PR TITLE
orchestrator: wait for namespace termination on K8s delete

### DIFF
--- a/roles/orchestrator/tasks/helm_uninstall.yml
+++ b/roles/orchestrator/tasks/helm_uninstall.yml
@@ -32,4 +32,11 @@
     api_version: v1
     kind: Namespace
     name: "{{ _k8s_namespace }}"
+    # Wait for the namespace to fully terminate before delete returns.
+    # Without this, deletion is async and an immediate `canasta create`
+    # races the still-Terminating namespace and fails its stale-namespace
+    # guard. Namespace teardown (finalizers, PVC/pod cleanup) can take a
+    # while, so allow generous time.
+    wait: true
+    wait_timeout: 300
   when: delete_namespace | default(true) | bool

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -997,3 +997,20 @@ class TestK8sStartProgressMessages:
 
     def test_crowdsec_enroll_has_progress_message(self):
         assert "enrolling the Caddy bouncer" in self._start()
+
+
+class TestK8sDeleteWaitsForNamespace:
+    """`canasta delete` must wait for the namespace to fully terminate before
+    returning — otherwise an immediate re-create races the still-Terminating
+    namespace and fails the stale-namespace guard (#684)."""
+
+    def test_namespace_deletion_waits(self):
+        with open(os.path.join(ORCHESTRATOR_TASKS, "helm_uninstall.yml")) as f:
+            tasks = yaml.safe_load(f)
+        ns = next(t for t in tasks if t.get("name") == "Delete namespace")
+        spec = ns["kubernetes.core.k8s"]
+        assert spec.get("kind") == "Namespace"
+        assert spec.get("state") == "absent"
+        assert spec.get("wait") is True, (
+            "namespace deletion must wait, so delete->create does not race"
+        )


### PR DESCRIPTION
Fixes #684.

`canasta delete` on K8s deleted the namespace asynchronously, returning while it was still `Terminating`. An immediate `canasta create` then raced the leftover namespace and failed its stale-namespace guard — breaking the natural `delete` → recreate flow (hit during live e2e).

## Fix

Add `wait: true` (+ `wait_timeout: 300`) to the namespace deletion in `helm_uninstall.yml`, so `delete` blocks until the namespace is fully gone. Regression test (`TestK8sDeleteWaitsForNamespace`) asserts it. `make test-unit` green (1041).

## Scope

K8s only; UX/correctness. Part of the live-e2e follow-ups (sibling to #683 CI coverage, #685 create-time crowdsec).