### PR TITLE
correctness: idempotent update_port, scoped domain rewrite, misc hardening

### DIFF
--- a/direct_commands/info.py
+++ b/direct_commands/info.py
@@ -20,7 +20,7 @@ def _gather_all_instances(instances):
     ordered_ids = list(instances.keys())
     results = {}
 
-    with ThreadPoolExecutor(max_workers=len(instances)) as pool:
+    with ThreadPoolExecutor(max_workers=min(len(instances), 16)) as pool:
         futures = {
             pool.submit(_helpers._gather_instance_info, iid, inst): iid
             for iid, inst in instances.items()
@@ -84,7 +84,7 @@ def cmd_list(args):
         # Probe all instances in parallel — remote classify can SSH.
         classifications = {}
         if instances:
-            with ThreadPoolExecutor(max_workers=len(instances)) as pool:
+            with ThreadPoolExecutor(max_workers=min(len(instances), 16)) as pool:
                 futures = {
                     pool.submit(_classify_for_cleanup, iid, inst): iid
                     for iid, inst in instances.items()

--- a/roles/common/library/canasta_registry.py
+++ b/roles/common/library/canasta_registry.py
@@ -244,7 +244,7 @@ def run_module():
         if inst_id not in instances:
             module.fail_json(msg="Instance '%s' not found in registry" % inst_id)
             return
-        result["instance"] = instances[inst_id]
+        result["instance"] = dict(instances[inst_id])
         result["instance"]["id"] = inst_id
 
     elif state == "query_all":
@@ -271,7 +271,7 @@ def run_module():
         if not found_id:
             module.fail_json(msg="No instance found for path '%s'" % inst_path)
             return
-        result["instance"] = found_inst
+        result["instance"] = dict(found_inst)
         result["instance"]["id"] = found_id
 
     elif state == "present":

--- a/roles/common/library/canasta_wikis_yaml.py
+++ b/roles/common/library/canasta_wikis_yaml.py
@@ -63,7 +63,7 @@ def wikis_yaml_path(instance_path):
     path = os.path.join(instance_path, "config", "wikis.yaml")
     real_path = os.path.realpath(path)
     real_base = os.path.realpath(instance_path)
-    if not real_path.startswith(real_base + os.sep) and real_path != real_base:
+    if not real_path.startswith(real_base + os.sep):
         raise ValueError(
             "wikis.yaml path '%s' escapes instance directory '%s'"
             % (real_path, real_base)
@@ -298,13 +298,18 @@ def run_module():
             return
         wikis = read_wikis(instance_path)
         updated = []
+        changed = False
         for w in wikis:
             w = dict(w)
-            w["url"] = update_url_port(w.get("url", ""), port, default_port)
+            old_url = w.get("url", "")
+            new_url = update_url_port(old_url, port, default_port)
+            if new_url != old_url:
+                w["url"] = new_url
+                changed = True
             updated.append(w)
-        if not module.check_mode:
+        if changed and not module.check_mode:
             write_wikis(instance_path, updated)
-        result["changed"] = True
+        result["changed"] = changed
         result["wikis"] = updated
 
     elif state == "update_domain":

--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -457,11 +457,12 @@
         key: MW_SITE_FQDN
         value: "{{ _new_fqdn }}"
 
-    - name: Update wikis.yaml URLs with new domain
-      ansible.builtin.replace:
-        path: "{{ instance_path }}/config/wikis.yaml"
-        regexp: "{{ _se_old_fqdn.value | regex_escape() }}"
-        replace: "{{ _new_fqdn }}"
+    - name: Update wikis.yaml URLs (only for wikis on the old FQDN)
+      canasta_wikis_yaml:
+        instance_path: "{{ instance_path }}"
+        state: update_domain
+        old_domain: "{{ _se_old_fqdn.value }}"
+        domain: "{{ _new_fqdn }}"
       when: _se_old_fqdn.found and _se_old_fqdn.value != _new_fqdn
 
     # Localhost → real-domain TLS cascade (K8s only).

--- a/tests/unit/test_canasta_wikis_yaml.py
+++ b/tests/unit/test_canasta_wikis_yaml.py
@@ -328,6 +328,23 @@ class TestRunModuleUpdatePort:
         assert not failed
         assert result["wikis"][0]["url"] == "localhost"
 
+    def test_update_port_idempotent_when_unchanged(self, tmp_dir):
+        """Re-applying the same port must report changed=False so
+        Ansible idempotency / check-mode stay accurate."""
+        os.makedirs(os.path.join(tmp_dir, "config"), exist_ok=True)
+        canasta_wikis_yaml.write_wikis(tmp_dir, [
+            {"id": "main", "url": "localhost:8443", "name": "Main"},
+        ])
+        result, failed, _ = run_module_with_params(canasta_wikis_yaml, {
+            "instance_path": tmp_dir, "state": "update_port",
+            "wiki_id": None, "domain": None,
+            "wiki_path": None, "site_name": None,
+            "port": "8443",
+        })
+        assert not failed
+        assert result["changed"] is False
+        assert result["wikis"][0]["url"] == "localhost:8443"
+
     def test_update_port_requires_port(self, sample_wikis_yaml):
         result, failed, msg = run_module_with_params(canasta_wikis_yaml, {
             "instance_path": sample_wikis_yaml, "state": "update_port",


### PR DESCRIPTION
## Summary

Correctness fixes from the comprehensive review (#730).

- **Config domain cascade**: replace the unanchored global text `replace` over `wikis.yaml` (the `MW_SITE_SERVER` path) with the structured `canasta_wikis_yaml` `update_domain`, which rewrites only URL fields on the old host. The raw replace could clobber the old FQDN anywhere it appeared (other wikis' URLs, paths, comments). The sibling `MW_SITE_FQDN` cascade already did this.
- **`canasta_wikis_yaml` `update_port`**: only report `changed` (and rewrite the file) when a URL actually changes, matching `update_domain` — restores idempotency and check-mode accuracy.
- **`canasta_registry` query / query_by_path**: copy the instance dict before injecting `id`, so a query never mutates the in-memory registry.
- **`info` cleanup/status**: cap the per-instance thread pool at 16 workers instead of one-thread-per-instance.
- **`canasta_wikis_yaml` path guard**: align with `canasta_settings_yaml` (drop the unnecessary `real_path == real_base` allowance; the file is always a subpath).

## Tests

Adds an `update_port` idempotency regression test. `make test-unit` green, `make lint` clean.

Fixes #730
