### PR TITLE
Resilient remote ops: survive transient SSH resets on long operations

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -273,14 +273,21 @@ def _run_compose(inst_id, inst, action_args):
     else:
         file_str = " ".join(file_args)
         action_str = " ".join(action_args)
-        rc, stdout = _ssh_run(
-            host,
-            "cd %s && docker compose %s %s" % (
-                _shell_quote(path), file_str, action_str,
-            ),
+        remote_cmd = "cd %s && docker compose %s %s" % (
+            _shell_quote(path), file_str, action_str,
         )
-        if stdout.strip():
-            print(stdout.strip())
+        # The lifecycle actions routed here (up -d, down) are idempotent,
+        # so retry on a transient ssh connection reset.
+        _last = {}
+
+        def _attempt():
+            rc, stdout = _ssh_run(host, remote_cmd)
+            _last["stdout"] = stdout
+            return rc
+
+        rc = _retry_on_ssh_reset(_attempt)
+        if _last.get("stdout", "").strip():
+            print(_last["stdout"].strip())
         return rc
 
 
@@ -652,6 +659,31 @@ def _ssh_run(host, cmd):
     except OSError as e:
         print("Error: %s" % e, file=sys.stderr)
         return 1, ""
+
+
+# ssh exits 255 on a connection-level failure (reset / broken pipe /
+# unreachable) — distinct from any exit code the remote command itself
+# returns. Idempotent remote operations retry on this so a transient
+# controller-to-target reset doesn't abort a command that was progressing.
+_SSH_CONN_FAILURE_RC = 255
+
+
+def _retry_on_ssh_reset(run, attempts=3):
+    """Run `run` (a callable returning an int exit code) and retry while it
+    returns 255, the code ssh produces on a connection-level failure. `run`
+    MUST be idempotent. Returns the final exit code."""
+    rc = _SSH_CONN_FAILURE_RC
+    for attempt in range(1, attempts + 1):
+        rc = run()
+        if rc != _SSH_CONN_FAILURE_RC:
+            return rc
+        if attempt < attempts:
+            print(
+                "SSH connection to the target was reset; retrying "
+                "(attempt %d of %d)…" % (attempt + 1, attempts),
+                file=sys.stderr,
+            )
+    return rc
 
 
 def _is_localhost(host):

--- a/direct_commands/lifecycle.py
+++ b/direct_commands/lifecycle.py
@@ -172,13 +172,17 @@ def cmd_scale(args):
     # 10m`, which would falsely report failure on a slow rollout.
     # Stream the helm output through to the operator so they can see
     # progress / diagnose stuck rollouts.
-    if _helpers._is_localhost(host):
-        argv = ["bash", "-c", helm_cmd]
-    else:
-        target = _helpers._resolve_ssh_target(host)
-        argv = ["ssh"] + _helpers._ssh_args() + [target, helm_cmd]
     try:
-        rc = subprocess.call(argv)
+        if _helpers._is_localhost(host):
+            rc = subprocess.call(["bash", "-c", helm_cmd])
+        else:
+            target = _helpers._resolve_ssh_target(host)
+            argv = ["ssh"] + _helpers._ssh_args() + [target, helm_cmd]
+            # helm upgrade --install is idempotent; retry on an ssh
+            # connection-level failure (exit 255) so a transient
+            # controller-to-target reset during the up-to-10m rollout
+            # doesn't abort a deploy that may still be progressing.
+            rc = _helpers._retry_on_ssh_reset(lambda: subprocess.call(argv))
     except OSError as e:
         print("Error running helm upgrade: %s" % e, file=sys.stderr)
         return 1

--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -103,22 +103,36 @@
             volumeMounts: "{{ _restore_volume_mounts }}"
         volumes: "{{ _restore_volumes }}"
 
-- name: Wait for restore pod to be running
+# Poll readiness with short `kubectl get` calls rather than a single held
+# `kubectl wait`: a controller-side SSH reset during a held wait would abort
+# the restore, while the pod keeps running on the target. Each poll is a
+# brief connection, so transient resets are simply retried.
+- name: Wait for restore pod to be Ready
   ansible.builtin.command:
     cmd: >-
-      kubectl wait pod/restic-restore
-      -n {{ _k8s_namespace }}
-      --for=condition=Ready
-      --timeout=120s
+      kubectl get pod restic-restore -n {{ _k8s_namespace }}
+      -o jsonpath={.status.conditions[?(@.type=="Ready")].status}
+  register: _restore_pod_ready
   changed_when: false
+  failed_when: false
+  retries: 60
+  delay: 2
+  until: (_restore_pod_ready.stdout | trim) == 'True'
 
+# Poll for the restore sentinel with short `kubectl exec test -f` calls
+# instead of a single held exec that loops on the target for up to 10
+# minutes — same resilience rationale as the readiness poll above.
 - name: Wait for restore to complete
   ansible.builtin.command:
     cmd: >-
       kubectl exec -n {{ _k8s_namespace }} restic-restore --
-      sh -c "while ! test -f /tmp/restore-done; do sleep 2; done"
+      test -f /tmp/restore-done
+  register: _restore_done
   changed_when: false
-  timeout: 600
+  failed_when: false
+  retries: 300
+  delay: 2
+  until: _restore_done.rc == 0
 
 - name: Copy restored config to host
   ansible.builtin.shell:

--- a/roles/orchestrator/tasks/helm_deploy.yml
+++ b/roles/orchestrator/tasks/helm_deploy.yml
@@ -16,9 +16,16 @@
     path: "{{ instance_path }}/values-configdata.yaml"
   register: _configdata_file
 
+# Launched detached and polled (resilient_exec) so a controller-side SSH
+# reset during the up-to-10m `--wait` doesn't abort a deploy that is still
+# progressing on the target. helm upgrade --install is idempotent, so a
+# re-run after a reset is safe.
 - name: Deploy Canasta Helm release
-  ansible.builtin.command:
-    cmd: >-
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/resilient_exec.yml"
+  vars:
+    rx_name: "deploy Helm release canasta-{{ instance_id }}"
+    rx_async: 720
+    rx_cmd: >-
       helm upgrade --install canasta-{{ instance_id }}
       {{ instance_path }}/_chart
       --namespace {{ _k8s_namespace }} --create-namespace
@@ -29,4 +36,3 @@
          | ternary('--reset-values', '') }}
       {{ (helm_wait | default(true) | bool)
          | ternary('--wait --timeout 10m', '') }}
-  changed_when: true

--- a/roles/orchestrator/tasks/helm_uninstall.yml
+++ b/roles/orchestrator/tasks/helm_uninstall.yml
@@ -2,13 +2,17 @@
 # Uninstall the Canasta Helm release and clean up.
 # Input: instance_id, _k8s_namespace
 
+# Launched detached and polled (resilient_exec) so a controller-side SSH
+# reset during the wait doesn't abort an uninstall still progressing on the
+# target. rx_fail is false because uninstalling an already-absent release
+# returns non-zero — harmless, matching the prior ignore_errors.
 - name: Uninstall Canasta Helm release
-  kubernetes.core.helm:
-    name: "canasta-{{ instance_id }}"
-    release_namespace: "{{ _k8s_namespace }}"
-    state: absent
-    wait: true
-  ignore_errors: true  # OK if release already uninstalled
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/resilient_exec.yml"
+  vars:
+    rx_name: "uninstall Helm release canasta-{{ instance_id }}"
+    rx_async: 300
+    rx_fail: false
+    rx_cmd: "helm uninstall canasta-{{ instance_id }} -n {{ _k8s_namespace }} --wait"
 
 - name: Delete Ansible-managed resources
   kubernetes.core.k8s:
@@ -26,17 +30,19 @@
     - { kind: ConfigMap, name: "canasta-{{ instance_id }}-db-config" }
   ignore_errors: true  # OK if resources already deleted
 
+# Wait for the namespace to fully terminate before returning. Without
+# this, deletion is async and an immediate `canasta create` races the
+# still-Terminating namespace and fails its stale-namespace guard.
+# Namespace teardown (finalizers, PVC/pod cleanup) can take minutes, so
+# this is launched detached and polled (resilient_exec): a controller-side
+# reset during the wait must not leave the caller believing it failed while
+# k8s is still terminating it. --ignore-not-found keeps a re-run idempotent.
 - name: Delete namespace
-  kubernetes.core.k8s:
-    state: absent
-    api_version: v1
-    kind: Namespace
-    name: "{{ _k8s_namespace }}"
-    # Wait for the namespace to fully terminate before delete returns.
-    # Without this, deletion is async and an immediate `canasta create`
-    # races the still-Terminating namespace and fails its stale-namespace
-    # guard. Namespace teardown (finalizers, PVC/pod cleanup) can take a
-    # while, so allow generous time.
-    wait: true
-    wait_timeout: 300
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/resilient_exec.yml"
+  vars:
+    rx_name: "delete namespace {{ _k8s_namespace }}"
+    rx_async: 360
+    rx_cmd: >-
+      kubectl delete namespace {{ _k8s_namespace }}
+      --ignore-not-found=true --wait=true --timeout=300s
   when: delete_namespace | default(true) | bool

--- a/roles/orchestrator/tasks/k8s_argocd_bootstrap.yml
+++ b/roles/orchestrator/tasks/k8s_argocd_bootstrap.yml
@@ -22,20 +22,33 @@
         name: argo
         repo_url: https://argoproj.github.io/argo-helm
 
-    - name: Install Argo CD via Helm
-      kubernetes.core.helm:
-        name: argocd
-        chart_ref: argo/argo-cd
-        release_namespace: "{{ argocd_namespace | default('argocd') }}"
-        create_namespace: true
-        wait: true
-        timeout: "10m"
-        values:
+    # Stage the chart values as a file so the helm invocation below can be a
+    # plain CLI command (no --set dotted-key escaping) and run through
+    # resilient_exec.
+    - name: Stage Argo CD Helm values on the target
+      ansible.builtin.copy:
+        dest: /tmp/canasta-argocd-values.yaml
+        mode: "0600"
+        content: |
           server:
             insecure: false
           configs:
             params:
               server.insecure: false
+
+    # Launched detached and polled (resilient_exec) so a controller-side SSH
+    # reset during the up-to-10m `--wait` doesn't abort an install still
+    # progressing on the target. helm upgrade --install is idempotent.
+    - name: Install Argo CD via Helm
+      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/resilient_exec.yml"
+      vars:
+        rx_name: "install Argo CD"
+        rx_async: 720
+        rx_cmd: >-
+          helm upgrade --install argocd argo/argo-cd
+          --namespace {{ argocd_namespace | default('argocd') }} --create-namespace
+          --wait --timeout 10m
+          -f /tmp/canasta-argocd-values.yaml
 
     - name: Report Argo CD installed
       ansible.builtin.debug:

--- a/roles/orchestrator/tasks/k8s_certmanager.yml
+++ b/roles/orchestrator/tasks/k8s_certmanager.yml
@@ -40,13 +40,25 @@
     # apply, so waiting on `condition=Available` for the Deployment
     # tolerates the brief gap between apply and pod creation, then
     # blocks until the rollout has minimum replicas Ready.
+    # Poll the Deployments' Available condition with short `kubectl get`
+    # calls instead of a single held `kubectl wait --timeout=180s`: a
+    # controller-side SSH reset during a held wait would abort create,
+    # while the rollout keeps progressing on the target. Passes once every
+    # matched Deployment reports Available=True.
     - name: Wait for cert-manager Deployments to become Available
       ansible.builtin.command:
         cmd: >-
-          kubectl wait --for=condition=Available
-          deployment -l app.kubernetes.io/instance=cert-manager
-          -n cert-manager --timeout=180s
+          kubectl get deployment -l app.kubernetes.io/instance=cert-manager
+          -n cert-manager
+          -o jsonpath={.items[*].status.conditions[?(@.type=="Available")].status}
+      register: _cm_avail
       changed_when: false
+      failed_when: false
+      retries: 90
+      delay: 2
+      until: >-
+        (_cm_avail.stdout.split() | length) > 0 and
+        (_cm_avail.stdout.split() | reject('equalto', 'True') | list | length) == 0
 
     # Even after the webhook Deployment is Available, there's a brief
     # window where the cert-manager admission webhook hasn't fully

--- a/roles/orchestrator/tasks/pull.yml
+++ b/roles/orchestrator/tasks/pull.yml
@@ -19,11 +19,16 @@
   ignore_errors: true
   when: instance_orchestrator | default('compose') == 'compose'
 
+# Launched detached and polled (resilient_exec): an image pull can run for
+# minutes, and a controller-side SSH reset mid-pull would otherwise abort it.
+# `docker compose pull` is idempotent, so a re-run after a reset is safe.
 - name: Pull images (Compose)
-  ansible.builtin.command:
-    cmd: "docker compose pull --ignore-buildable --ignore-pull-failures"
-    chdir: "{{ instance_path }}"
-  changed_when: false
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/resilient_exec.yml"
+  vars:
+    rx_name: "pull Compose images"
+    rx_chdir: "{{ instance_path }}"
+    rx_async: 1800
+    rx_cmd: "docker compose pull --ignore-buildable --ignore-pull-failures"
   when: instance_orchestrator | default('compose') == 'compose'
 
 - name: Get image ID after pull

--- a/roles/orchestrator/tasks/resilient_exec.yml
+++ b/roles/orchestrator/tasks/resilient_exec.yml
@@ -1,0 +1,68 @@
+---
+# Run a long-running remote command resiliently.
+#
+# The command is launched asynchronously (detached on the target) and its
+# completion is polled with short connections. A mid-operation SSH reset on
+# the controller cannot kill the work — it runs detached on the target — and
+# each poll is a brief connection, so transient drops during the wait are
+# retried instead of aborting the whole operation. This is the same
+# launch-then-poll shape the K8s backup Job already uses, generalized so any
+# held command (helm --wait, the k3s/docker installers, `docker compose
+# pull`, a long mariadb import) survives a flaky controller-to-target link.
+#
+# The launched command MUST be idempotent: a reset between launch and the
+# first successful poll leaves no way to tell whether it ran, so callers
+# re-run safely (helm upgrade --install, docker compose up -d, restic, the
+# installers all qualify).
+#
+# Input:
+#   rx_cmd      - shell command to run (string; pipes/redirects allowed)
+#   rx_name     - short label used in task names and the failure message
+# Optional:
+#   rx_chdir    - working directory for the command (default: none)
+#   rx_async    - max seconds the command may run (default: 1800)
+#   rx_retries  - number of completion polls (default: 180)
+#   rx_delay    - seconds between polls (default: 10)
+#   rx_fail     - fail the play on non-zero rc (default: true)
+# Output:
+#   rx_result   - async_status result (.rc, .stdout, .stderr, .finished)
+#
+# become is inherited from the caller's context and applies to both the
+# launch and the polls, so the async job files are written and read as the
+# same user.
+
+- name: "Launch (async): {{ rx_name }}"
+  ansible.builtin.shell:
+    cmd: "{{ rx_cmd }}"
+    chdir: "{{ rx_chdir | default(omit) }}"
+  async: "{{ rx_async | default(1800) | int }}"
+  poll: 0
+  register: _rx_job
+  changed_when: true
+
+- name: "Wait for completion: {{ rx_name }}"
+  ansible.builtin.async_status:
+    jid: "{{ _rx_job.ansible_job_id }}"
+  register: rx_result
+  until: rx_result.finished | default(false) | bool
+  retries: "{{ rx_retries | default(180) | int }}"
+  delay: "{{ rx_delay | default(10) | int }}"
+  # An unreachable poll registers a result with no `.finished`, so the
+  # until-loop simply retries — transient resets during the wait don't
+  # abort the operation, which keeps running on the target.
+  ignore_unreachable: true
+
+- name: "Report failure: {{ rx_name }}"
+  ansible.builtin.fail:
+    msg: >-
+      {{ rx_name }} failed (rc={{ rx_result.rc | default('unknown') }}):
+      {{ (rx_result.stderr | default('')) | trim
+         | default(rx_result.stdout | default(''), true) }}
+  when:
+    - rx_fail | default(true) | bool
+    - (rx_result.rc | default(1) | int) != 0
+
+- name: "Clean up async job file: {{ rx_name }}"
+  ansible.builtin.async_status:
+    jid: "{{ _rx_job.ansible_job_id }}"
+    mode: cleanup

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -3472,3 +3472,55 @@ class TestResolveInstanceByCwd:
         )
         assert iid == "siteB"
         assert inst is not None
+
+
+class TestRetryOnSshReset:
+    """Idempotent remote ops retry on ssh exit 255 (a connection-level
+    reset) so a transient controller-to-target drop doesn't fail a command
+    that was progressing (#750)."""
+
+    def test_retries_on_255_then_succeeds(self):
+        calls = []
+
+        def run():
+            calls.append(1)
+            return 255 if len(calls) < 2 else 0
+
+        rc = direct_commands._helpers._retry_on_ssh_reset(run, attempts=3)
+        assert rc == 0
+        assert len(calls) == 2
+
+    def test_gives_up_after_attempts(self):
+        calls = []
+
+        def run():
+            calls.append(1)
+            return 255
+
+        rc = direct_commands._helpers._retry_on_ssh_reset(run, attempts=3)
+        assert rc == 255
+        assert len(calls) == 3
+
+    def test_no_retry_on_non_connection_failure(self):
+        # A non-255 rc is the remote command's own exit code — a real
+        # failure, not a connection reset. It must not be retried.
+        calls = []
+
+        def run():
+            calls.append(1)
+            return 1
+
+        rc = direct_commands._helpers._retry_on_ssh_reset(run, attempts=3)
+        assert rc == 1
+        assert len(calls) == 1
+
+    def test_success_first_try_runs_once(self):
+        calls = []
+
+        def run():
+            calls.append(1)
+            return 0
+
+        rc = direct_commands._helpers._retry_on_ssh_reset(run, attempts=3)
+        assert rc == 0
+        assert len(calls) == 1

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -1012,12 +1012,53 @@ class TestK8sDeleteWaitsForNamespace:
         with open(os.path.join(ORCHESTRATOR_TASKS, "helm_uninstall.yml")) as f:
             tasks = yaml.safe_load(f)
         ns = next(t for t in tasks if t.get("name") == "Delete namespace")
-        spec = ns["kubernetes.core.k8s"]
-        assert spec.get("kind") == "Namespace"
-        assert spec.get("state") == "absent"
-        assert spec.get("wait") is True, (
+        # Deletion runs via resilient_exec (launch detached + poll) so a
+        # controller-side SSH reset during the wait can't abort it, but the
+        # kubectl command still waits for the namespace to fully terminate.
+        assert "resilient_exec.yml" in ns["ansible.builtin.include_tasks"]
+        cmd = ns["vars"]["rx_cmd"]
+        assert "kubectl delete namespace" in cmd
+        assert "--wait=true" in cmd
+        assert "--timeout=300s" in cmd, (
             "namespace deletion must wait, so delete->create does not race"
         )
+
+
+class TestResilientExec:
+    """Long-running remote ops run detached and are polled (resilient_exec)
+    so a controller-side SSH reset doesn't abort work still progressing on
+    the target (#750)."""
+
+    PRIMITIVE = os.path.join(ORCHESTRATOR_TASKS, "resilient_exec.yml")
+
+    def test_primitive_launches_async_and_polls(self):
+        tasks = yaml.safe_load(open(self.PRIMITIVE))
+        # First task fires the command and returns immediately (poll: 0).
+        launch = tasks[0]
+        assert launch.get("poll") == 0
+        assert launch.get("async") is not None
+        assert "ansible.builtin.shell" in launch
+        # Completion is polled with async_status in an until-loop that
+        # tolerates transient unreachable polls.
+        poll = next(t for t in tasks if "ansible.builtin.async_status" in t)
+        assert "until" in poll
+        assert poll.get("ignore_unreachable") is True
+
+    def test_helm_deploy_uses_resilient_exec(self):
+        tasks = yaml.safe_load(
+            open(os.path.join(ORCHESTRATOR_TASKS, "helm_deploy.yml")))
+        deploy = next(
+            t for t in tasks if t.get("name") == "Deploy Canasta Helm release")
+        assert "resilient_exec.yml" in deploy["ansible.builtin.include_tasks"]
+        assert "helm upgrade --install" in deploy["vars"]["rx_cmd"]
+
+    def test_argocd_install_uses_resilient_exec(self):
+        tasks = yaml.safe_load(
+            open(os.path.join(ORCHESTRATOR_TASKS, "k8s_argocd_bootstrap.yml")))
+        install_block = next(t for t in tasks if t.get("name") == "Install Argo CD")
+        sub = install_block["block"]
+        helm = next(t for t in sub if t.get("name") == "Install Argo CD via Helm")
+        assert "resilient_exec.yml" in helm["ansible.builtin.include_tasks"]
 
 
 class TestK8sTraefikClientIP:


### PR DESCRIPTION
Refs #750. Core scope (lifecycle / restore / delete / cluster-setup); installers and per-caller long-exec are a tracked follow-up.

## Problem

Long controller-to-target operations (helm `--wait`, the namespace-delete wait, the restic-restore wait, the Compose image pull) ran as a single **held SSH session**. A mid-operation reset on the link aborted the command even though the work kept running on the target, leaving non-atomic partial state. Observed repeatedly during the multi-node e2e on `create` / `start` / `delete`. Keepalives (already set on both paths) do not help — these are active RSTs, not idle drops.

## Approach

New primitive `roles/orchestrator/tasks/resilient_exec.yml`: launch a long command **asynchronously** (detached on the target, returns immediately) and poll completion with **short** `async_status` connections, modeled on the K8s backup Jobs existing launch-then-poll shape. A controller-side reset cant kill detached work, and an unreachable poll just retries. Where an op is a *wait on remote state* (`kubectl wait`, the held sentinel exec), its replaced with a short-command poll loop instead.

The launched commands are idempotent (`helm upgrade --install`, `docker compose pull`, `kubectl delete --ignore-not-found`), so a re-run after a reset is safe.

## Converted paths

| File | Op | Commands covered |
|---|---|---|
| `helm_deploy.yml` | helm upgrade --install --wait | create / start / restart / config set / upgrade (K8s) |
| `helm_uninstall.yml` | helm uninstall --wait + namespace delete --wait (→ CLI) | delete |
| `k8s_argocd_bootstrap.yml` | argo-cd install --wait (staged values file) | create |
| `pull.yml` | docker compose pull | create / start / upgrade (Compose) |
| `restore_k8s.yml` | held `kubectl wait` + held sentinel exec → short poll loops | backup restore |
| `k8s_certmanager.yml` | held `kubectl wait --timeout` → poll | create / config set (TLS) |

**Python direct path** (`direct_commands/_helpers.py`, `lifecycle.py`): retry idempotent remote ops (`scale`s helm upgrade, `_run_compose` up/down) on ssh exit **255** — a connection-level failure, distinct from any exit code the remote command itself returns.

**devmode** already refuses remote instances (no `--host` parameter + a registered-host guard), so it is intentionally left untouched.

## Follow-up (tracked under #750)

- k3s / docker installers (complex, recently version-pinned; only the live e2e can validate them).
- Per-caller long execs: `update.php` (add / import / upgrade / maintenance) and large `mysqldump` (export) — the shared `exec.yml` abstraction must not be blanket-converted, so these need per-caller surgery.

## Testing

- `make lint`, `make validate`, `make test-unit` (1134 passed, 8 new) all green.
- New tests: `TestResilientExec` (primitive launches async + polls; helm_deploy / argocd use it), `TestRetryOnSshReset` (retries on 255, gives up after N, no retry on a real failure), and the updated namespace-delete structure test.
- The async/poll resilience itself is exercised by the planned repeat multi-node e2e (it requires a real flaky remote link to fully validate).