### PR TITLE
install: build worker K3S_URL from a single IPv4, not the dual-stack pair

### DIFF
--- a/roles/install/tasks/k3s_worker.yml
+++ b/roles/install/tasks/k3s_worker.yml
@@ -91,9 +91,22 @@
   register: _cp_internal_ip_raw
   changed_when: false
 
+# A dual-stack control-plane node reports both an IPv4 and an IPv6
+# InternalIP, and the jsonpath above returns them space-separated
+# (e.g. "10.0.0.5 2001:db8::5"). Building the server URL from the raw
+# string yields "https://10.0.0.5 2001:db8::5:6443", which k3s rejects
+# ("invalid character ' ' in host name") so the agent never joins. Pick a
+# single IPv4 address (k3s and the API-server cert SAN are IPv4-centric
+# here); fall back to the first address if somehow no IPv4 is present.
+- name: Select a single control-plane InternalIP (prefer IPv4)
+  ansible.builtin.set_fact:
+    _cp_internal_ip: >-
+      {{ ((_cp_internal_ip_raw.stdout | trim | split(' ') | select('match', '^[0-9.]+$') | list)
+          + (_cp_internal_ip_raw.stdout | trim | split(' ') | list)) | first | default('') }}
+
 - name: Set k3s join parameters
   ansible.builtin.set_fact:
-    _k3s_server_url: "https://{{ _cp_internal_ip_raw.stdout | trim }}:6443"
+    _k3s_server_url: "https://{{ _cp_internal_ip }}:6443"
     _k3s_join_token: "{{ _cp_token_raw.stdout | trim }}"
   no_log: true
 

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -1059,3 +1059,46 @@ class TestK8sTraefikClientIP:
         # k3s auto-applies manifests dropped here; must be root-written.
         assert spec["dest"].startswith("/var/lib/rancher/k3s/server/manifests/")
         assert copy.get("become") is True
+
+
+class TestK8sWorkerJoinDualStackIP:
+    """A dual-stack control-plane node reports both an IPv4 and an IPv6
+    InternalIP. The worker join must build K3S_URL from a single IPv4 address,
+    not the raw space-separated pair — k3s rejects the latter with
+    'invalid character " " in host name' and the agent never joins (#687-era
+    multi-node e2e finding)."""
+
+    WORKER = os.path.join(REPO_ROOT, "roles", "install", "tasks", "k3s_worker.yml")
+
+    def _select_ip(self, raw):
+        import re
+        import jinja2
+        tasks = yaml.safe_load(open(self.WORKER))
+        task = next(
+            t for t in tasks
+            if isinstance(t, dict)
+            and str(t.get("name", "")).startswith("Select a single control-plane InternalIP")
+        )
+        expr = task["ansible.builtin.set_fact"]["_cp_internal_ip"]
+        env = jinja2.Environment()
+        env.filters["split"] = lambda s, sep=None: s.split(sep)
+        env.tests["match"] = lambda s, pat: re.match(pat, s) is not None
+        return env.from_string(expr).render(_cp_internal_ip_raw={"stdout": raw}).strip()
+
+    def test_dualstack_returns_only_ipv4(self):
+        assert self._select_ip("209.112.76.164 2607:29c0:3001:20::a") == "209.112.76.164"
+
+    def test_ipv4_only_unchanged(self):
+        assert self._select_ip("10.0.0.5") == "10.0.0.5"
+
+    def test_selected_ip_has_no_whitespace(self):
+        out = self._select_ip("209.112.76.164 2607:29c0:3001:20::a")
+        assert " " not in out and ":" not in out
+
+    def test_server_url_built_from_selected_ip(self):
+        tasks = yaml.safe_load(open(self.WORKER))
+        task = next(
+            t for t in tasks
+            if isinstance(t, dict) and "_k3s_server_url" in str(t.get("ansible.builtin.set_fact", {}))
+        )
+        assert task["ansible.builtin.set_fact"]["_k3s_server_url"] == "https://{{ _cp_internal_ip }}:6443"


### PR DESCRIPTION
Fixes #689.

`canasta install --host <worker> k8s-worker --cp-host <cp>` fails on a **dual-stack** control-plane node: the k3s agent crashloops with `parse "https://<v4> <v6>:6443": invalid character " " in host name` and the worker never joins. Found during the live 2‑VPS multi-node e2e.

## Cause

`k3s_worker.yml` fetches the cp InternalIP via `jsonpath={...InternalIP].address}`, which on a dual-stack node returns **both** addresses space-separated, and `K3S_URL` was built straight from the raw string.

## Fix

Select a single **IPv4** InternalIP before constructing the URL (k3s + the `--public-ip` cert SAN are IPv4-centric here), falling back to the first address if no IPv4 is present. Regression test renders the real selection expression: dual-stack input → only the IPv4, IPv4-only unchanged, result whitespace/colon-free, and the URL built from the selected IP. `make test-unit` green (1054).

## Scope

Multi-node only; required for the worker join on any dual-stack cp host. IPv6-only clusters (bracketed URL) are a separate, rare case, out of scope.