### PR TITLE
fix: pin local-path restic backups/restores to the control-plane node (multi-node)

### DIFF
--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -28,6 +28,16 @@
     _restore_local_repo: >-
       {{ (_restore_env.variables.RESTIC_REPOSITORY | default('')) is match('^/') }}
 
+# Pin a local-path restore to the control-plane node — the same node the
+# backup Job pins to — so the restore reads the repo that backup wrote.
+# Without this the restore pod could land on a node with no repo (an empty
+# DirectoryOrCreate hostPath) and find nothing. Cloud backends need no pin.
+- name: Pin local-path restore to the control-plane node
+  ansible.builtin.set_fact:
+    _restore_node_selector: >-
+      {{ {'node-role.kubernetes.io/control-plane': 'true'}
+         if (_restore_local_repo | bool) else {} }}
+
 - name: Build restore pod volume mounts
   ansible.builtin.set_fact:
     _restore_volume_mounts:
@@ -79,6 +89,10 @@
         namespace: "{{ _k8s_namespace }}"
       spec:
         restartPolicy: Never
+        # Pin to the control-plane node for a local-path repo so the restore
+        # reads the same hostPath the backup wrote; empty ({}) for cloud
+        # backends imposes no constraint.
+        nodeSelector: "{{ _restore_node_selector }}"
         containers:
           - name: restic
             image: restic/restic:latest

--- a/roles/orchestrator/tasks/backup_schedule_set.yml
+++ b/roles/orchestrator/tasks/backup_schedule_set.yml
@@ -282,6 +282,13 @@
               spec:
                 template:
                   spec:
+                    # Pin to the control-plane node so every scheduled run
+                    # uses the same on-disk repo. A hostPath repo is
+                    # node-local; without this the CronJob could land on a
+                    # node with an empty DirectoryOrCreate repo and back up
+                    # nothing (or to an orphaned directory).
+                    nodeSelector:
+                      node-role.kubernetes.io/control-plane: "true"
                     volumes:
                       - name: local-repo
                         hostPath:

--- a/roles/orchestrator/tasks/k8s_run_backup.yml
+++ b/roles/orchestrator/tasks/k8s_run_backup.yml
@@ -34,6 +34,18 @@
   ansible.builtin.set_fact:
     _restic_local_repo: "{{ _restic_repo is match('^/') }}"
 
+# A local-path repo is a node-local hostPath. With no node affinity the Job
+# could land on any node and DirectoryOrCreate would silently make an empty
+# repo there, so init / create / restore could each see a different
+# directory on a multi-node cluster. Pin local-path backups to the
+# control-plane node so every operation shares one repo. Cloud-backend
+# repos (s3:, b2:, ...) are node-agnostic and need no pin.
+- name: Pin local-path backups to the control-plane node
+  ansible.builtin.set_fact:
+    _restic_node_selector: >-
+      {{ {'node-role.kubernetes.io/control-plane': 'true'}
+         if (_restic_local_repo | bool) else {} }}
+
 # Detect 'backup' verb in backup_args. The on-demand Job is also used
 # for non-snapshot operations (forget, snapshots, init, unlock, etc.);
 # only true backup operations need the DB-dump and Secret-dump init
@@ -193,6 +205,10 @@
         template:
           spec:
             restartPolicy: Never
+            # Pin to the control-plane node for a local-path repo so the
+            # hostPath is the same directory every run; empty ({}) for
+            # cloud backends, which imposes no constraint.
+            nodeSelector: "{{ _restic_node_selector }}"
             # Both init containers (when present) and the restic
             # main container can use the dedicated backup SA. For
             # non-backup ops the SA is unused and harmless.

--- a/tests/unit/test_backup_schedule_k8s.py
+++ b/tests/unit/test_backup_schedule_k8s.py
@@ -968,9 +968,12 @@ class TestK8sRestoreCloudBackendDoesNotMountHostPath:
         volumes/volumeMounts. Inline values would re-introduce the
         unconditional hostPath mount that #519 was about."""
         c = self._content()
-        # The Create restore pod block should reference the facts
-        idx = c.find("Create restore pod")
-        block = c[idx:idx + 1500]
+        # Scope to the Create-restore-pod task (up to the next task) rather
+        # than a fixed char window, so additions to the Pod spec don't push
+        # the volume facts out of range.
+        idx = c.find("- name: Create restore pod")
+        end = c.find("- name: Wait for restore pod", idx)
+        block = c[idx:end] if end != -1 else c[idx:]
         assert "_restore_volume_mounts" in block, (
             "Create restore pod must read volumeMounts from "
             "_restore_volume_mounts fact (built conditionally)"
@@ -1081,3 +1084,50 @@ class TestK8sRestoreUsesWebPodForDbImport:
             "ties auth to the controller-side .env read instead of the "
             "pod env vars that match the running cluster"
         )
+
+
+class TestK8sBackupLocalRepoNodeAffinity:
+    """#749: a local-path restic repo is a node-local hostPath, so the
+    backup Job, restore Pod, and scheduled CronJob must pin to one node
+    (the control-plane) — otherwise on a multi-node cluster they land on
+    different nodes and each DirectoryOrCreate makes a separate empty repo.
+    Cloud backends are node-agnostic and stay unpinned."""
+
+    RUN_BACKUP = os.path.join(
+        REPO_ROOT, "roles", "orchestrator", "tasks", "k8s_run_backup.yml")
+    RESTORE = os.path.join(
+        REPO_ROOT, "roles", "backup", "tasks", "restore_k8s.yml")
+    SCHEDULE = os.path.join(
+        REPO_ROOT, "roles", "orchestrator", "tasks", "backup_schedule_set.yml")
+
+    @staticmethod
+    def _read(path):
+        with open(path) as f:
+            return f.read()
+
+    def test_backup_job_pins_local_repo_to_control_plane(self):
+        c = self._read(self.RUN_BACKUP)
+        assert "_restic_node_selector" in c
+        assert 'nodeSelector: "{{ _restic_node_selector }}"' in c
+        assert "node-role.kubernetes.io/control-plane" in c
+
+    def test_restore_pod_pins_local_repo_to_control_plane(self):
+        c = self._read(self.RESTORE)
+        assert "_restore_node_selector" in c
+        assert 'nodeSelector: "{{ _restore_node_selector }}"' in c
+        assert "node-role.kubernetes.io/control-plane" in c
+
+    def test_scheduled_cronjob_pins_local_repo(self):
+        c = self._read(self.SCHEDULE)
+        patch_idx = c.find("Patch local-repo volume into CronJob")
+        assert patch_idx != -1
+        block = c[patch_idx:]
+        assert "nodeSelector" in block
+        assert "node-role.kubernetes.io/control-plane" in block
+
+    def test_cloud_backend_is_not_pinned(self):
+        # The selector resolves to {} (no constraint) for non-local repos.
+        c = self._read(self.RUN_BACKUP)
+        assert "if (_restic_local_repo | bool) else {}" in c
+        r = self._read(self.RESTORE)
+        assert "if (_restore_local_repo | bool) else {}" in r


### PR DESCRIPTION
Fixes #749. Found during a hands-on multi-node K8s e2e.

## Problem

A local-path `RESTIC_REPOSITORY` (a value beginning with `/`) is mounted into the backup/restore pods as a `hostPath` (`type: DirectoryOrCreate`) with **no node affinity**. On a multi-node cluster the backup Job, restore Pod, and scheduled CronJob can each be scheduled on any node, and `DirectoryOrCreate` silently creates an empty directory wherever it lands — so `backup init` on one node and `backup create` / `restore` on another see different (empty) repos.

Observed live (control-plane `big`, worker `small`): `backup init` landed on `small` (repo created there), then the `restic-restore` pod landed on `big` with an empty repo and restored nothing.

## Fix

Pin local-path backup/restore/CronJob pods to the **control-plane node** (`nodeSelector: node-role.kubernetes.io/control-plane: "true"`) so every operation shares one on-disk repo. The selector resolves to `{}` (no constraint) for cloud backends (`s3:`, `b2:`, ...), which are node-agnostic.

Changed:
- `k8s_run_backup.yml` — on-demand backup Job
- `restore_k8s.yml` — restore Pod
- `backup_schedule_set.yml` — scheduled CronJob (local-repo patch)

Also makes the restore volume-facts structure test scope to the task (not a fixed char window) so Pod-spec additions do not break it.

## Testing

- `make lint`, `make validate`, `make test-unit` (1140 passed) green.
- New `TestK8sBackupLocalRepoNodeAffinity`: backup Job, restore Pod, and CronJob pin local-path repos to the control-plane; cloud backends stay unpinned.
- Runtime behavior needs the planned repeat multi-node e2e for live validation.

## Note

Overlaps #753 (the #748 silent-restore fix) on `restore_k8s.yml` (different regions) and `test_backup_schedule_k8s.py`; whichever merges second will need a small conflict resolution, which I will handle.