### PR TITLE
caddy: fix `canasta create` broken by nonexistent ansible.builtin.unsafe filter

### DIFF
--- a/filter_plugins/canasta_caddy.py
+++ b/filter_plugins/canasta_caddy.py
@@ -16,6 +16,18 @@
 
 import re
 
+try:
+    from ansible.utils.unsafe_proxy import wrap_var
+except ImportError:  # pragma: no cover - unexpected on supported ansible-core
+    def wrap_var(value):
+        return value
+
+
+def caddy_unsafe(value):
+    """Mark a string unsafe so a literal {{ … }} in the user's Caddyfile.global
+    is never re-evaluated as a template when inlined into the Caddyfile."""
+    return wrap_var(value)
+
 
 def _skip_string(text, i, quote):
     """text[i] == quote (`"` or backtick). Return index just past the close."""
@@ -179,4 +191,7 @@ def meld_caddy_global_blocks(text):
 
 class FilterModule(object):
     def filters(self):
-        return {"meld_caddy_global_blocks": meld_caddy_global_blocks}
+        return {
+            "meld_caddy_global_blocks": meld_caddy_global_blocks,
+            "caddy_unsafe": caddy_unsafe,
+        }

--- a/roles/orchestrator/tasks/rewrite_caddy.yml
+++ b/roles/orchestrator/tasks/rewrite_caddy.yml
@@ -146,9 +146,10 @@
 
 - name: Resolve inlined user global content
   ansible.builtin.set_fact:
-    # unsafe: the content is inlined into the template via lookup('template'),
-    # so a literal {{ … }} in the user's file must not be re-evaluated.
-    _caddyfile_global_content: "{{ _caddy_global_raw.content | default('') | b64decode | ansible.builtin.unsafe }}"
+    # caddy_unsafe: the content is inlined into the template via
+    # lookup('template'), so a literal {{ … }} in the user's file must not be
+    # re-evaluated.
+    _caddyfile_global_content: "{{ _caddy_global_raw.content | default('') | b64decode | caddy_unsafe }}"
 
 # Render the template (CLI global block + inlined Caddyfile.global, which may
 # leave two global blocks) and meld them into one on the way out.

--- a/tests/unit/test_caddy_meld.py
+++ b/tests/unit/test_caddy_meld.py
@@ -12,7 +12,11 @@ import sys
 sys.path.insert(
     0, os.path.join(os.path.dirname(__file__), "..", "..", "filter_plugins")
 )
-from canasta_caddy import meld_caddy_global_blocks, _parse_top_level  # noqa: E402
+from canasta_caddy import (  # noqa: E402
+    meld_caddy_global_blocks,
+    caddy_unsafe,
+    _parse_top_level,
+)
 
 
 def _count_global_blocks(text):
@@ -168,9 +172,18 @@ class TestMeld:
 
     def test_jinja_braces_passed_through(self):
         # The melder is pure string work — a user's literal {{ … }} survives;
-        # render-time safety is the `| ansible.builtin.unsafe` in rewrite_caddy.
+        # render-time safety is the `| caddy_unsafe` in rewrite_caddy.
         out = meld_caddy_global_blocks(
             '{\n    debug\n}\nexample.com {\n    respond "{{ not_evaluated }}"\n}\n'
         )
         assert "{{ not_evaluated }}" in out
         assert _count_global_blocks(out) == 1
+
+
+class TestCaddyUnsafe:
+    def test_preserves_value(self):
+        # caddy_unsafe wraps via ansible's wrap_var (unsafe-tagging on the older
+        # 2.15–2.18 engine; a no-op pass-through on 2.19+ where slurped values
+        # are not re-templated). Either way the string value is unchanged.
+        s = 'respond "{{ not_evaluated }}"'
+        assert str(caddy_unsafe(s)) == s


### PR DESCRIPTION
Fixes #697. Regression from #695.

## Problem

`canasta create` (and any config regeneration via `rewrite_caddy.yml`) is broken on `main`:

```
Error while resolving value for '_caddyfile_global_content':
Syntax error in template: No filter named 'ansible.builtin.unsafe'.
```

`rewrite_caddy.yml` inlined the user's `Caddyfile.global` with `| ansible.builtin.unsafe`, but Ansible has no `unsafe` filter (only the `!unsafe` YAML tag and Python's `wrap_var`). The `set_fact` runs with `| default('')` regardless of whether a `Caddyfile.global` exists, so it failed on every create/regen — taking down all five integration suites on the merge push while unit/lint stayed green (unit tests exercise the Python melder directly and never run `rewrite_caddy.yml`).

## Fix

Add a real `caddy_unsafe` filter (backed by `wrap_var`) to `filter_plugins/canasta_caddy.py` and use it in place of the invented filter. `wrap_var` unsafe-tags the string on the 2.15–2.18 engine (where a literal `{{ }}` in the inlined content could be re-evaluated) and is a harmless pass-through on 2.19+ (where slurped values are not re-templated).

## Validation

- End-to-end ansible run on **ansible-core 2.20.5 and 2.21.0** (CI's version): two global blocks meld into one, and a literal `{{ 7*7 }}` in `Caddyfile.global` stays literal (not `49`).
- **1071/1071** unit tests pass; `yamllint` clean; `make validate` passes.
- No other `ansible.builtin.unsafe` usage in the repo.

## Note

The integration jobs are gated to push-to-main only (#67), which is why #695 merged green. Worth a follow-up to run them on PRs touching `roles/orchestrator/` etc.