### PR TITLE
upgrade: dispatch orchestrator-specific steps to orchestrator role (#696)

### DIFF
--- a/roles/orchestrator/tasks/upgrade_db_migration.yml
+++ b/roles/orchestrator/tasks/upgrade_db_migration.yml
@@ -1,0 +1,10 @@
+---
+# Run orchestrator-specific upgrade DB migrations.
+# Compose: the MySQL-to-MariaDB migration. Kubernetes: no-op — the K8s
+# DB image is set by the chart, not migrated in place.
+# Input: instance_path, instance_id, instance_orchestrator
+
+- name: MySQL-to-MariaDB migration (Compose only)
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
+  when: instance_orchestrator | default('compose') == 'compose'

--- a/roles/orchestrator/tasks/upgrade_image_tag.yml
+++ b/roles/orchestrator/tasks/upgrade_image_tag.yml
@@ -1,0 +1,58 @@
+---
+# Bump the instance's configured image to the new default for the
+# orchestrator. Kubernetes: update values.yaml image.tag. Compose:
+# update CANASTA_IMAGE in .env (only when it's the default ghcr.io
+# image and not a custom/local build).
+# Input: instance_path, instance_orchestrator, canasta_default_image,
+#        _upgrade_inst, _mig
+
+# --- Update K8s values.yaml image tag ---
+- name: Update Kubernetes image tag in values.yaml
+  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+  block:
+    - name: Read current values.yaml
+      ansible.builtin.slurp:
+        src: "{{ instance_path }}/values.yaml"
+      register: _upgrade_values_raw
+
+    - name: Update image tag
+      ansible.builtin.set_fact:
+        _upgrade_values: "{{ _upgrade_values_raw.content | b64decode | from_yaml }}"
+
+    - name: Build updated values
+      ansible.builtin.set_fact:
+        _upgrade_new_values: >-
+          {{ _upgrade_values | combine({
+            'image': {
+              'repository': _upgrade_values.image.repository
+                | default('ghcr.io/canastawiki/canasta'),
+              'tag': canasta_default_image
+                | regex_replace('^[^:]+:', '')
+            }
+          }, recursive=True) }}
+
+    - name: Write updated values.yaml
+      ansible.builtin.copy:
+        content: "{{ _upgrade_new_values | to_nice_yaml }}"
+        dest: "{{ instance_path }}/values.yaml"
+        mode: "0644"
+
+# --- Update Compose CANASTA_IMAGE tag ---
+# Match Go CLI behavior: bump the tag if it's the default ghcr.io image,
+# leave it alone if user set a custom/local-build image.
+- name: Update Compose image tag
+  when:
+    - instance_orchestrator | default('compose') == 'compose'
+    - _upgrade_inst.instance.buildFrom | default('') == ''
+    # CANASTA_IMAGE was already read by the migration probe; reuse
+    # those values instead of re-reading .env.
+    - _mig.env_present.CANASTA_IMAGE
+    - _mig.env.CANASTA_IMAGE is match('^ghcr\\.io/canastawiki/canasta:')
+    - _mig.env.CANASTA_IMAGE != canasta_default_image
+  block:
+    - name: Update CANASTA_IMAGE to latest default tag
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: set
+        key: CANASTA_IMAGE
+        value: "{{ canasta_default_image }}"

--- a/roles/orchestrator/tasks/upgrade_publish_rebuilt_image.yml
+++ b/roles/orchestrator/tasks/upgrade_publish_rebuilt_image.yml
@@ -1,0 +1,11 @@
+---
+# Publish a rebuilt-from-source custom image for the orchestrator.
+# Kubernetes: push to the in-cluster registry so the deployment can pull
+# it. Compose: no-op — the locally built image is used directly.
+# Input: instance_orchestrator, _built_image
+
+- name: Push rebuilt image to registry (Kubernetes)
+  ansible.builtin.command:
+    cmd: "docker push {{ _built_image }}"
+  changed_when: true
+  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']

--- a/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
+++ b/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
@@ -1,0 +1,123 @@
+---
+# Compose-only: detect whether a service with a `build:` directive needs
+# rebuilding after an upgrade and rebuild it. Kubernetes builds custom
+# images from source and pushes them to the registry instead (handled by
+# upgrade_publish_rebuilt_image.yml), so every task here is gated on the
+# Compose orchestrator and is a no-op on K8s.
+#
+# Reads/writes the shared _images_updated fact (set by the pull step,
+# consumed by the restart decision in the upgrade role).
+# Input: instance_path, instance_orchestrator, instance_devmode,
+#        _images_updated
+
+# Detect services that have a `build:` directive. The merged compose
+# config (main + override + dev) is what docker actually uses, so
+# query it directly rather than parsing the override file alone.
+# Covers operator overrides (custom Dockerfile) and devmode xdebug.
+- name: Enumerate buildable services from merged compose config (Compose)
+  when: instance_orchestrator | default('compose') == 'compose'
+  block:
+    - name: Check for docker-compose.override.yml
+      ansible.builtin.stat:
+        path: "{{ instance_path }}/docker-compose.override.yml"
+      register: _override_exists_upgrade
+
+    - name: Build compose file arguments
+      ansible.builtin.set_fact:
+        _upgrade_compose_files: >-
+          {{ ['-f', 'docker-compose.yml'] +
+             (_override_exists_upgrade.stat.exists | ternary(['-f', 'docker-compose.override.yml'], [])) +
+             ((instance_devmode | default(false) | bool) | ternary(['-f', 'docker-compose.dev.yml'], [])) }}
+
+    - name: Render merged compose config as JSON
+      ansible.builtin.command:
+        cmd: "docker compose {{ _upgrade_compose_files | join(' ') }} config --format json"
+        chdir: "{{ instance_path }}"
+      register: _upgrade_compose_config
+      changed_when: false
+      failed_when: false
+
+    - name: Extract buildable service names
+      ansible.builtin.set_fact:
+        _buildable_services: >-
+          {{ ((_upgrade_compose_config.stdout | from_json).services
+              | default({})
+              | dict2items
+              | selectattr('value.build', 'defined')
+              | map(attribute='key')
+              | list) if (_upgrade_compose_config.rc | default(1)) == 0 else [] }}
+
+# Running-vs-configured check. Catches the case where pull skipped
+# the buildable web service (--ignore-buildable) but the configured
+# CANASTA_IMAGE is newer than what's running. Only meaningful when
+# at least one service has a build directive — otherwise the regular
+# pull-based detection is authoritative.
+- name: Check running container image vs configured (Compose)
+  when:
+    - instance_orchestrator | default('compose') == 'compose'
+    - (_buildable_services | default([]) | length) > 0
+    - not (_images_updated | bool)
+  block:
+    - name: Get running web container image ID
+      ansible.builtin.shell:
+        cmd: >-
+          docker compose ps web --format {% raw %}'{{.Image}}'{% endraw %}
+        chdir: "{{ instance_path }}"
+      register: _running_image
+      changed_when: false
+      ignore_errors: true
+
+    - name: Read configured CANASTA_IMAGE
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read
+        key: CANASTA_IMAGE
+      register: _configured_image
+
+    - name: Pull configured image if not on disk (handles buildable services skipped by docker compose pull)
+      ansible.builtin.command:
+        cmd: "docker pull {{ _configured_image.value }}"
+      register: _ensure_pull
+      changed_when: "'Downloaded newer image' in (_ensure_pull.stdout | default(''))"
+      ignore_errors: true
+      when: _configured_image.found
+
+    - name: Get configured image ID
+      ansible.builtin.command:
+        cmd: "docker image inspect {{ _configured_image.value }} --format {% raw %}{{.Id}}{% endraw %}"
+      register: _configured_id
+      changed_when: false
+      ignore_errors: true
+
+    - name: Get running image ID
+      ansible.builtin.command:
+        cmd: "docker image inspect {{ _running_image.stdout | trim }} --format {% raw %}{{.Id}}{% endraw %}"
+      register: _running_id
+      changed_when: false
+      ignore_errors: true
+      when: _running_image is succeeded
+
+    - name: Flag restart if running image differs from configured
+      ansible.builtin.set_fact:
+        _images_updated: true
+      when:
+        - _configured_id is succeeded
+        - _running_id is succeeded
+        - (_configured_id.stdout | default('')) != (_running_id.stdout | default(''))
+
+# Rebuild every service with a `build:` directive whenever any image
+# change is detected. This fires even when `_images_updated` was set
+# by the pull task (e.g., varnish/caddy updated) — the rebuild is
+# cheap thanks to Docker layer caching and avoids a stale buildable
+# image when other services updated.
+- name: Rebuild buildable services if image was bumped (Compose)
+  ansible.builtin.command:
+    cmd: "docker compose {{ _upgrade_compose_files | join(' ') }} build {{ item }}"
+    chdir: "{{ instance_path }}"
+  loop: "{{ _buildable_services | default([]) }}"
+  changed_when: true
+  ignore_errors: true
+  when:
+    - instance_orchestrator | default('compose') == 'compose'
+    - _images_updated | bool
+    - (_buildable_services | default([]) | length) > 0

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -50,10 +50,10 @@
   loop_control:
     loop_var: _migration
 
-# --- MySQL to MariaDB migration (Compose only) ---
-- name: MySQL-to-MariaDB migration
-  ansible.builtin.include_tasks: migrations/mysql_to_mariadb.yml
-  when: instance_orchestrator | default('compose') == 'compose'
+# --- DB migrations (orchestrator-specific; Compose runs MySQL->MariaDB) ---
+- name: Run orchestrator DB migrations
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/upgrade_db_migration.yml
 
 # --- Rebuild custom image if instance was built from source ---
 - name: Check for BuildFrom in registry
@@ -76,12 +76,9 @@
       vars:
         build_from: "{{ _upgrade_inst.instance.buildFrom }}"
 
-    - name: Push rebuilt image to registry (if K8s with build_from)
-      ansible.builtin.command:
-        cmd: "docker push {{ _built_image }}"
-      changed_when: true
-      when:
-        - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+    - name: Publish rebuilt image for the orchestrator
+      ansible.builtin.include_tasks: >-
+        {{ canasta_root }}/roles/orchestrator/tasks/upgrade_publish_rebuilt_image.yml
 
 # --- Refresh config ---
 # Force-refresh the managed docker-compose.yml so compose changes (e.g. a
@@ -99,56 +96,11 @@
     name: orchestrator
     tasks_from: init_config.yml
 
-# --- Update K8s values.yaml image tag ---
-- name: Update Kubernetes image tag in values.yaml
-  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
-  block:
-    - name: Read current values.yaml
-      ansible.builtin.slurp:
-        src: "{{ instance_path }}/values.yaml"
-      register: _upgrade_values_raw
-
-    - name: Update image tag
-      ansible.builtin.set_fact:
-        _upgrade_values: "{{ _upgrade_values_raw.content | b64decode | from_yaml }}"
-
-    - name: Build updated values
-      ansible.builtin.set_fact:
-        _upgrade_new_values: >-
-          {{ _upgrade_values | combine({
-            'image': {
-              'repository': _upgrade_values.image.repository
-                | default('ghcr.io/canastawiki/canasta'),
-              'tag': canasta_default_image
-                | regex_replace('^[^:]+:', '')
-            }
-          }, recursive=True) }}
-
-    - name: Write updated values.yaml
-      ansible.builtin.copy:
-        content: "{{ _upgrade_new_values | to_nice_yaml }}"
-        dest: "{{ instance_path }}/values.yaml"
-        mode: "0644"
-
-# --- Update Compose CANASTA_IMAGE tag ---
-# Match Go CLI behavior: bump the tag if it's the default ghcr.io image,
-# leave it alone if user set a custom/local-build image.
-- name: Update Compose image tag
-  when:
-    - instance_orchestrator | default('compose') == 'compose'
-    - _upgrade_inst.instance.buildFrom | default('') == ''
-    # CANASTA_IMAGE was already read by the migration probe; reuse
-    # those values instead of re-reading .env.
-    - _mig.env_present.CANASTA_IMAGE
-    - _mig.env.CANASTA_IMAGE is match('^ghcr\\.io/canastawiki/canasta:')
-    - _mig.env.CANASTA_IMAGE != canasta_default_image
-  block:
-    - name: Update CANASTA_IMAGE to latest default tag
-      canasta_env:
-        path: "{{ instance_path }}/.env"
-        state: set
-        key: CANASTA_IMAGE
-        value: "{{ canasta_default_image }}"
+# --- Bump configured image tag (orchestrator-specific) ---
+# K8s updates values.yaml image.tag; Compose updates CANASTA_IMAGE in .env.
+- name: Update configured image tag
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/upgrade_image_tag.yml
 
 # --- Pull and restart ---
 - name: Report pulling images
@@ -166,117 +118,13 @@
   ansible.builtin.set_fact:
     _images_updated: "{{ _pull_changed | default(false) | bool }}"
 
-# Detect services that have a `build:` directive. The merged compose
-# config (main + override + dev) is what docker actually uses, so
-# query it directly rather than parsing the override file alone.
-# Covers operator overrides (custom Dockerfile) and devmode xdebug.
-- name: Enumerate buildable services from merged compose config (Compose)
-  when: instance_orchestrator | default('compose') == 'compose'
-  block:
-    - name: Check for docker-compose.override.yml
-      ansible.builtin.stat:
-        path: "{{ instance_path }}/docker-compose.override.yml"
-      register: _override_exists_upgrade
-
-    - name: Build compose file arguments
-      ansible.builtin.set_fact:
-        _upgrade_compose_files: >-
-          {{ ['-f', 'docker-compose.yml'] +
-             (_override_exists_upgrade.stat.exists | ternary(['-f', 'docker-compose.override.yml'], [])) +
-             ((instance_devmode | default(false) | bool) | ternary(['-f', 'docker-compose.dev.yml'], [])) }}
-
-    - name: Render merged compose config as JSON
-      ansible.builtin.command:
-        cmd: "docker compose {{ _upgrade_compose_files | join(' ') }} config --format json"
-        chdir: "{{ instance_path }}"
-      register: _upgrade_compose_config
-      changed_when: false
-      failed_when: false
-
-    - name: Extract buildable service names
-      ansible.builtin.set_fact:
-        _buildable_services: >-
-          {{ ((_upgrade_compose_config.stdout | from_json).services
-              | default({})
-              | dict2items
-              | selectattr('value.build', 'defined')
-              | map(attribute='key')
-              | list) if (_upgrade_compose_config.rc | default(1)) == 0 else [] }}
-
-# Running-vs-configured check. Catches the case where pull skipped
-# the buildable web service (--ignore-buildable) but the configured
-# CANASTA_IMAGE is newer than what's running. Only meaningful when
-# at least one service has a build directive — otherwise the regular
-# pull-based detection is authoritative.
-- name: Check running container image vs configured (Compose)
-  when:
-    - instance_orchestrator | default('compose') == 'compose'
-    - (_buildable_services | default([]) | length) > 0
-    - not (_images_updated | bool)
-  block:
-    - name: Get running web container image ID
-      ansible.builtin.shell:
-        cmd: >-
-          docker compose ps web --format {% raw %}'{{.Image}}'{% endraw %}
-        chdir: "{{ instance_path }}"
-      register: _running_image
-      changed_when: false
-      ignore_errors: true
-
-    - name: Read configured CANASTA_IMAGE
-      canasta_env:
-        path: "{{ instance_path }}/.env"
-        state: read
-        key: CANASTA_IMAGE
-      register: _configured_image
-
-    - name: Pull configured image if not on disk (handles buildable services skipped by docker compose pull)
-      ansible.builtin.command:
-        cmd: "docker pull {{ _configured_image.value }}"
-      register: _ensure_pull
-      changed_when: "'Downloaded newer image' in (_ensure_pull.stdout | default(''))"
-      ignore_errors: true
-      when: _configured_image.found
-
-    - name: Get configured image ID
-      ansible.builtin.command:
-        cmd: "docker image inspect {{ _configured_image.value }} --format {% raw %}{{.Id}}{% endraw %}"
-      register: _configured_id
-      changed_when: false
-      ignore_errors: true
-
-    - name: Get running image ID
-      ansible.builtin.command:
-        cmd: "docker image inspect {{ _running_image.stdout | trim }} --format {% raw %}{{.Id}}{% endraw %}"
-      register: _running_id
-      changed_when: false
-      ignore_errors: true
-      when: _running_image is succeeded
-
-    - name: Flag restart if running image differs from configured
-      ansible.builtin.set_fact:
-        _images_updated: true
-      when:
-        - _configured_id is succeeded
-        - _running_id is succeeded
-        - (_configured_id.stdout | default('')) != (_running_id.stdout | default(''))
-
-# Rebuild every service with a `build:` directive whenever any image
-# change is detected. This fires even when `_images_updated` was set
-# by the pull task (e.g., varnish/caddy updated) — the rebuild is
-# cheap thanks to Docker layer caching and avoids a stale buildable
-# image when other services updated.
-- name: Rebuild buildable services if image was bumped (Compose)
-  ansible.builtin.command:
-    cmd: "docker compose {{ _upgrade_compose_files | join(' ') }} build {{ item }}"
-    chdir: "{{ instance_path }}"
-  loop: "{{ _buildable_services | default([]) }}"
-  changed_when: true
-  ignore_errors: true
-  when:
-    - instance_orchestrator | default('compose') == 'compose'
-    - _images_updated | bool
-    - (_buildable_services | default([]) | length) > 0
+# --- Rebuild buildable services (orchestrator-specific; Compose only) ---
+# Compose detects services with a `build:` directive and rebuilds them
+# when an image change is detected; updates the shared _images_updated
+# fact. K8s builds + pushes custom images instead, so this is a no-op.
+- name: Rebuild buildable services if needed
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
 
 # A compose-only change (e.g. gaining the crowdsec service) must also
 # trigger a recreate, not just an image bump.

--- a/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
+++ b/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
@@ -1,16 +1,12 @@
 ---
 # Migration: Detect MySQL 8.0 data and migrate to MariaDB.
 # Matches Go upgrade.go mysql_to_mariadb.go logic.
-# Only runs for Docker Compose instances.
-# Input: instance_path, instance_orchestrator
-
-- name: Skip MySQL migration for non-Compose instances
-  ansible.builtin.debug:
-    msg: "MySQL-to-MariaDB migration only applies to Docker Compose instances."
-  when: instance_orchestrator | default('compose') != 'compose'
+# Compose-only; the orchestrator guard is owned by the caller
+# (roles/orchestrator/tasks/upgrade_db_migration.yml), so no
+# instance_orchestrator switch is needed here.
+# Input: instance_path
 
 - name: Check for MySQL 8.0 data
-  when: instance_orchestrator | default('compose') == 'compose'
   block:
     # Detection (and the migration itself) requires a live db container to
     # exec into. A stopped instance has no db service, so skip rather than

--- a/tests/unit/test_upgrade_rebuild.py
+++ b/tests/unit/test_upgrade_rebuild.py
@@ -10,13 +10,13 @@ import os
 import yaml
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
-UPGRADE_MAIN = os.path.join(
-    REPO_ROOT, "roles", "upgrade", "tasks", "main.yml"
+REBUILD_TASKS = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "upgrade_rebuild_buildable.yml"
 )
 
 
 def _load_tasks():
-    with open(UPGRADE_MAIN) as f:
+    with open(REBUILD_TASKS) as f:
         return yaml.safe_load(f)
 
 
@@ -39,7 +39,7 @@ class TestDynamicBuildableServiceDetection:
         )
 
     def test_uses_merged_compose_config_json(self):
-        with open(UPGRADE_MAIN) as f:
+        with open(REBUILD_TASKS) as f:
             content = f.read()
         assert "config --format json" in content, (
             "Buildable-service detection must use `docker compose "
@@ -48,7 +48,7 @@ class TestDynamicBuildableServiceDetection:
         )
 
     def test_extract_uses_build_attribute(self):
-        with open(UPGRADE_MAIN) as f:
+        with open(REBUILD_TASKS) as f:
             content = f.read()
         assert "selectattr('value.build', 'defined')" in content, (
             "Must filter merged services by presence of a build: key"


### PR DESCRIPTION
## Summary

Part of #696 — move `when: instance_orchestrator == compose/k8s` switches out of action code into orchestrator-role primitives that own the Compose-vs-Kubernetes difference. This PR covers the **upgrade role** (the heaviest remaining offender after the backup role landed in #706/#707).

## Changes

`upgrade/main.yml` carried 7 conditional switches interleaved with the common upgrade flow. Each orchestrator-specific step moves into an orchestrator primitive that `main.yml` calls unconditionally:

- `upgrade_db_migration.yml` — Compose MySQL→MariaDB migration (no-op on K8s)
- `upgrade_publish_rebuilt_image.yml` — K8s registry push after build-from-source
- `upgrade_image_tag.yml` — K8s `values.yaml` image.tag / Compose `CANASTA_IMAGE`
- `upgrade_rebuild_buildable.yml` — Compose buildable-service detection + rebuild

The buildable-rebuild tasks move **verbatim** — same per-task guards, order, and shared `_images_updated` fact flow — so the #562 regression guards still hold; `test_upgrade_rebuild.py` is repointed to the new primitive.

A follow-up commit removes the now-redundant guards inside `migrations/mysql_to_mariadb.yml`: it's reached only via the compose-guarded `upgrade_db_migration.yml`, so its `!= compose` skip-debug task was dead code and its `== compose` block guard was always true. The upgrade role now has **zero** orchestrator conditionals.

## Testing

- `make test-unit` — 1086 passed
- `make lint`, `make validate` — clean

Refs #696