### PR TITLE
cleanup: remove dead vars/imports; add ruff F401 lint gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -409,5 +409,8 @@ jobs:
           .venv/bin/yamllint -c .yamllint.yml
           meta/ roles/ playbooks/ inventory/ canasta.yml
 
+      - name: Python unused-import check
+        run: .venv/bin/ruff check --select F401 .
+
       - name: Validate definitions
         run: .venv/bin/python scripts/validate_definitions.py

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PYTHON := $(VENV)/bin/python
 PIP := $(VENV)/bin/pip
 PYTEST := $(VENV)/bin/pytest
 YAMLLINT := $(VENV)/bin/yamllint
+RUFF := $(VENV)/bin/ruff
 
 # --- Setup -------------------------------------------------------------------
 
@@ -31,6 +32,7 @@ test: test-unit
 
 lint: venv
 	$(YAMLLINT) --strict meta/ roles/ playbooks/ inventory/ canasta.yml
+	$(RUFF) check --select F401 .
 	$(PYTHON) scripts/validate_definitions.py
 
 # --- Documentation -----------------------------------------------------------

--- a/canasta.py
+++ b/canasta.py
@@ -700,7 +700,6 @@ def handle_interactive_exec(args):
         command = ["/bin/bash"]
 
     if orchestrator in ("kubernetes", "k8s"):
-        import subprocess
         # Find the pod for this service
         ns = "canasta-%s" % inst["id"]
         result = subprocess.run(

--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -9,7 +9,6 @@ import os
 import re
 import subprocess
 import sys
-from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import yaml
 

--- a/direct_commands/argocd.py
+++ b/direct_commands/argocd.py
@@ -1,11 +1,8 @@
 """argocd password / apps / ui commands."""
 
-import os
-import re
 import subprocess
 import sys
 
-import yaml
 
 from . import _helpers
 from ._helpers import register

--- a/direct_commands/backup.py
+++ b/direct_commands/backup.py
@@ -1,11 +1,9 @@
 """backup list command."""
 
 import os
-import re
 import subprocess
 import sys
 
-import yaml
 
 from . import _helpers
 from ._helpers import register

--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -1,11 +1,9 @@
 """doctor command — dependency checks."""
 
 import os
-import re
 import subprocess
 import sys
 
-import yaml
 
 from . import _helpers
 from ._helpers import register

--- a/direct_commands/extension_skin.py
+++ b/direct_commands/extension_skin.py
@@ -1,11 +1,7 @@
 """extension list, skin list commands."""
 
-import os
-import re
-import subprocess
 import sys
 
-import yaml
 
 from . import _helpers
 from ._helpers import register

--- a/direct_commands/gitops.py
+++ b/direct_commands/gitops.py
@@ -1,7 +1,6 @@
 """gitops status, gitops diff commands."""
 
 import json
-import os
 import re
 import subprocess
 import sys

--- a/direct_commands/host.py
+++ b/direct_commands/host.py
@@ -1,11 +1,7 @@
 """host list / add / remove commands."""
 
-import os
-import re
-import subprocess
 import sys
 
-import yaml
 
 from . import _helpers
 from ._helpers import register

--- a/direct_commands/info.py
+++ b/direct_commands/info.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-import yaml
 
 from . import _helpers
 from ._helpers import register

--- a/direct_commands/lifecycle.py
+++ b/direct_commands/lifecycle.py
@@ -1,7 +1,6 @@
 """start, stop, restart, scale — lifecycle commands."""
 
 import os
-import re
 import subprocess
 import sys
 

--- a/direct_commands/maintenance.py
+++ b/direct_commands/maintenance.py
@@ -1,8 +1,6 @@
 """maintenance script / extension / update commands."""
 
 import os
-import re
-import subprocess
 import sys
 
 import yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest-mock>=3.0
 pyyaml>=6.0
 ansible-lint>=6.0
 yamllint>=1.0
+ruff>=0.6

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -1,3 +1,0 @@
----
-# Defaults for the backup role.
-canasta_backup_service: web

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,16 +1,5 @@
 ---
 # Default values for the common role.
 
-# Password generation defaults (30 chars, 4 digits, 6 symbols)
-canasta_password_length: 30
-canasta_password_digits: 4
-canasta_password_symbols: 6
-
-# Instance ID regex: ^[a-zA-Z0-9]([a-zA-Z0-9-_]*[a-zA-Z0-9])?$
-canasta_instance_id_pattern: "^[a-zA-Z0-9]([a-zA-Z0-9\\-_]*[a-zA-Z0-9])?$"
-
 # Default Canasta image (overridden by canasta.yml from CANASTA_VERSION)
 canasta_default_image: "ghcr.io/canastawiki/canasta:latest"
-
-# Verbose output (set via -e verbose=true or the wrapper --verbose flag)
-canasta_verbose: false

--- a/roles/common/library/canasta_farmsettings.py
+++ b/roles/common/library/canasta_farmsettings.py
@@ -31,7 +31,6 @@ import re
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.canasta_validate import (
-    RESERVED_WIKI_IDS,
     validate_wiki_id,
 )
 

--- a/roles/common/library/canasta_wikis_yaml.py
+++ b/roles/common/library/canasta_wikis_yaml.py
@@ -53,7 +53,6 @@ import yaml
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.canasta_validate import (
-    RESERVED_WIKI_IDS,
     validate_wiki_id,
 )
 

--- a/roles/create/defaults/main.yml
+++ b/roles/create/defaults/main.yml
@@ -1,9 +1,0 @@
----
-# Defaults for the create role.
-
-# Default values
-create_orchestrator: compose
-create_admin: WikiSysop
-create_domain_name: localhost
-create_wikidbuser: root
-create_registry: "localhost:5000"

--- a/roles/orchestrator/defaults/main.yml
+++ b/roles/orchestrator/defaults/main.yml
@@ -4,10 +4,6 @@
 # Default Canasta image (overridden by canasta.yml from CANASTA_VERSION)
 canasta_default_image: "ghcr.io/canastawiki/canasta:latest"
 
-# Docker Compose service names
-canasta_web_service: web
-canasta_db_service: db
-
 # Wait-for-it timeout (seconds)
 canasta_db_wait_timeout: 10
 

--- a/roles/orchestrator/files/scripts/check_node_resources.py
+++ b/roles/orchestrator/files/scripts/check_node_resources.py
@@ -17,7 +17,6 @@ stdout so Ansible can include it in its failure message.
 """
 
 import os
-import re
 import sys
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,7 @@
+# Focused lint gate: catch unused imports (F401) across the Python code.
+# Other rule families are intentionally left off for now to keep the gate
+# narrow and low-noise; expand deliberately if desired.
+extend-exclude = [".claude"]
+
+[lint]
+select = ["F401"]

--- a/tests/unit/mock_ansible.py
+++ b/tests/unit/mock_ansible.py
@@ -1,7 +1,6 @@
 """Mock AnsibleModule for testing run_module() functions."""
 
-import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 
 class MockAnsibleModule:

--- a/tests/unit/test_audit_command_coverage.py
+++ b/tests/unit/test_audit_command_coverage.py
@@ -4,7 +4,6 @@ import os
 import sys
 import tempfile
 
-import pytest
 
 
 SCRIPTS_DIR = os.path.abspath(

--- a/tests/unit/test_backup_schedule_k8s.py
+++ b/tests/unit/test_backup_schedule_k8s.py
@@ -11,7 +11,6 @@ issue #424).
 """
 
 import os
-import re
 
 import yaml
 

--- a/tests/unit/test_canasta_env.py
+++ b/tests/unit/test_canasta_env.py
@@ -1,6 +1,5 @@
 """Tests for the canasta_env Ansible module."""
 
-import os
 
 import canasta_env
 from mock_ansible import run_module_with_params

--- a/tests/unit/test_canasta_minimal_callback.py
+++ b/tests/unit/test_canasta_minimal_callback.py
@@ -4,7 +4,6 @@ import os
 import sys
 from types import SimpleNamespace
 
-import pytest
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 sys.path.insert(0, REPO_ROOT)

--- a/tests/unit/test_check_node_resources.py
+++ b/tests/unit/test_check_node_resources.py
@@ -12,7 +12,6 @@ import os
 import subprocess
 import sys
 
-import pytest
 
 SCRIPT = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),

--- a/tests/unit/test_gitops_init_security.py
+++ b/tests/unit/test_gitops_init_security.py
@@ -12,7 +12,6 @@ that the canonical file still contains the security-critical entries.
 """
 
 import os
-import re
 
 import yaml
 

--- a/tests/unit/test_rebuild.py
+++ b/tests/unit/test_rebuild.py
@@ -4,7 +4,6 @@ import json
 import os
 import sys
 
-import pytest
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 sys.path.insert(0, REPO_ROOT)

--- a/tests/unit/test_validate_definitions.py
+++ b/tests/unit/test_validate_definitions.py
@@ -3,7 +3,6 @@
 import os
 import sys
 
-import pytest
 import yaml
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts"))

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -9,7 +9,6 @@ page at the wrong title.
 import os
 import sys
 
-import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts"))


### PR DESCRIPTION
## Summary

Dead-code cleanup from the comprehensive review (#728), plus a lint gate to stop it recurring.

### Removed dead role-default vars (verified zero references)
- `roles/common/defaults/main.yml`: `canasta_password_length`, `canasta_password_digits`, `canasta_password_symbols`, `canasta_instance_id_pattern`, `canasta_verbose`
- `roles/orchestrator/defaults/main.yml`: `canasta_web_service`, `canasta_db_service` (kept `canasta_db_wait_timeout`)
- Deleted the all-dead `roles/create/defaults/main.yml` and `roles/backup/defaults/main.yml`

### Removed unused imports
- 36 unused imports across `direct_commands/`, the custom modules (`RESERVED_WIKI_IDS`), `check_node_resources.py`, and several test files
- The redundant local `import subprocess` in `canasta.py`

### Lint gate
- Added `ruff` (scoped to **F401** only) to `requirements.txt`, `make lint`, and the CI lint job, with `ruff.toml` excluding the local `.claude` worktrees dir.

## Testing

`make lint` (yamllint + ruff F401 + validate) clean; `make test-unit` 1100 passing.

Fixes #728
