### PR TITLE
export/devmode: dispatch export copy to orchestrator role; justify the rest (#696)

### DIFF
--- a/playbooks/add.yml
+++ b/playbooks/add.yml
@@ -189,6 +189,9 @@
     name: orchestrator
     tasks_from: update_config.yml
 
+# Intrinsically K8s: the served domains live in values.yaml (Compose
+# routes new wikis via the Caddyfile regenerated above). No Compose
+# equivalent to dispatch to; kept here by design.
 - name: Update Kubernetes values.yaml domains list
   when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
   block:

--- a/playbooks/export.yml
+++ b/playbooks/export.yml
@@ -56,26 +56,15 @@
   ansible.builtin.set_fact:
     _container_file: "/tmp/{{ wiki }}.sql{{ (_export_gzip | bool) | ternary('.gz', '') }}"
 
-- name: Copy dump from container to host (Compose)
-  ansible.builtin.command:
-    cmd: "docker compose cp {{ ('db:' + _container_file) | quote }} {{ _export_file | quote }}"
-    chdir: "{{ instance_path }}"
-  changed_when: true
-  when: instance_orchestrator | default('compose') == 'compose'
-
-- name: Copy dump from container to host (Kubernetes)
-  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
-  block:
-    - name: Get DB pod name
-      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_get_pod.yml"
-      vars:
-        _k8s_namespace: "canasta-{{ instance_id }}"
-        _k8s_component: db
-
-    - name: Copy dump via kubectl cp
-      ansible.builtin.command:
-        cmd: "kubectl cp canasta-{{ instance_id }}/{{ _k8s_pod_name }}:{{ _container_file }} {{ _export_file }}"
-      changed_when: true
+# The orchestrator owns how a file is copied out of the db container
+# (docker compose cp vs kubectl cp); dispatch.
+- name: Copy dump from the db container to the host
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/copy_from_container.yml
+  vars:
+    copy_service: db
+    copy_src: "{{ _container_file }}"
+    copy_dest: "{{ _export_file }}"
 
 - name: Clean up temp files in container
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"

--- a/roles/devmode/tasks/disable.yml
+++ b/roles/devmode/tasks/disable.yml
@@ -11,6 +11,8 @@
     msg: "Dev mode is only supported for local instances."
   when: _instance_host | default('localhost') != 'localhost'
 
+# Validation: devmode is Compose-only. No K8s-equivalent action to
+# dispatch to; kept here by design.
 - name: Not applicable for Kubernetes
   ansible.builtin.fail:
     msg: >-

--- a/roles/devmode/tasks/enable.yml
+++ b/roles/devmode/tasks/enable.yml
@@ -12,6 +12,9 @@
     msg: "Dev mode is only supported for local instances."
   when: _instance_host | default('localhost') != 'localhost'
 
+# Validation: devmode is Compose-only (xdebug needs a custom image build
+# and values.yaml config). No K8s-equivalent action to dispatch to; kept
+# here by design.
 - name: Not applicable for Kubernetes
   ansible.builtin.fail:
     msg: >-

--- a/roles/orchestrator/tasks/copy_from_container.yml
+++ b/roles/orchestrator/tasks/copy_from_container.yml
@@ -1,0 +1,33 @@
+---
+# Copy a file from a service container/pod to the target host.
+# Compose: docker compose cp. Kubernetes: kubectl cp from the running pod.
+# Input:
+#   instance_path, instance_orchestrator, instance_id
+#   copy_service - component/service to copy from (e.g. db)
+#   copy_src     - source path inside the container/pod
+#   copy_dest    - destination path on the target host
+
+- name: Copy file from container (Compose)
+  ansible.builtin.command:
+    cmd: >-
+      docker compose cp {{ (copy_service + ':' + copy_src) | quote }}
+      {{ copy_dest | quote }}
+    chdir: "{{ instance_path }}"
+  changed_when: true
+  when: instance_orchestrator | default('compose') == 'compose'
+
+- name: Copy file from pod (Kubernetes)
+  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+  block:
+    - name: Get pod for copy source
+      ansible.builtin.include_tasks: k8s_get_pod.yml
+      vars:
+        _k8s_namespace: "canasta-{{ instance_id }}"
+        _k8s_component: "{{ copy_service }}"
+
+    - name: Copy file via kubectl cp
+      ansible.builtin.command:
+        cmd: >-
+          kubectl cp canasta-{{ instance_id }}/{{ _k8s_pod_name }}:{{ copy_src }}
+          {{ copy_dest }}
+      changed_when: true


### PR DESCRIPTION
## Summary

Part of #696, clean subset + justify.

## Dispatched (2)

`canasta export` copied the DB dump out of the container with separate Compose (`docker compose cp`) and Kubernetes (`kubectl cp`) tasks. Consolidate into a new orchestrator primitive `copy_from_container.yml` — the container→host mirror of the existing `copy_into_container.yml` (added in #713). `export.yml` now dispatches unconditionally.

## Justified in place (3), documented inline

- **`devmode/enable.yml`, `disable.yml`** — `fail:` guards rejecting devmode on K8s; devmode is Compose-only (xdebug needs a custom image build + values.yaml config). No K8s-equivalent action to dispatch to.
- **`add.yml`** — updating `values.yaml`'s `domains` list after adding a wiki is intrinsically K8s (Compose routes new wikis via the Caddyfile regenerated just above).

## Testing

- `make test-unit` — 1090 passed
- `make lint`, `make validate` — clean

Refs #696