### PR TITLE
cli: tighten verbose K8s error messages to lead with the fix

### DIFF
--- a/roles/create/tasks/_validate_inputs.yml
+++ b/roles/create/tasks/_validate_inputs.yml
@@ -153,14 +153,10 @@
       ansible.builtin.fail:
         msg: >-
           Kubernetes namespace 'canasta-{{ id }}' already exists but
-          instance '{{ id }}' is not in the canasta registry. This
-          usually means a previous 'canasta create' failed mid-flight
-          and left state (PVCs, Secrets, helm release) behind.
-          Re-running would generate fresh DB passwords that do not
-          match the existing PVCs, producing an unrecoverable auth
-          mismatch. To recover, delete the stale namespace
-          ('kubectl delete namespace canasta-{{ id }}' — cascades
-          through the helm release, PVCs, and Secrets), then re-run.
+          instance '{{ id }}' is not in the registry — leftover from a
+          create that failed mid-flight. Re-running would orphan its
+          PVCs/Secrets, so delete it and re-run:
+          kubectl delete namespace canasta-{{ id }}
       when: _stale_ns.rc | default(1) == 0
 
     - name: Install Argo CD if not skipped

--- a/roles/install/tasks/k3s_worker.yml
+++ b/roles/install/tasks/k3s_worker.yml
@@ -41,18 +41,12 @@
 
 - name: Fail if cp-host has no active k3s control plane
   ansible.builtin.fail:
-    msg: |-
+    msg: >-
       Host '{{ cp_host }}' is not running a k3s control plane
-      (systemctl is-active k3s returned: {{ (_cp_k3s_active.stdout | default('') | trim) or 'no output (SSH or sudo failure)' }}).
-
-      Common causes:
-        - You haven't installed k3s on '{{ cp_host }}' yet. Run
-            canasta install k8s-cp --host {{ cp_host }}
-          first, then retry this worker install.
-        - The cp-host you specified is itself a worker, not a control plane.
-          The cp-host argument must point at the cluster's control-plane node.
-        - The k3s service is installed but stopped. Start it on '{{ cp_host }}'
-          (sudo systemctl start k3s) and retry.
+      (systemctl is-active k3s: {{ (_cp_k3s_active.stdout | default('') | trim) or 'no output (SSH or sudo failure)' }}).
+      Check that k3s is installed there ('canasta install k8s-cp --host
+      {{ cp_host }}'), that --cp-host points at the control plane (not a
+      worker), and that the k3s service is started.
   when: >-
     _cp_k3s_active.rc != 0
     or (_cp_k3s_active.stdout | default('') | trim) != 'active'

--- a/roles/install/tasks/uninstall_k3s.yml
+++ b/roles/install/tasks/uninstall_k3s.yml
@@ -48,12 +48,9 @@
 - name: Require --cp-host for worker uninstalls
   ansible.builtin.fail:
     msg: >-
-      Uninstalling a k3s worker requires --cp-host <name>, where
-      <name> is the registered control-plane host. Canasta SSHs there
-      after stopping the agent and deletes this worker's Node entry
-      from the cluster. Without it, the Node lingers in 'kubectl get
-      nodes' and a worker rejoining with the same hostname reclaims
-      it.
+      --cp-host <name> is required when uninstalling a k3s worker
+      (the registered control-plane host, so the worker's Node is
+      removed from the cluster).
   when:
     - _k3s_role_label == 'worker'
     - not (cp_host is defined and (cp_host | length > 0))


### PR DESCRIPTION
Fixes #691.

Trims three wordy K8s error messages so the actionable part leads, keeping recovery guidance but cutting rationale that's non-essential or duplicated in code comments:

- **`uninstall_k3s.yml`** worker `--cp-host` guard — the flagged one. Was 3 sentences of SSH/lingering-Node rationale (which already lives in the code comment right above it); now one line naming the missing arg and what to pass.
- **`_validate_inputs.yml`** stale-namespace — keeps the problem + the `kubectl delete namespace` recovery command; drops the DB-password / "unrecoverable auth mismatch" paragraph.
- **`k3s_worker.yml`** cp-host "no control plane" probe — compresses the 3-bullet "Common causes" block into one compact "check that…" line; all three checks retained.

Left already-concise messages (instance-exists, path-not-dir, dir-not-empty, …) untouched. UX only, no behavior change; no message-asserting test references the old wording; `make test-unit` green (1054).