### PR TITLE
fix: K8s restore must fail loudly when restic fails (not silently succeed)

### DIFF
--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -86,11 +86,13 @@
               - sh
               - -c
               - |
-                # Don't gate the sentinel on restic's exit code: snapshots from
-                # EBS-backed PVCs include security.selinux xattrs that the
-                # restore pod's overlay fs can't accept, so restic exits 1 on
-                # the lost+found dirs even though all wiki content restored.
-                restic --cache-dir /tmp/restic-cache restore {{ _resolved_snapshot }} --target /
+                # Capture restic's rc + output so the controller can tell a
+                # real failure (restic prints "Fatal:") from the benign exit 1
+                # on EBS-backed PVCs whose selinux xattrs the overlay fs
+                # rejects. Sentinel still fires unconditionally so the wait
+                # can't hang; the controller inspects the rc + log below.
+                restic --cache-dir /tmp/restic-cache restore {{ _resolved_snapshot }} --target / > /tmp/restore-log 2>&1
+                echo $? > /tmp/restore-rc
                 touch /tmp/restore-done
                 sleep 3600
             # canasta-<id>-backup-env carries every cloud-backend
@@ -133,6 +135,46 @@
   retries: 300
   delay: 2
   until: _restore_done.rc == 0
+
+# Inspect restic's captured exit code and output. A non-zero rc is only
+# tolerated when it is the known xattr noise (no "Fatal:" line); anything
+# restic flagged as fatal — repo unreachable, wrong password, snapshot not
+# found — must abort loudly instead of being reported as a successful
+# restore that actually restored nothing.
+- name: Read restic restore exit code
+  ansible.builtin.command:
+    cmd: kubectl exec -n {{ _k8s_namespace }} restic-restore -- cat /tmp/restore-rc
+  register: _restore_rc
+  changed_when: false
+  failed_when: false
+
+- name: Read restic restore log
+  ansible.builtin.command:
+    cmd: kubectl exec -n {{ _k8s_namespace }} restic-restore -- cat /tmp/restore-log
+  register: _restore_log
+  changed_when: false
+  failed_when: false
+
+- name: Fail when restic restore reported a fatal error
+  ansible.builtin.fail:
+    msg: |-
+      restic restore failed (exit {{ _restore_rc.stdout | default('?') | trim }}).
+      The snapshot was NOT restored. restic output:
+      {{ _restore_log.stdout | default('(no log captured)') }}
+  when: >-
+    (_restore_rc.stdout | default('1') | trim) != '0'
+    and (_restore_log.stdout | default('') is search('Fatal'))
+
+- name: Warn about ignored non-fatal restore errors
+  ansible.builtin.debug:
+    msg: >-
+      restic exited {{ _restore_rc.stdout | default('?') | trim }} with
+      non-fatal errors (treated as the known xattr-on-overlay case); wiki
+      content was restored. Output:
+      {{ _restore_log.stdout | default('') | truncate(500) }}
+  when: >-
+    (_restore_rc.stdout | default('0') | trim) != '0'
+    and not (_restore_log.stdout | default('') is search('Fatal'))
 
 - name: Copy restored config to host
   ansible.builtin.shell:

--- a/tests/unit/test_backup_schedule_k8s.py
+++ b/tests/unit/test_backup_schedule_k8s.py
@@ -546,6 +546,45 @@ class TestK8sRestorePreservesCurrentDBPassword:
         )
 
 
+class TestK8sRestoreFailsLoudlyOnResticError:
+    """#748: a restore must NOT report success when restic actually failed
+    (repo unreachable, wrong password, snapshot missing). The pod captures
+    restic's exit code + output, and the controller fails loudly on a fatal
+    error while still tolerating the benign xattr exit 1."""
+
+    RESTORE_K8S = os.path.join(
+        REPO_ROOT, "roles", "backup", "tasks", "restore_k8s.yml",
+    )
+
+    def _content(self):
+        with open(self.RESTORE_K8S) as f:
+            return f.read()
+
+    def test_pod_captures_restic_exit_code_and_log(self):
+        content = self._content()
+        assert "echo $? > /tmp/restore-rc" in content, (
+            "the restore pod must capture restic's exit code so the "
+            "controller can tell a real failure from benign xattr noise"
+        )
+        assert "/tmp/restore-log" in content, (
+            "the restore pod must capture restic's output for diagnosis"
+        )
+
+    def test_fails_loudly_on_fatal_restic_error(self):
+        content = self._content()
+        assert "Fail when restic restore reported a fatal error" in content, (
+            "restore_k8s.yml must have an explicit fail task for fatal "
+            "restic errors so a failed restore is not reported as success"
+        )
+        # Gated on a non-zero rc AND restic's 'Fatal:' marker, so the
+        # benign xattr exit 1 (no Fatal) is tolerated, not aborted.
+        assert "is search('Fatal')" in content, (
+            "the fail must key on restic's 'Fatal:' marker to distinguish "
+            "real failures from the xattr-on-overlay exit 1"
+        )
+        assert "_restore_rc" in content
+
+
 class TestOnDemandBackupCapturesDB:
     """Guard #513: on-demand 'canasta backup create' on K8s must
     capture the wiki database. Pre-fix the dump ran via 'kubectl


### PR DESCRIPTION
Fixes #748. Found during a hands-on multi-node K8s e2e.

## Problem

`canasta backup restore` on Kubernetes could print **"Restored from snapshot X." and exit 0 while having restored nothing**. The restore pod touched its completion sentinel *unconditionally* after `restic restore`:

```sh
restic ... restore SNAPSHOT --target /
touch /tmp/restore-done      # fired even if restic exited non-zero
```

The comment justified this narrowly (restic exits 1 on selinux xattrs from EBS-backed PVCs even when content restored), but it masked **every** restic failure — repo unreachable, wrong password, snapshot missing. With nothing restored, the DB-import step then silently skipped (no dump files), so the operator was told the restore succeeded when it completely failed.

Seen live: the `restic-restore` pod was scheduled on a node whose local-path repo was empty (see #749), restic failed, yet the CLI reported success.

## Fix

Capture restic's exit code and output in the pod, then inspect them on the controller after the wait:

```sh
restic ... restore SNAPSHOT --target / > /tmp/restore-log 2>&1
echo $? > /tmp/restore-rc
touch /tmp/restore-done
```

- **Fail loudly** when `rc != 0` AND the log contains `Fatal:` — restic prints `Fatal:` for repo-open / wrong-password / snapshot-missing. The snapshot was not restored, so abort instead of reporting success.
- **Tolerate** the benign xattr exit 1 (a non-zero rc with no `Fatal:` line) — wiki content was restored; emit a warning rather than failing.

## Testing

- `make lint`, `make validate`, `make test-unit` (1138 passed) all green.
- New `TestK8sRestoreFailsLoudlyOnResticError`: the pod captures the rc + log, and there is an explicit fail task gated on a non-zero rc and restic's `Fatal:` marker.
- The runtime behavior needs the planned repeat multi-node e2e for full live validation.