### PR TITLE
upgrade: keep `canasta upgrade` within the current major by default

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -186,12 +186,16 @@ def find_ansible_playbook():
 _RELEASE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
 
 
-def _pick_latest_release_tag(tags):
+def _pick_latest_release_tag(tags, max_major=None):
     """Return the highest strict vX.Y.Z tag from `tags`, or None.
 
     Pre-releases (e.g. v5.0.0-rc1) and non-version tags are ignored so we
     only ever move to a real release. Comparison is by numeric (major,
     minor, patch) tuple, not lexical, so v4.0.10 sorts above v4.0.9.
+
+    When `max_major` is set, tags whose major exceeds it are skipped, so
+    the result never crosses into a higher major version than the caller
+    permits (the default `canasta upgrade` stays within the current major).
     """
     best = None
     best_key = None
@@ -200,17 +204,30 @@ def _pick_latest_release_tag(tags):
         if not m:
             continue
         key = tuple(int(p) for p in m.groups())
+        if max_major is not None and key[0] > max_major:
+            continue
         if best_key is None or key > best_key:
             best, best_key = tag.strip(), key
     return best
 
 
-def self_update_cli(dev=False):
+def _version_major(version):
+    """Return the integer major component of a vX.Y.Z / X.Y.Z string, or None."""
+    m = re.match(r"^v?(\d+)\.", version.strip())
+    return int(m.group(1)) if m else None
+
+
+def self_update_cli(dev=False, allow_major=False):
     """Update the CLI code before invoking ansible-playbook.
 
-    By default the CLI moves to the latest released version — the highest
-    vX.Y.Z git tag, via a detached checkout. Pass ``dev=True`` to instead
-    track the head of main (``git checkout main && git pull --ff-only``).
+    By default the CLI moves to the latest released version that does not
+    cross into a higher major than the one currently installed — the
+    highest vX.Y.Z git tag whose major matches the current VERSION — via a
+    detached checkout. Pass ``allow_major=True`` to lift that cap and move
+    to the latest release overall (which may be a new major with breaking
+    changes). Pass ``dev=True`` to instead track the head of main
+    (``git checkout main && git pull --ff-only``); ``allow_major`` has no
+    effect with ``dev``.
     Release tags are used rather than the GitHub Releases API because the
     Releases API deliberately keeps v3.7.0 as 'latest' for legacy clients
     (see .github/workflows/docker.yml).
@@ -285,20 +302,45 @@ def self_update_cli(dev=False):
         return
 
     # Resolve the ref this run should move to: head of main for --dev, or
-    # the latest release tag otherwise.
+    # the latest release tag otherwise. The release pick is capped to the
+    # current major so 'canasta upgrade' never crosses a major boundary;
+    # --allow-major (allow_major=True) lifts the cap to the latest overall.
+    major_hint = ""
     if dev:
         target_ref = "origin/main"
     else:
         tags = _git(["tag", "-l", "v*"], timeout=10).stdout.split()
-        target_ref = _pick_latest_release_tag(tags)
+        max_major = None if allow_major else _version_major(current_version)
+        target_ref = _pick_latest_release_tag(tags, max_major=max_major)
+        latest_overall = _pick_latest_release_tag(tags)
         if target_ref is None:
-            print(
-                "WARNING: self-update skipped — no release tags found.\n"
-                "Use 'canasta upgrade --dev' to track the development "
-                "branch (head of main) instead.",
-                file=sys.stderr,
-            )
+            if latest_overall is not None:
+                # Tags exist but all sit above the current major and the cap
+                # is in effect — point the operator at --allow-major.
+                print(
+                    "WARNING: self-update skipped — no release found at or "
+                    "below the current major (v%s.x); the latest release is "
+                    "%s.\nRun 'canasta upgrade --allow-major' to move to it "
+                    "(may include breaking changes), or 'canasta upgrade "
+                    "--dev' to track the development branch."
+                    % (max_major, latest_overall),
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    "WARNING: self-update skipped — no release tags found.\n"
+                    "Use 'canasta upgrade --dev' to track the development "
+                    "branch (head of main) instead.",
+                    file=sys.stderr,
+                )
             return
+        if latest_overall and latest_overall != target_ref:
+            # A newer release exists beyond the current-major cap.
+            major_hint = (
+                "\nA newer major release (%s) is available. Run 'canasta "
+                "upgrade --allow-major' to move to it (may include breaking "
+                "changes)." % latest_overall
+            )
 
     target_commit = _git(
         ["rev-parse", "--short", target_ref], timeout=5,
@@ -335,8 +377,8 @@ def self_update_cli(dev=False):
             if target_commit == current_commit:
                 print(
                     "Canasta CLI is already up to date "
-                    "(version %s, commit %s, release %s)."
-                    % (current_version, current_commit, target_ref)
+                    "(version %s, commit %s, release %s).%s"
+                    % (current_version, current_commit, target_ref, major_hint)
                 )
             else:
                 print(
@@ -345,8 +387,8 @@ def self_update_cli(dev=False):
                     "rather than moving backward.\nUse 'canasta upgrade --dev' "
                     "to keep tracking development builds, or re-run the "
                     "installer at https://get.canasta.wiki to return to the "
-                    "latest release."
-                    % (target_ref, current_version, current_commit)
+                    "latest release.%s"
+                    % (target_ref, current_version, current_commit, major_hint)
                 )
             return
         # HEAD is behind the latest release (or on a divergent line that
@@ -427,8 +469,8 @@ def self_update_cli(dev=False):
     )
 
     print(
-        "Updated Canasta CLI from %s (%s) to %s (%s)."
-        % (current_version, current_commit, new_version, new_commit)
+        "Updated Canasta CLI from %s (%s) to %s (%s).%s"
+        % (current_version, current_commit, new_version, new_commit, major_hint)
     )
     if not (pip_ok and galaxy_ok):
         print(
@@ -1459,7 +1501,10 @@ def main():
     # but running it inside the playbook means ansible-playbook's
     # in-memory config goes stale on cfg changes — see #489.
     if command_name == "upgrade":
-        self_update_cli(dev=getattr(args, "dev", False))
+        self_update_cli(
+            dev=getattr(args, "dev", False),
+            allow_major=getattr(args, "allow_major", False),
+        )
 
     os.execvp(ansible_args[0], ansible_args)
 

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -772,10 +772,14 @@ commands:
       pulling latest images, running migrations, and restarting containers.
 
       By default the CLI itself updates to the latest released version
-      (the highest vX.Y.Z tag). Pass --dev to track the development branch
-      (head of main) instead.
+      within the current major (the highest vX.Y.Z tag whose major matches
+      the installed version), so an upgrade never crosses a major boundary
+      on its own. Pass --allow-major to move to the latest release overall,
+      including a new major version (which may include breaking changes).
+      Pass --dev to track the development branch (head of main) instead.
     examples:
       - "canasta upgrade"
+      - "canasta upgrade --allow-major"
       - "canasta upgrade --dev"
       - "canasta upgrade --dry-run"
     playbook: upgrade.yml
@@ -788,6 +792,10 @@ commands:
         type: bool
         default: false
         description: "Track the development branch (head of main) instead of the latest release"
+      - name: allow_major
+        type: bool
+        default: false
+        description: "Allow upgrading across a major version boundary to the latest release overall (may include breaking changes)"
 
   # ---------------------------------------------------------------------------
   # Wiki management

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -1047,6 +1047,24 @@ class TestSelfUpdateCli:
         assert canasta_cli._pick_latest_release_tag([]) is None
         assert canasta_cli._pick_latest_release_tag(["v5.0.0-rc1"]) is None
 
+    def test_pick_latest_release_tag_max_major(self):
+        tags = "v4.2.1 v4.2.3 v4.3.1 v5.0.0 v6.1.0".split()
+        # Uncapped: highest overall, crossing majors.
+        assert canasta_cli._pick_latest_release_tag(tags) == "v6.1.0"
+        # Capped to major 4: never crosses into v5/v6.
+        assert canasta_cli._pick_latest_release_tag(
+            tags, max_major=4) == "v4.3.1"
+        # max_major=0 (no eligible tag) → None even though tags exist.
+        assert canasta_cli._pick_latest_release_tag(
+            tags, max_major=0) is None
+
+    def test_version_major(self):
+        assert canasta_cli._version_major("4.2.1") == 4
+        assert canasta_cli._version_major("v5.0.0") == 5
+        assert canasta_cli._version_major("10.0.0") == 10
+        assert canasta_cli._version_major("unknown") is None
+        assert canasta_cli._version_major("") is None
+
     def test_no_op_when_not_a_git_repo(
         self, monkeypatch, tmp_path, capsys,
     ):
@@ -1294,6 +1312,82 @@ class TestSelfUpdateCli:
         err = capsys.readouterr().err
         assert "no release tags found" in err
         assert "--dev" in err
+
+    def test_default_stays_within_current_major(
+        self, monkeypatch, tmp_path, capsys,
+    ):
+        # Installed 4.2.1 with a newer major (v5.0.0) tagged: default
+        # 'canasta upgrade' moves to the latest 4.x (v4.3.1), not v5.0.0,
+        # and surfaces the --allow-major hint.
+        self._patch_repo(monkeypatch, tmp_path, version="4.2.1")
+        monkeypatch.setattr(canasta_cli.os, "execv", lambda *a: None)
+        runner, calls = self._make_runner([
+            {"stdout": "old1234\n"},                      # rev-parse HEAD
+            {"stdout": ""},                                # fetch --tags
+            {"stdout": "v4.2.1\nv4.3.1\nv5.0.0\n"},        # tag -l v*
+            {"stdout": "new4031\n"},                       # rev-parse v4.3.1
+            {"returncode": 1},                             # merge-base → move
+            {"stdout": ""},                                # checkout v4.3.1
+            {"stdout": "new4031\n"},                       # rev-parse new HEAD
+            {"stdout": "2026-05-05 10:00:00\n"},           # log -1 date
+            {"stdout": ""},                                # pip install
+            {"stdout": ""},                                # ansible-galaxy
+        ])
+        monkeypatch.setattr(_subprocess, "run", runner)
+        canasta_cli.self_update_cli()
+        out = capsys.readouterr().out
+        assert "Updated Canasta CLI" in out
+        assert any("v4.3.1" in c for c in calls)        # checked out 4.3.1
+        assert not any("v5.0.0" in c for c in calls)    # never touched v5
+        assert "newer major release (v5.0.0)" in out
+        assert "--allow-major" in out
+
+    def test_allow_major_crosses_to_latest_overall(
+        self, monkeypatch, tmp_path, capsys,
+    ):
+        # With --allow-major the cap is lifted: from 4.2.1 it jumps straight
+        # to the latest overall (v5.0.0), and prints no major hint.
+        self._patch_repo(monkeypatch, tmp_path, version="4.2.1")
+        monkeypatch.setattr(canasta_cli.os, "execv", lambda *a: None)
+        runner, calls = self._make_runner([
+            {"stdout": "old1234\n"},                      # rev-parse HEAD
+            {"stdout": ""},                                # fetch --tags
+            {"stdout": "v4.2.1\nv4.3.1\nv5.0.0\n"},        # tag -l v*
+            {"stdout": "new5000\n"},                       # rev-parse v5.0.0
+            {"returncode": 1},                             # merge-base → move
+            {"stdout": ""},                                # checkout v5.0.0
+            {"stdout": "new5000\n"},                       # rev-parse new HEAD
+            {"stdout": "2026-05-05 10:00:00\n"},           # log -1 date
+            {"stdout": ""},                                # pip install
+            {"stdout": ""},                                # ansible-galaxy
+        ])
+        monkeypatch.setattr(_subprocess, "run", runner)
+        canasta_cli.self_update_cli(allow_major=True)
+        out = capsys.readouterr().out
+        assert "Updated Canasta CLI" in out
+        assert any("v5.0.0" in c for c in calls)         # checked out v5
+        assert "newer major release" not in out          # no cap → no hint
+
+    def test_no_release_at_or_below_major_warns(
+        self, monkeypatch, tmp_path, capsys,
+    ):
+        # Installed 4.2.1 but the only tags are a higher major: the default
+        # cap leaves nothing eligible, so skip and point at --allow-major.
+        self._patch_repo(monkeypatch, tmp_path, version="4.2.1")
+        runner, calls = self._make_runner([
+            {"stdout": "abc1234\n"},   # rev-parse HEAD
+            {"stdout": ""},             # fetch --tags
+            {"stdout": "v5.0.0\n"},     # tag -l → only a higher major
+        ])
+        monkeypatch.setattr(_subprocess, "run", runner)
+        canasta_cli.self_update_cli()
+        err = capsys.readouterr().err
+        assert "no release found at or below the current major" in err
+        assert "v4.x" in err
+        assert "v5.0.0" in err
+        assert "--allow-major" in err
+        # Capped out → no checkout.
+        assert not any("checkout" in c for c in calls)
 
     def test_fetch_failure_warns_and_returns(
         self, monkeypatch, tmp_path, capsys,


### PR DESCRIPTION
Closes #746.

### What

`canasta upgrade` now stays within the installed major version by default, and a new `--allow-major` flag opts into crossing a major boundary.

| Command | Picks |
|---|---|
| `canasta upgrade` | highest `vX.Y.Z` tag **within the current major** (4.2.1 → 4.3.1, never 5.0.0) |
| `canasta upgrade --allow-major` | latest release **overall**, crossing majors (→ 5.0.0) |
| `canasta upgrade --dev` | head of `main` (unchanged; `--allow-major` is a no-op here) |

### How

- `_pick_latest_release_tag(tags, max_major=...)` gained an optional cap. The default run derives `max_major` from the installed `VERSION` file's major; `--allow-major` passes no cap.
- The existing "never move backward" guard and all messaging are preserved. When a newer major exists beyond the cap, the up-to-date / already-ahead / updated lines append a hint pointing at `--allow-major`.
- Edge case: if the only tags are a higher major, the self-update skips with a clear warning that points at `--allow-major` (rather than the generic "no release tags found").

### Tests

- New unit coverage for `_pick_latest_release_tag(max_major=...)`, `_version_major`, the default within-major move + hint, `--allow-major` crossing to the latest overall, and the "no release at or below current major" warning.
- `make test-unit` (1117 passed), `make lint`, and `make validate` all green. Generated command docs refreshed.