### PR TITLE
crowdsec: enroll + reconcile at deploy time so create-time enable works on both orchestrators

### DIFF
--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -362,7 +362,7 @@
   when:
     - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
     - _config_key in ['MW_SITE_FQDN', 'CANASTA_ENABLE_VARNISH',
-                      'CANASTA_ENABLE_ELASTICSEARCH', 'CANASTA_ENABLE_CROWDSEC',
+                      'CANASTA_ENABLE_ELASTICSEARCH',
                       'CANASTA_STAGING_CERTS']
   block:
     - name: Read current values.yaml
@@ -389,11 +389,6 @@
         _k8s_override: "{{ {'elasticsearch': {'enabled': _config_value | lower == 'true'}} }}"
       when: _config_key == 'CANASTA_ENABLE_ELASTICSEARCH'
 
-    - name: Build values.yaml override for CANASTA_ENABLE_CROWDSEC
-      ansible.builtin.set_fact:
-        _k8s_override: "{{ {'crowdsec': {'enabled': _config_value | lower == 'true'}} }}"
-      when: _config_key == 'CANASTA_ENABLE_CROWDSEC'
-
     - name: Build values.yaml override for CANASTA_STAGING_CERTS
       ansible.builtin.set_fact:
         _k8s_override:
@@ -411,67 +406,12 @@
         dest: "{{ instance_path }}/values.yaml"
         mode: "0644"
 
-# K8s analog of sync_compose_profiles.yml's CANASTA_CADDY_IMAGE reconcile:
-# the caddy deployment needs the plugin image (canasta-caddy) when a plugin
-# feature is on — CrowdSec (the bouncer) or a provider trusted-proxy mode
-# (cloudflare/imperva, which need caddy-cdn-ranges + caddy-combine-ip-ranges).
-# Both flags are read from .env (already updated by the time this fires) so
-# toggling either one recomputes the image. The field is treated as managed
-# when empty, the stock default, or any managed tag — a custom operator image
-# is left untouched.
-- name: Reconcile K8s caddy plugin image
-  when:
-    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
-    - _config_key in ['CANASTA_ENABLE_CROWDSEC', 'CADDY_TRUSTED_PROXIES']
-  block:
-    - name: Read feature flags from .env for image reconcile
-      canasta_env:
-        path: "{{ instance_path }}/.env"
-        state: read_all
-      register: _k8s_img_env
-
-    - name: Read values.yaml for image reconcile
-      ansible.builtin.slurp:
-        src: "{{ instance_path }}/values.yaml"
-      register: _k8s_img_values_raw
-
-    - name: Compute desired caddy image and managed state
-      vars:
-        # Side effects run BEFORE the .env write (see _set_single.yml), so the
-        # key currently being set is not yet in _k8s_img_env. Overlay
-        # _config_value for it — otherwise a fresh
-        # `config set CANASTA_ENABLE_CROWDSEC=true` reads the stale 'false',
-        # leaves the stock caddy image, and the pod crashloops on the crowdsec
-        # Caddyfile directive. (Compose self-heals via the start-time profile
-        # re-sync; the K8s start path has no equivalent, so fix it at source.)
-        _eff_crowdsec: >-
-          {{ _config_value if _config_key == 'CANASTA_ENABLE_CROWDSEC'
-             else (_k8s_img_env.variables.CANASTA_ENABLE_CROWDSEC | default('false')) }}
-        _eff_tp: >-
-          {{ _config_value if _config_key == 'CADDY_TRUSTED_PROXIES'
-             else (_k8s_img_env.variables.CADDY_TRUSTED_PROXIES | default('')) }}
-        _crowdsec_on: "{{ _eff_crowdsec | lower == 'true' }}"
-        _tp_mode: "{{ _eff_tp | trim | lower }}"
-        _plugin_needed: "{{ _crowdsec_on or (_tp_mode in ['cloudflare', 'imperva']) }}"
-      ansible.builtin.set_fact:
-        _k8s_img_values: "{{ _k8s_img_values_raw.content | b64decode | from_yaml }}"
-        _k8s_current_caddy_image: "{{ (_k8s_img_values_raw.content | b64decode | from_yaml).get('caddy', {}).get('image', '') }}"
-        _k8s_desired_caddy_image: "{{ 'ghcr.io/canastawiki/canasta-caddy:2.11.3' if _plugin_needed else 'caddy:2.10.2-alpine' }}"
-
-    - name: Write reconciled caddy image to values.yaml
-      ansible.builtin.copy:
-        content: >-
-          {{ _k8s_img_values
-             | combine({'caddy': {'image': _k8s_desired_caddy_image}}, recursive=True)
-             | to_nice_yaml(indent=2) }}
-        dest: "{{ instance_path }}/values.yaml"
-        mode: "0644"
-      when:
-        - >-
-          _k8s_current_caddy_image == ''
-          or _k8s_current_caddy_image == 'caddy:2.10.2-alpine'
-          or _k8s_current_caddy_image.startswith('ghcr.io/canastawiki/canasta-caddy:')
-        - _k8s_current_caddy_image != _k8s_desired_caddy_image
+# CrowdSec enablement (crowdsec.enabled) and the caddy plugin image are
+# reconciled into values.yaml from .env at deploy time by the orchestrator
+# start path (roles/orchestrator/tasks/k8s_reconcile_caddy.yml), so the
+# config-set restart picks them up. CADDY_TRUSTED_PROXIES feeds that same
+# reconcile (cloudflare/imperva need the plugin image), so neither needs a
+# config-set-time values.yaml write here.
 
 # --- MW_SITE_SERVER domain change cascade ---
 # When the domain changes, update MW_SITE_FQDN, wikis.yaml URLs,

--- a/roles/create/tasks/_start.yml
+++ b/roles/create/tasks/_start.yml
@@ -20,11 +20,25 @@
   ansible.builtin.include_role:
     name: orchestrator
     tasks_from: start.yml
+  vars:
+    # Defer CrowdSec enrollment to after registration (main.yml): the
+    # crowdsec preflight resolves the instance from the registry, which
+    # this create has not written yet. The step-14 restart re-runs start
+    # too, but enrollment is idempotent (skips once the key is stored).
+    crowdsec_autoenroll: false
   when: (orchestrator | default('compose')) == 'compose'
 
 - name: Start containers (Kubernetes)
   when: (orchestrator | default('compose')) in ['kubernetes', 'k8s']
   block:
+    # Reconcile caddy image + crowdsec.enabled from .env before deploy, so
+    # a create-time `-e CANASTA_ENABLE_CROWDSEC=true` brings up the engine
+    # sidecar on the plugin image (the rendered values.yaml has neither).
+    - name: Reconcile caddy image and crowdsec.enabled in values.yaml
+      ansible.builtin.include_role:
+        name: orchestrator
+        tasks_from: k8s_reconcile_caddy.yml
+
     - name: Sync config to Kubernetes ConfigMaps
       ansible.builtin.include_role:
         name: orchestrator
@@ -44,3 +58,7 @@
           kubectl rollout status deployment/canasta-{{ id }}-web
           -n canasta-{{ id }} --timeout=600s
       changed_when: false
+
+    # CrowdSec bouncer enrollment happens after registration (main.yml),
+    # because the crowdsec role's preflight resolves the instance from the
+    # registry — which this create has not written yet.

--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -175,6 +175,17 @@
 - name: Register instance in controller and target host
   ansible.builtin.include_tasks: _register.yml
 
+# --- Step 13b: Enroll CrowdSec bouncer (after registration) ---
+# The first start defers CrowdSec enrollment (the crowdsec preflight
+# resolves the instance from the registry, not written until _register).
+# Enroll here for both orchestrators; the task self-gates on CrowdSec being
+# enabled and is idempotent (skips once the bouncer key is stored, so the
+# Compose step-14 restart's own enroll becomes a no-op).
+- name: Enroll CrowdSec bouncer
+  ansible.builtin.include_role:
+    name: orchestrator
+    tasks_from: crowdsec_autoenroll.yml
+
 # --- Step 14: Restart with full config (Compose only) ---
 # Kubernetes pods are already running with the correct config from PVC.
 - name: Stop containers

--- a/roles/crowdsec/tasks/bouncer_enroll.yml
+++ b/roles/crowdsec/tasks/bouncer_enroll.yml
@@ -1,7 +1,9 @@
 ---
 # canasta crowdsec bouncer-enroll - register the Caddy bouncer with the
 # CrowdSec engine, persist its API key, and restart so it starts enforcing.
-# Input: id (optional), force (bool)
+# Input: id (optional), force (bool), bouncer_enroll_auto (bool — set by the
+# start/create auto-enroll path to suppress the interactive "already
+# enrolled" hint on steady-state starts).
 
 - name: Preflight (resolve, crowdsec running, build cscli prefix)
   ansible.builtin.include_tasks: _preflight.yml
@@ -55,6 +57,7 @@
     - _crowdsec_existing | bool
     - _crowdsec_have_key | bool
     - not (force | default(false) | bool)
+    - not (bouncer_enroll_auto | default(false) | bool)
 
 # Enroll when forced, when no bouncer is registered yet, or when one is
 # registered but we have no stored key (cscli can't reveal an existing

--- a/roles/orchestrator/tasks/crowdsec_autoenroll.yml
+++ b/roles/orchestrator/tasks/crowdsec_autoenroll.yml
@@ -1,0 +1,59 @@
+---
+# Register CAPI + auto-enroll the CrowdSec bouncer, when CrowdSec is
+# enabled but no bouncer key is stored yet. Orchestrator-agnostic: the
+# crowdsec role tasks dispatch Compose vs k8s internally via
+# _resolve_cscli, so only the K8s sidecar-readiness wait is guarded here.
+#
+# Shared by the orchestrator start path and the create first-start path so
+# every entry point brings up a fully-enforcing CrowdSec (engine +
+# community blocklist + bouncer) rather than an inert engine.
+#
+# bouncer_enroll is idempotent: it re-enrolls when forced, when the engine
+# has no bouncer registered, or when no key is stored, and is a silent
+# no-op otherwise (bouncer_enroll_auto suppresses its interactive hint).
+# It must run unconditionally (not gated on a stored key): on K8s,
+# disabling CrowdSec prunes the engine PVC and wipes the bouncer
+# registration while the key persists in .env, so re-enabling needs a
+# re-enroll even though a key is present. bouncer_enroll stores the new key
+# before its own restart, so the re-entrant start sees the bouncer already
+# registered and no-ops — no recursion.
+#
+# Inputs: instance_id, instance_path, instance_orchestrator. On K8s the
+# namespace is derived from instance_id.
+
+- name: Read CrowdSec enablement and bouncer key for auto-enroll
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read_all
+  register: _autoenroll_env
+
+- name: Register CAPI and enroll the CrowdSec bouncer when enabled
+  when: _autoenroll_env.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true'
+  block:
+    # The K8s engine is a sidecar in the caddy pod, so wait for that pod to
+    # be Ready before exec-ing cscli into it (helm --wait usually covers it,
+    # but the first-deploy / scale-from-stopped paths can outrun it).
+    # Compose starts the crowdsec service synchronously, so no wait needed.
+    - name: Wait for caddy (CrowdSec sidecar) readiness before enroll
+      ansible.builtin.command:
+        cmd: >-
+          kubectl rollout status deployment/canasta-{{ instance_id }}-caddy
+          -n canasta-{{ instance_id }} --timeout=300s
+      changed_when: false
+      when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+
+    - name: Report enrolling CrowdSec
+      ansible.builtin.debug:
+        msg: "CrowdSec is enabled — registering with the Central API and enrolling the Caddy bouncer..."
+
+    - name: Ensure CrowdSec is registered with the Central API
+      ansible.builtin.include_role:
+        name: crowdsec
+        tasks_from: ensure_capi.yml
+
+    - name: Auto-enroll the CrowdSec bouncer (re-enrolls if the engine lost it)
+      ansible.builtin.include_role:
+        name: crowdsec
+        tasks_from: bouncer_enroll.yml
+      vars:
+        bouncer_enroll_auto: true

--- a/roles/orchestrator/tasks/k8s_reconcile_caddy.yml
+++ b/roles/orchestrator/tasks/k8s_reconcile_caddy.yml
@@ -1,0 +1,66 @@
+---
+# Reconcile the K8s caddy image and crowdsec.enabled in values.yaml from
+# the instance .env, before every helm deploy (start + create). This is
+# the K8s analog of Compose's start-time sync_compose_profiles reconcile:
+# it keeps the deployed manifests in step with the feature flags in .env
+# no matter how they got there (create -e, config set, or a hand edit),
+# so there is a single reconcile point instead of one per entry path.
+#
+# The caddy deployment needs the plugin image (canasta-caddy) when a
+# plugin feature is on — CrowdSec (the bouncer) or a provider
+# trusted-proxy mode (cloudflare/imperva, which need caddy-cdn-ranges +
+# caddy-combine-ip-ranges). The image field is treated as managed when
+# empty, the stock default, or any managed tag — a custom operator image
+# is left untouched. crowdsec.enabled gates the engine sidecar in the
+# chart and is always reconciled from the flag.
+#
+# Runs on the target host (instance_path lives there), matching the
+# values.yaml slurp in start.yml. Input: instance_path.
+
+- name: Read feature flags from .env for values reconcile
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read_all
+  register: _reconcile_env
+
+- name: Read values.yaml for reconcile
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/values.yaml"
+  register: _reconcile_values_raw
+
+- name: Compute desired caddy image and crowdsec state
+  vars:
+    _crowdsec_on: "{{ _reconcile_env.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true' }}"
+    _tp_mode: "{{ _reconcile_env.variables.CADDY_TRUSTED_PROXIES | default('') | trim | lower }}"
+    _plugin_needed: "{{ _crowdsec_on or (_tp_mode in ['cloudflare', 'imperva']) }}"
+    _values: "{{ _reconcile_values_raw.content | b64decode | from_yaml }}"
+    _current_image: "{{ (_reconcile_values_raw.content | b64decode | from_yaml).get('caddy', {}).get('image', '') }}"
+  ansible.builtin.set_fact:
+    _reconcile_values: "{{ _values }}"
+    _reconcile_crowdsec_on: "{{ _crowdsec_on }}"
+    _reconcile_current_crowdsec_on: "{{ _values.get('crowdsec', {}).get('enabled', false) | bool }}"
+    _reconcile_current_image: "{{ _current_image }}"
+    _reconcile_desired_image: "{{ 'ghcr.io/canastawiki/canasta-caddy:2.11.3' if _plugin_needed else 'caddy:2.10.2-alpine' }}"
+    _reconcile_image_managed: >-
+      {{ _current_image == ''
+         or _current_image == 'caddy:2.10.2-alpine'
+         or _current_image.startswith('ghcr.io/canastawiki/canasta-caddy:') }}
+
+- name: Build reconciled values overlay
+  ansible.builtin.set_fact:
+    _reconcile_overlay: >-
+      {{ {'crowdsec': {'enabled': _reconcile_crowdsec_on | bool}}
+         | combine({'caddy': {'image': _reconcile_desired_image}} if _reconcile_image_managed | bool else {},
+                   recursive=True) }}
+
+- name: Write reconciled values.yaml
+  ansible.builtin.copy:
+    content: >-
+      {{ _reconcile_values
+         | combine(_reconcile_overlay, recursive=True)
+         | to_nice_yaml(indent=2) }}
+    dest: "{{ instance_path }}/values.yaml"
+    mode: "0644"
+  when: >-
+    _reconcile_current_crowdsec_on != (_reconcile_crowdsec_on | bool)
+    or (_reconcile_image_managed | bool and _reconcile_current_image != _reconcile_desired_image)

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -125,31 +125,13 @@
         - _start_web_cid.stdout | trim != ''
         - _start_web_has_health.stdout | default('') | trim == 'has'
 
-    # Auto-enroll the bouncer when CrowdSec is on but no key is stored yet.
-    # bouncer_enroll stores the key before its restart, so the re-entrant
-    # start sees the key and skips — gated on key-absent, no recursion.
-    - name: Read CrowdSec enablement and bouncer key for auto-enroll
-      canasta_env:
-        path: "{{ instance_path }}/.env"
-        state: read_all
-      register: _start_crowdsec_env
-
-    # Register CAPI before bouncer auto-enroll (console enrollment depends on
-    # it). Idempotent; restarts only the crowdsec container.
-    - name: Ensure CrowdSec is registered with the Central API
-      ansible.builtin.include_role:
-        name: crowdsec
-        tasks_from: ensure_capi.yml
-      when:
-        - _start_crowdsec_env.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true'
-
-    - name: Auto-enroll the CrowdSec bouncer when enabled but unenrolled
-      ansible.builtin.include_role:
-        name: crowdsec
-        tasks_from: bouncer_enroll.yml
-      when:
-        - _start_crowdsec_env.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true'
-        - (_start_crowdsec_env.variables.CROWDSEC_BOUNCER_API_KEY | default('') | length) == 0
+    # Register CAPI + auto-enroll the bouncer when CrowdSec is on. Shared
+    # with the K8s start path and create. crowdsec_autoenroll is false only
+    # for create's first start, which defers enrollment until after the
+    # instance is registered (the crowdsec preflight resolves it).
+    - name: Auto-enroll CrowdSec (register CAPI + enroll bouncer) when enabled
+      ansible.builtin.include_tasks: crowdsec_autoenroll.yml
+      when: crowdsec_autoenroll | default(true) | bool
 
 - name: Start (Kubernetes)
   when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
@@ -157,6 +139,12 @@
     - name: Set K8s namespace
       ansible.builtin.set_fact:
         _k8s_namespace: "canasta-{{ instance_id }}"
+
+    # Reconcile caddy image + crowdsec.enabled from .env before reading
+    # values.yaml, so the deployed manifests match the feature flags no
+    # matter how they were set (config set, create -e, or a hand edit).
+    - name: Reconcile caddy image and crowdsec.enabled in values.yaml
+      ansible.builtin.include_tasks: k8s_reconcile_caddy.yml
 
     # Slurp values.yaml from the target host once and parse it. All
     # three downstream reads (web.replicaCount, db.enabled,
@@ -263,48 +251,11 @@
           -n {{ _k8s_namespace }} --timeout=300s
       changed_when: false
 
-    # Auto-enroll the bouncer when CrowdSec is on but no key is stored yet.
-    # Mirrors the Compose flow (register CAPI for the community blocklist,
-    # then enroll the bouncer). bouncer_enroll stores the key before its
-    # restart, so the re-entrant start sees the key and skips — no recursion.
-    - name: Read CrowdSec enablement and bouncer key for auto-enroll
-      canasta_env:
-        path: "{{ instance_path }}/.env"
-        state: read_all
-      register: _start_crowdsec_env
-
-    # The CrowdSec engine is a sidecar in the caddy pod; make sure that pod is
-    # Ready before exec-ing cscli into it (helm --wait usually covers this, but
-    # the scale-from-stopped path can outrun it).
-    - name: Wait for caddy (CrowdSec sidecar) readiness before enroll
-      ansible.builtin.command:
-        cmd: >-
-          kubectl rollout status deployment/canasta-{{ instance_id }}-caddy
-          -n {{ _k8s_namespace }} --timeout=300s
-      changed_when: false
-      when:
-        - _start_crowdsec_env.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true'
-
-    - name: Report enrolling CrowdSec
-      ansible.builtin.debug:
-        msg: "CrowdSec is enabled — registering with the Central API and enrolling the Caddy bouncer..."
-      when:
-        - _start_crowdsec_env.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true'
-
-    - name: Ensure CrowdSec is registered with the Central API
-      ansible.builtin.include_role:
-        name: crowdsec
-        tasks_from: ensure_capi.yml
-      when:
-        - _start_crowdsec_env.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true'
-
-    - name: Auto-enroll the CrowdSec bouncer when enabled but unenrolled
-      ansible.builtin.include_role:
-        name: crowdsec
-        tasks_from: bouncer_enroll.yml
-      when:
-        - _start_crowdsec_env.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true'
-        - (_start_crowdsec_env.variables.CROWDSEC_BOUNCER_API_KEY | default('') | length) == 0
+    # Register CAPI + auto-enroll the bouncer when CrowdSec is on but no
+    # key is stored yet. Shared with the Compose start path and create.
+    - name: Auto-enroll CrowdSec (register CAPI + enroll bouncer) when enabled
+      ansible.builtin.include_tasks: crowdsec_autoenroll.yml
+      when: crowdsec_autoenroll | default(true) | bool
 
     # Re-enable Argo CD auto-sync after start. The stop flow suspends
     # sync to prevent selfHeal from reverting the scale-to-zero. We

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -1132,13 +1132,21 @@ class TestCrowdsecCapiRegistration:
         )
 
     def test_start_ensures_capi_when_enabled(self):
-        """start.yml must register CAPI when CrowdSec is enabled, before the
-        bouncer auto-enroll (console enrollment depends on CAPI)."""
-        content = _read(os.path.join(
+        """The shared autoenroll task (used by start + create) must register
+        CAPI when CrowdSec is enabled, before the bouncer auto-enroll (console
+        enrollment depends on CAPI)."""
+        start = _read(os.path.join(
             REPO_ROOT, "roles", "orchestrator", "tasks", "start.yml",
         ))
+        assert "crowdsec_autoenroll.yml" in start, (
+            "start.yml must run the shared CrowdSec autoenroll task"
+        )
+        content = _read(os.path.join(
+            REPO_ROOT, "roles", "orchestrator", "tasks",
+            "crowdsec_autoenroll.yml",
+        ))
         assert "tasks_from: ensure_capi.yml" in content, (
-            "start.yml must ensure CAPI registration via the crowdsec role"
+            "autoenroll must ensure CAPI registration via the crowdsec role"
         )
         assert content.index("tasks_from: ensure_capi.yml") < content.index(
             "tasks_from: bouncer_enroll.yml"
@@ -1243,27 +1251,58 @@ class TestCrowdsecPreflightK8sReadiness:
 
 
 class TestCrowdsecK8sCaddyImageReconcile:
-    """A fresh `config set CANASTA_ENABLE_CROWDSEC=true` on K8s must switch the
-    caddy image to the plugin build. The reconcile runs in _side_effects BEFORE
-    .env is written (_set_single.yml: validate -> side effects -> set), so it
-    must overlay _config_value for the key being set rather than read the stale
-    .env — otherwise caddy keeps the stock image and crashloops on the crowdsec
-    Caddyfile directive. (K8s, unlike Compose, has no start-time image re-sync.)"""
+    """The K8s caddy image + crowdsec.enabled are reconciled into values.yaml
+    from .env at deploy time by k8s_reconcile_caddy.yml — the analog of
+    Compose's start-time sync_compose_profiles. A single reconcile point serves
+    every entry path (config set restart, create -e, hand edit), so the deployed
+    manifests always match the feature flags. Because it runs at deploy time
+    (.env already written), it reads .env directly with no overlay."""
 
-    def _side_effects(self):
+    def _reconcile(self):
         return _read(os.path.join(
-            REPO_ROOT, "roles", "config", "tasks", "_side_effects.yml"))
+            REPO_ROOT, "roles", "orchestrator", "tasks",
+            "k8s_reconcile_caddy.yml"))
 
-    def test_reconcile_overlays_config_value_for_the_key_being_set(self):
-        content = self._side_effects()
-        assert "_config_value if _config_key == 'CANASTA_ENABLE_CROWDSEC'" in content, (
-            "K8s caddy-image reconcile must overlay _config_value for "
-            "CANASTA_ENABLE_CROWDSEC — .env is written after side effects, so "
-            "reading .env alone yields the stale value"
+    def test_reconcile_reads_flags_and_picks_plugin_image(self):
+        content = self._reconcile()
+        assert "CANASTA_ENABLE_CROWDSEC" in content
+        assert "CADDY_TRUSTED_PROXIES" in content
+        assert "cloudflare" in content and "imperva" in content
+        assert PLUGIN_CADDY_IMAGE in content
+        assert "caddy:2.10.2-alpine" in content
+
+    def test_reconcile_sets_crowdsec_enabled_from_flag(self):
+        content = self._reconcile()
+        assert "'crowdsec': {'enabled':" in content, (
+            "reconcile must set crowdsec.enabled in values.yaml from the flag"
         )
-        assert "_config_value if _config_key == 'CADDY_TRUSTED_PROXIES'" in content, (
-            "the trusted-proxy branch must overlay _config_value too"
+
+    def test_reconcile_only_touches_managed_images(self):
+        # A custom operator image must be left untouched; managed = empty,
+        # stock default, or any managed-prefix tag.
+        content = self._reconcile()
+        assert "ghcr.io/canastawiki/canasta-caddy:" in content
+        assert ".startswith(" in content
+
+    def test_reconcile_wired_into_start_and_create(self):
+        start = _read(os.path.join(
+            REPO_ROOT, "roles", "orchestrator", "tasks", "start.yml"))
+        create = _read(os.path.join(
+            REPO_ROOT, "roles", "create", "tasks", "_start.yml"))
+        assert "k8s_reconcile_caddy.yml" in start, (
+            "the start path must reconcile before reading values.yaml"
         )
+        assert "k8s_reconcile_caddy.yml" in create, (
+            "create's K8s deploy bypasses start.yml, so it must reconcile too"
+        )
+
+    def test_side_effects_no_longer_reconciles_k8s_caddy(self):
+        # Superseded by the start-path reconcile; leaving a second copy here
+        # would re-introduce the create/config-set divergence #685 closed.
+        content = _read(os.path.join(
+            REPO_ROOT, "roles", "config", "tasks", "_side_effects.yml"))
+        assert "Reconcile K8s caddy plugin image" not in content
+        assert "_config_value if _config_key == 'CANASTA_ENABLE_CROWDSEC'" not in content
 
 
 class TestCrowdsecK8sChart:
@@ -1327,22 +1366,136 @@ class TestCrowdsecK8sConfigSync:
 
 
 class TestCrowdsecK8sValuesPropagation:
+    """crowdsec.enabled + the caddy plugin image reach the cluster via the
+    deploy-time reconcile (k8s_reconcile_caddy.yml), not a config-set-time
+    write in _side_effects (that path is superseded)."""
+
     def _content(self):
         return _read(os.path.join(
-            REPO_ROOT, "roles", "config", "tasks", "_side_effects.yml",
+            REPO_ROOT, "roles", "orchestrator", "tasks",
+            "k8s_reconcile_caddy.yml",
         ))
 
     def test_enable_flag_maps_to_chart_toggle(self):
         content = self._content()
-        assert "{'crowdsec': {'enabled': _config_value | lower == 'true'}}" in content
+        assert "'crowdsec': {'enabled':" in content
 
     def test_reconciles_caddy_plugin_image_on_k8s(self):
         content = self._content()
-        # Toggling CrowdSec or a provider trusted-proxy mode swaps caddy.image
-        # to the plugin image on K8s.
-        assert "Reconcile K8s caddy plugin image" in content
+        # CrowdSec or a provider trusted-proxy mode swaps caddy.image to the
+        # plugin image on K8s.
         assert PLUGIN_CADDY_IMAGE in content
         assert "CADDY_TRUSTED_PROXIES" in content
+
+
+class TestCrowdsecAutoEnroll:
+    """Create-time `-e CANASTA_ENABLE_CROWDSEC=true` must produce a working
+    CrowdSec on BOTH orchestrators, not an inert engine. One shared,
+    orchestrator-agnostic enroll task (crowdsec_autoenroll.yml) registers CAPI
+    and enrolls the bouncer when enabled-but-unenrolled; the crowdsec role
+    dispatches Compose vs k8s internally, so only the K8s sidecar-wait is
+    guarded in the task."""
+
+    def _autoenroll(self):
+        return _read(os.path.join(
+            REPO_ROOT, "roles", "orchestrator", "tasks",
+            "crowdsec_autoenroll.yml"))
+
+    def test_autoenroll_registers_capi_and_enrolls_bouncer(self):
+        content = self._autoenroll()
+        assert "ensure_capi.yml" in content
+        assert "bouncer_enroll.yml" in content
+        # Self-gates on CrowdSec being enabled.
+        assert "CANASTA_ENABLE_CROWDSEC" in content
+
+    def test_autoenroll_calls_bouncer_unconditionally(self):
+        # bouncer_enroll must NOT be gated on a stored key: on K8s, disabling
+        # CrowdSec prunes the engine PVC (wipes the bouncer registration) while
+        # the key persists in .env, so re-enabling needs a re-enroll even with
+        # a key present. bouncer_enroll itself enrolls when the engine has no
+        # bouncer (idempotent), and bouncer_enroll_auto keeps it quiet.
+        auto = self._autoenroll()
+        assert "CROWDSEC_BOUNCER_API_KEY" not in auto, (
+            "the bouncer enroll must not be gated on a stored key"
+        )
+        assert "bouncer_enroll_auto: true" in auto
+        enroll = _read(os.path.join(
+            REPO_ROOT, "roles", "crowdsec", "tasks", "bouncer_enroll.yml"))
+        # bouncer_enroll re-enrolls when the engine has no bouncer registered.
+        assert "not (_crowdsec_existing | bool)" in enroll
+
+    def test_bouncer_enroll_auto_suppresses_already_enrolled_hint(self):
+        # In the auto path a steady-state start would otherwise print the
+        # interactive "already enrolled — use --force" hint on every start.
+        enroll = _read(os.path.join(
+            REPO_ROOT, "roles", "crowdsec", "tasks", "bouncer_enroll.yml"))
+        hint = enroll[enroll.index("already enrolled"):]
+        assert "not (bouncer_enroll_auto | default(false) | bool)" in hint
+
+    def test_autoenroll_sidecar_wait_is_k8s_guarded(self):
+        # The sidecar rollout wait is K8s-only; Compose starts the service
+        # synchronously. The guard lives inside the orchestrator task (allowed
+        # by the orchestrator-dispatch design), not in action code.
+        content = self._autoenroll()
+        assert "rollout status deployment/canasta-{{ instance_id }}-caddy" in content
+        wait = content[content.index("rollout status"):]
+        assert "instance_orchestrator | default('compose') in ['kubernetes', 'k8s']" in wait
+
+    def test_autoenroll_shared_by_start_and_create(self):
+        start = _read(os.path.join(
+            REPO_ROOT, "roles", "orchestrator", "tasks", "start.yml"))
+        create = _read(os.path.join(
+            REPO_ROOT, "roles", "create", "tasks", "main.yml"))
+        assert "crowdsec_autoenroll.yml" in start
+        assert "crowdsec_autoenroll.yml" in create
+        assert "k8s_crowdsec_autoenroll.yml" not in start
+        assert "k8s_crowdsec_autoenroll.yml" not in create
+
+    def test_create_enroll_is_orchestrator_agnostic(self):
+        # The create-time enroll must NOT switch on the orchestrator in action
+        # code (#696) — it dispatches unconditionally; the task self-gates.
+        create = _read(os.path.join(
+            REPO_ROOT, "roles", "create", "tasks", "main.yml"))
+        start = create.index("Enroll CrowdSec bouncer")
+        step = create[start:create.index("Step 14", start)]
+        assert "crowdsec_autoenroll.yml" in step
+        assert "when:" not in step, (
+            "create-time enroll must dispatch unconditionally, not gate on the "
+            "orchestrator"
+        )
+
+    def test_create_enrolls_after_register(self):
+        # The crowdsec preflight resolves the instance from the registry, so
+        # the create-time enroll must run after _register, not in _start.
+        create = _read(os.path.join(
+            REPO_ROOT, "roles", "create", "tasks", "main.yml"))
+        assert create.index("_register.yml") < create.index(
+            "crowdsec_autoenroll.yml"), (
+            "create must enroll CrowdSec after registering the instance"
+        )
+        start = _read(os.path.join(
+            REPO_ROOT, "roles", "create", "tasks", "_start.yml"))
+        assert "crowdsec_autoenroll.yml" not in start, (
+            "enroll must not run in _start (instance not yet registered)"
+        )
+
+    def test_create_first_start_defers_compose_enroll(self):
+        # Compose's first start goes through orchestrator start.yml, which would
+        # enroll before _register and fail the registry resolve. create defers
+        # it with crowdsec_autoenroll: false; start.yml honors that flag.
+        cstart = _read(os.path.join(
+            REPO_ROOT, "roles", "create", "tasks", "_start.yml"))
+        assert "crowdsec_autoenroll: false" in cstart
+        start = _read(os.path.join(
+            REPO_ROOT, "roles", "orchestrator", "tasks", "start.yml"))
+        assert "crowdsec_autoenroll | default(true)" in start
+
+    def test_autoenroll_is_self_contained(self):
+        # The task derives its namespace from instance_id (a global fact in
+        # both paths), so it must not depend on a caller-set _k8s_namespace.
+        content = self._autoenroll()
+        assert "-n canasta-{{ instance_id }}" in content
+        assert "_k8s_namespace" not in content
 
 
 class TestCrowdsecK8sTrustedProxy:
@@ -1402,10 +1555,3 @@ class TestCrowdsecK8sTrustedProxy:
         assert "combine" not in out
 
 
-class TestCrowdsecK8sAutoEnroll:
-    def test_start_waits_for_caddy_before_enroll(self):
-        content = _read(os.path.join(
-            REPO_ROOT, "roles", "orchestrator", "tasks", "start.yml",
-        ))
-        # K8s auto-enroll waits for the caddy pod (sidecar) to be Ready.
-        assert "rollout status deployment/canasta-{{ instance_id }}-caddy" in content

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -996,7 +996,11 @@ class TestK8sStartProgressMessages:
         assert "Waiting for pods to become ready" in self._start()
 
     def test_crowdsec_enroll_has_progress_message(self):
-        assert "enrolling the Caddy bouncer" in self._start()
+        # The enroll tail (with its progress line) is shared by start + create
+        # via crowdsec_autoenroll.yml, included from the start path.
+        assert "crowdsec_autoenroll.yml" in self._start()
+        with open(os.path.join(ORCHESTRATOR_TASKS, "crowdsec_autoenroll.yml")) as f:
+            assert "enrolling the Caddy bouncer" in f.read()
 
 
 class TestK8sDeleteWaitsForNamespace:


### PR DESCRIPTION
## Summary

Enabling CrowdSec at **create time** (`canasta create -e <env with CANASTA_ENABLE_CROWDSEC=true>`) produced a broken setup on **both** orchestrators:

- **K8s:** the rendered `values.yaml` got neither `crowdsec.enabled` nor the caddy plugin image, so the engine sidecar never came up (and caddy could crashloop on the crowdsec Caddyfile directive).
- **Both:** the first start tried to enroll the bouncer *before* the instance was registered, so the crowdsec preflight's registry resolve failed (`Instance not found in registry`).

`config set` was patched separately (#682), but the create path was still unhandled. This makes create-time CrowdSec work on Compose and Kubernetes, and consolidates the moving parts.

## Changes

- **`roles/orchestrator/tasks/k8s_reconcile_caddy.yml` (new):** reconciles `crowdsec.enabled` + the caddy plugin image into `values.yaml` from `.env` at every K8s deploy — the K8s analog of Compose's start-time `sync_compose_profiles` re-sync. Called from both the orchestrator start path and create's first start. **Supersedes** the config-set-time reconcile in `_side_effects.yml` (the config-set restart runs `start.yml`), collapsing the create / config-set / drift divergence into one place.
- **`roles/orchestrator/tasks/crowdsec_autoenroll.yml` (new):** shared, orchestrator-agnostic CAPI-register + bouncer-enroll (the crowdsec role dispatches Compose vs k8s internally, so only the K8s sidecar-readiness wait is guarded inside the task). Replaces the inline enroll tail in `start.yml`.
- **create:** the first start defers enrollment (`crowdsec_autoenroll: false`), and enrollment runs as a single dispatched step **after `_register`** (so the crowdsec preflight can resolve the instance). Dispatched unconditionally for both orchestrators — no `when: orchestrator` switch in action code.
- **Pre-existing K8s disable→enable fix:** disabling CrowdSec prunes the engine PVC (wiping the bouncer registration) while the key persists in `.env`, so re-enabling left the bouncer unregistered. Auto-enroll now calls `bouncer_enroll` unconditionally — it re-enrolls when the engine has no bouncer even if a key is stored, and `bouncer_enroll_auto` keeps it a silent no-op on steady-state starts.

## Behavior note

`config set --no-restart` on K8s no longer writes `values.yaml` immediately; the reconcile applies on the next start. Harmless — nothing is deployed with `--no-restart`.

## Testing

- 1081 unit tests pass; `make lint` + `make validate` clean.
- Live e2e on a multi-node k3s cluster + local Compose:
  - K8s create-time (`-e`): caddy 2/2 on the plugin image, `values.yaml` reconciled, bouncer enrolled + CAPI registered straight from create, ban → 403 via both node IPs (real client IP preserved).
  - K8s `config set` false → true: reconcile flips the sidecar off (1/1, stock image) then on (2/2, plugin image) and re-enrolls via `start.yml`.
  - K8s disable → enable: reproduced the bouncer loss, then confirmed the fix re-registers the bouncer (`cscli bouncers list` shows `canasta-caddy` valid).
  - Compose create-time: enrolled + active, no enroll recursion, clean teardown.

Fixes #685