### PR TITLE
tests: add K8s backup end-to-end integration test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -277,6 +277,53 @@ jobs:
           k8s-crowdsec
         timeout-minutes: 35
 
+  # Separate job (own runner) so the K8s backup Jobs/CronJob run against a
+  # fresh single-node cluster with their own time budget, in parallel with
+  # the other k8s jobs rather than serializing behind them.
+  integration-k8s-backup:
+    name: "Integration: Kubernetes Backup"
+    if: github.event_name != 'pull_request'  # See #67
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git-crypt
+      - name: Install Python dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install -r requirements.txt
+          .venv/bin/pip install kubernetes
+          # Retry to ride out transient Ansible Galaxy CDN timeouts.
+          for attempt in 1 2 3 4; do
+            .venv/bin/ansible-galaxy collection install kubernetes.core && break
+            if [ "$attempt" -eq 4 ]; then
+              echo "ansible-galaxy install failed after 4 attempts" >&2
+              exit 1
+            fi
+            echo "ansible-galaxy install attempt $attempt failed; retrying in $((attempt * 10))s..." >&2
+            sleep $((attempt * 10))
+          done
+          git config --global user.name "CI"
+          git config --global user.email "ci@canasta.wiki"
+      # Bootstrap the cluster via the product's own install path so CI
+      # exercises 'canasta install k8s-cp' (which installs k3s + helm at the
+      # pinned canasta_k3s_version / canasta_helm_version, writing
+      # ~/.kube/config) instead of a separate, unpinned curl | sh that
+      # depended on update.k3s.io.
+      - name: Bootstrap k3s control plane via canasta
+        run: ./canasta-native install k8s-cp
+      - name: Run K8s backup test
+        run: >-
+          .venv/bin/python tests/integration/run_tests.py
+          k8s-backup
+        timeout-minutes: 20
+
   remote-integration:
     name: Remote Host Integration Tests
     if: github.event_name != 'pull_request'  # See #67

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -1515,6 +1515,102 @@ def test_k8s_lifecycle(inst):
     assert inst.id not in output, "Instance still in list after delete"
 
 
+def test_k8s_backup(inst):
+    """K8s backup end-to-end on a single-node cluster.
+
+    Exercises the runtime backup path that previously had only unit
+    coverage: a local (hostPath) restic repo, the on-demand backup Job
+    with its dump-databases init container, and the schedule CronJob
+    lifecycle. Restore is covered by the Compose backup test; here the
+    focus is that the K8s Job/CronJob machinery actually runs.
+    """
+    result = subprocess.run(["kubectl", "cluster-info"], capture_output=True)
+    if result.returncode != 0:
+        raise SkipTest("kubectl not available or cluster not reachable")
+    result = subprocess.run(["helm", "version", "--short"], capture_output=True)
+    if result.returncode != 0:
+        raise SkipTest("helm not installed")
+
+    ns = "canasta-%s" % inst.id
+    cronjob = "canasta-backup-%s" % inst.id
+    # Local restic repo as a hostPath on the node. k8s_run_backup mounts
+    # it with type DirectoryOrCreate, so the path is created on demand.
+    repo = "/var/lib/canasta-k8s-backup-test-%s" % inst.id
+
+    # Backup repo config has to be present before create so it lands in
+    # the backup-env Secret the Job reads.
+    with open(inst.env_file, "a") as f:
+        f.write("RESTIC_REPOSITORY=%s\n" % repo)
+        f.write("RESTIC_PASSWORD=testpass\n")
+
+    try:
+        print("Creating Kubernetes instance...")
+        inst.run_ok(
+            "create", "-i", inst.id, "-w", "main",
+            "-n", "localhost", "-p", inst.work_dir,
+            "--orchestrator", "kubernetes",
+            "--skip-argocd-install",
+            "-e", inst.env_file,
+        )
+
+        # The dump-databases init container connects to the db, so the
+        # db StatefulSet must be ready before a backup can succeed.
+        print("Waiting for the database to be ready...")
+        result = subprocess.run(
+            ["kubectl", "rollout", "status",
+             "statefulset/canasta-%s-db" % inst.id,
+             "-n", ns, "--timeout=300s"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, (
+            "db not ready: %s\n%s" % (result.stdout, result.stderr)
+        )
+
+        print("Initializing backup repository...")
+        inst.run_ok("backup", "init", "-i", inst.id)
+
+        print("Creating backup snapshot...")
+        inst.run_ok("backup", "create", "-i", inst.id, "-t", "k8s-test-snapshot")
+
+        print("Listing snapshots...")
+        output = inst.run_quiet("backup", "list", "-i", inst.id)
+        assert "k8s-test-snapshot" in output, (
+            "Snapshot tag not found in list output:\n%s" % output
+        )
+
+        print("Setting a backup schedule (CronJob)...")
+        inst.run_ok("backup", "schedule", "set", "-i", inst.id, "0 3 * * *")
+        result = subprocess.run(
+            ["kubectl", "get", "cronjob", cronjob, "-n", ns],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, (
+            "CronJob %s not created: %s" % (cronjob, result.stderr)
+        )
+
+        print("Listing the backup schedule...")
+        output = inst.run_quiet("backup", "schedule", "list", "-i", inst.id)
+        assert "0 3 * * *" in output, (
+            "Schedule not shown in list output:\n%s" % output
+        )
+
+        print("Removing the backup schedule...")
+        inst.run_ok("backup", "schedule", "remove", "-i", inst.id)
+        for _ in range(6):
+            result = subprocess.run(
+                ["kubectl", "get", "cronjob", cronjob, "-n", ns],
+                capture_output=True,
+            )
+            if result.returncode != 0:
+                break
+            time.sleep(2)
+        assert result.returncode != 0, "CronJob still present after remove"
+    finally:
+        # The hostPath repo lives on the node (created by the Job as root);
+        # cleanup() removes the instance but not this path.
+        subprocess.run(["sudo", "rm", "-rf", repo], capture_output=True)
+
+
 def test_version(inst):
     """`canasta version` reports a version string and orchestrator info."""
     output = inst.run_quiet("version")
@@ -2534,6 +2630,7 @@ def test_k8s_crowdsec(inst):
 ALL_TESTS = {
     "k8s-lifecycle": test_k8s_lifecycle,
     "k8s-crowdsec": test_k8s_crowdsec,
+    "k8s-backup": test_k8s_backup,
     "lifecycle": test_lifecycle,
     "import": test_import_export,
     "upgrade": test_upgrade,


### PR DESCRIPTION
## Summary

K8s backup (local restic repo, the on-demand backup Job with its `dump-databases` init container, and the schedule CronJob) had only unit coverage (`tests/unit/test_backup_schedule_k8s.py`). This adds a live-cluster integration test.

`test_k8s_backup` (single-node k3s):
- Creates a K8s instance with a hostPath restic repo (`RESTIC_REPOSITORY` / `RESTIC_PASSWORD` via the create env file; mounted with `type: DirectoryOrCreate`).
- Waits for the db StatefulSet to be ready (the `dump-databases` init container needs it).
- `backup init` → `backup create -t k8s-test-snapshot` → asserts the tag appears in `backup list`.
- Schedule CronJob lifecycle: `schedule set` → `kubectl get cronjob canasta-backup-<id>` → `schedule list` (asserts the cron expression) → `schedule remove` → asserts the CronJob is gone.
- Cleans up the node-side hostPath repo in a `finally`.

Restore is already covered by the Compose backup test; this focuses on the K8s Job/CronJob machinery actually running.

## CI

Runs as its own parallel job **`integration-k8s-backup`** (own runner, bootstraps k3s via `canasta install k8s-cp`, 25-min budget) so it doesn't extend the existing k8s job runtimes.

## Validation

`make test-unit` (1113) and `make lint` (incl. ruff F401) pass. The e2e itself is exercised by the new CI job (no local cluster available).

Closes #726
