### PR TITLE
config: dispatch gitops re-render to orchestrator role; justify the rest (#696)

### DIFF
--- a/playbooks/config_regenerate.yml
+++ b/playbooks/config_regenerate.yml
@@ -19,13 +19,12 @@
     path: "{{ instance_path }}/.gitops-host"
   register: _regen_gitops_stat
 
+# The orchestrator owns the compose-vs-K8s decision (K8s gitops uses a
+# different layout); dispatch.
 - name: Re-render gitops templates
-  ansible.builtin.include_role:
-    name: gitops
-    tasks_from: render_compose.yml
-  when:
-    - _regen_gitops_stat.stat.exists | default(false)
-    - instance_orchestrator | default('compose') == 'compose'
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/render_gitops_config.yml
+  when: _regen_gitops_stat.stat.exists | default(false)
 
 - name: Regenerate orchestrator config (e.g. Caddyfile)
   ansible.builtin.include_role:

--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -295,6 +295,9 @@
 
 # Also reconciles CANASTA_CADDY_IMAGE, so CADDY_TRUSTED_PROXIES (which can
 # require the plugin image) belongs in this trigger list too.
+# Intrinsic config-apply side effect; the K8s equivalent is reconciled at
+# deploy time by k8s_reconcile_caddy.yml. Kept in place per #696 (justified,
+# not dispatched).
 - name: Sync COMPOSE_PROFILES / caddy image when feature flags change
   when:
     - instance_orchestrator | default('compose') == 'compose'
@@ -308,6 +311,7 @@
 # registered. The restart this config-set triggers auto-enrolls the bouncer
 # (orchestrator start.yml), so the normal case just works; only flag the
 # manual fallback for --no-restart, where no start runs to enroll it.
+# Compose-only advisory side effect of a config change. Kept per #696.
 - name: Note bouncer enrollment when CrowdSec is enabled without a key
   when:
     - instance_orchestrator | default('compose') == 'compose'
@@ -359,6 +363,8 @@
 # propagated here — _validate_key.yml blocks them as immutable after
 # create. The values.yaml mapping is populated at create time only
 # (see roles/create/tasks/main.yml and templates/k8s_values.yaml.j2).
+# Intrinsically K8s config-apply (writes values.yaml); no Compose equivalent
+# (Compose reads .env directly). Kept per #696 (justified, not dispatched).
 - name: Propagate config key to K8s values.yaml
   when:
     - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
@@ -466,6 +472,7 @@
     # Let's Encrypt cert on the next restart. Without this, the user
     # would either serve Traefik's default self-signed cert or have
     # to delete and recreate the instance.
+    # Intrinsically K8s (cert-manager + values.yaml). Kept per #696.
     - name: Enable TLS for K8s instance on localhost→domain change
       when:
         - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']

--- a/roles/config/tasks/_update_gitops_vars.yml
+++ b/roles/config/tasks/_update_gitops_vars.yml
@@ -1,0 +1,97 @@
+---
+# Propagate config-set changes into a gitops instance's vars.yaml so they
+# survive the next gitops pull (which re-renders .env from env.template).
+# Extracted from set.yml; the Compose-only orchestrator guard now lives in
+# the caller, roles/orchestrator/tasks/config_update_gitops_vars.yml.
+# Input: instance_path, _config_settings, _config_gitops_stat
+- name: Load gitops placeholder definitions
+  ansible.builtin.include_vars:
+    file: "{{ canasta_root }}/roles/gitops/vars/main.yml"
+
+- name: Read .gitops-host
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/.gitops-host"
+  register: _config_host_raw
+
+# If config set introduces a new credential key (SMTP_PASSWORD,
+# AWS_*, etc.) that wasn't in .env at gitops init time, env.template
+# won't have a placeholder for it. Add one so the map-building step
+# below picks it up and the propagation to vars.yaml fires.
+- name: Ensure env.template has placeholders for new credential keys
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/config/tasks/_ensure_env_template_placeholder.yml
+  loop: "{{ _config_settings.split() }}"
+  loop_control:
+    loop_var: _ep_setting
+    label: "{{ _ep_setting.split('=', 1)[0] }}"
+
+- name: Build key-to-placeholder map from env.template
+  ansible.builtin.shell:
+    cmd: |
+      python3 -c "
+      import json, re
+      with open('{{ instance_path }}/env.template') as f:
+          lines = f.readlines()
+      m = {}
+      for line in lines:
+          match = re.match(r'^([A-Z][^=]*)=\{\{([^}]+)\}\}', line.strip())
+          if match:
+              m[match.group(1)] = match.group(2)
+      print(json.dumps(m))
+      "
+  register: _config_map_raw
+  changed_when: false
+
+- name: Parse placeholder map
+  ansible.builtin.set_fact:
+    _config_placeholder_map: "{{ _config_map_raw.stdout | from_json }}"
+
+- name: Update vars.yaml for each changed key
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/config/tasks/_update_gitops_var.yml
+  loop: "{{ _config_settings.split() }}"
+  loop_control:
+    loop_var: _config_setting
+    label: "{{ _config_setting.split('=', 1)[0] }}"
+
+# MW_SITE_FQDN / HTTP_PORT / HTTPS_PORT / CADDY_AUTO_HTTPS re-derive
+# MW_SITE_FQDN/MW_SITE_SERVER and rewrite wiki URLs in the rendered
+# .env and config/wikis.yaml via _side_effects.yml. Those derived
+# values are not in the typed settings, so the loop above never
+# propagates them; without this block the next 'config regenerate' /
+# 'gitops pull' re-renders them back to the pre-change domain.
+- name: Propagate domain side effects to gitops vars
+  when: >-
+    _config_settings.split() | map('regex_replace', '=.*$', '') | list
+    | intersect(['MW_SITE_FQDN', 'HTTP_PORT', 'HTTPS_PORT', 'CADDY_AUTO_HTTPS'])
+    | length > 0
+  block:
+    - name: Read final .env for derived domain keys
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read_all
+      register: _config_env_final
+
+    - name: Propagate derived MW_SITE_FQDN/MW_SITE_SERVER to vars.yaml
+      ansible.builtin.include_tasks: >-
+        {{ canasta_root }}/roles/config/tasks/_update_gitops_var.yml
+      loop:
+        - "MW_SITE_FQDN={{ _config_env_final.variables.MW_SITE_FQDN | default('') }}"
+        - "MW_SITE_SERVER={{ _config_env_final.variables.MW_SITE_SERVER | default('') }}"
+      loop_control:
+        loop_var: _config_setting
+        label: "{{ _config_setting.split('=', 1)[0] }}"
+
+    - name: Read final wikis.yaml for URL propagation
+      canasta_wikis_yaml:
+        instance_path: "{{ instance_path }}"
+        state: read
+      register: _config_wikis_final
+
+    - name: Propagate wiki URLs to vars.yaml
+      ansible.builtin.include_tasks: >-
+        {{ canasta_root }}/roles/config/tasks/_update_gitops_wiki_url.yml
+      loop: "{{ _config_wikis_final.wikis }}"
+      loop_control:
+        loop_var: _gw_wiki
+        label: "wiki_url_{{ _gw_wiki.id }}"

--- a/roles/config/tasks/_validate_key.yml
+++ b/roles/config/tasks/_validate_key.yml
@@ -21,6 +21,8 @@
 # and point at the kubectl-based rotation flow. Compose reads .env
 # directly at container start, so the same keys are mutable there
 # (config set + canasta restart propagates).
+# Input validation, not action dispatch — there is no Compose-equivalent
+# action to dispatch to, so this orchestrator check stays here (#696).
 - name: Block secret-bearing keys on Kubernetes (K8s Secret is the source of truth)
   ansible.builtin.fail:
     msg: |
@@ -52,6 +54,7 @@
 # guard, so on K8s they would rewrite MW_SITE_SERVER / MW_SITE_FQDN in
 # .env with a :port suffix nothing serves. Block the keys on K8s rather
 # than let the change silently mislead the operator.
+# Input validation, not action dispatch — kept here by design (#696).
 - name: Block port keys on Kubernetes (Ingress serves 80/443)
   ansible.builtin.fail:
     msg: |

--- a/roles/config/tasks/set.yml
+++ b/roles/config/tasks/set.yml
@@ -58,98 +58,12 @@
     path: "{{ instance_path }}/.gitops-host"
   register: _config_gitops_stat
 
+# The orchestrator owns the compose-vs-K8s decision (K8s gitops uses a
+# different layout, values.template.yaml, not vars.yaml); dispatch.
 - name: Update gitops vars for changed keys
-  when:
-    - _config_gitops_stat.stat.exists | default(false)
-    - instance_orchestrator | default('compose') == 'compose'
-  block:
-    - name: Load gitops placeholder definitions
-      ansible.builtin.include_vars:
-        file: "{{ canasta_root }}/roles/gitops/vars/main.yml"
-
-    - name: Read .gitops-host
-      ansible.builtin.slurp:
-        src: "{{ instance_path }}/.gitops-host"
-      register: _config_host_raw
-
-    # If config set introduces a new credential key (SMTP_PASSWORD,
-    # AWS_*, etc.) that wasn't in .env at gitops init time, env.template
-    # won't have a placeholder for it. Add one so the map-building step
-    # below picks it up and the propagation to vars.yaml fires.
-    - name: Ensure env.template has placeholders for new credential keys
-      ansible.builtin.include_tasks: _ensure_env_template_placeholder.yml
-      loop: "{{ _config_settings.split() }}"
-      loop_control:
-        loop_var: _ep_setting
-        label: "{{ _ep_setting.split('=', 1)[0] }}"
-
-    - name: Build key-to-placeholder map from env.template
-      ansible.builtin.shell:
-        cmd: |
-          python3 -c "
-          import json, re
-          with open('{{ instance_path }}/env.template') as f:
-              lines = f.readlines()
-          m = {}
-          for line in lines:
-              match = re.match(r'^([A-Z][^=]*)=\{\{([^}]+)\}\}', line.strip())
-              if match:
-                  m[match.group(1)] = match.group(2)
-          print(json.dumps(m))
-          "
-      register: _config_map_raw
-      changed_when: false
-
-    - name: Parse placeholder map
-      ansible.builtin.set_fact:
-        _config_placeholder_map: "{{ _config_map_raw.stdout | from_json }}"
-
-    - name: Update vars.yaml for each changed key
-      ansible.builtin.include_tasks: _update_gitops_var.yml
-      loop: "{{ _config_settings.split() }}"
-      loop_control:
-        loop_var: _config_setting
-        label: "{{ _config_setting.split('=', 1)[0] }}"
-
-    # MW_SITE_FQDN / HTTP_PORT / HTTPS_PORT / CADDY_AUTO_HTTPS re-derive
-    # MW_SITE_FQDN/MW_SITE_SERVER and rewrite wiki URLs in the rendered
-    # .env and config/wikis.yaml via _side_effects.yml. Those derived
-    # values are not in the typed settings, so the loop above never
-    # propagates them; without this block the next 'config regenerate' /
-    # 'gitops pull' re-renders them back to the pre-change domain.
-    - name: Propagate domain side effects to gitops vars
-      when: >-
-        _config_settings.split() | map('regex_replace', '=.*$', '') | list
-        | intersect(['MW_SITE_FQDN', 'HTTP_PORT', 'HTTPS_PORT', 'CADDY_AUTO_HTTPS'])
-        | length > 0
-      block:
-        - name: Read final .env for derived domain keys
-          canasta_env:
-            path: "{{ instance_path }}/.env"
-            state: read_all
-          register: _config_env_final
-
-        - name: Propagate derived MW_SITE_FQDN/MW_SITE_SERVER to vars.yaml
-          ansible.builtin.include_tasks: _update_gitops_var.yml
-          loop:
-            - "MW_SITE_FQDN={{ _config_env_final.variables.MW_SITE_FQDN | default('') }}"
-            - "MW_SITE_SERVER={{ _config_env_final.variables.MW_SITE_SERVER | default('') }}"
-          loop_control:
-            loop_var: _config_setting
-            label: "{{ _config_setting.split('=', 1)[0] }}"
-
-        - name: Read final wikis.yaml for URL propagation
-          canasta_wikis_yaml:
-            instance_path: "{{ instance_path }}"
-            state: read
-          register: _config_wikis_final
-
-        - name: Propagate wiki URLs to vars.yaml
-          ansible.builtin.include_tasks: _update_gitops_wiki_url.yml
-          loop: "{{ _config_wikis_final.wikis }}"
-          loop_control:
-            loop_var: _gw_wiki
-            label: "wiki_url_{{ _gw_wiki.id }}"
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/config_update_gitops_vars.yml
+  when: _config_gitops_stat.stat.exists | default(false)
 
 - name: Regenerate Caddyfile after config change
   ansible.builtin.include_role:

--- a/roles/orchestrator/tasks/config_update_gitops_vars.yml
+++ b/roles/orchestrator/tasks/config_update_gitops_vars.yml
@@ -1,0 +1,12 @@
+---
+# Propagate config-set changes into gitops vars for this orchestrator.
+# Compose: update vars.yaml (the compose-gitops source of truth) so the
+# change survives the next gitops pull. Kubernetes: no-op — K8s gitops
+# uses a different layout (values.template.yaml), not vars.yaml.
+# Input: instance_path, instance_orchestrator, _config_settings,
+#        _config_gitops_stat
+
+- name: Update gitops vars for changed keys (Compose)
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/config/tasks/_update_gitops_vars.yml
+  when: instance_orchestrator | default('compose') == 'compose'

--- a/roles/orchestrator/tasks/render_gitops_config.yml
+++ b/roles/orchestrator/tasks/render_gitops_config.yml
@@ -1,0 +1,13 @@
+---
+# Re-render a gitops instance's rendered files for this orchestrator.
+# Compose: re-render .env / wikis.yaml / admin password files from
+# env.template + host vars. Kubernetes: no-op — K8s gitops uses a
+# different layout (values.template.yaml + k8s_sync_config), so
+# render_compose does not apply.
+# Input: instance_path, instance_orchestrator
+
+- name: Re-render gitops templates (Compose)
+  ansible.builtin.include_role:
+    name: gitops
+    tasks_from: render_compose.yml
+  when: instance_orchestrator | default('compose') == 'compose'


### PR DESCRIPTION
## Summary

Part of #696. The config role had 8 `when: instance_orchestrator ...` switches. This PR takes the **clean-subset + justify** approach: dispatch the two low-risk gitops switches, and deliberately keep the other six in place (documented inline) where there is no clean dispatch home.

## Dispatched (2)

- `config set`'s compose-only "update gitops vars" block (K8s gitops uses a different layout) is extracted to `roles/config/tasks/_update_gitops_vars.yml` and called via a thin orchestrator primitive `orchestrator/tasks/config_update_gitops_vars.yml` that owns the Compose guard. `set.yml` now dispatches unconditionally (keeping only the gitops-instance stat check). The extracted file's cross-role task includes are made `canasta_root`-absolute per repo convention.
- `config regenerate`'s gitops re-render dispatches to `orchestrator/tasks/render_gitops_config.yml`.

## Justified in place (6), documented inline

- `_validate_key.yml` (2): input-validation guards that reject secret/port keys on K8s — these reject an invalid operation, there is no Compose-equivalent action to dispatch to.
- `_side_effects.yml` (4): intrinsic per-key config-apply side effects (compose profile/caddy sync, crowdsec advisory, K8s `values.yaml` propagation, K8s TLS cascade) — orchestrator-specific by nature and covered by existing tests (left untouched).

## Testing

- `make test-unit` — 1090 passed
- `make lint`, `make validate` — clean

Refs #696