### PR TITLE
mediawiki: dispatch install/import container ops to orchestrator role (#696)

### DIFF
--- a/roles/mediawiki/tasks/import_database.yml
+++ b/roles/mediawiki/tasks/import_database.yml
@@ -25,36 +25,21 @@
     mode: "0644"
   register: _import_transferred
 
-- name: Copy database dump to container (Compose)
-  ansible.builtin.command:
-    cmd: >-
-      docker compose cp /tmp/canasta-import{{ _is_gzipped | bool | ternary('.sql.gz', '.sql') }}
-      {{ ('db:' + _import_container_file) | quote }}
-    chdir: "{{ instance_path }}"
-  changed_when: true
-  when: instance_orchestrator | default('compose') == 'compose'
+# The orchestrator owns how a file lands in the db container (docker
+# compose cp vs kubectl cp); dispatch. Runs before the host-side cleanup
+# below so the dump still exists when kubectl cp reads it on K8s.
+- name: Copy database dump into the db container
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/copy_into_container.yml
+  vars:
+    copy_service: db
+    copy_src: "/tmp/canasta-import{{ _is_gzipped | bool | ternary('.sql.gz', '.sql') }}"
+    copy_dest: "{{ _import_container_file }}"
 
 - name: Clean up transferred dump from target host
   ansible.builtin.file:
     path: "/tmp/canasta-import{{ _is_gzipped | bool | ternary('.sql.gz', '.sql') }}"
     state: absent
-
-- name: Copy database dump to container (Kubernetes)
-  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
-  block:
-    - name: Get DB pod name for import
-      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_get_pod.yml"
-      vars:
-        _k8s_namespace: "canasta-{{ instance_id }}"
-        _k8s_component: db
-
-    - name: Copy dump via kubectl cp
-      ansible.builtin.command:
-        cmd: >-
-          kubectl cp /tmp/canasta-import{{ _is_gzipped | bool
-          | ternary('.sql.gz', '.sql') }} canasta-{{ instance_id
-          }}/{{ _k8s_pod_name }}:{{ _import_container_file }}
-      changed_when: true
 
 - name: Import gzipped database
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"

--- a/roles/mediawiki/tasks/install_single_wiki.yml
+++ b/roles/mediawiki/tasks/install_single_wiki.yml
@@ -57,84 +57,30 @@
 - name: Extract MW_SECRET_KEY from first wiki
   when: _wiki_idx == 0
   block:
-    - name: Build extract command based on orchestrator
-      ansible.builtin.set_fact:
-        _extract_cmd: >-
-          docker compose exec -T web grep -oP
-          'wgSecretKey\s*=\s*"\K[0-9a-fA-F]+'
-          /tmp/canasta-install/LocalSettings.php
-        _extract_chdir: "{{ instance_path }}"
-      when: instance_orchestrator | default('compose') == 'compose'
-
-    - name: Get K8s pod for extraction
-      ansible.builtin.command:
-        cmd: >-
-          kubectl get pods
-          -n canasta-{{ instance_id }}
-          -l app.kubernetes.io/component=web
-          --field-selector=status.phase=Running
-          -o jsonpath={.items[0].metadata.name}
-      register: _k8s_pod
-      changed_when: false
-      when: >-
-        instance_orchestrator | default('compose')
-        in ['kubernetes', 'k8s']
-
-    - name: Fail if no running web pod found
-      ansible.builtin.fail:
-        msg: >-
-          No running web pod found in namespace canasta-{{ instance_id }}.
-          Check that the instance is started and the web pod is Ready.
-      when:
-        - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
-        - _k8s_pod.stdout | default('') | trim == ''
-
-    - name: Build K8s extract command
-      ansible.builtin.set_fact:
-        _extract_cmd: >-
-          kubectl exec {{ _k8s_pod.stdout | trim }}
-          -n canasta-{{ instance_id }} --
-          grep -oP 'wgSecretKey\s*=\s*"\K[0-9a-fA-F]+'
-          /tmp/canasta-install/LocalSettings.php
-        _extract_chdir: null
-      when: >-
-        instance_orchestrator | default('compose')
-        in ['kubernetes', 'k8s']
-
+    # Exec in the web container/pod via the orchestrator's exec primitive,
+    # which dispatches Compose vs K8s (and resolves the running web pod).
     - name: Extract secret key from LocalSettings.php
-      ansible.builtin.command:
-        cmd: "{{ _extract_cmd }}"
-        chdir: "{{ _extract_chdir | default(omit) }}"
-      register: _secret_key_result
-      changed_when: false
+      ansible.builtin.include_tasks: >-
+        {{ canasta_root }}/roles/orchestrator/tasks/exec.yml
+      vars:
+        exec_service: web
+        exec_no_log: true
+        exec_command: "grep -oP 'wgSecretKey\\s*=\\s*\"\\K[0-9a-fA-F]+' /tmp/canasta-install/LocalSettings.php"
 
     - name: Save MW_SECRET_KEY to .env
       canasta_env:
         path: "{{ instance_path }}/.env"
         state: set
         key: MW_SECRET_KEY
-        value: "{{ _secret_key_result.stdout | trim }}"
+        value: "{{ exec_result.stdout | trim }}"
       no_log: true
 
-    - name: Delete LocalSettings.php (Compose)
-      ansible.builtin.command:
-        cmd: >-
-          docker compose exec -T web
-          rm -f /tmp/canasta-install/LocalSettings.php
-        chdir: "{{ instance_path }}"
-      changed_when: true
-      when: instance_orchestrator | default('compose') == 'compose'
-
-    - name: Delete LocalSettings.php (Kubernetes)
-      ansible.builtin.command:
-        cmd: >-
-          kubectl exec {{ _k8s_pod.stdout | default('') | trim }}
-          -n canasta-{{ instance_id }} --
-          rm -f /tmp/canasta-install/LocalSettings.php
-      changed_when: true
-      when: >-
-        instance_orchestrator | default('compose')
-        in ['kubernetes', 'k8s']
+    - name: Delete LocalSettings.php
+      ansible.builtin.include_tasks: >-
+        {{ canasta_root }}/roles/orchestrator/tasks/exec.yml
+      vars:
+        exec_service: web
+        exec_command: "rm -f /tmp/canasta-install/LocalSettings.php"
 
 - name: Pause between wiki installations
   ansible.builtin.pause:

--- a/roles/orchestrator/tasks/copy_into_container.yml
+++ b/roles/orchestrator/tasks/copy_into_container.yml
@@ -1,0 +1,33 @@
+---
+# Copy a file from the target host into a service container/pod.
+# Compose: docker compose cp. Kubernetes: kubectl cp into the running pod.
+# Input:
+#   instance_path, instance_orchestrator, instance_id
+#   copy_service - component/service to copy into (e.g. db)
+#   copy_src     - source path on the target host
+#   copy_dest    - destination path inside the container/pod
+
+- name: Copy file into container (Compose)
+  ansible.builtin.command:
+    cmd: >-
+      docker compose cp {{ copy_src | quote }}
+      {{ (copy_service + ':' + copy_dest) | quote }}
+    chdir: "{{ instance_path }}"
+  changed_when: true
+  when: instance_orchestrator | default('compose') == 'compose'
+
+- name: Copy file into pod (Kubernetes)
+  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+  block:
+    - name: Get pod for copy target
+      ansible.builtin.include_tasks: k8s_get_pod.yml
+      vars:
+        _k8s_namespace: "canasta-{{ instance_id }}"
+        _k8s_component: "{{ copy_service }}"
+
+    - name: Copy file via kubectl cp
+      ansible.builtin.command:
+        cmd: >-
+          kubectl cp {{ copy_src }}
+          canasta-{{ instance_id }}/{{ _k8s_pod_name }}:{{ copy_dest }}
+      changed_when: true


### PR DESCRIPTION
## Summary

Part of #696. Removes the orchestrator switches from the mediawiki role by delegating container/pod operations to existing orchestrator primitives.

## Changes

**`install_single_wiki.yml` — use the exec primitive.** The MW_SECRET_KEY extraction from `LocalSettings.php` and its deletion hand-rolled `docker compose exec` / `kubectl exec` with orchestrator branching throughout (~84 → ~25 lines). These now call the orchestrator `exec.yml` primitive (already used in this same file for `install.php`), which dispatches Compose vs K8s and resolves the running web pod via `k8s_get_pod.yml` — the **same** label selector and "no running pod" guard as the inline code. The extraction also now runs under `no_log` (the inline command did not, so it could leak the key under `-v`).

**`import_database.yml` — consolidate the dump copy + fix a latent K8s bug.** The separate Compose/K8s "copy dump into the db container" tasks consolidate into a new orchestrator primitive `copy_into_container.yml` (`docker compose cp` vs `kubectl cp`). This also fixes an ordering bug: the unconditional host-side dump cleanup ran **between** the Compose and K8s copy tasks, so on K8s the dump was deleted before `kubectl cp` could read it. The single dispatched copy now runs before the cleanup, so it works on both orchestrators.

Compose behavior is preserved. The mediawiki role now has zero orchestrator conditionals.

## Testing

- `make test-unit` — 1090 passed
- `make lint`, `make validate` — clean

Note: these touch the `canasta create` / import K8s paths, which PR CI does not exercise (integration tests run push-to-main only) — worth covering in the live K8s test before release.

Refs #696