### PR TITLE
fix: retry remote maintenance streams on transient SSH reset (closes #750)

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -530,31 +530,44 @@ def _stream_in_container(inst_id, inst, command, service="web"):
         ]
         cwd = None
 
-    try:
-        proc = subprocess.Popen(
-            argv,
-            cwd=cwd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,
-        )
-    except OSError as e:
-        print("Error: %s" % e, file=sys.stderr)
-        return 1
-
-    try:
-        for line in iter(proc.stdout.readline, ""):
-            sys.stdout.write(line)
-            sys.stdout.flush()
-    except KeyboardInterrupt:
-        proc.terminate()
+    def _run():
         try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-        return 130
-    return proc.wait()
+            proc = subprocess.Popen(
+                argv,
+                cwd=cwd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+        except OSError as e:
+            print("Error: %s" % e, file=sys.stderr)
+            return 1
+
+        try:
+            for line in iter(proc.stdout.readline, ""):
+                sys.stdout.write(line)
+                sys.stdout.flush()
+        except KeyboardInterrupt:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            return 130
+        return proc.wait()
+
+    # update.php / runJobs.php / ad-hoc maintenance scripts are idempotent
+    # and re-runnable. When streaming over SSH to a remote host, retry on a
+    # connection-level reset (ssh exit 255) so a transient controller-to-
+    # target drop doesn't abort a long maintenance run — it re-streams from
+    # the start. localhost and in-cluster `kubectl exec` never return 255.
+    is_remote_ssh = (
+        orchestrator not in ("kubernetes", "k8s") and not _is_localhost(host)
+    )
+    if is_remote_ssh:
+        return _retry_on_ssh_reset(_run)
+    return _run()
 
 
 def _normalize_script_args(args):

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -3524,3 +3524,48 @@ class TestRetryOnSshReset:
         rc = direct_commands._helpers._retry_on_ssh_reset(run, attempts=3)
         assert rc == 0
         assert len(calls) == 1
+
+
+class TestMaintenanceStreamRetriesOnSshReset:
+    """#750: maintenance update/script stream over SSH to a remote compose
+    host with no timeout (long runs are fine) but must retry on a
+    connection-level reset (ssh exit 255) — they are idempotent and
+    re-runnable. localhost / in-cluster exec must not retry."""
+
+    class _FakeStdout:
+        def readline(self):
+            return ""  # no streamed output in the test
+
+    class _FakeProc:
+        def __init__(self, rc):
+            self.stdout = TestMaintenanceStreamRetriesOnSshReset._FakeStdout()
+            self._rc = rc
+
+        def wait(self, timeout=None):
+            return self._rc
+
+    def _popen_factory(self, rcs, calls):
+        def factory(*args, **kwargs):
+            rc = rcs[calls["n"]]
+            calls["n"] += 1
+            return TestMaintenanceStreamRetriesOnSshReset._FakeProc(rc)
+        return factory
+
+    def test_remote_compose_retries_on_ssh_reset(self, monkeypatch):
+        calls = {"n": 0}
+        monkeypatch.setattr(
+            subprocess, "Popen", self._popen_factory([255, 0], calls))
+        inst = {"host": "remote", "path": "/srv/x", "orchestrator": "compose"}
+        rc = direct_commands._helpers._stream_in_container(
+            "x", inst, "php maintenance/update.php")
+        assert rc == 0
+        assert calls["n"] == 2, "should re-stream once after the 255 reset"
+
+    def test_localhost_does_not_retry(self, monkeypatch):
+        calls = {"n": 0}
+        monkeypatch.setattr(
+            subprocess, "Popen", self._popen_factory([255, 0], calls))
+        inst = {"host": "localhost", "path": "/srv/x", "orchestrator": "compose"}
+        rc = direct_commands._helpers._stream_in_container("x", inst, "cmd")
+        assert rc == 255
+        assert calls["n"] == 1, "localhost must not retry on 255"


### PR DESCRIPTION
Closes #750 — the last exposed long-running remote op, and the one #752 explicitly deferred.

## Problem

`canasta maintenance update` / `maintenance script` / `maintenance extension` are Python `direct_only` commands, so they bypass the Ansible `exec_long` path added in #752. They stream `update.php` / `runJobs.php` / ad-hoc scripts over SSH to a remote compose host via `_stream_in_container`, which has no timeout (so long runs work) — but **no retry on a connection-level reset**. A mid-run SSH drop (ssh exit 255) aborted the command, leaving the operator to re-run by hand.

## Fix

`update.php` / `runJobs.php` / maintenance scripts are idempotent and re-runnable, so retry the remote-SSH stream on a 255 connection failure (bounded, via the existing `_retry_on_ssh_reset`); on a reset it re-streams from the start. localhost and in-cluster `kubectl exec` never return 255, so they are unaffected (no retry).

The streaming body was extracted into a local `_run()` closure; the retry wraps it only for the remote-SSH path (hence the diff's reindent).

## Testing

- `make lint`, `make validate`, `make test-unit` (1146 passed) green.
- New `TestMaintenanceStreamRetriesOnSshReset`: a remote-compose stream re-runs once after a 255 reset then succeeds; localhost does not retry on 255.
- Live validation: the planned repeat multi-node e2e (a real flaky link is needed to exercise the reset path).