### PR TITLE
k8s: preserve real client IP via Traefik externalTrafficPolicy=Local

### DIFF
--- a/roles/orchestrator/files/traefik-externaltrafficpolicy.yaml
+++ b/roles/orchestrator/files/traefik-externaltrafficpolicy.yaml
@@ -6,14 +6,18 @@
 # real-client-IP behaviour on K8s: CrowdSec sees only private IPs and
 # whitelists all traffic (protecting nothing), and access logs are useless.
 #
-# Local preserves the client IP. k3s auto-applies manifests dropped in its
-# server/manifests dir and the helm-controller reconciles Traefik with these
-# merged values, so this is durable across k3s restarts/upgrades (a direct
-# `kubectl patch` would be reverted on the next Traefik chart redeploy).
+# externalTrafficPolicy: Local preserves the client IP, but a node only serves
+# the traffic if it has a LOCAL Traefik pod — so on a multi-node cluster Local
+# alone would drop external traffic that lands on any node without Traefik.
+# k3s deploys Traefik as a single-replica Deployment by default, so we also run
+# it as a DaemonSet: one Traefik pod per node, so every node that can receive
+# external traffic has a local endpoint and preserves the client IP. (Single-
+# node is unaffected — the DaemonSet schedules exactly one pod there.)
 #
-# Caveat: Local routes external traffic only to nodes running a Traefik pod —
-# correct for single-node; multi-node clusters must ensure the ingress runs
-# on the nodes that receive external traffic.
+# k3s auto-applies manifests dropped in its server/manifests dir and the
+# helm-controller reconciles Traefik with these merged values, so this is
+# durable across k3s restarts/upgrades (a direct `kubectl patch` would be
+# reverted on the next Traefik chart redeploy).
 apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig
 metadata:
@@ -21,6 +25,8 @@ metadata:
   namespace: kube-system
 spec:
   valuesContent: |-
+    deployment:
+      kind: DaemonSet
     service:
       spec:
         externalTrafficPolicy: Local

--- a/roles/orchestrator/files/traefik-externaltrafficpolicy.yaml
+++ b/roles/orchestrator/files/traefik-externaltrafficpolicy.yaml
@@ -1,0 +1,26 @@
+# Preserve the real client IP at the ingress.
+#
+# The k3s-bundled Traefik LoadBalancer service defaults to
+# externalTrafficPolicy: Cluster, which SNATs the source IP to the node CNI
+# gateway before the request reaches Traefik/Caddy. That breaks every
+# real-client-IP behaviour on K8s: CrowdSec sees only private IPs and
+# whitelists all traffic (protecting nothing), and access logs are useless.
+#
+# Local preserves the client IP. k3s auto-applies manifests dropped in its
+# server/manifests dir and the helm-controller reconciles Traefik with these
+# merged values, so this is durable across k3s restarts/upgrades (a direct
+# `kubectl patch` would be reverted on the next Traefik chart redeploy).
+#
+# Caveat: Local routes external traffic only to nodes running a Traefik pod —
+# correct for single-node; multi-node clusters must ensure the ingress runs
+# on the nodes that receive external traffic.
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    service:
+      spec:
+        externalTrafficPolicy: Local

--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -70,6 +70,21 @@
       delay: 5
       changed_when: false
 
+# Preserve the real client IP at the ingress. The k3s-bundled Traefik
+# LoadBalancer defaults to externalTrafficPolicy: Cluster, which SNATs the
+# source IP before it reaches Traefik/Caddy — breaking CrowdSec (all traffic
+# looks private and is whitelisted) and accurate access logs. Dropping a k3s
+# HelmChartConfig flips it to Local durably; k3s auto-applies manifests from
+# this dir and the helm-controller reconciles Traefik (redeploys it on an
+# existing cluster). Runs for fresh and existing clusters (outside the
+# install-only block above).
+- name: Preserve client IP — set Traefik externalTrafficPolicy=Local
+  ansible.builtin.copy:
+    src: traefik-externaltrafficpolicy.yaml
+    dest: /var/lib/rancher/k3s/server/manifests/canasta-traefik-config.yaml
+    mode: "0644"
+  become: true
+
 # k3s bundles kubectl as 'k3s kubectl' but many tools (Helm, Ansible
 # k8s modules) expect a standalone 'kubectl' binary on the PATH.
 - name: Create kubectl symlink

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -1035,6 +1035,18 @@ class TestK8sTraefikClientIP:
         values = yaml.safe_load(doc["spec"]["valuesContent"])
         assert values["service"]["spec"]["externalTrafficPolicy"] == "Local"
 
+    def test_traefik_runs_as_daemonset(self):
+        # Local only preserves the client IP on nodes with a local Traefik pod;
+        # on multi-node clusters Local without a DaemonSet would drop external
+        # traffic landing on Traefik-less nodes. DaemonSet guarantees a Traefik
+        # pod (local endpoint) on every node.
+        doc = yaml.safe_load(open(self.CONFIG))
+        values = yaml.safe_load(doc["spec"]["valuesContent"])
+        assert values["deployment"]["kind"] == "DaemonSet", (
+            "Traefik must run as a DaemonSet so externalTrafficPolicy=Local "
+            "preserves the client IP on every node (multi-node safe)"
+        )
+
     def test_install_drops_the_config_into_k3s_manifests(self):
         with open(os.path.join(ORCHESTRATOR_TASKS, "k8s_install_k3s.yml")) as f:
             tasks = yaml.safe_load(f)

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -1014,3 +1014,36 @@ class TestK8sDeleteWaitsForNamespace:
         assert spec.get("wait") is True, (
             "namespace deletion must wait, so delete->create does not race"
         )
+
+
+class TestK8sTraefikClientIP:
+    """The k3s-bundled Traefik LoadBalancer defaults to externalTrafficPolicy:
+    Cluster, which SNATs the client IP — breaking CrowdSec (all traffic looks
+    private) and access logs. install k8s-cp must drop a HelmChartConfig that
+    flips Traefik to Local so the real client IP is preserved (#687)."""
+
+    CONFIG = os.path.join(
+        REPO_ROOT, "roles", "orchestrator", "files",
+        "traefik-externaltrafficpolicy.yaml",
+    )
+
+    def test_helmchartconfig_sets_local_policy(self):
+        doc = yaml.safe_load(open(self.CONFIG))
+        assert doc["kind"] == "HelmChartConfig"
+        assert doc["metadata"]["name"] == "traefik"
+        assert doc["metadata"]["namespace"] == "kube-system"
+        values = yaml.safe_load(doc["spec"]["valuesContent"])
+        assert values["service"]["spec"]["externalTrafficPolicy"] == "Local"
+
+    def test_install_drops_the_config_into_k3s_manifests(self):
+        with open(os.path.join(ORCHESTRATOR_TASKS, "k8s_install_k3s.yml")) as f:
+            tasks = yaml.safe_load(f)
+        copy = next(
+            t for t in tasks
+            if isinstance(t.get("ansible.builtin.copy"), dict)
+            and t["ansible.builtin.copy"].get("src") == "traefik-externaltrafficpolicy.yaml"
+        )
+        spec = copy["ansible.builtin.copy"]
+        # k3s auto-applies manifests dropped here; must be root-written.
+        assert spec["dest"].startswith("/var/lib/rancher/k3s/server/manifests/")
+        assert copy.get("become") is True


### PR DESCRIPTION
Fixes #687.

On k3s, the Traefik `LoadBalancer` service defaults to `externalTrafficPolicy: Cluster`, which SNATs the client source IP to the node CNI gateway (`10.42.0.1`) before it reaches Traefik/Caddy. CrowdSec then sees only private IPs and **whitelists all traffic** (protecting nothing); access logs are useless too. Canasta's Caddy trusted-proxy config was correct but fed a SNAT'd IP. Found during the live K8s CrowdSec e2e.

## Fix

`install k8s-cp` drops a k3s `HelmChartConfig` (`roles/orchestrator/files/traefik-externaltrafficpolicy.yaml`) into `/var/lib/rancher/k3s/server/manifests/`, setting:
- `service.spec.externalTrafficPolicy: Local` — preserve the client IP, and
- `deployment.kind: DaemonSet` — run a Traefik pod on **every** node.

The DaemonSet is essential, not cosmetic: `Local` only preserves the IP on nodes that have a *local* Traefik pod, and k3s's default Traefik is a single-replica Deployment. On a **multi-node** cluster (a supported topology), `Local` alone would drop external traffic landing on any Traefik-less node. The DaemonSet guarantees a local endpoint on every node. Single-node is unaffected (one pod, as before).

k3s auto-applies the manifest and the helm-controller reconciles Traefik — durable across k3s restarts/upgrades (a direct `kubectl patch` would be reverted). Runs for fresh and existing clusters.

## Confirmed live (single-node k3s)

- `externalTrafficPolicy: Local` → an external request that previously logged `client_ip: 10.42.0.5  XFF: 10.42.0.1` now logs `client_ip: <real public IP>  XFF: <real public IP>`; CrowdSec acts on real source IPs.
- HelmChartConfig mechanism: dropping the manifest on a `Cluster`-policy service flips it to `Local` via the helm-controller and persists.

## Still to validate

The DaemonSet + multi-node client-IP preservation should be verified on an actual multi-node cluster. Unit tests assert the manifest (Local + DaemonSet) and that install copies it to the k3s manifests dir; `make test-unit` green (1050).

## Scope / notes

- Release blocker for K8s CrowdSec (security-ineffective without real client IPs); also fixes accurate access logging on K8s generally.
- BYO ingress (`--ingress-class`): client-IP preservation is the operator's responsibility — worth a docs note.