### PR TITLE
maintenance: dispatch service listing to orchestrator role (#696)

### DIFF
--- a/roles/maintenance/tasks/exec.yml
+++ b/roles/maintenance/tasks/exec.yml
@@ -9,43 +9,25 @@
 - name: List running services
   when: (exec_args | default('')) == ''
   block:
-    - name: Get service list (Compose)
-      ansible.builtin.command:
-        cmd: "docker compose ps --services --filter status=running"
-        chdir: "{{ instance_path }}"
-      register: _exec_services_compose
-      changed_when: false
-      when: instance_orchestrator | default('compose') == 'compose'
-
-    - name: Get service list (Kubernetes)
-      ansible.builtin.command:
-        cmd: >-
-          kubectl get pods -n canasta-{{ instance_id }}
-          -o jsonpath='{range .items[*]}{.metadata.labels.app\.kubernetes\.io/component}{"\n"}{end}'
-      register: _exec_services_k8s
-      changed_when: false
-      when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
-
-    - name: Set service list
-      ansible.builtin.set_fact:
-        _exec_services_stdout: >-
-          {{ (_exec_services_compose.stdout | default(''))
-             if (instance_orchestrator | default('compose')) == 'compose'
-             else (_exec_services_k8s.stdout | default('')) }}
+    # The orchestrator owns how running services are listed (compose
+    # service names vs k8s pod component labels); dispatch.
+    - name: Get running services for this orchestrator
+      ansible.builtin.include_tasks: >-
+        {{ canasta_root }}/roles/orchestrator/tasks/list_running_services.yml
 
     - name: Display running services
       ansible.builtin.debug:
         msg: |
           Running services:
-          {% for svc in (_exec_services_stdout | trim).split('\n') | sort %}
+          {% for svc in (_running_services | trim).split('\n') | sort %}
             {{ svc }}
           {% endfor %}
-      when: (_exec_services_stdout | trim) != ''
+      when: (_running_services | trim) != ''
 
     - name: No services running
       ansible.builtin.debug:
         msg: "No running services found."
-      when: (_exec_services_stdout | trim) == ''
+      when: (_running_services | trim) == ''
 
 - name: Execute command in container
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"

--- a/roles/orchestrator/tasks/list_running_services.yml
+++ b/roles/orchestrator/tasks/list_running_services.yml
@@ -1,0 +1,29 @@
+---
+# List the running service/component names for an instance.
+# Compose: docker compose service names. K8s: pod component labels.
+# Input: instance_path, instance_id, instance_orchestrator
+# Output: _running_services (newline-separated names, may be empty)
+
+- name: Get service list (Compose)
+  ansible.builtin.command:
+    cmd: "docker compose ps --services --filter status=running"
+    chdir: "{{ instance_path }}"
+  register: _list_services_compose
+  changed_when: false
+  when: instance_orchestrator | default('compose') == 'compose'
+
+- name: Get service list (Kubernetes)
+  ansible.builtin.command:
+    cmd: >-
+      kubectl get pods -n canasta-{{ instance_id }}
+      -o jsonpath='{range .items[*]}{.metadata.labels.app\.kubernetes\.io/component}{"\n"}{end}'
+  register: _list_services_k8s
+  changed_when: false
+  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+
+- name: Set running services output
+  ansible.builtin.set_fact:
+    _running_services: >-
+      {{ (_list_services_compose.stdout | default(''))
+         if (instance_orchestrator | default('compose')) == 'compose'
+         else (_list_services_k8s.stdout | default('')) }}


### PR DESCRIPTION
## Summary

Part of #696. `maintenance exec` with no args listed running services using separate Compose (`docker compose ps --services`) and Kubernetes (`kubectl get pods` component labels) tasks plus an orchestrator ternary to select the output — 3 orchestrator switches in action code.

Move the listing into a new orchestrator primitive `list_running_services.yml` that sets a single `_running_services` fact. `maintenance/exec.yml` now dispatches unconditionally and renders the result. (The command-exec path already used the orchestrator `exec.yml` primitive.)

Behavior preserved. The maintenance role now has zero orchestrator conditionals.

## Testing

- `make test-unit` — 1090 passed
- `make lint`, `make validate` — clean

Refs #696