### PR TITLE
fix: run Kubernetes `canasta stop` on the instance's host

### DIFF
--- a/direct_commands/__init__.py
+++ b/direct_commands/__init__.py
@@ -115,7 +115,6 @@ from .info import (  # noqa: F401
 )
 from .config import cmd_config_get  # noqa: F401
 from .lifecycle import cmd_start, cmd_stop, cmd_restart, cmd_scale  # noqa: F401
-from .lifecycle import _k8s_namespace, _k8s_stop, _run_kubectl  # noqa: F401
 from .maintenance import (  # noqa: F401
     cmd_maintenance_script,
     cmd_maintenance_extension,

--- a/direct_commands/lifecycle.py
+++ b/direct_commands/lifecycle.py
@@ -10,56 +10,6 @@ from . import _helpers
 from ._helpers import register
 
 
-# _k8s_namespace lives in _helpers.py — _exec_in_container (a shared
-# helper) needs it too, so it can't be lifecycle-only.
-_k8s_namespace = _helpers._k8s_namespace
-
-
-def _run_kubectl(kubectl_args, timeout=30):
-    """Run a kubectl command. Returns exit code."""
-    cmd = ["kubectl"] + kubectl_args
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-        if result.stdout.strip():
-            print(result.stdout.strip())
-        if result.returncode != 0 and result.stderr.strip():
-            print(result.stderr.strip(), file=sys.stderr)
-        return result.returncode
-    except (subprocess.TimeoutExpired, OSError) as e:
-        print("Error: %s" % e, file=sys.stderr)
-        return 1
-
-
-def _k8s_stop(instance_id):
-    """Stop a K8s instance: suspend Argo CD sync, scale everything to 0."""
-    ns = _k8s_namespace(instance_id)
-
-    result = subprocess.run(
-        ["kubectl", "get", "application", "canasta-%s" % instance_id,
-         "-n", "argocd", "-o", "jsonpath={.metadata.name}"],
-        capture_output=True, text=True, timeout=10,
-    )
-    if result.returncode == 0:
-        _run_kubectl([
-            "patch", "application", "canasta-%s" % instance_id,
-            "-n", "argocd", "--type", "merge",
-            "-p", '{"spec":{"syncPolicy":null}}',
-        ])
-
-    _run_kubectl(["scale", "deployment", "--all", "--replicas=0", "-n", ns])
-
-    # External-DB instances with Elasticsearch disabled have no
-    # StatefulSets; 'kubectl scale --all' errors with "no objects
-    # passed to scale". Check first and skip if none exist.
-    sts_check = subprocess.run(
-        ["kubectl", "get", "statefulset", "-n", ns, "-o", "name"],
-        capture_output=True, text=True, timeout=10,
-    )
-    if sts_check.returncode == 0 and sts_check.stdout.strip():
-        _run_kubectl(["scale", "statefulset", "--all", "--replicas=0", "-n", ns])
-    return 0
-
-
 @register("start")
 def cmd_start(args):
     inst_id, inst = _helpers._resolve_instance(args)
@@ -79,7 +29,11 @@ def cmd_start(args):
 def cmd_stop(args):
     inst_id, inst = _helpers._resolve_instance(args)
     if inst.get("orchestrator", "compose") in ("kubernetes", "k8s"):
-        return _k8s_stop(inst_id)
+        # K8s stop suspends Argo CD sync and scales the instance's
+        # workloads to 0 — kubectl must run on the instance's host
+        # (where the cluster kubeconfig lives), not the controller.
+        # Ansible resolves the host and switches the connection.
+        return _helpers.FALLBACK
     return _helpers._run_compose(inst_id, inst, ["down"])
 
 

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -469,7 +469,7 @@ commands:
       Docker volumes.
     examples:
       - "canasta stop"
-    direct_only: true
+    playbook: stop.yml
     parameters:
       - name: id
         short: i

--- a/playbooks/stop.yml
+++ b/playbooks/stop.yml
@@ -1,0 +1,7 @@
+---
+# canasta stop - Stop a Canasta instance.
+
+- name: Stop instance
+  ansible.builtin.include_role:
+    name: instance_lifecycle
+    tasks_from: stop.yml

--- a/roles/instance_lifecycle/tasks/stop.yml
+++ b/roles/instance_lifecycle/tasks/stop.yml
@@ -1,0 +1,20 @@
+---
+# Stop a Canasta instance.
+# Input: id (optional)
+
+# Top-level callers (`playbooks/stop.yml`) need this; nested callers
+# already passed through resolve_instance.yml or have instance_path set.
+# Resolving here also switches the connection to the instance's host, so
+# the orchestrator stop runs there rather than on the controller.
+- name: Resolve instance (skip if caller already resolved it)
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
+  when: instance_path is not defined
+
+- name: Stop containers
+  ansible.builtin.include_role:
+    name: orchestrator
+    tasks_from: stop.yml
+
+- name: Report stopped
+  ansible.builtin.debug:
+    msg: "Instance '{{ instance_id }}' stopped."

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1261,21 +1261,11 @@ class TestLifecycleCommands:
         args = type("Args", (), {"id": "k8s-site"})()
         assert direct_commands.cmd_restart(args) is direct_commands.FALLBACK
 
-    def test_k8s_stop_runs_kubectl(self, monkeypatch):
-        kubectl_cmds = []
-
-        def mock_run(cmd, **kw):
-            kubectl_cmds.append(cmd)
-            # Return a STS when queried so the scale-sts step runs
-            if "statefulset" in cmd and "-o" in cmd and "name" in cmd:
-                return type("R", (), {
-                    "returncode": 0,
-                    "stdout": "statefulset.apps/foo-db\n",
-                    "stderr": "",
-                })()
-            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
-
-        monkeypatch.setattr(subprocess, "run", mock_run)
+    def test_k8s_stop_falls_back(self, monkeypatch):
+        # K8s stop must run kubectl on the instance's host (where the
+        # cluster kubeconfig lives), so it defers to Ansible — which
+        # resolves the host and switches the connection — rather than
+        # running kubectl on the controller.
         monkeypatch.setattr(direct_commands._helpers, "_resolve_instance",
             lambda args: ("k8s-site", {
                 "path": "/srv/k8s-site",
@@ -1283,58 +1273,7 @@ class TestLifecycleCommands:
             }),
         )
         args = type("Args", (), {"id": "k8s-site"})()
-        rc = direct_commands.cmd_stop(args)
-        assert rc == 0
-        cmds_str = str(kubectl_cmds)
-        assert "scale" in cmds_str
-        assert "replicas=0" in cmds_str
-
-    def test_k8s_stop_skips_sts_scale_when_none_exist(self, monkeypatch):
-        # External-DB instances with Elasticsearch disabled have zero
-        # StatefulSets. 'kubectl scale statefulset --all' errors with
-        # "no objects passed to scale" in that case — we must check
-        # first and skip the scale step.
-        kubectl_cmds = []
-
-        def mock_run(cmd, **kw):
-            kubectl_cmds.append(cmd)
-            # "No Argo CD application" + "no statefulsets" scenario
-            if "application" in cmd:
-                return type("R", (), {
-                    "returncode": 1, "stdout": "", "stderr": "not found",
-                })()
-            if "statefulset" in cmd and "-o" in cmd and "name" in cmd:
-                return type("R", (), {
-                    "returncode": 0, "stdout": "", "stderr": "",
-                })()
-            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
-
-        monkeypatch.setattr(subprocess, "run", mock_run)
-        monkeypatch.setattr(direct_commands._helpers, "_resolve_instance",
-            lambda args: ("extdb-site", {
-                "path": "/srv/extdb-site",
-                "orchestrator": "kubernetes",
-            }),
-        )
-        args = type("Args", (), {"id": "extdb-site"})()
-        rc = direct_commands.cmd_stop(args)
-        assert rc == 0
-        # Deployment scale must have happened...
-        deployment_scale = [
-            c for c in kubectl_cmds
-            if "scale" in c and "deployment" in c
-        ]
-        assert deployment_scale, "deployment scale should still run"
-        # ... but STS scale must NOT, since 'kubectl get statefulset'
-        # returned no objects.
-        sts_scale = [
-            c for c in kubectl_cmds
-            if "scale" in c and "statefulset" in c
-        ]
-        assert not sts_scale, (
-            "statefulset scale must be skipped when no STS exist "
-            "(would error 'no objects passed to scale')"
-        )
+        assert direct_commands.cmd_stop(args) is direct_commands.FALLBACK
 
     def test_start_runs_up(self, monkeypatch):
         captured_cmds = []


### PR DESCRIPTION
Fixes #741.

## Problem

`canasta stop` was a direct (Python) command. For Kubernetes instances its handler ran `kubectl` on the **controller**, targeting whatever cluster the controller's local kubeconfig pointed at — never the instance's host. On a multi-host setup the stop hit the wrong cluster (or none), so the instance never went down. `start`/`restart` do not have this bug because they fall back to Ansible for Kubernetes.

## Fix

Mirror `start`/`restart`: the direct `stop` handler now returns `FALLBACK` for Kubernetes instances, deferring to Ansible. Ansible resolves the instance, switches the connection to its host, and runs the existing `orchestrator/tasks/stop.yml` there (suspend Argo CD sync → scale deployments/statefulsets to 0). Compose `stop` is unchanged — it still runs `docker compose down` directly.

## Changes

- `direct_commands/lifecycle.py`: `cmd_stop` returns `FALLBACK` for K8s; removed the controller-local `_k8s_stop`/`_run_kubectl` helpers and the unused `_k8s_namespace` alias.
- `direct_commands/__init__.py`: dropped the re-export of the removed helpers.
- `meta/command_definitions.yml`: `stop` is now `playbook: stop.yml` instead of `direct_only: true`.
- `playbooks/stop.yml` + `roles/instance_lifecycle/tasks/stop.yml`: new Ansible path (resolve instance → orchestrator stop), matching `start.yml`.
- `tests/unit/test_direct_commands.py`: replaced the two controller-kubectl stop tests with a K8s-falls-back test (mirrors the start/restart fallback tests).

## Testing

- `make validate`, `make lint`, `make test-unit` (1112 passed) all green.
- Found during a hands-on multi-host K8s e2e (controller → `big`/`small` VPSes) where `canasta stop -i` targeted a stale controller context instead of the instance's cluster.