### PR TITLE
crowdsec: make CAPI registration resilient to transient outages (#709)

### DIFF
--- a/roles/crowdsec/tasks/ensure_capi.yml
+++ b/roles/crowdsec/tasks/ensure_capi.yml
@@ -27,16 +27,49 @@
           Registering the CrowdSec engine with the Central API so the
           community blocklist is active...
 
-    # cscli writes the credentials to stdout; redirect them into the
-    # credentials file. no_log so they never reach Ansible output.
-    - name: Register CAPI and write the credentials file
-      ansible.builtin.command:
-        cmd: >-
-          {{ _cscli_prefix }}
-          sh -c 'cscli capi register > /etc/crowdsec/online_api_credentials.yaml'
-        chdir: "{{ _cscli_chdir | default(omit) }}"
-      changed_when: true
-      no_log: true
+    # cscli capi register reaches CrowdSec's Central API over the
+    # network. Tolerate a transient outage: retry a few times, and if it
+    # still fails, fall through to the rescue rather than aborting the
+    # whole create. CAPI registration only enables the community
+    # blocklist — the instance is fully functional without it, and this
+    # task is idempotent (guarded by `cscli capi status`), so the next
+    # start/restart re-attempts it.
+    - name: Register CAPI (retry, tolerating a sustained outage)
+      block:
+        # cscli writes the credentials to stdout. Write to a temp file
+        # and only move it into place on success, so a failed attempt
+        # never leaves an empty/corrupt online_api_credentials.yaml.
+        # no_log so the credentials never reach Ansible output.
+        - name: Register CAPI and write the credentials file
+          ansible.builtin.command:
+            cmd: >-
+              {{ _cscli_prefix }}
+              sh -c 'cscli capi register
+              > /etc/crowdsec/online_api_credentials.yaml.tmp
+              && mv /etc/crowdsec/online_api_credentials.yaml.tmp
+              /etc/crowdsec/online_api_credentials.yaml'
+            chdir: "{{ _cscli_chdir | default(omit) }}"
+          register: _crowdsec_capi_register
+          changed_when: _crowdsec_capi_register.rc == 0
+          retries: 3
+          delay: 5
+          until: _crowdsec_capi_register.rc == 0
+          no_log: true
 
-    - name: Restart the engine so it loads the CAPI credentials
-      ansible.builtin.include_tasks: _restart_engine.yml
+        - name: Restart the engine so it loads the CAPI credentials
+          ansible.builtin.include_tasks: _restart_engine.yml
+      rescue:
+        - name: Warn that CAPI registration did not succeed
+          ansible.builtin.debug:
+            msg: >-
+              CrowdSec Central API registration did not succeed — the CAPI
+              service may be temporarily unavailable. Continuing without
+              the community blocklist; it will be retried on the next
+              start (or run 'canasta restart' to re-attempt).
+
+        - name: Remove leftover temp credentials file
+          ansible.builtin.command:
+            cmd: "{{ _cscli_prefix }} rm -f /etc/crowdsec/online_api_credentials.yaml.tmp"
+            chdir: "{{ _cscli_chdir | default(omit) }}"
+          changed_when: false
+          failed_when: false

--- a/tests/unit/test_crowdsec_capi_resilient.py
+++ b/tests/unit/test_crowdsec_capi_resilient.py
@@ -1,0 +1,99 @@
+"""Guards for CrowdSec CAPI registration resilience (#709).
+
+`cscli capi register` reaches CrowdSec's Central API over the network.
+A transient outage must NOT abort `canasta create`: the registration is
+retried, a sustained failure is tolerated via rescue (the instance works
+without the community blocklist and the next start re-attempts), and the
+credentials file is written atomically so a failed attempt never leaves
+an empty/corrupt online_api_credentials.yaml behind.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+ENSURE_CAPI = os.path.join(
+    REPO_ROOT, "roles", "crowdsec", "tasks", "ensure_capi.yml"
+)
+
+
+def _load():
+    with open(ENSURE_CAPI) as f:
+        return yaml.safe_load(f)
+
+
+def _iter_tasks(tasks):
+    """Yield every task, descending into block/rescue/always wrappers."""
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _iter_tasks(t[nested])
+
+
+def _find(name_substring):
+    for t in _iter_tasks(_load()):
+        if name_substring in t.get("name", ""):
+            return t
+    return None
+
+
+def test_register_task_retries():
+    """The register call must retry to ride out a transient CAPI blip."""
+    reg = _find("Register CAPI and write the credentials file")
+    assert reg is not None, "register task must exist"
+    assert int(reg.get("retries", 0)) >= 2, (
+        "CAPI registration must set retries to survive a transient "
+        "Central API outage (#709)"
+    )
+    assert "rc == 0" in str(reg.get("until", "")), (
+        "registration must retry until the command succeeds"
+    )
+
+
+def test_register_is_in_a_rescued_block():
+    """A sustained CAPI failure must be tolerated, not abort create."""
+    block_task = _find("Register CAPI (retry")
+    assert block_task is not None and "block" in block_task, (
+        "the register call must live in a block:"
+    )
+    assert "rescue" in block_task, (
+        "the register block must have a rescue: so a sustained CAPI "
+        "failure does not abort 'canasta create' (#709)"
+    )
+    # The rescue must not itself hard-fail.
+    rescue_names = [t.get("name", "") for t in block_task["rescue"]]
+    assert any("Warn" in n for n in rescue_names), (
+        "rescue should warn that registration was skipped"
+    )
+
+
+def test_credentials_written_atomically():
+    """Write to a temp file and move into place on success, so a failed
+    register never corrupts online_api_credentials.yaml."""
+    reg = _find("Register CAPI and write the credentials file")
+    cmd = reg["ansible.builtin.command"]["cmd"]
+    assert "online_api_credentials.yaml.tmp" in cmd, (
+        "register must write to a temp file, not directly to the real "
+        "credentials file (#709)"
+    )
+    assert "mv" in cmd and "&&" in cmd, (
+        "the temp file must be moved into place only on success (&&)"
+    )
+
+
+def test_restart_only_on_success():
+    """The engine restart belongs in the success block, not the rescue,
+    so it does not run when registration failed."""
+    block_task = _find("Register CAPI (retry")
+    block_names = [t.get("name", "") for t in block_task["block"]]
+    rescue_names = [t.get("name", "") for t in block_task["rescue"]]
+    assert any("Restart the engine" in n for n in block_names), (
+        "engine restart must be in the success block"
+    )
+    assert not any("Restart the engine" in n for n in rescue_names), (
+        "engine restart must not run on the failure path"
+    )


### PR DESCRIPTION
## Summary

Fixes #709. `cscli capi register` reaches CrowdSec's Central API over the network. The task had no retries and no error tolerance, so a transient CAPI outage hard-failed the whole `canasta create` and rolled the instance back — and because it redirected `cscli capi register` straight into `online_api_credentials.yaml`, a failed attempt also left an empty/corrupt credentials file.

This was observed as the "Integration: Kubernetes CrowdSec" job failing all 3 attempts on the #706 merge run while CrowdSec's CAPI was briefly unavailable; the next `main` commit passed once it recovered.

## Change

Wrap the registration in a `block`/`rescue`:
- retry 3× (`until rc == 0`) to ride out transient blips;
- on sustained failure, fall through to the rescue (warn + clean up the temp file) instead of aborting create — the instance is fully functional without the community blocklist, and registration is idempotent (guarded by `cscli capi status`), so the next start/restart re-attempts it;
- write to `online_api_credentials.yaml.tmp` and `mv` into place only on success, so a failed register never corrupts the real file;
- restart the engine only on success.

Adds `tests/unit/test_crowdsec_capi_resilient.py` (4 static guards).

## Testing

- `make test-unit` — 1090 passed
- `make lint`, `make validate` — clean