### PR TITLE
gitops: dispatch gitops sync to orchestrator role; justify the rest (#696)

### DIFF
--- a/playbooks/gitops_sync.yml
+++ b/playbooks/gitops_sync.yml
@@ -5,11 +5,8 @@
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
-- name: Not applicable for Compose
-  ansible.builtin.debug:
-    msg: "'gitops sync' is only applicable for the kubernetes orchestrator. No action taken."
-  when: instance_orchestrator | default('compose') == 'compose'
-
-- name: Trigger Argo CD sync
-  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_argocd_sync.yml"
-  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+# The orchestrator owns what a sync means (K8s Argo CD sync vs Compose
+# no-op); dispatch.
+- name: Trigger gitops sync for this orchestrator
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/gitops_trigger_sync.yml

--- a/roles/gitops/tasks/_reinit_cleanup.yml
+++ b/roles/gitops/tasks/_reinit_cleanup.yml
@@ -36,7 +36,7 @@
 
 # Intrinsically K8s: removes the K8s-only gitops files (Chart.yaml,
 # values.template.yaml, argocd, ...) that Compose instances never have.
-# Kept in place per #696 (no Compose-equivalent cleanup to dispatch to).
+# Kept in place by design (no Compose-equivalent cleanup to dispatch to).
 - name: Reinit cleanup — Kubernetes-only gitops files
   ansible.builtin.file:
     path: "{{ instance_path }}/{{ item }}"

--- a/roles/gitops/tasks/_reinit_cleanup.yml
+++ b/roles/gitops/tasks/_reinit_cleanup.yml
@@ -34,6 +34,9 @@
     - wikis.yaml.template
     - hosts
 
+# Intrinsically K8s: removes the K8s-only gitops files (Chart.yaml,
+# values.template.yaml, argocd, ...) that Compose instances never have.
+# Kept in place per #696 (no Compose-equivalent cleanup to dispatch to).
 - name: Reinit cleanup — Kubernetes-only gitops files
   ansible.builtin.file:
     path: "{{ instance_path }}/{{ item }}"

--- a/roles/gitops/tasks/fix_submodules.yml
+++ b/roles/gitops/tasks/fix_submodules.yml
@@ -4,7 +4,7 @@
 
 # Input validation rejecting an operation that does not apply on K8s
 # (extensions are image-bundled, not git submodules) — no Compose-
-# equivalent action to dispatch to. Kept in place per #696.
+# equivalent action to dispatch to. Kept in place by design.
 - name: Not applicable for Kubernetes
   ansible.builtin.fail:
     msg: >-

--- a/roles/gitops/tasks/fix_submodules.yml
+++ b/roles/gitops/tasks/fix_submodules.yml
@@ -2,6 +2,9 @@
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
+# Input validation rejecting an operation that does not apply on K8s
+# (extensions are image-bundled, not git submodules) — no Compose-
+# equivalent action to dispatch to. Kept in place per #696.
 - name: Not applicable for Kubernetes
   ansible.builtin.fail:
     msg: >-

--- a/roles/gitops/tasks/join.yml
+++ b/roles/gitops/tasks/join.yml
@@ -11,7 +11,7 @@
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
 # Early-dispatch to the K8s join, then end_play so the ~400-line Compose
-# join flow below does not run on K8s. Kept in place per #696: a full
+# join flow below does not run on K8s. Kept in place by design: a full
 # dispatch would extract the Compose flow into its own file, but the
 # end_play ends the whole play (not just this role), so the split needs a
 # dedicated, integration-tested change rather than a mechanical move.

--- a/roles/gitops/tasks/join.yml
+++ b/roles/gitops/tasks/join.yml
@@ -10,6 +10,11 @@
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
+# Early-dispatch to the K8s join, then end_play so the ~400-line Compose
+# join flow below does not run on K8s. Kept in place per #696: a full
+# dispatch would extract the Compose flow into its own file, but the
+# end_play ends the whole play (not just this role), so the split needs a
+# dedicated, integration-tested change rather than a mechanical move.
 - name: Dispatch to K8s join
   ansible.builtin.include_tasks: join_kubernetes.yml
   when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']

--- a/roles/orchestrator/tasks/gitops_trigger_sync.yml
+++ b/roles/orchestrator/tasks/gitops_trigger_sync.yml
@@ -1,0 +1,14 @@
+---
+# Trigger an immediate gitops sync for this orchestrator.
+# Kubernetes: trigger an Argo CD sync. Compose: no-op — Compose gitops
+# has no continuous reconciler, so there is nothing to sync.
+# Input: instance_id, instance_orchestrator
+
+- name: Not applicable for Compose
+  ansible.builtin.debug:
+    msg: "'gitops sync' is only applicable for the kubernetes orchestrator. No action taken."
+  when: instance_orchestrator | default('compose') == 'compose'
+
+- name: Trigger Argo CD sync
+  ansible.builtin.include_tasks: k8s_argocd_sync.yml
+  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']


### PR DESCRIPTION
## Summary

Part of #696, **clean subset + justify** (same approach as #712).

## Dispatched (2)

`canasta gitops sync` (K8s Argo CD sync vs Compose no-op) moves into a new orchestrator primitive `gitops_trigger_sync.yml`; `playbooks/gitops_sync.yml` now dispatches unconditionally.

## Justified in place (4), documented inline

- **`join.yml` (2)** — early-dispatch to the K8s join followed by `meta: end_play` to skip the ~400-line Compose flow. `end_play` ends the *whole play* (not just the role), so a clean compose/k8s split needs a dedicated, integration-tested change rather than a mechanical extraction.
- **`fix_submodules.yml` (1)** — input validation rejecting the op on K8s (extensions are image-bundled, not git submodules); no Compose-equivalent action to dispatch to.
- **`_reinit_cleanup.yml` (1)** — removes the K8s-only gitops files (Chart.yaml, values.template.yaml, argocd, …) during reinit; intrinsically K8s, no Compose-equivalent cleanup.

## Testing

- `make test-unit` — 1090 passed
- `make lint`, `make validate` — clean

Refs #696