### PR TITLE
create: read --envfile from the controller, not the target host

### DIFF
--- a/roles/create/tasks/_envfile.yml
+++ b/roles/create/tasks/_envfile.yml
@@ -12,9 +12,15 @@
 - name: Merge custom env file if provided
   when: envfile is defined and envfile != ''
   block:
+    # envfile is a controller-side path (path_kind: local), so read it on
+    # the controller. Without delegation the slurp runs on the target host
+    # and looks for the controller's path on the remote filesystem.
     - name: Read custom env file
       ansible.builtin.slurp:
         src: "{{ envfile }}"
+      delegate_to: localhost
+      vars:
+        ansible_connection: local
       register: _custom_env
 
     - name: Parse and apply custom env variables


### PR DESCRIPTION
## Summary

`canasta create --host <remote> -e <envfile>` could not read the env file. The `-e/--envfile` path is **controller-local** (`path_kind` defaults to `local`; `canasta.py` resolves it against the machine running the CLI), but the task reading it ran on the target host, so with `--host` set it looked for the controller's path on the remote filesystem and failed.

This fixes the read to happen on the controller via `delegate_to: localhost` + `ansible_connection: local` — matching the controller-side-read idiom in `roles/common/tasks/resolve_cp_host_ssh.yml` and the `copy`-based handling of the other controller-local file parameters (`--yamlfile`, `--database`, `--override`, `--wiki-settings`, `--global-settings`, `--composer`). `--envfile` was the lone controller-local file parameter that misbehaved with `--host`.

## Impact

Unblocks external-DB deployments on remote / multi-node targets — the documented production-HA path (Help:Multi-node Kubernetes, Help:External database), which requires passing `MYSQL_*` via `-e`. Previously this only worked when controller == target (no `--host`).

## Testing

- `make lint` passes
- `make test-unit` passes (1090 tests)

Fixes #715