### PR TITLE
Resilient remote ops follow-up: harden installers + long container execs

### DIFF
--- a/playbooks/export.yml
+++ b/playbooks/export.yml
@@ -38,6 +38,7 @@
   vars:
     exec_service: db
     exec_no_log: true
+    exec_long: true
     exec_command: >-
       mariadb-dump -u root
       -p{{ _export_db_password | quote }}

--- a/roles/extensions_skins/tasks/enable.yml
+++ b/roles/extensions_skins/tasks/enable.yml
@@ -34,6 +34,7 @@
   vars:
     exec_service: web
     exec_command: "php maintenance/update.php --wiki={{ wiki | default('') | quote }}"
+    exec_long: true
 
 - name: "Report {{ _item_type }} enabled"
   ansible.builtin.debug:

--- a/roles/install/tasks/docker.yml
+++ b/roles/install/tasks/docker.yml
@@ -86,6 +86,9 @@
             state: present
             filename: docker
 
+        # Launched detached and polled: the package download/install runs
+        # for minutes, and a controller-side SSH reset mid-install would
+        # otherwise abort it. apt is idempotent, so a re-run is safe.
         - name: Install Docker packages
           ansible.builtin.apt:
             name:
@@ -95,6 +98,18 @@
               - docker-compose-plugin
             state: present
             update_cache: true
+          async: 600
+          poll: 0
+          register: _docker_pkg_job
+
+        - name: Wait for Docker packages to install (apt)
+          ansible.builtin.async_status:
+            jid: "{{ _docker_pkg_job.ansible_job_id }}"
+          register: _docker_pkg
+          until: _docker_pkg.finished | default(false) | bool
+          retries: 60
+          delay: 10
+          ignore_unreachable: true
 
     - name: Install Docker (RHEL/CentOS/Fedora)
       when: ansible_os_family == 'RedHat'
@@ -112,6 +127,7 @@
               https://download.docker.com/linux/centos/docker-ce.repo
           changed_when: true
 
+        # Launched detached and polled, like the apt path above.
         - name: Install Docker packages
           ansible.builtin.dnf:
             name:
@@ -120,6 +136,18 @@
               - containerd.io
               - docker-compose-plugin
             state: present
+          async: 600
+          poll: 0
+          register: _docker_pkg_job
+
+        - name: Wait for Docker packages to install (dnf)
+          ansible.builtin.async_status:
+            jid: "{{ _docker_pkg_job.ansible_job_id }}"
+          register: _docker_pkg
+          until: _docker_pkg.finished | default(false) | bool
+          retries: 60
+          delay: 10
+          ignore_unreachable: true
 
     - name: Enable and start Docker
       ansible.builtin.systemd:

--- a/roles/mediawiki/tasks/import_database.yml
+++ b/roles/mediawiki/tasks/import_database.yml
@@ -47,6 +47,7 @@
     exec_service: db
     exec_command: "gunzip -c /tmp/import.sql.gz | mariadb -u root -p'{{ import_db_password }}' '{{ import_wiki_id }}'"
     exec_no_log: true
+    exec_long: true
   when: _is_gzipped | bool
 
 - name: Import plain SQL database
@@ -55,6 +56,7 @@
     exec_service: db
     exec_command: "mariadb -u root -p'{{ import_db_password }}' '{{ import_wiki_id }}' < /tmp/import.sql"
     exec_no_log: true
+    exec_long: true
   when: not (_is_gzipped | bool)
 
 - name: Clean up temp dump file

--- a/roles/mediawiki/tasks/install_single_wiki.yml
+++ b/roles/mediawiki/tasks/install_single_wiki.yml
@@ -29,6 +29,7 @@
   vars:
     exec_service: web
     exec_no_log: true
+    exec_long: true
     exec_command: >-
       env -u MW_SECRET_KEY php maintenance/install.php
       --skins='Vector'

--- a/roles/orchestrator/tasks/backup_stage_db_dumps.yml
+++ b/roles/orchestrator/tasks/backup_stage_db_dumps.yml
@@ -28,6 +28,7 @@
   vars:
     exec_service: web
     exec_no_log: true
+    exec_long: true
     exec_command: >-
       mariadb-dump -h "${MYSQL_HOST:-db}" -u "${MYSQL_USER:-root}"
       -p{{ _backup_dbpass.value | quote }}

--- a/roles/orchestrator/tasks/exec.yml
+++ b/roles/orchestrator/tasks/exec.yml
@@ -9,6 +9,10 @@
 #   exec_service (str) - service name (default: web)
 #   exec_command (str) - command to run
 #   exec_no_log (bool, optional) - suppress command in output
+#   exec_long (bool, optional) - run detached + polled for long commands
+#     (update.php on a big wiki, a large mysqldump) so a controller-side
+#     SSH reset doesn't abort them. Default false (held single connection).
+#   exec_long_async (int, optional) - max seconds for a long exec (3600)
 # Output:
 #   exec_result (registered result with .stdout, .rc, etc.)
 
@@ -55,4 +59,25 @@
     chdir: "{{ _exec_chdir | default(omit) }}"
   register: exec_result
   changed_when: false
+  no_log: "{{ exec_no_log | default(false) }}"
+  when: not (exec_long | default(false) | bool)
+
+# Long commands (update.php on a big wiki, a large mysqldump) run detached
+# and polled so a controller-side SSH reset doesn't abort work still
+# progressing on the target. The result is mapped back to exec_result so
+# callers consume it the same way.
+- name: "Execute (long, detached + polled): {{ exec_command | truncate(60) }}"
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/resilient_exec.yml"
+  vars:
+    rx_name: "{{ exec_command | truncate(60) }}"
+    rx_cmd: "{{ _exec_full_cmd }}"
+    rx_chdir: "{{ _exec_chdir | default(omit) }}"
+    rx_async: "{{ exec_long_async | default(3600) }}"
+    rx_no_log: "{{ exec_no_log | default(false) }}"
+  when: exec_long | default(false) | bool
+
+- name: Map long-exec result to exec_result
+  ansible.builtin.set_fact:
+    exec_result: "{{ rx_result }}"
+  when: exec_long | default(false) | bool
   no_log: "{{ exec_no_log | default(false) }}"

--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -48,13 +48,19 @@
     # directly from GitHub instead of asking update.k3s.io to resolve a
     # channel — removing that single point of failure and keeping every
     # node in the cluster on the same version (see canasta_k3s_version).
+    # Launched detached and polled (resilient_exec): the installer downloads
+    # and sets up k3s over a minute or more, and a controller-side SSH reset
+    # mid-install would otherwise abort it. The k3s installer is idempotent,
+    # so a re-run after a reset is safe.
     - name: Download and install k3s
-      ansible.builtin.shell:
-        cmd: >-
+      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/resilient_exec.yml"
+      vars:
+        rx_name: "install k3s"
+        rx_async: 600
+        rx_cmd: >-
           curl -sfL --retry 3 --retry-delay 5 https://get.k3s.io |
           INSTALL_K3S_VERSION={{ canasta_k3s_version | quote }}
           INSTALL_K3S_EXEC={{ _k3s_install_exec | quote }} sh -
-      changed_when: true
 
     - name: Make k3s kubeconfig readable (before verification)
       ansible.builtin.file:
@@ -106,13 +112,16 @@
   changed_when: false
   ignore_errors: true
 
+# Launched detached and polled (resilient_exec) like the k3s install above.
 - name: Install helm
-  ansible.builtin.shell:
-    cmd: >-
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/resilient_exec.yml"
+  vars:
+    rx_name: "install helm"
+    rx_async: 300
+    rx_cmd: >-
       curl -fsSL --retry 3 --retry-delay 5
       https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
       | DESIRED_VERSION={{ canasta_helm_version | quote }} bash
-  changed_when: true
   when: _helm_installed.rc != 0
 
 # Ansible k8s modules require the Python kubernetes library.

--- a/roles/orchestrator/tasks/k8s_install_k3s_agent.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s_agent.yml
@@ -36,16 +36,22 @@
     # Pin the same k3s version as the control plane (canasta_k3s_version)
     # so a later-joining worker can't outpace the cp, and so the install
     # doesn't depend on update.k3s.io resolving a channel.
+    # Launched detached and polled (resilient_exec): the installer runs for
+    # a minute or more and a controller-side SSH reset mid-join would abort
+    # it. rx_no_log hides the command because it carries the join token. The
+    # k3s installer is idempotent, so a re-run after a reset is safe.
     - name: Download and install k3s agent
-      ansible.builtin.shell:
-        cmd: >-
+      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/resilient_exec.yml"
+      vars:
+        rx_name: "install k3s agent"
+        rx_async: 600
+        rx_no_log: true
+        rx_cmd: >-
           curl -sfL --retry 3 --retry-delay 5 https://get.k3s.io |
           INSTALL_K3S_VERSION={{ canasta_k3s_version | quote }}
           K3S_URL={{ server | quote }}
           K3S_TOKEN={{ token | quote }}
           sh -
-      changed_when: true
-      no_log: true  # token is sensitive
 
     - name: Wait for k3s-agent service to be active
       ansible.builtin.command:

--- a/roles/orchestrator/tasks/resilient_exec.yml
+++ b/roles/orchestrator/tasks/resilient_exec.yml
@@ -24,6 +24,8 @@
 #   rx_retries  - number of completion polls (default: 180)
 #   rx_delay    - seconds between polls (default: 10)
 #   rx_fail     - fail the play on non-zero rc (default: true)
+#   rx_no_log   - hide the command and its output, for secrets in rx_cmd
+#                 (default: false)
 # Output:
 #   rx_result   - async_status result (.rc, .stdout, .stderr, .finished)
 #
@@ -39,6 +41,7 @@
   poll: 0
   register: _rx_job
   changed_when: true
+  no_log: "{{ rx_no_log | default(false) | bool }}"
 
 - name: "Wait for completion: {{ rx_name }}"
   ansible.builtin.async_status:
@@ -61,6 +64,7 @@
   when:
     - rx_fail | default(true) | bool
     - (rx_result.rc | default(1) | int) != 0
+  no_log: "{{ rx_no_log | default(false) | bool }}"
 
 - name: "Clean up async job file: {{ rx_name }}"
   ansible.builtin.async_status:

--- a/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
+++ b/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
@@ -61,6 +61,7 @@
           vars:
             exec_service: db
             exec_no_log: true
+            exec_long: true
             exec_command: >-
               mysqldump -u root
               -p{{ _mig_dbpass.value | quote }}
@@ -107,6 +108,7 @@
           vars:
             exec_service: db
             exec_no_log: true
+            exec_long: true
             exec_command: >-
               mariadb -u root
               -p{{ _mig_dbpass.value | quote }}

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -1060,6 +1060,29 @@ class TestResilientExec:
         helm = next(t for t in sub if t.get("name") == "Install Argo CD via Helm")
         assert "resilient_exec.yml" in helm["ansible.builtin.include_tasks"]
 
+    def test_k3s_install_uses_resilient_exec(self):
+        tasks = yaml.safe_load(
+            open(os.path.join(ORCHESTRATOR_TASKS, "k8s_install_k3s.yml")))
+        block = next(t for t in tasks if t.get("name") == "Install k3s")
+        install = next(
+            t for t in block["block"]
+            if t.get("name") == "Download and install k3s")
+        assert "resilient_exec.yml" in install["ansible.builtin.include_tasks"]
+
+    def test_exec_supports_opt_in_long_mode(self):
+        # The shared exec abstraction gains an opt-in long mode (detached +
+        # polled) used by update.php / mysqldump callers, while short callers
+        # keep the held single connection (gated by exec_long).
+        tasks = yaml.safe_load(
+            open(os.path.join(ORCHESTRATOR_TASKS, "exec.yml")))
+        held = next(t for t in tasks if str(t.get("name", "")).startswith("Execute:"))
+        assert "not (exec_long" in str(held.get("when", ""))
+        long_task = next(
+            t for t in tasks
+            if "resilient_exec.yml" in str(
+                t.get("ansible.builtin.include_tasks", "")))
+        assert "exec_long" in str(long_task.get("when", ""))
+
 
 class TestK8sTraefikClientIP:
     """The k3s-bundled Traefik LoadBalancer defaults to externalTrafficPolicy:


### PR DESCRIPTION
Closes #750. Follow-up to #751 (merged), which delivered the core `resilient_exec` primitive and the lifecycle / restore / delete / cluster-setup conversions. This completes the remaining exposed paths.

## A — Installers

- **k3s** control-plane install, the **k3s agent join**, and the **helm** install (`curl | sh`) now launch detached and poll via `resilient_exec`. Added an `rx_no_log` option to the primitive so the agent join token is never logged.
- **docker.yml** `apt`/`dnf` package installs run async + poll.

These are the install paths the multi-node e2e hit SSH resets on.

## B — Long container execs

`roles/orchestrator/tasks/exec.yml` gains an opt-in **`exec_long`** mode: when set, the long container command is routed through `resilient_exec` (detached + polled) and the result is mapped back to `exec_result`, so callers consume it unchanged. Short callers keep the held single connection (default).

Flagged long callers:
- `install.php` — wiki install (create)
- `update.php` — extension enable
- DB import (`mariadb < dump`) — import
- `mariadb-dump` — export
- Compose backup DB dump
- mysql -> mariadb migration dump + import

## Known gap

`canasta maintenance update` / `maintenance script` are Python `direct_only` commands and do not flow through the Ansible `exec.yml` path, so `exec_long` does not cover them. Hardening those would be a small separate change in the Python direct path (retry / stream rather than the 30s `_ssh_run` cap). Noting here rather than expanding this PR.

## Testing

- `make lint`, `make validate`, `make test-unit` (1136 passed) all green.
- New structural tests: k3s install uses `resilient_exec`; `exec.yml` supports the opt-in `exec_long` mode (held path gated on `not exec_long`).
- The async/poll resilience and the installer conversions need the planned repeat multi-node e2e for live validation (no real flaky link in unit tests).