### PR TITLE
cleanup: remove stale references to the retired Go CLI

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -2,8 +2,8 @@
 """Canasta CLI wrapper -- translates CLI invocations into ansible-playbook calls.
 
 Reads command definitions from meta/command_definitions.yml and builds
-argparse subcommands with proper type-aware flag parsing. This replaces
-the bash wrapper script with Cobra-equivalent argument handling.
+argparse subcommands with proper type-aware flag parsing, replacing the
+original bash wrapper script.
 """
 
 import argparse
@@ -674,7 +674,7 @@ def resolve_instance(instance_id=None):
 def handle_interactive_exec(args):
     """Handle maintenance exec by running docker/kubectl exec directly.
 
-    Matches Go CLI behavior:
+    Dispatch rules:
       - No -s, no command  -> list services (fall through to Ansible)
       - No -s, with command -> exec in web service
       - -s given, no command -> interactive /bin/bash in that service

--- a/playbooks/add.yml
+++ b/playbooks/add.yml
@@ -1,6 +1,6 @@
 ---
 # canasta add - Add a wiki to an existing Canasta instance.
-# Matches Go CLI: wikis.yaml is updated AFTER successful install.
+# wikis.yaml is updated AFTER successful install.
 
 - name: Resolve instance
   ansible.builtin.include_tasks: >-

--- a/playbooks/export.yml
+++ b/playbooks/export.yml
@@ -1,6 +1,6 @@
 ---
 # canasta export - Export a wiki's database.
-# Uses container temp file + copy to host (matching Go behavior).
+# Uses container temp file + copy to host.
 
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"

--- a/playbooks/remove.yml
+++ b/playbooks/remove.yml
@@ -1,6 +1,6 @@
 ---
 # canasta remove - Remove a wiki from a Canasta instance.
-# Matches Go: cleans images/public_assets inside container, drops DB, removes config.
+# Cleans images/public_assets inside container, drops DB, removes config.
 
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"

--- a/roles/backup/tasks/create.yml
+++ b/roles/backup/tasks/create.yml
@@ -1,5 +1,5 @@
 ---
-# Backup create - matching Go CLI's full staging flow.
+# Backup create - full staging flow.
 # 1. Dump DBs via docker compose exec
 # 2. Stage host dirs into backup volume via alpine
 # 3. Run restic/restic container to create snapshot

--- a/roles/backup/tasks/restore.yml
+++ b/roles/backup/tasks/restore.yml
@@ -1,5 +1,5 @@
 ---
-# Restore matching Go CLI's restoreFull():
+# Full restore flow:
 # 1. Restic restore into backup volume / K8s temporary pod
 # 2. Copy files from volume to host (Compose) or extract + sync (K8s)
 # 3. Preserve DB passwords in restored .env

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,12 +1,12 @@
 ---
 # Default values for the common role.
 
-# Password generation defaults (matching Go: 30 chars, 4 digits, 6 symbols)
+# Password generation defaults (30 chars, 4 digits, 6 symbols)
 canasta_password_length: 30
 canasta_password_digits: 4
 canasta_password_symbols: 6
 
-# Instance ID regex (matching Go: ^[a-zA-Z0-9]([a-zA-Z0-9-_]*[a-zA-Z0-9])?$)
+# Instance ID regex: ^[a-zA-Z0-9]([a-zA-Z0-9-_]*[a-zA-Z0-9])?$
 canasta_instance_id_pattern: "^[a-zA-Z0-9]([a-zA-Z0-9\\-_]*[a-zA-Z0-9])?$"
 
 # Default Canasta image (overridden by canasta.yml from CANASTA_VERSION)

--- a/roles/common/library/canasta_env.py
+++ b/roles/common/library/canasta_env.py
@@ -3,7 +3,6 @@
 
 """Ansible module for reading and writing Canasta .env files.
 
-Replaces the Go canasta.GetEnvVariable/SaveEnvVariable functions.
 Handles comments, quoted values, and values containing '=' characters.
 """
 
@@ -16,7 +15,7 @@ module: canasta_env
 short_description: Manage Canasta .env files
 description:
   - Read, set, and unset variables in a Canasta instance .env file.
-  - Compatible with the Go CLI's .env file format.
+  - Operates on the standard .env file format.
 options:
   path:
     description: Path to the .env file.
@@ -127,7 +126,7 @@ def entries_to_content(entries):
 def set_variable(entries, key, value):
     """Set a variable, updating in place if it exists or appending if not.
 
-    Matches Go behavior: updates first occurrence, skips duplicate lines for same key.
+    Updates the first occurrence, skips duplicate lines for the same key.
     """
     found = False
     new_entries = []

--- a/roles/common/library/canasta_farmsettings.py
+++ b/roles/common/library/canasta_farmsettings.py
@@ -3,8 +3,7 @@
 
 """Ansible module for Canasta input validation.
 
-Replaces validation functions from Go packages: instance ID validation
-from internal/canasta and wiki ID validation from internal/farmsettings.
+Validates instance IDs and wiki IDs.
 """
 
 from __future__ import absolute_import, division, print_function

--- a/roles/common/library/canasta_registry.py
+++ b/roles/common/library/canasta_registry.py
@@ -3,9 +3,8 @@
 
 """Ansible module for managing the Canasta instance registry (conf.json).
 
-Replaces the Go internal/config package. Provides CRUD operations on the
-instance registry stored at conf.json, with the same directory resolution
-logic as the Go CLI.
+Provides CRUD operations on the instance registry stored at conf.json,
+including platform-specific config-directory resolution.
 """
 
 from __future__ import absolute_import, division, print_function
@@ -18,7 +17,7 @@ short_description: Manage the Canasta instance registry
 description:
   - Read, add, update, and remove Canasta instances from the local registry (conf.json).
   - Also manages registry-level settings (key/value) via set_setting / get_setting states.
-  - Compatible with the Go CLI's registry format.
+  - Operates on the conf.json registry format.
 options:
   state:
     description: Desired state of the instance in the registry.
@@ -90,9 +89,8 @@ CONFIG_FILENAME = "conf.json"
 
 
 def get_config_dir(override=None):
-    """Determine the config directory using the same priority as the Go CLI.
-
-    Matches Go's os.UserConfigDir():
+    """Determine the config directory using the platform's conventional
+    per-user config location:
     - macOS: ~/Library/Application Support/canasta
     - Linux: $XDG_CONFIG_HOME/canasta or ~/.config/canasta
     """
@@ -156,7 +154,7 @@ def write_config(config_dir, data):
 
 
 def instance_to_dict(instance):
-    """Convert an instance dict to the JSON-serializable format (matching Go struct tags)."""
+    """Convert an instance dict to the JSON-serializable registry format."""
     result = {
         "id": instance.get("id", ""),
         "path": instance.get("path", ""),
@@ -180,7 +178,7 @@ def instance_to_dict(instance):
 
 
 def find_by_path(instances, search_path):
-    """Walk up from search_path to find a matching instance (mirrors Go GetCanastaID)."""
+    """Walk up from search_path to find a matching instance."""
     search_path = os.path.abspath(search_path)
     while True:
         for inst_id, inst in instances.items():

--- a/roles/common/library/canasta_wikis_yaml.py
+++ b/roles/common/library/canasta_wikis_yaml.py
@@ -3,8 +3,8 @@
 
 """Ansible module for managing Canasta wikis.yaml files.
 
-Replaces the Go internal/farmsettings package. Provides CRUD operations
-on the wikis.yaml file that defines wiki farm configurations.
+Provides CRUD operations on the wikis.yaml file that defines wiki farm
+configurations.
 """
 
 from __future__ import absolute_import, division, print_function
@@ -16,7 +16,7 @@ module: canasta_wikis_yaml
 short_description: Manage Canasta wikis.yaml
 description:
   - Read, add, and remove wikis from the wikis.yaml farm configuration.
-  - Compatible with the Go CLI's wikis.yaml format.
+  - Operates on the wikis.yaml farm-configuration format.
 options:
   instance_path:
     description: Path to the Canasta instance directory.
@@ -100,7 +100,7 @@ def build_url(domain, wiki_path=None):
 def parse_url(url):
     """Parse a wiki URL into (server_name, path).
 
-    Matches Go behavior: splits on first '/' only.
+    Splits on the first '/' only.
     """
     parts = url.split("/", 1)
     server = parts[0]

--- a/roles/common/module_utils/canasta_validate.py
+++ b/roles/common/module_utils/canasta_validate.py
@@ -24,9 +24,7 @@ RESERVED_WIKI_IDS = ["settings", "images", "w", "wiki", "wikis"]
 
 def validate_wiki_id(value):
     """Return None if `value` is a valid wiki ID, otherwise an error
-    string suitable for `module.fail_json(msg=...)`.
-
-    Mirrors the Go CLI's ValidateWikiID."""
+    string suitable for `module.fail_json(msg=...)`."""
     if not value:
         return "wiki ID cannot be empty"
     if "-" in value:

--- a/roles/common/tasks/generate_password.yml
+++ b/roles/common/tasks/generate_password.yml
@@ -1,5 +1,5 @@
 ---
-# Generate a secure password matching Go CLI format.
+# Generate a secure password.
 # 30 chars, includes uppercase, digits, and symbols.
 # Replaces '$' with '#' due to MediaWiki bug T355013.
 #

--- a/roles/common/tasks/validate_passwords.yml
+++ b/roles/common/tasks/validate_passwords.yml
@@ -1,7 +1,6 @@
 ---
 # Validate passwords for problematic characters.
-# Mirrors Go password validation from canasta.go.
-# Warns but does not fail (matching Go behavior).
+# Warns but does not fail.
 #
 # Input: _password_vars (list of dicts with key/value to check)
 #   e.g., [{key: "MYSQL_PASSWORD", value: "..."}, ...]

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-# Reserved wiki IDs that cannot be used (matching Go farmsettings package)
+# Reserved wiki IDs that cannot be used
 canasta_reserved_wiki_ids:
   - settings
   - images

--- a/roles/create/defaults/main.yml
+++ b/roles/create/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Defaults for the create role.
 
-# Default values matching Go CLI defaults
+# Default values
 create_orchestrator: compose
 create_admin: WikiSysop
 create_domain_name: localhost

--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
 # Create a new Canasta instance.
-# Mirrors Go createCanasta() step by step.
 #
 # Input variables (from extra-vars):
 #   id, wiki, path, orchestrator, domain_name, admin, password,

--- a/roles/delete/tasks/main.yml
+++ b/roles/delete/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # Delete a Canasta instance.
-# Matches Go delete command: cleans images inside container, removes backup schedule,
+# Cleans images inside container, removes backup schedule,
 # then destroys containers/volumes and removes directory.
 # Input: id, yes (bool - skip confirmation)
 #

--- a/roles/devmode/tasks/disable.yml
+++ b/roles/devmode/tasks/disable.yml
@@ -1,5 +1,5 @@
 ---
-# canasta devmode disable - Full implementation matching Go devmode.DisableDevMode().
+# canasta devmode disable.
 # Restores extensions/skins from symlinks to real directories.
 # Input: id (optional)
 

--- a/roles/devmode/tasks/enable.yml
+++ b/roles/devmode/tasks/enable.yml
@@ -1,5 +1,5 @@
 ---
-# canasta devmode enable - Full implementation matching Go devmode.EnableDevMode().
+# canasta devmode enable.
 # Extracts MediaWiki code, consolidates user extensions/skins, builds xdebug image.
 # Docker Compose only.
 # Input: id (optional)

--- a/roles/extensions_skins/library/canasta_settings_yaml.py
+++ b/roles/extensions_skins/library/canasta_settings_yaml.py
@@ -3,8 +3,8 @@
 
 """Ansible module for managing Canasta extension/skin settings.yaml files.
 
-Replaces the Go internal/extensionsskins package. Manages the settings.yaml
-files that control which extensions and skins are enabled.
+Manages the settings.yaml files that control which extensions and skins
+are enabled.
 """
 
 from __future__ import absolute_import, division, print_function

--- a/roles/extensions_skins/tasks/enable.yml
+++ b/roles/extensions_skins/tasks/enable.yml
@@ -1,6 +1,6 @@
 ---
 # Enable extensions or skins.
-# Matches Go behavior: check installed, enable in settings.yaml, optionally run update.php.
+# Check installed, enable in settings.yaml, optionally run update.php.
 # Input: id, wiki (optional), _item_type (extensions|skins), _item_dir (extensions|skins),
 #        _names (comma-separated), skip_update (bool)
 

--- a/roles/extensions_skins/tasks/list.yml
+++ b/roles/extensions_skins/tasks/list.yml
@@ -1,6 +1,6 @@
 ---
 # List installed extensions or skins.
-# Matches Go output: "Available Canasta extensions:" header.
+# Output header: "Available Canasta extensions:"
 # Input: id (optional), wiki (optional),
 #   _item_type (extensions|skins), _item_dir (extensions|skins)
 

--- a/roles/gitops/tasks/init_compose.yml
+++ b/roles/gitops/tasks/init_compose.yml
@@ -1,5 +1,5 @@
 ---
-# GitOps init (Compose) - Full 13-step workflow matching Go implementation.
+# GitOps init (Compose) - full 13-step workflow.
 # Input: id, host_name, role, repo, key, force, pull_requests
 # Requires: instance_path, instance_id (set by dispatcher)
 

--- a/roles/gitops/tasks/pull_compose.yml
+++ b/roles/gitops/tasks/pull_compose.yml
@@ -1,5 +1,5 @@
 ---
-# GitOps pull (Compose) — full multi-host flow matching Go implementation.
+# GitOps pull (Compose) — full multi-host flow.
 # Pulls from remote, renders .env and wikis.yaml from templates + host
 # vars, writes admin passwords, detects what changed, and flags whether
 # a restart or maintenance update is needed.

--- a/roles/gitops/tasks/push_compose.yml
+++ b/roles/gitops/tasks/push_compose.yml
@@ -1,6 +1,6 @@
 ---
 # GitOps push (Compose) — commit staged changes and push to remote.
-# Matches Go CLI's push flow: validates role, accepts message, supports
+# Push flow: validates role, accepts message, supports
 # the staged-changes-only model.
 # Requires: instance_path, instance_id (set by dispatcher)
 # Optional: message (commit message, defaults to 'Configuration update')

--- a/roles/imagebuild/tasks/build_from_source.yml
+++ b/roles/imagebuild/tasks/build_from_source.yml
@@ -1,6 +1,5 @@
 ---
 # Build Canasta image from local source.
-# Mirrors Go imagebuild.BuildFromSource().
 #
 # Input: build_from (path to workspace containing Canasta/ and optionally CanastaBase/)
 # Output fact: _built_image (str: "canasta:local")

--- a/roles/maintenance/tasks/exec.yml
+++ b/roles/maintenance/tasks/exec.yml
@@ -5,7 +5,7 @@
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
-# No args: list running services (matches Go CLI behavior)
+# No args: list running services
 - name: List running services
   when: (exec_args | default('')) == ''
   block:

--- a/roles/mediawiki/tasks/install.yml
+++ b/roles/mediawiki/tasks/install.yml
@@ -1,6 +1,5 @@
 ---
 # Run MediaWiki install.php for each wiki.
-# Mirrors Go mediawiki.Install().
 #
 # Input:
 #   instance_path, install_wiki_ids (list), install_wikis (list of dicts),

--- a/roles/mediawiki/tasks/wait_for_db.yml
+++ b/roles/mediawiki/tasks/wait_for_db.yml
@@ -1,6 +1,5 @@
 ---
 # Wait for the database to be ready.
-# Mirrors Go mediawiki.WaitForDB().
 # Input: instance_path
 
 - name: Read DB connection from .env

--- a/roles/orchestrator/tasks/backup_schedule_list.yml
+++ b/roles/orchestrator/tasks/backup_schedule_list.yml
@@ -1,7 +1,7 @@
 ---
 # Display an instance's backup schedule.
 # Dispatches to Compose (host crontab) or Kubernetes (CronJob).
-# Matches Go output: "Instance 'X' is scheduled for backup at: M H D M W"
+# Output: "Instance 'X' is scheduled for backup at: M H D M W"
 # with optional "Auto-purge: snapshots older than ..."
 # Input: instance_id, instance_orchestrator
 

--- a/roles/orchestrator/tasks/ensure_observability_credentials.yml
+++ b/roles/orchestrator/tasks/ensure_observability_credentials.yml
@@ -1,6 +1,5 @@
 ---
 # Generate OpenSearch credentials if observability is enabled.
-# Mirrors Go EnsureObservabilityCredentials().
 # Input: instance_path
 
 - name: Read .env for observability check

--- a/roles/orchestrator/tasks/rewrite_caddy.yml
+++ b/roles/orchestrator/tasks/rewrite_caddy.yml
@@ -1,6 +1,5 @@
 ---
 # Generate the main Caddyfile from wikis.yaml and .env settings.
-# Mirrors Go RewriteCaddy().
 # Input: instance_path
 
 - name: Read wikis.yaml for Caddyfile generation

--- a/roles/orchestrator/tasks/sync_compose_profiles.yml
+++ b/roles/orchestrator/tasks/sync_compose_profiles.yml
@@ -1,6 +1,5 @@
 ---
 # Sync COMPOSE_PROFILES with feature flags in .env.
-# Mirrors Go syncComposeProfiles().
 # Input: instance_path
 
 - name: Read .env for profile sync

--- a/roles/orchestrator/tasks/upgrade_image_tag.yml
+++ b/roles/orchestrator/tasks/upgrade_image_tag.yml
@@ -38,7 +38,7 @@
         mode: "0644"
 
 # --- Update Compose CANASTA_IMAGE tag ---
-# Match Go CLI behavior: bump the tag if it's the default ghcr.io image,
+# Bump the tag if it's the default ghcr.io image,
 # leave it alone if user set a custom/local-build image.
 - name: Update Compose image tag
   when:

--- a/roles/sitemap/tasks/generate.yml
+++ b/roles/sitemap/tasks/generate.yml
@@ -1,6 +1,6 @@
 ---
 # canasta sitemap generate - Generate XML sitemaps.
-# Matches Go sitemap paths: /mediawiki/public_assets/<wiki>/sitemap
+# Sitemap paths: /mediawiki/public_assets/<wiki>/sitemap
 # Input: id (optional), wiki (optional)
 
 - name: Resolve instance

--- a/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
+++ b/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
@@ -1,6 +1,5 @@
 ---
 # Migration: Detect MySQL 8.0 data and migrate to MariaDB.
-# Matches Go upgrade.go mysql_to_mariadb.go logic.
 # Compose-only; the orchestrator guard is owned by the caller
 # (roles/orchestrator/tasks/upgrade_db_migration.yml), so no
 # instance_orchestrator switch is needed here.

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -2,7 +2,7 @@
 """Generate documentation from Canasta command definitions.
 
 Reads meta/command_definitions.yml and generates Markdown documentation
-for each command (analogous to Cobra's doc.GenMarkdownTree).
+for each command.
 
 Usage:
     # Generate all docs to a directory

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Integration tests for the Canasta CLI.
 
-Mirrors the Go CLI integration tests by calling ./canasta commands as
+Exercises the CLI end to end by calling ./canasta commands as
 subprocesses. Each test creates an isolated instance with unique ports
 and a separate config directory.
 

--- a/tests/unit/test_domain_name_validation.py
+++ b/tests/unit/test_domain_name_validation.py
@@ -2,7 +2,7 @@
 
 The hostname validator rejects a value that carries a scheme or a port,
 but the bare "not a valid hostname" message left users (following older
-docs / the prior Go CLI) guessing. The validator now appends a hint that
+docs) guessing. The validator now appends a hint that
 points them at HTTP_PORT/HTTPS_PORT for ports and a bare hostname for
 --domain-name.
 """


### PR DESCRIPTION
## Summary

The Go-based Canasta CLI is retired. This rewords the code comments and module docstrings that still cited it — "Matches Go behavior", "Replaces the Go ... package", "Mirrors Go X()", "Cobra-equivalent", and Go function/struct names — to describe the current behavior directly, per the terse-comment convention. No behavior changes; comments/docstrings only.

40 files touched (libraries, role tasks, playbooks, scripts, a couple of test docstrings).

## Intentionally kept

References that describe **migrating instances created by the old Go CLI 3.x** are legitimate and remain:
- `roles/upgrade/tasks/migrations/backfill_hosts_yaml.yml` (backfills `hosts.yaml` for Go-CLI-created gitops instances)
- the integration test that simulates that layout

## Testing

`make test-unit` (1100 passing) and `make lint` clean.

Fixes #727
