### PR TITLE
delete: dispatch orchestrator-specific steps to orchestrator role (#696)

### DIFF
--- a/roles/delete/tasks/main.yml
+++ b/roles/delete/tasks/main.yml
@@ -115,41 +115,12 @@
     - name: End play for unreachable host
       ansible.builtin.meta: end_play
 
-# For registered K8s instances, the host can be reachable via SSH but
-# the cluster API behind it can be gone (operator ran `canasta uninstall
-# k8s` while instances were still registered, or k3s crashed). Without
-# this probe, the play falls through to helm/kubectl cleanup tasks that
-# emit ugly `Connection refused` errors for every cluster-side step.
-# We probe up front and gate the K8s cleanup on the result.
-- name: Probe K8s API reachability
-  ansible.builtin.command:
-    cmd: kubectl version --request-timeout=5s
-  register: _k8s_reachable
-  changed_when: false
-  ignore_errors: true
-  when:
-    - _delete_query is succeeded
-    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
-
-- name: Set K8s reachability fact
-  ansible.builtin.set_fact:
-    _k8s_api_reachable: >-
-      {{ (_k8s_reachable.rc | default(1)) == 0 }}
-  when:
-    - _delete_query is succeeded
-    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
-
-- name: Warn when K8s API is unreachable
-  ansible.builtin.debug:
-    msg: >-
-      K8s API unreachable on host '{{ _instance_host }}' — the cluster
-      appears to be uninstalled or down. Deregistering
-      '{{ instance_id }}' from the registry; skipping cluster-side
-      cleanup (Argo CD Application, helm release, namespace).
-  when:
-    - _delete_query is succeeded
-    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
-    - not _k8s_api_reachable
+# Probe K8s API reachability up front and record _k8s_api_reachable so
+# downstream cluster-side cleanup can be skipped cleanly when the cluster
+# is gone. No-op on Compose.
+- name: Probe orchestrator API reachability
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/delete_probe_k8s_api.yml
 
 - name: Discover unregistered instance
   when: _delete_query is failed
@@ -307,38 +278,11 @@
     state: absent
   when: _instance_host | default('localhost') != 'localhost'
 
-# Clean up container-owned files (important on Linux where files are
-# owned by www-data). Uses 'docker compose run' instead of 'exec' so
-# it works even when containers are stopped or unhealthy.
-- name: Clean up container-owned files (Compose)
-  ansible.builtin.command:
-    cmd: >-
-      docker compose run --rm --no-deps -T web
-      find /mediawiki/images /mediawiki/config /mediawiki/public_assets
-      -mindepth 1 -delete
-    chdir: "{{ instance_path }}"
-  when: instance_orchestrator | default('compose') == 'compose'
-  changed_when: true
-  ignore_errors: true  # OK if containers already removed
-
-- name: Clean up container-owned files (Kubernetes)
-  when:
-    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
-    - _k8s_api_reachable | default(true)
-  block:
-    - name: Check if K8s pods are running
-      ansible.builtin.include_role:
-        name: orchestrator
-        tasks_from: check_running.yml
-      ignore_errors: true  # OK if pods not running
-
-    - name: Remove files inside K8s pod
-      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
-      vars:
-        exec_service: web
-        exec_command: "find /mediawiki/images /mediawiki/config /mediawiki/public_assets -mindepth 1 -delete 2>/dev/null || true"
-      ignore_errors: true  # OK if dirs already empty or missing
-      when: _container_running | default(false) | bool
+# Remove instance content files via the orchestrator (Compose uses
+# `docker compose run`; K8s execs into the web pod when reachable).
+- name: Clean up container-owned files
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/delete_cleanup_files.yml
 
 # Remove backup schedule from crontab
 - name: Remove backup schedule
@@ -348,25 +292,18 @@
   ignore_errors: true  # OK if no crontab entry exists
 
 - name: Remove Argo CD Application if present
-  kubernetes.core.k8s:
-    state: absent
-    api_version: argoproj.io/v1alpha1
-    kind: Application
-    name: "canasta-{{ instance_id }}"
-    namespace: "{{ argocd_namespace | default('argocd') }}"
-  ignore_errors: true  # OK if Argo CD not installed
-  when:
-    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
-    - _k8s_api_reachable | default(true)
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/delete_remove_argocd_app.yml
 
 - name: Destroy containers and volumes
   ansible.builtin.include_role:
     name: orchestrator
     tasks_from: destroy.yml
   ignore_errors: true  # OK if already destroyed
-  when: >-
-    instance_orchestrator | default('compose') == 'compose'
-    or _k8s_api_reachable | default(true)
+  # Compose never sets _k8s_api_reachable, so default(true) runs destroy;
+  # K8s skips only when the cluster API was probed unreachable. destroy.yml
+  # itself dispatches Compose vs K8s.
+  when: _k8s_api_reachable | default(true)
 
 # Require a non-trivial absolute path before running 'find -delete'.
 # 'length > 5' rejects '/', '/a', '/ab', '/abc' — values short enough to

--- a/roles/orchestrator/tasks/delete_cleanup_files.yml
+++ b/roles/orchestrator/tasks/delete_cleanup_files.yml
@@ -1,0 +1,39 @@
+---
+# Remove instance content files for the orchestrator before teardown.
+# Compose: `docker compose run` find-delete (works even when containers
+# are stopped/unhealthy). Kubernetes: exec find-delete inside the web
+# pod when one is running and the cluster API is reachable.
+# Input: instance_path, instance_orchestrator, _k8s_api_reachable
+
+# Clean up container-owned files (important on Linux where files are
+# owned by www-data). Uses 'docker compose run' instead of 'exec' so
+# it works even when containers are stopped or unhealthy.
+- name: Clean up container-owned files (Compose)
+  ansible.builtin.command:
+    cmd: >-
+      docker compose run --rm --no-deps -T web
+      find /mediawiki/images /mediawiki/config /mediawiki/public_assets
+      -mindepth 1 -delete
+    chdir: "{{ instance_path }}"
+  when: instance_orchestrator | default('compose') == 'compose'
+  changed_when: true
+  ignore_errors: true  # OK if containers already removed
+
+- name: Clean up container-owned files (Kubernetes)
+  when:
+    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+    - _k8s_api_reachable | default(true)
+  block:
+    - name: Check if K8s pods are running
+      ansible.builtin.include_role:
+        name: orchestrator
+        tasks_from: check_running.yml
+      ignore_errors: true  # OK if pods not running
+
+    - name: Remove files inside K8s pod
+      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+      vars:
+        exec_service: web
+        exec_command: "find /mediawiki/images /mediawiki/config /mediawiki/public_assets -mindepth 1 -delete 2>/dev/null || true"
+      ignore_errors: true  # OK if dirs already empty or missing
+      when: _container_running | default(false) | bool

--- a/roles/orchestrator/tasks/delete_probe_k8s_api.yml
+++ b/roles/orchestrator/tasks/delete_probe_k8s_api.yml
@@ -1,0 +1,44 @@
+---
+# Probe orchestrator API reachability for delete and record
+# _k8s_api_reachable.
+#
+# For registered K8s instances, the host can be reachable via SSH but
+# the cluster API behind it can be gone (operator ran `canasta uninstall
+# k8s` while instances were still registered, or k3s crashed). Without
+# this probe, the play falls through to helm/kubectl cleanup tasks that
+# emit ugly `Connection refused` errors for every cluster-side step. We
+# probe up front and gate the K8s cleanup on the result. No-op on
+# Compose (consumers read _k8s_api_reachable with default(true)).
+#
+# Input: instance_orchestrator, instance_id, _instance_host, _delete_query
+# Output: _k8s_api_reachable
+
+- name: Probe K8s API reachability
+  ansible.builtin.command:
+    cmd: kubectl version --request-timeout=5s
+  register: _k8s_reachable
+  changed_when: false
+  ignore_errors: true
+  when:
+    - _delete_query is succeeded
+    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+
+- name: Set K8s reachability fact
+  ansible.builtin.set_fact:
+    _k8s_api_reachable: >-
+      {{ (_k8s_reachable.rc | default(1)) == 0 }}
+  when:
+    - _delete_query is succeeded
+    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+
+- name: Warn when K8s API is unreachable
+  ansible.builtin.debug:
+    msg: >-
+      K8s API unreachable on host '{{ _instance_host }}' — the cluster
+      appears to be uninstalled or down. Deregistering
+      '{{ instance_id }}' from the registry; skipping cluster-side
+      cleanup (Argo CD Application, helm release, namespace).
+  when:
+    - _delete_query is succeeded
+    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+    - not _k8s_api_reachable

--- a/roles/orchestrator/tasks/delete_remove_argocd_app.yml
+++ b/roles/orchestrator/tasks/delete_remove_argocd_app.yml
@@ -1,0 +1,17 @@
+---
+# Remove the instance's Argo CD Application before teardown so it can't
+# re-sync and recreate what destroy removes. Kubernetes-only; skipped on
+# Compose and when the cluster API is unreachable.
+# Input: instance_id, instance_orchestrator, _k8s_api_reachable, argocd_namespace
+
+- name: Remove Argo CD Application if present
+  kubernetes.core.k8s:
+    state: absent
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    name: "canasta-{{ instance_id }}"
+    namespace: "{{ argocd_namespace | default('argocd') }}"
+  ignore_errors: true  # OK if Argo CD not installed
+  when:
+    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+    - _k8s_api_reachable | default(true)


### PR DESCRIPTION
## Summary

Part of #696 — move `when: instance_orchestrator == compose/k8s` switches out of action code into orchestrator-role primitives. This PR covers the **delete role** (7 conditionals).

## Changes

The orchestrator-specific delete steps move into orchestrator primitives that `main.yml` calls unconditionally (tasks moved verbatim with their existing guards):

- `delete_probe_k8s_api.yml` — K8s API reachability probe + warn (no-op on Compose); sets `_k8s_api_reachable`
- `delete_cleanup_files.yml` — Compose `docker compose run` find-delete vs K8s pod-exec find-delete
- `delete_remove_argocd_app.yml` — K8s-only Argo CD Application removal

The destroy step's guard `instance_orchestrator == compose or _k8s_api_reachable` is simplified to `_k8s_api_reachable | default(true)`: Compose never sets that fact so it defaults true (destroy runs), and K8s skips only when the API was probed unreachable — equivalent across compose, K8s-reachable, K8s-unreachable, and unregistered-K8s paths. `destroy.yml` already dispatches Compose vs K8s internally.

The delete role now has zero orchestrator conditionals.

## Testing

- `make test-unit` — 1086 passed
- `make lint`, `make validate` — clean

Note: `delete` is destructive and the integration test runs push-to-main only, so a live Compose + K8s delete is worth running before merge.