### PR TITLE
fix: run resilient_exec commands as a single shell line (restore K8s CI)

### DIFF
--- a/roles/orchestrator/tasks/resilient_exec.yml
+++ b/roles/orchestrator/tasks/resilient_exec.yml
@@ -33,9 +33,15 @@
 # launch and the polls, so the async job files are written and read as the
 # same user.
 
+# Collapse whitespace to single spaces so a command runs as ONE shell line.
+# rx_cmd often comes from a `>-` folded scalar; a more-indented Jinja
+# continuation line preserves a newline in the folded result, and under
+# `ansible.builtin.shell` (/bin/sh -c) a bare newline is a command
+# separator — splitting e.g. `helm upgrade ... --reset-values` into two
+# commands. Callers pass single logical command lines, so normalizing is safe.
 - name: "Launch (async): {{ rx_name }}"
   ansible.builtin.shell:
-    cmd: "{{ rx_cmd }}"
+    cmd: "{{ rx_cmd.split() | join(' ') }}"
     chdir: "{{ rx_chdir | default(omit) }}"
   async: "{{ rx_async | default(1800) | int }}"
   poll: 0

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -1044,6 +1044,40 @@ class TestResilientExec:
         assert "until" in poll
         assert poll.get("ignore_unreachable") is True
 
+    def test_launch_normalizes_command_whitespace(self):
+        # rx_cmd often comes from a `>-` folded scalar whose more-indented
+        # Jinja continuations preserve newlines. Under `shell` (/bin/sh -c)
+        # a bare newline is a command separator, so the launch must collapse
+        # whitespace to one line (regression for the helm `--reset-values`
+        # "not found" rc=127 break).
+        tasks = yaml.safe_load(open(self.PRIMITIVE))
+        cmd = tasks[0]["ansible.builtin.shell"]["cmd"]
+        assert ".split()" in cmd and "join(' ')" in cmd, (
+            "resilient_exec launch must normalize rx_cmd whitespace so a "
+            "folded multi-line command runs as a single shell line"
+        )
+
+    def test_folded_rx_cmds_have_no_newline_after_normalization(self):
+        # Every resilient_exec caller's rx_cmd, once folded by YAML and
+        # whitespace-normalized, must be a single line.
+        for rel in ("helm_deploy.yml", "helm_uninstall.yml",
+                    "k8s_argocd_bootstrap.yml"):
+            tasks = yaml.safe_load(open(os.path.join(ORCHESTRATOR_TASKS, rel)))
+            for t in self._walk(tasks):
+                rx = (t.get("vars") or {}).get("rx_cmd")
+                if rx:
+                    assert "\n" not in " ".join(rx.split()), rel
+
+    @staticmethod
+    def _walk(tasks):
+        for t in tasks or []:
+            if not isinstance(t, dict):
+                continue
+            yield t
+            for nested in ("block", "rescue", "always"):
+                if nested in t:
+                    yield from TestResilientExec._walk(t[nested])
+
     def test_helm_deploy_uses_resilient_exec(self):
         tasks = yaml.safe_load(
             open(os.path.join(ORCHESTRATOR_TASKS, "helm_deploy.yml")))


### PR DESCRIPTION
Fixes the K8s integration test failures introduced by #751 (Kubernetes / Kubernetes CrowdSec / Kubernetes Backup all red on main).

## Root cause

`resilient_exec` launches the command via `ansible.builtin.shell` (i.e. `/bin/sh -c`). But `rx_cmd` typically comes from a `>-` folded scalar whose more-indented Jinja `| ternary(...)` continuation lines **preserve newlines** in the folded result. Under `sh -c`, a bare newline is a **command separator**, so for `helm_deploy`:

```
helm upgrade --install ... -f .../values-configdata.yaml
--reset-values
--wait --timeout 10m
```

`sh` ran line 1 (helm installed the release WITHOUT `--reset-values`/`--wait`), then ran `--reset-values` as its own command:

```
/bin/sh: 2: --reset-values: not found   (rc 127)
```

so the async job reported failure and `canasta create` aborted on K8s. The pre-#751 task used `ansible.builtin.command` (argv split on whitespace), which tolerated the newlines; `shell` does not.

Local `make lint` / `make test-unit` cannot catch this — they do not render the Jinja and run it through a shell. Only the push-to-main integration tests exercise it.

## Fix

Normalize `rx_cmd` whitespace in the launch task so a folded multi-line command always runs as a single shell line:

```yaml
cmd: "{{ rx_cmd.split() | join(' ') }}"
```

Callers pass single logical command lines (pipes/redirects preserved; no command relies on literal newlines or multi-space runs), so this is safe and protects every current and future caller from the folded-scalar footgun.

## Testing

- `make lint`, `make validate`, `make test-unit` (1138 passed) green.
- New regression tests: the launch task normalizes whitespace; every `resilient_exec` caller's folded `rx_cmd` collapses to a single line.
- Real validation is the next push-to-main integration run (these failures are K8s-runtime-only).