### PR TITLE
k8s: pin k3s and helm versions; bootstrap CI via canasta install k8s-cp (#720)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -200,17 +200,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y git-crypt
-      - name: Install Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.20.1
-      - name: Install k3s
-        run: |
-          curl -sfL https://get.k3s.io | sudo sh -
-          mkdir -p ~/.kube
-          sudo k3s kubectl config view --raw > ~/.kube/config
-          chmod 600 ~/.kube/config
-          kubectl cluster-info
       - name: Install Python dependencies
         run: |
           python -m venv .venv
@@ -228,6 +217,13 @@ jobs:
           done
           git config --global user.name "CI"
           git config --global user.email "ci@canasta.wiki"
+      # Bootstrap the cluster via the product's own install path so CI
+      # exercises 'canasta install k8s-cp' (which installs k3s + helm at the
+      # pinned canasta_k3s_version / canasta_helm_version, writing
+      # ~/.kube/config) instead of a separate, unpinned curl | sh that
+      # depended on update.k3s.io.
+      - name: Bootstrap k3s control plane via canasta
+        run: ./canasta-native install k8s-cp
       - name: Run K8s tests
         run: >-
           .venv/bin/python tests/integration/run_tests.py
@@ -251,17 +247,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y git-crypt
-      - name: Install Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.20.1
-      - name: Install k3s
-        run: |
-          curl -sfL https://get.k3s.io | sudo sh -
-          mkdir -p ~/.kube
-          sudo k3s kubectl config view --raw > ~/.kube/config
-          chmod 600 ~/.kube/config
-          kubectl cluster-info
       - name: Install Python dependencies
         run: |
           python -m venv .venv
@@ -279,6 +264,13 @@ jobs:
           done
           git config --global user.name "CI"
           git config --global user.email "ci@canasta.wiki"
+      # Bootstrap the cluster via the product's own install path so CI
+      # exercises 'canasta install k8s-cp' (which installs k3s + helm at the
+      # pinned canasta_k3s_version / canasta_helm_version, writing
+      # ~/.kube/config) instead of a separate, unpinned curl | sh that
+      # depended on update.k3s.io.
+      - name: Bootstrap k3s control plane via canasta
+        run: ./canasta-native install k8s-cp
       - name: Run K8s CrowdSec test
         run: >-
           .venv/bin/python tests/integration/run_tests.py

--- a/roles/orchestrator/defaults/main.yml
+++ b/roles/orchestrator/defaults/main.yml
@@ -10,3 +10,12 @@ canasta_db_service: db
 
 # Wait-for-it timeout (seconds)
 canasta_db_wait_timeout: 10
+
+# Pinned k3s and helm versions for Kubernetes installs. Pinning keeps the
+# control plane and any workers on the same version (a later-joining worker
+# must not outpace the cp — Kubernetes version-skew policy) and avoids
+# depending on update.k3s.io to resolve a channel at install time. Reviewed
+# and bumped per release. Override per-host if a specific version is required
+# (all nodes in a cluster must use the same one).
+canasta_k3s_version: "v1.34.8+k3s1"
+canasta_helm_version: "v3.20.1"

--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -44,10 +44,15 @@
         msg: "Adding to k3s API server TLS cert: {{ public_ip | join(', ') }}"
       when: (public_ip | default([])) | length > 0
 
+    # INSTALL_K3S_VERSION pins the release so the installer downloads it
+    # directly from GitHub instead of asking update.k3s.io to resolve a
+    # channel — removing that single point of failure and keeping every
+    # node in the cluster on the same version (see canasta_k3s_version).
     - name: Download and install k3s
       ansible.builtin.shell:
         cmd: >-
-          curl -sfL https://get.k3s.io |
+          curl -sfL --retry 3 --retry-delay 5 https://get.k3s.io |
+          INSTALL_K3S_VERSION={{ canasta_k3s_version | quote }}
           INSTALL_K3S_EXEC={{ _k3s_install_exec | quote }} sh -
       changed_when: true
 
@@ -103,7 +108,10 @@
 
 - name: Install helm
   ansible.builtin.shell:
-    cmd: "curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash"
+    cmd: >-
+      curl -fsSL --retry 3 --retry-delay 5
+      https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+      | DESIRED_VERSION={{ canasta_helm_version | quote }} bash
   changed_when: true
   when: _helm_installed.rc != 0
 

--- a/roles/orchestrator/tasks/k8s_install_k3s_agent.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s_agent.yml
@@ -33,10 +33,14 @@
     # K3S_URL pre-set on the install command flips the upstream
     # installer into agent mode (vs the default server install).
     # Both env vars are required.
+    # Pin the same k3s version as the control plane (canasta_k3s_version)
+    # so a later-joining worker can't outpace the cp, and so the install
+    # doesn't depend on update.k3s.io resolving a channel.
     - name: Download and install k3s agent
       ansible.builtin.shell:
         cmd: >-
-          curl -sfL https://get.k3s.io |
+          curl -sfL --retry 3 --retry-delay 5 https://get.k3s.io |
+          INSTALL_K3S_VERSION={{ canasta_k3s_version | quote }}
           K3S_URL={{ server | quote }}
           K3S_TOKEN={{ token | quote }}
           sh -


### PR DESCRIPTION
## Summary

Fixes #720. The control-plane, worker, and CI all installed k3s unpinned (`curl get.k3s.io | sh`), which:
1. **Depended on `update.k3s.io`** to resolve a channel → a single point of failure that took down `canasta install k8s-cp` and every push-to-main K8s CI job during a k3s outage (2026-06-17).
2. **Allowed multi-node version skew** — a worker that joins later could get a newer k3s than the control plane, violating Kubernetes' version-skew policy.

## Changes

- **`roles/orchestrator/defaults/main.yml`** — `canasta_k3s_version` (`v1.34.8+k3s1`) and `canasta_helm_version` (`v3.20.1`) as the single source of truth.
- **cp + agent installs** pass `INSTALL_K3S_VERSION` → installer downloads directly from GitHub releases (no `update.k3s.io`), and every node lands on the same version. Helm pinned via `DESIRED_VERSION`. `--retry` added to the download curls.
- **CI (both K8s jobs)** bootstrap the cluster with `canasta install k8s-cp` instead of a separate unpinned `curl | sh` + `azure/setup-helm`, so CI exercises the product's real install path and automatically uses the pinned versions (no separate CI pin to drift).

The pinned version is the supported Kubernetes version, reviewed/bumped per release (added to the release process).

## Testing

- `make test-unit` (1090), `make lint`, `make validate` — pass.
- Note: the K8s integration jobs run push-to-main only, so the CI bootstrap change is validated by the post-merge `main` run (which, with `update.k3s.io` currently down, also confirms the pin fixes the outage).

Fixes #720