### PR TITLE
comments: remove issue-number references from recently-added comments

### DIFF
--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -296,8 +296,8 @@
 # Also reconciles CANASTA_CADDY_IMAGE, so CADDY_TRUSTED_PROXIES (which can
 # require the plugin image) belongs in this trigger list too.
 # Intrinsic config-apply side effect; the K8s equivalent is reconciled at
-# deploy time by k8s_reconcile_caddy.yml. Kept in place per #696 (justified,
-# not dispatched).
+# deploy time by k8s_reconcile_caddy.yml. Kept in place by design
+# (orchestrator-specific side effect, not dispatched).
 - name: Sync COMPOSE_PROFILES / caddy image when feature flags change
   when:
     - instance_orchestrator | default('compose') == 'compose'
@@ -311,7 +311,7 @@
 # registered. The restart this config-set triggers auto-enrolls the bouncer
 # (orchestrator start.yml), so the normal case just works; only flag the
 # manual fallback for --no-restart, where no start runs to enroll it.
-# Compose-only advisory side effect of a config change. Kept per #696.
+# Compose-only advisory side effect of a config change. Kept in place by design.
 - name: Note bouncer enrollment when CrowdSec is enabled without a key
   when:
     - instance_orchestrator | default('compose') == 'compose'
@@ -364,7 +364,7 @@
 # create. The values.yaml mapping is populated at create time only
 # (see roles/create/tasks/main.yml and templates/k8s_values.yaml.j2).
 # Intrinsically K8s config-apply (writes values.yaml); no Compose equivalent
-# (Compose reads .env directly). Kept per #696 (justified, not dispatched).
+# (Compose reads .env directly). Kept in place by design (not dispatched).
 - name: Propagate config key to K8s values.yaml
   when:
     - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
@@ -472,7 +472,7 @@
     # Let's Encrypt cert on the next restart. Without this, the user
     # would either serve Traefik's default self-signed cert or have
     # to delete and recreate the instance.
-    # Intrinsically K8s (cert-manager + values.yaml). Kept per #696.
+    # Intrinsically K8s (cert-manager + values.yaml). Kept in place by design.
     - name: Enable TLS for K8s instance on localhost→domain change
       when:
         - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']

--- a/roles/config/tasks/_validate_key.yml
+++ b/roles/config/tasks/_validate_key.yml
@@ -22,7 +22,7 @@
 # directly at container start, so the same keys are mutable there
 # (config set + canasta restart propagates).
 # Input validation, not action dispatch — there is no Compose-equivalent
-# action to dispatch to, so this orchestrator check stays here (#696).
+# action to dispatch to, so this orchestrator check stays here by design.
 - name: Block secret-bearing keys on Kubernetes (K8s Secret is the source of truth)
   ansible.builtin.fail:
     msg: |
@@ -54,7 +54,7 @@
 # guard, so on K8s they would rewrite MW_SITE_SERVER / MW_SITE_FQDN in
 # .env with a :port suffix nothing serves. Block the keys on K8s rather
 # than let the change silently mislead the operator.
-# Input validation, not action dispatch — kept here by design (#696).
+# Input validation, not action dispatch — kept here by design.
 - name: Block port keys on Kubernetes (Ingress serves 80/443)
   ansible.builtin.fail:
     msg: |

--- a/tests/unit/test_crowdsec_capi_resilient.py
+++ b/tests/unit/test_crowdsec_capi_resilient.py
@@ -1,4 +1,4 @@
-"""Guards for CrowdSec CAPI registration resilience (#709).
+"""Guards for CrowdSec CAPI registration resilience.
 
 `cscli capi register` reaches CrowdSec's Central API over the network.
 A transient outage must NOT abort `canasta create`: the registration is
@@ -47,7 +47,7 @@ def test_register_task_retries():
     assert reg is not None, "register task must exist"
     assert int(reg.get("retries", 0)) >= 2, (
         "CAPI registration must set retries to survive a transient "
-        "Central API outage (#709)"
+        "Central API outage"
     )
     assert "rc == 0" in str(reg.get("until", "")), (
         "registration must retry until the command succeeds"
@@ -62,7 +62,7 @@ def test_register_is_in_a_rescued_block():
     )
     assert "rescue" in block_task, (
         "the register block must have a rescue: so a sustained CAPI "
-        "failure does not abort 'canasta create' (#709)"
+        "failure does not abort 'canasta create'"
     )
     # The rescue must not itself hard-fail.
     rescue_names = [t.get("name", "") for t in block_task["rescue"]]
@@ -78,7 +78,7 @@ def test_credentials_written_atomically():
     cmd = reg["ansible.builtin.command"]["cmd"]
     assert "online_api_credentials.yaml.tmp" in cmd, (
         "register must write to a temp file, not directly to the real "
-        "credentials file (#709)"
+        "credentials file"
     )
     assert "mv" in cmd and "&&" in cmd, (
         "the temp file must be moved into place only on success (&&)"


### PR DESCRIPTION
## Summary

Strips inline issue numbers from comments added during the #696 orchestrator-dispatch work and the CrowdSec CAPI fix, per our convention of not referencing issues in code comments. Each comment now stands on its own.

- `roles/config/tasks/_validate_key.yml`, `_side_effects.yml` — the "justify in place" comments (merged via #712) cited `#696`.
- `tests/unit/test_crowdsec_capi_resilient.py` — module docstring and assertion messages (merged via #710) cited `#709`.

Comments/messages only — no behavior change.

## Testing

- `make test-unit` — passes
- `make lint` — clean