### PR TITLE
wiki_publish: fix --prune deleting every page (capitalization) + harden

### DIFF
--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -42,6 +42,12 @@ EDIT_DELAY = 2  # seconds between edits
 HTTP_TIMEOUT = 30  # seconds; a hung wiki API must not stall the publish
 
 
+class PermissionDeniedError(RuntimeError):
+    """The bot account lacks the right for an API action (e.g. delete
+    requires the Administrators group). Treated as a skip, not a
+    publish failure."""
+
+
 def load_definitions():
     with open(DEFINITIONS_PATH) as f:
         return yaml.safe_load(f)
@@ -749,10 +755,11 @@ class MediaWikiClient:
             "format": "json",
         })
         if "error" in result:
-            raise RuntimeError(
-                "API error: %s: %s"
-                % (result["error"]["code"], result["error"]["info"])
-            )
+            code = result["error"]["code"]
+            msg = "API error: %s: %s" % (code, result["error"]["info"])
+            if code == "permissiondenied":
+                raise PermissionDeniedError(msg)
+            raise RuntimeError(msg)
 
 
 def main():
@@ -845,20 +852,34 @@ def prune_orphans(client, pages):
     existing = client.list_pages_in_namespace(ns_id)
     orphans = [t for t in existing if t not in generated]
 
+    if not orphans:
+        print("No orphaned %s pages to prune" % PAGE_PREFIX)
+        return 0
+
     errors = 0
-    for title in orphans:
+    for i, title in enumerate(orphans):
         try:
             client.delete_page(
                 title, "Orphaned Canasta CLI reference (command removed)"
             )
             print("Deleted orphan %s" % title)
+        except PermissionDeniedError as e:
+            # The bot can't delete (needs Administrators). Every orphan
+            # would fail the same way, so warn once with the full list
+            # for manual cleanup and don't fail the publish job.
+            remaining = orphans[i:]
+            print(
+                "WARNING: cannot delete orphaned %s pages (%s). "
+                "%d page(s) need manual deletion by an administrator: %s"
+                % (PAGE_PREFIX, e, len(remaining), ", ".join(remaining)),
+                file=sys.stderr,
+            )
+            return errors
         except Exception as e:
             print(
                 "ERROR deleting %s: %s" % (title, e), file=sys.stderr
             )
             errors += 1
-    if not orphans:
-        print("No orphaned %s pages to prune" % PAGE_PREFIX)
     return errors
 
 

--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -835,6 +835,25 @@ def main():
     print("Done: %d pages published" % len(pages))
 
 
+def _normalize_title(title):
+    """Canonicalize a title the way MediaWiki does, so generated titles
+    compare equal to the titles the API returns. MediaWiki treats
+    underscores as spaces and (with the default $wgCapitalLinks) upper-
+    cases the first letter of the page name. The generator emits
+    'CLI:canasta ...' (lowercase) but the stored page is 'CLI:Canasta
+    ...'; without this normalization every page looks like an orphan."""
+    title = title.replace("_", " ").strip()
+    prefix, sep, name = title.partition(":")
+    if not sep:
+        prefix, name = "", title
+    else:
+        prefix = prefix + ":"
+    name = name.strip()
+    if name:
+        name = name[0].upper() + name[1:]
+    return prefix + name
+
+
 def prune_orphans(client, pages):
     """Delete CLI: pages on the wiki that the current run no longer
     generates. Returns the number of deletion errors."""
@@ -848,13 +867,28 @@ def prune_orphans(client, pages):
         )
         return 0
 
-    generated = {title for title, _ in pages}
+    generated = {_normalize_title(title) for title, _ in pages}
     existing = client.list_pages_in_namespace(ns_id)
-    orphans = [t for t in existing if t not in generated]
+    orphans = [t for t in existing if _normalize_title(t) not in generated]
 
     if not orphans:
         print("No orphaned %s pages to prune" % PAGE_PREFIX)
         return 0
+
+    # Safety valve: real orphans (renamed/removed commands) are few. An
+    # implausibly large orphan set means the comparison is broken (e.g. a
+    # title-normalization regression), so refuse to delete rather than
+    # risk wiping the namespace. This is a hard failure to draw attention.
+    safety_limit = max(10, len(existing) // 4)
+    if len(orphans) > safety_limit:
+        print(
+            "ERROR: prune would delete %d of %d %s pages (safety limit "
+            "%d) — refusing. This indicates a title-matching bug, not "
+            "real orphans; no pages were deleted."
+            % (len(orphans), len(existing), PAGE_PREFIX, safety_limit),
+            file=sys.stderr,
+        )
+        return 1
 
     errors = 0
     for i, title in enumerate(orphans):

--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -39,6 +39,7 @@ DEFINITIONS_PATH = os.path.join(REPO_ROOT, "meta", "command_definitions.yml")
 
 PAGE_PREFIX = "CLI:"
 EDIT_DELAY = 2  # seconds between edits
+HTTP_TIMEOUT = 30  # seconds; a hung wiki API must not stall the publish
 
 
 def load_definitions():
@@ -656,14 +657,14 @@ class MediaWikiClient:
     def _post(self, params):
         data = urllib.parse.urlencode(params).encode()
         req = urllib.request.Request(self.api_url, data=data)
-        with self.opener.open(req) as resp:
+        with self.opener.open(req, timeout=HTTP_TIMEOUT) as resp:
             return json.loads(resp.read())
 
     def _get_token(self, token_type):
         url = "%s?action=query&meta=tokens&type=%s&format=json" % (
             self.api_url, token_type,
         )
-        with self.opener.open(url) as resp:
+        with self.opener.open(url, timeout=HTTP_TIMEOUT) as resp:
             data = json.loads(resp.read())
         return data["query"]["tokens"][token_type + "token"]
 
@@ -709,7 +710,7 @@ class MediaWikiClient:
             "%s?action=query&meta=siteinfo&siprop=namespaces&format=json"
             % self.api_url
         )
-        with self.opener.open(url) as resp:
+        with self.opener.open(url, timeout=HTTP_TIMEOUT) as resp:
             data = json.loads(resp.read())
         for ns in data["query"]["namespaces"].values():
             if name in (ns.get("*"), ns.get("canonical")):
@@ -727,7 +728,7 @@ class MediaWikiClient:
             )
             if apcontinue:
                 url += "&apcontinue=" + urllib.parse.quote(apcontinue)
-            with self.opener.open(url) as resp:
+            with self.opener.open(url, timeout=HTTP_TIMEOUT) as resp:
                 data = json.loads(resp.read())
             titles.extend(
                 p["title"] for p in data["query"]["allpages"]

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -549,21 +549,54 @@ class TestPruneOrphans:
     class, #723)."""
 
     def test_deletes_only_orphans(self):
+        # Generated titles are lowercase 'canasta'; the wiki stores them
+        # capitalized ('Canasta'). Only the genuinely renamed page is an
+        # orphan — capitalization alone must not flag a page.
         generated = [
             (wp.PAGE_PREFIX + "canasta crowdsec bouncer-enroll", "x"),
             (wp.PAGE_PREFIX + "canasta create", "x"),
         ]
         existing = [
-            wp.PAGE_PREFIX + "canasta crowdsec bouncer-enroll",
-            wp.PAGE_PREFIX + "canasta create",
-            wp.PAGE_PREFIX + "canasta crowdsec enroll",  # renamed -> orphan
+            wp.PAGE_PREFIX + "Canasta crowdsec bouncer-enroll",
+            wp.PAGE_PREFIX + "Canasta create",
+            wp.PAGE_PREFIX + "Canasta crowdsec enroll",  # renamed -> orphan
         ]
         client = _StubClient(100, existing)
         errors = wp.prune_orphans(client, generated)
         assert errors == 0
         assert client.deleted == [
-            wp.PAGE_PREFIX + "canasta crowdsec enroll"
+            wp.PAGE_PREFIX + "Canasta crowdsec enroll"
         ]
+
+    def test_capitalization_difference_is_not_an_orphan(self):
+        """Regression: the generator emits 'CLI:canasta ...' but the wiki
+        stores 'CLI:Canasta ...'. A raw string compare flags every page
+        as an orphan and (with delete rights) would wipe the namespace."""
+        generated = [
+            (wp.PAGE_PREFIX + "canasta", "x"),
+            (wp.PAGE_PREFIX + "canasta create", "x"),
+            (wp.PAGE_PREFIX + "canasta backup schedule set", "x"),
+        ]
+        existing = [
+            wp.PAGE_PREFIX + "Canasta",
+            wp.PAGE_PREFIX + "Canasta create",
+            wp.PAGE_PREFIX + "Canasta backup schedule set",
+        ]
+        client = _StubClient(100, existing)
+        errors = wp.prune_orphans(client, generated)
+        assert errors == 0
+        assert client.deleted == []
+
+    def test_safety_valve_refuses_mass_deletion(self):
+        """If the orphan set is implausibly large (a comparison bug),
+        prune must refuse to delete anything and fail loudly."""
+        generated = [(wp.PAGE_PREFIX + "canasta create", "x")]
+        existing = [wp.PAGE_PREFIX + "Canasta page %d" % i
+                    for i in range(40)]
+        client = _StubClient(100, existing)
+        errors = wp.prune_orphans(client, generated)
+        assert errors == 1
+        assert client.delete_attempts == []  # nothing deleted
 
     def test_no_orphans_deletes_nothing(self):
         generated = [(wp.PAGE_PREFIX + "canasta create", "x")]

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -522,10 +522,12 @@ class _StubClient:
     """Minimal stand-in for MediaWikiClient: no network, records the
     delete calls so tests can assert which orphans were pruned."""
 
-    def __init__(self, ns_id, existing):
+    def __init__(self, ns_id, existing, delete_exc=None):
         self._ns_id = ns_id
         self._existing = list(existing)
+        self._delete_exc = delete_exc
         self.deleted = []
+        self.delete_attempts = []
 
     def resolve_namespace_id(self, name):
         return self._ns_id
@@ -535,6 +537,9 @@ class _StubClient:
         return self._existing
 
     def delete_page(self, title, reason):
+        self.delete_attempts.append(title)
+        if self._delete_exc is not None:
+            raise self._delete_exc
         self.deleted.append(title)
 
 
@@ -574,3 +579,37 @@ class TestPruneOrphans:
         errors = wp.prune_orphans(client, generated)
         assert errors == 0
         assert client.deleted == []
+
+    def test_permission_denied_warns_not_fails(self):
+        """If the bot lacks delete rights, prune must not fail the
+        publish job — warn and leave the orphans for an admin."""
+        generated = [(wp.PAGE_PREFIX + "canasta create", "x")]
+        existing = [
+            wp.PAGE_PREFIX + "canasta create",
+            wp.PAGE_PREFIX + "canasta crowdsec enroll",
+            wp.PAGE_PREFIX + "canasta old two",
+        ]
+        client = _StubClient(
+            100, existing,
+            delete_exc=wp.PermissionDeniedError(
+                "API error: permissiondenied: not an admin"
+            ),
+        )
+        errors = wp.prune_orphans(client, generated)
+        assert errors == 0
+        # Stops after the first denial (all would fail identically).
+        assert len(client.delete_attempts) == 1
+        assert client.deleted == []
+
+    def test_non_permission_error_still_counts(self):
+        """A non-permission deletion failure is still a real error."""
+        generated = [(wp.PAGE_PREFIX + "canasta create", "x")]
+        existing = [
+            wp.PAGE_PREFIX + "canasta create",
+            wp.PAGE_PREFIX + "canasta crowdsec enroll",
+        ]
+        client = _StubClient(
+            100, existing, delete_exc=RuntimeError("API error: badtoken"),
+        )
+        errors = wp.prune_orphans(client, generated)
+        assert errors == 1


### PR DESCRIPTION
## Critical bug in the merged `--prune` pass

The `--prune` pass added in #735 treats **every** `CLI:` page as an orphan. The generator emits titles as `CLI:canasta …` (lowercase `canasta`), but MediaWiki force-capitalizes the first letter of the page name, so the stored/listed pages are `CLI:Canasta …`. `prune_orphans` compared raw strings, so no generated title matched any existing page and all 93 pages were flagged for deletion.

The scheduled wiki-publish run failed with `permissiondenied` on every page ([run log](https://github.com/CanastaWiki/Canasta-CLI/actions)) — the bot lacks the Administrators `delete` right, which is the only thing that prevented the entire CLI reference from being wiped.

## Fixes

- **Normalize titles before comparing** (underscores→spaces, first letter uppercased) on both the generated set and the listed pages. Verified against the real definitions: only the one genuine orphan (`CLI:Canasta crowdsec enroll`) is detected out of 93 pages.
- **Safety valve**: if the orphan set is implausibly large (> max(10, 25% of the namespace)), refuse to delete anything and fail loudly — a comparison-bug guard so this can never mass-delete again.
- **Graceful degradation**: a `permissiondenied` on delete now warns once with the full list of orphans needing manual admin deletion, instead of failing the publish job. Other deletion errors still count as failures.
- **HTTP timeout** on all API calls so a hung wiki can't stall the publish.

## Tests

New regression tests: capitalization-difference is not an orphan, safety valve refuses mass deletion, permission-denied warns (not fails), non-permission errors still count. `make test-unit` green.

Refs #723
