### PR TITLE
tests: add canasta_validate tests; fix audit-coverage self-bugs

### DIFF
--- a/scripts/audit_command_coverage.py
+++ b/scripts/audit_command_coverage.py
@@ -94,8 +94,13 @@ def extract_test_invocations(test_file, subcommand_groups):
         func = node.func
         if not (isinstance(func, ast.Attribute) and func.attr in RUN_METHODS):
             continue
-        # Filter to inst.run* calls (the test instance method).
-        if not (isinstance(func.value, ast.Name) and func.value.id == "inst"):
+        # Filter to test-instance run* calls. The primary instance is
+        # `inst`; tests that need a second instance use `inst_b`, `inst_a`,
+        # etc. Match those too, but not unrelated receivers like
+        # `subprocess.run` or a TestInstance method's own `self.run`.
+        if not (isinstance(func.value, ast.Name)
+                and (func.value.id == "inst"
+                     or func.value.id.startswith("inst_"))):
             continue
 
         # First positional arg is the command name (or group name).
@@ -110,7 +115,11 @@ def extract_test_invocations(test_file, subcommand_groups):
         if first in subcommand_groups and len(node.args) >= 2:
             second = _string_const(node.args[1])
             if second is not None:
-                command = "%s_%s" % (first, second)
+                # command_definitions.yml names subcommands with
+                # underscores (crowdsec_bouncer_enroll), but the CLI and
+                # tests use the hyphenated user-facing form
+                # (crowdsec bouncer-enroll). Normalize so they match.
+                command = ("%s_%s" % (first, second)).replace("-", "_")
             else:
                 command = first
         else:

--- a/tests/unit/test_audit_command_coverage.py
+++ b/tests/unit/test_audit_command_coverage.py
@@ -4,8 +4,6 @@ import os
 import sys
 import tempfile
 
-import pytest
-
 
 SCRIPTS_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "scripts"),
@@ -16,7 +14,7 @@ import audit_command_coverage as audit  # noqa: E402
 
 
 GROUPS = {"backup", "config", "extension", "skin", "gitops", "host",
-          "maintenance", "sitemap", "devmode", "storage"}
+          "maintenance", "sitemap", "devmode", "storage", "crowdsec"}
 
 
 def write_test_file(content):
@@ -104,11 +102,47 @@ class TestExtractInvocations:
             'def test_x(inst):\n'
             '    other.run_ok("create")\n'
             '    subprocess.run_ok("backup", "create")\n'
+            '    subprocess.run("backup", "create")\n'
+            '    self.run("create")\n'
             '    inst.run_ok("delete", "-i", "x")\n'
         )
         try:
             results = list(audit.extract_test_invocations(path, GROUPS))
             assert results == [("test_x", "delete")]
+        finally:
+            os.unlink(path)
+
+    def test_secondary_instance_receiver_captured(self):
+        # A second test instance (inst_b, inst_a, ...) runs real commands
+        # too; the audit must not miss them (it used to only match `inst`).
+        path = write_test_file(
+            'def test_x(inst):\n'
+            '    inst_b.run_ok("create", "-i", "y")\n'
+            '    inst_b.run_ok("gitops", "join", "-i", "y")\n'
+        )
+        try:
+            results = list(audit.extract_test_invocations(path, GROUPS))
+            assert sorted(results) == [
+                ("test_x", "create"),
+                ("test_x", "gitops_join"),
+            ]
+        finally:
+            os.unlink(path)
+
+    def test_hyphenated_subcommand_normalized(self):
+        # The CLI/tests use the hyphenated user-facing form, but
+        # command_definitions.yml names subcommands with underscores.
+        path = write_test_file(
+            'def test_x(inst):\n'
+            '    inst.run_ok("crowdsec", "bouncer-enroll", "-i", "x")\n'
+            '    inst.run_ok("gitops", "fix-submodules", "-i", "x")\n'
+        )
+        try:
+            results = list(audit.extract_test_invocations(path, GROUPS))
+            assert sorted(results) == [
+                ("test_x", "crowdsec_bouncer_enroll"),
+                ("test_x", "gitops_fix_submodules"),
+            ]
         finally:
             os.unlink(path)
 

--- a/tests/unit/test_canasta_validate.py
+++ b/tests/unit/test_canasta_validate.py
@@ -1,0 +1,50 @@
+"""Tests for the shared canasta_validate module_util.
+
+This helper was previously exercised only transitively via the
+canasta_wikis_yaml and canasta_farmsettings suites. These tests target
+it directly so a change to the reserved-name list or the validation
+rules is caught at the source.
+"""
+
+import canasta_validate
+
+
+class TestValidateWikiId:
+    def test_valid_simple(self):
+        assert canasta_validate.validate_wiki_id("main") is None
+
+    def test_valid_with_underscore(self):
+        assert canasta_validate.validate_wiki_id("my_wiki") is None
+
+    def test_valid_alphanumeric(self):
+        assert canasta_validate.validate_wiki_id("wiki2") is None
+
+    def test_empty_rejected(self):
+        err = canasta_validate.validate_wiki_id("")
+        assert err is not None
+        assert "empty" in err
+
+    def test_none_rejected(self):
+        # A None value is falsy and must be rejected, not crash.
+        err = canasta_validate.validate_wiki_id(None)
+        assert err is not None
+        assert "empty" in err
+
+    def test_hyphen_rejected(self):
+        err = canasta_validate.validate_wiki_id("my-wiki")
+        assert err is not None
+        assert "hyphen" in err
+
+    def test_each_reserved_id_rejected(self):
+        for reserved in canasta_validate.RESERVED_WIKI_IDS:
+            err = canasta_validate.validate_wiki_id(reserved)
+            assert err is not None, "%r should be reserved" % reserved
+            assert "reserved" in err
+
+    def test_reserved_list_is_exactly_expected(self):
+        # Guard the canonical reserved set — these collide with paths the
+        # canasta image controls (wikis/ mount, images dir, w/ and wiki/
+        # URL prefixes, settings/ overrides).
+        assert canasta_validate.RESERVED_WIKI_IDS == [
+            "settings", "images", "w", "wiki", "wikis",
+        ]


### PR DESCRIPTION
## Summary

Two low-risk test-coverage fixes from the comprehensive review (#732).

### `canasta_validate` unit tests
Adds `tests/unit/test_canasta_validate.py` — a direct test for the shared `canasta_validate` module_util, which was previously only exercised transitively via the `canasta_wikis_yaml` / `canasta_farmsettings` suites. Covers valid IDs, empty/None, hyphen rejection, every reserved ID, and pins the canonical reserved list.

### `audit_command_coverage.py` self-bugs
The static coverage auditor produced false "NOT covered" reports:
- It only matched the `inst` receiver, missing commands run on a second test instance (`inst_b`) — e.g. `gitops_join` in `test_gitops_join`.
- It joined group+subcommand without normalizing hyphens, so the hyphenated user-facing names (`crowdsec bouncer-enroll`, `gitops fix-submodules`) never matched the underscore canonical names — wrongly flagged uncovered and as "unknown" invocations.

Reported integration coverage corrected from **54/77 to 57/77**. Adds regression tests for both (and the redundant `import pytest` is dropped while editing the file).

The remaining #732 items (multi-instance coexistence, K8s e2e for gitops/storage/devmode) need a live cluster and are left for the infra-dependent follow-ups (#725/#726 territory).

## Testing

`make test-unit` 1110 passing; `make lint` clean.

Refs #732
