### PR TITLE
review: Round 3 hardening of resilient remote ops + restore

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -256,7 +256,15 @@ def _compose_file_args(path, host, devmode=False):
 
 
 def _run_compose(inst_id, inst, action_args):
-    """Run a docker compose command for an instance. Returns exit code."""
+    """Run a docker compose command for an instance. Returns exit code.
+
+    Output streams to the terminal and there is NO timeout: the actions
+    routed here (`up -d` with image pulls, `down`, `build` from rebuild)
+    legitimately run for minutes. (A prior 120s local / 30s remote cap
+    falsely reported failure on slow pulls/builds while the work kept
+    running.) On a remote host these actions are idempotent, so a
+    connection-level reset (ssh exit 255) is retried.
+    """
     host = inst.get("host") or "localhost"
     path = inst.get("path", "")
     devmode = inst.get("devMode", False)
@@ -265,30 +273,32 @@ def _run_compose(inst_id, inst, action_args):
     if _is_localhost(host):
         cmd = ["docker", "compose"] + file_args + action_args
         try:
-            result = subprocess.run(cmd, cwd=path, timeout=120)
-            return result.returncode
-        except (subprocess.TimeoutExpired, OSError) as e:
+            return subprocess.call(cmd, cwd=path)
+        except OSError as e:
             print("Error: %s" % e, file=sys.stderr)
             return 1
-    else:
-        file_str = " ".join(file_args)
-        action_str = " ".join(action_args)
-        remote_cmd = "cd %s && docker compose %s %s" % (
-            _shell_quote(path), file_str, action_str,
-        )
-        # The lifecycle actions routed here (up -d, down) are idempotent,
-        # so retry on a transient ssh connection reset.
-        _last = {}
 
-        def _attempt():
-            rc, stdout = _ssh_run(host, remote_cmd)
-            _last["stdout"] = stdout
-            return rc
+    file_str = " ".join(file_args)
+    action_str = " ".join(action_args)
+    remote_cmd = "cd %s && docker compose %s %s" % (
+        _shell_quote(path), file_str, action_str,
+    )
+    # SSH does not pass env; propagate DOCKER_HOST like _ssh_run does so a
+    # rootless socket on the target is honored.
+    docker_host = os.environ.get("DOCKER_HOST")
+    if docker_host:
+        remote_cmd = "DOCKER_HOST=%s %s" % (_shell_quote(docker_host), remote_cmd)
+    target = _resolve_ssh_target(host)
+    argv = ["ssh"] + _ssh_args() + [target, remote_cmd]
 
-        rc = _retry_on_ssh_reset(_attempt)
-        if _last.get("stdout", "").strip():
-            print(_last["stdout"].strip())
-        return rc
+    def _attempt():
+        try:
+            return subprocess.call(argv)
+        except OSError as e:
+            print("Error: %s" % e, file=sys.stderr)
+            return 1
+
+    return _retry_on_ssh_reset(_attempt)
 
 
 # Profiles that Canasta derives from CANASTA_ENABLE_* feature flags.
@@ -480,7 +490,8 @@ def _exec_in_container(inst_id, inst, command, service="web"):
     return rc, stdout
 
 
-def _stream_in_container(inst_id, inst, command, service="web"):
+def _stream_in_container(inst_id, inst, command, service="web",
+                         retry_on_reset=False):
     """Run a command inside a container/pod, streaming combined
     stdout+stderr to the user's terminal as it arrives. Returns the
     process return code.
@@ -489,6 +500,13 @@ def _stream_in_container(inst_id, inst, command, service="web"):
     rebuildData.php, ad-hoc maintenance scripts) so the operator can
     distinguish 'still working' from 'stuck' without having to drop
     down to `docker compose exec` directly. See issue #433.
+
+    retry_on_reset re-streams from the start on an SSH connection reset
+    (ssh exit 255). Only pass it for IDEMPOTENT commands (update.php,
+    runJobs.php, rebuildData.php). It must stay false for arbitrary
+    operator-supplied scripts, which may be destructive and non-idempotent
+    (deleteBatch.php, nukePage.php, importDump.php) — re-running those
+    after a mid-run reset would double-apply the work.
 
     `stdbuf -oL` is prepended to force line-buffered stdout from any
     coreutils-style child the script spawns; PHP CLI is line-buffered
@@ -557,15 +575,14 @@ def _stream_in_container(inst_id, inst, command, service="web"):
             return 130
         return proc.wait()
 
-    # update.php / runJobs.php / ad-hoc maintenance scripts are idempotent
-    # and re-runnable. When streaming over SSH to a remote host, retry on a
-    # connection-level reset (ssh exit 255) so a transient controller-to-
-    # target drop doesn't abort a long maintenance run — it re-streams from
-    # the start. localhost and in-cluster `kubectl exec` never return 255.
+    # When streaming over SSH to a remote host, retry on a connection-level
+    # reset (ssh exit 255) ONLY when the caller opted in (idempotent command)
+    # — re-streaming a non-idempotent operator script would double-apply it.
+    # localhost and in-cluster `kubectl exec` never return 255.
     is_remote_ssh = (
         orchestrator not in ("kubernetes", "k8s") and not _is_localhost(host)
     )
-    if is_remote_ssh:
+    if is_remote_ssh and retry_on_reset:
         return _retry_on_ssh_reset(_run)
     return _run()
 

--- a/direct_commands/maintenance.py
+++ b/direct_commands/maintenance.py
@@ -131,6 +131,7 @@ def cmd_maintenance_update(args):
         rc = _helpers._stream_in_container(
             inst_id, inst,
             "php maintenance/update.php --wiki=%s" % _helpers._shell_quote(w),
+            retry_on_reset=True,  # update.php is idempotent
         )
         if rc != 0:
             overall_rc = rc
@@ -141,6 +142,7 @@ def cmd_maintenance_update(args):
             rc = _helpers._stream_in_container(
                 inst_id, inst,
                 "php maintenance/runJobs.php --wiki=%s" % _helpers._shell_quote(w),
+                retry_on_reset=True,  # runJobs.php is idempotent
             )
             if rc != 0:
                 overall_rc = rc
@@ -163,6 +165,7 @@ def cmd_maintenance_update(args):
                     inst_id, inst,
                     "php extensions/SemanticMediaWiki/maintenance/"
                     "rebuildData.php --wiki=%s" % _helpers._shell_quote(w),
+                    retry_on_reset=True,  # rebuildData.php is idempotent
                 )
 
     print("\nMaintenance update complete for: %s" % ", ".join(wikis))

--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -169,6 +169,18 @@
   changed_when: false
   failed_when: false
 
+# If the exit code couldn't be read (e.g. the pod died after touching the
+# sentinel but before this read), we cannot confirm the restore — treat it
+# as failed rather than falling through and reporting a success that may not
+# have happened.
+- name: Fail when the restic restore exit code is unreadable
+  ansible.builtin.fail:
+    msg: >-
+      Could not read the restic restore exit code from the restore pod
+      (got '{{ _restore_rc.stdout | default('') | trim }}'). The restore
+      could not be confirmed and is treated as failed.
+  when: (_restore_rc.stdout | default('') | trim) is not match('^[0-9]+$')
+
 - name: Fail when restic restore reported a fatal error
   ansible.builtin.fail:
     msg: |-
@@ -176,7 +188,7 @@
       The snapshot was NOT restored. restic output:
       {{ _restore_log.stdout | default('(no log captured)') }}
   when: >-
-    (_restore_rc.stdout | default('1') | trim) != '0'
+    (_restore_rc.stdout | trim | int) != 0
     and (_restore_log.stdout | default('') is search('Fatal'))
 
 - name: Warn about ignored non-fatal restore errors

--- a/roles/orchestrator/tasks/resilient_exec.yml
+++ b/roles/orchestrator/tasks/resilient_exec.yml
@@ -33,15 +33,16 @@
 # launch and the polls, so the async job files are written and read as the
 # same user.
 
-# Collapse whitespace to single spaces so a command runs as ONE shell line.
-# rx_cmd often comes from a `>-` folded scalar; a more-indented Jinja
-# continuation line preserves a newline in the folded result, and under
-# `ansible.builtin.shell` (/bin/sh -c) a bare newline is a command
-# separator — splitting e.g. `helm upgrade ... --reset-values` into two
-# commands. Callers pass single logical command lines, so normalizing is safe.
+# Fold the command onto ONE shell line. rx_cmd often comes from a `>-`
+# folded scalar whose more-indented Jinja continuation lines leave embedded
+# newlines, and under `ansible.builtin.shell` (/bin/sh -c) a bare newline is
+# a command separator (it split `helm upgrade ... --reset-values` into two
+# commands). Collapse only newline runs — NOT all whitespace — so intra-line
+# spacing is preserved: a secret containing a tab or double space on the
+# exec_long path must not be silently mangled.
 - name: "Launch (async): {{ rx_name }}"
   ansible.builtin.shell:
-    cmd: "{{ rx_cmd.split() | join(' ') }}"
+    cmd: "{{ rx_cmd | regex_replace('[\\r\\n]+', ' ') | trim }}"
     chdir: "{{ rx_chdir | default(omit) }}"
   async: "{{ rx_async | default(1800) | int }}"
   poll: 0
@@ -60,6 +61,10 @@
   # until-loop simply retries — transient resets during the wait don't
   # abort the operation, which keeps running on the target.
   ignore_unreachable: true
+  # async_status returns the wrapped job's result, including its `cmd`, so
+  # honor rx_no_log here too — otherwise a secret in rx_cmd (e.g. the k3s
+  # join token) surfaces in this task's output under -v.
+  no_log: "{{ rx_no_log | default(false) | bool }}"
 
 - name: "Report failure: {{ rx_name }}"
   ansible.builtin.fail:
@@ -76,3 +81,4 @@
   ansible.builtin.async_status:
     jid: "{{ _rx_job.ansible_job_id }}"
     mode: cleanup
+  no_log: "{{ rx_no_log | default(false) | bool }}"

--- a/tests/unit/test_backup_schedule_k8s.py
+++ b/tests/unit/test_backup_schedule_k8s.py
@@ -584,6 +584,19 @@ class TestK8sRestoreFailsLoudlyOnResticError:
         )
         assert "_restore_rc" in content
 
+    def test_fails_when_exit_code_unreadable(self):
+        # If the rc can't be read (e.g. the pod died after the sentinel but
+        # before the read), the restore is unconfirmed and must abort, not
+        # fall through to a false success.
+        content = self._content()
+        assert "Fail when the restic restore exit code is unreadable" in content, (
+            "restore_k8s.yml must abort when the exit code can't be read, "
+            "closing the dead-pod-after-sentinel false-success window"
+        )
+        assert "is not match('^[0-9]+$')" in content, (
+            "the unreadable-rc guard must require the rc to be a clean integer"
+        )
+
 
 class TestOnDemandBackupCapturesDB:
     """Guard #513: on-demand 'canasta backup create' on K8s must

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1278,11 +1278,11 @@ class TestLifecycleCommands:
     def test_start_runs_up(self, monkeypatch):
         captured_cmds = []
 
-        def mock_run(cmd, **kw):
+        def mock_call(cmd, **kw):
             captured_cmds.append(cmd)
-            return type("R", (), {"returncode": 0})()
+            return 0
 
-        monkeypatch.setattr(subprocess, "run", mock_run)
+        monkeypatch.setattr(subprocess, "call", mock_call)
         monkeypatch.setattr(direct_commands._helpers, "_resolve_instance",
             lambda args: ("test", {
                 "path": "/srv/test",
@@ -1303,11 +1303,11 @@ class TestLifecycleCommands:
     def test_stop_runs_down(self, monkeypatch):
         captured_cmds = []
 
-        def mock_run(cmd, **kw):
+        def mock_call(cmd, **kw):
             captured_cmds.append(cmd)
-            return type("R", (), {"returncode": 0})()
+            return 0
 
-        monkeypatch.setattr(subprocess, "run", mock_run)
+        monkeypatch.setattr(subprocess, "call", mock_call)
         monkeypatch.setattr(direct_commands._helpers, "_resolve_instance",
             lambda args: ("test", {
                 "path": "/srv/test",
@@ -1326,11 +1326,11 @@ class TestLifecycleCommands:
     def test_restart_runs_down_then_up(self, monkeypatch):
         captured_cmds = []
 
-        def mock_run(cmd, **kw):
+        def mock_call(cmd, **kw):
             captured_cmds.append(cmd)
-            return type("R", (), {"returncode": 0})()
+            return 0
 
-        monkeypatch.setattr(subprocess, "run", mock_run)
+        monkeypatch.setattr(subprocess, "call", mock_call)
         monkeypatch.setattr(direct_commands._helpers, "_resolve_instance",
             lambda args: ("test", {
                 "path": "/srv/test",
@@ -1351,11 +1351,11 @@ class TestLifecycleCommands:
     def test_restart_stops_on_down_failure(self, monkeypatch):
         call_count = [0]
 
-        def mock_run(cmd, **kw):
+        def mock_call(cmd, **kw):
             call_count[0] += 1
-            return type("R", (), {"returncode": 1})()
+            return 1
 
-        monkeypatch.setattr(subprocess, "run", mock_run)
+        monkeypatch.setattr(subprocess, "call", mock_call)
         monkeypatch.setattr(direct_commands._helpers, "_resolve_instance",
             lambda args: ("test", {
                 "path": "/srv/test",
@@ -1372,14 +1372,21 @@ class TestLifecycleCommands:
         assert call_count[0] == 1
 
     def test_remote_start_uses_ssh(self, monkeypatch):
-        ssh_cmds = []
-
+        # The sync-profiles .env read still goes through _ssh_run...
         def mock_ssh(host, cmd):
-            ssh_cmds.append((host, cmd))
-            # Return empty .env for the sync-profiles read
-            return 0, ""
+            return 0, ""  # empty .env → no write
 
         monkeypatch.setattr(direct_commands._helpers, "_ssh_run", mock_ssh)
+
+        # ...but the long `up -d` runs via `ssh <target> <remote_cmd>` through
+        # subprocess.call (no 30s _ssh_run cap, which would kill image pulls).
+        call_argvs = []
+
+        def mock_call(argv, **kw):
+            call_argvs.append(argv)
+            return 0
+
+        monkeypatch.setattr(subprocess, "call", mock_call)
         monkeypatch.setattr(direct_commands._helpers, "_resolve_instance",
             lambda args: ("test", {
                 "path": "/srv/test",
@@ -1394,11 +1401,10 @@ class TestLifecycleCommands:
         args = type("Args", (), {"id": "test"})()
         rc = direct_commands.cmd_start(args)
         assert rc == 0
-        # The sync-profiles read + the up -d: 2 SSH calls total.
-        # Empty .env returned above → no write.
-        up_calls = [c for _, c in ssh_cmds if "up -d" in c]
-        assert len(up_calls) == 1
-        assert all(h == "admin@remote" for h, _ in ssh_cmds)
+        up_argv = [a for a in call_argvs if a and "up -d" in a[-1]]
+        assert len(up_argv) == 1
+        assert up_argv[0][0] == "ssh"
+        assert "admin@remote" in up_argv[0]
 
 
 class TestEnvFileWriter:
@@ -2831,7 +2837,8 @@ class TestMaintenanceScript:
         self._patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_stream(inst_id, inst, command, service="web"):
+        def fake_stream(inst_id, inst, command, service="web",
+                        retry_on_reset=False):
             captured["command"] = command
             return 0
 
@@ -2856,7 +2863,8 @@ class TestMaintenanceScript:
         self._patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_stream(inst_id, inst, command, service="web"):
+        def fake_stream(inst_id, inst, command, service="web",
+                        retry_on_reset=False):
             captured["command"] = command
             return 0
 
@@ -2871,7 +2879,8 @@ class TestMaintenanceScript:
         self._patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_stream(inst_id, inst, command, service="web"):
+        def fake_stream(inst_id, inst, command, service="web",
+                        retry_on_reset=False):
             captured["command"] = command
             return 0
 
@@ -2886,7 +2895,8 @@ class TestMaintenanceScript:
         self._patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_stream(inst_id, inst, command, service="web"):
+        def fake_stream(inst_id, inst, command, service="web",
+                        retry_on_reset=False):
             captured["command"] = command
             return 0
 
@@ -2903,7 +2913,8 @@ class TestMaintenanceScript:
         self._patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_stream(inst_id, inst, command, service="web"):
+        def fake_stream(inst_id, inst, command, service="web",
+                        retry_on_reset=False):
             captured["command"] = command
             return 0
 
@@ -2920,7 +2931,8 @@ class TestMaintenanceScript:
         self._patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_stream(inst_id, inst, command, service="web"):
+        def fake_stream(inst_id, inst, command, service="web",
+                        retry_on_reset=False):
             captured["command"] = command
             return 0
 
@@ -2954,7 +2966,8 @@ class TestMaintenanceExtension:
         self._patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_stream(inst_id, inst, command, service="web"):
+        def fake_stream(inst_id, inst, command, service="web",
+                        retry_on_reset=False):
             captured["command"] = command
             return 0
 
@@ -2968,7 +2981,8 @@ class TestMaintenanceExtension:
         self._patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_stream(inst_id, inst, command, service="web"):
+        def fake_stream(inst_id, inst, command, service="web",
+                        retry_on_reset=False):
             captured["command"] = command
             return 0
 
@@ -2985,7 +2999,8 @@ class TestMaintenanceExtension:
         self._patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_stream(inst_id, inst, command, service="web"):
+        def fake_stream(inst_id, inst, command, service="web",
+                        retry_on_reset=False):
             captured["command"] = command
             return 0
 
@@ -3002,7 +3017,8 @@ class TestMaintenanceExtension:
         self._patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_stream(inst_id, inst, command, service="web"):
+        def fake_stream(inst_id, inst, command, service="web",
+                        retry_on_reset=False):
             captured["command"] = command
             return 0
 
@@ -3019,7 +3035,8 @@ class TestMaintenanceExtension:
         self._patch_resolve(monkeypatch)
         captured = {}
 
-        def fake_stream(inst_id, inst, command, service="web"):
+        def fake_stream(inst_id, inst, command, service="web",
+                        retry_on_reset=False):
             captured["command"] = command
             return 0
 
@@ -3068,7 +3085,8 @@ class TestMaintenanceUpdate:
         )
         commands = []
 
-        def fake_stream(inst_id, inst, command, service="web"):
+        def fake_stream(inst_id, inst, command, service="web",
+                        retry_on_reset=False):
             commands.append(command)
             return 0
 
@@ -3093,7 +3111,8 @@ class TestMaintenanceUpdate:
         )
         commands = []
         monkeypatch.setattr(direct_commands._helpers, "_stream_in_container",
-            lambda iid, i, c, service="web": commands.append(c) or 0,
+            lambda iid, i, c, service="web", retry_on_reset=False:
+                commands.append(c) or 0,
         )
         direct_commands.cmd_maintenance_update(self._args(skip_jobs=True))
         assert any("update.php" in c for c in commands)
@@ -3106,7 +3125,8 @@ class TestMaintenanceUpdate:
         )
         commands = []
         monkeypatch.setattr(direct_commands._helpers, "_stream_in_container",
-            lambda iid, i, c, service="web": commands.append(c) or 0,
+            lambda iid, i, c, service="web", retry_on_reset=False:
+                commands.append(c) or 0,
         )
         direct_commands.cmd_maintenance_update(self._args())
         assert any("rebuildData.php" in c for c in commands)
@@ -3120,7 +3140,8 @@ class TestMaintenanceUpdate:
         )
         commands = []
         monkeypatch.setattr(direct_commands._helpers, "_stream_in_container",
-            lambda iid, i, c, service="web": commands.append(c) or 0,
+            lambda iid, i, c, service="web", retry_on_reset=False:
+                commands.append(c) or 0,
         )
         direct_commands.cmd_maintenance_update(self._args(skip_smw=True))
         assert not any("rebuildData.php" in c for c in commands)
@@ -3132,7 +3153,8 @@ class TestMaintenanceUpdate:
         )
         commands = []
         monkeypatch.setattr(direct_commands._helpers, "_stream_in_container",
-            lambda iid, i, c, service="web": commands.append(c) or 0,
+            lambda iid, i, c, service="web", retry_on_reset=False:
+                commands.append(c) or 0,
         )
         direct_commands.cmd_maintenance_update(self._args(wiki="draft"))
         # Only the named wiki should appear in the commands.
@@ -3551,15 +3573,29 @@ class TestMaintenanceStreamRetriesOnSshReset:
             return TestMaintenanceStreamRetriesOnSshReset._FakeProc(rc)
         return factory
 
-    def test_remote_compose_retries_on_ssh_reset(self, monkeypatch):
+    def test_remote_retries_only_when_opted_in(self, monkeypatch):
+        # retry_on_reset=True (idempotent command, e.g. update.php): re-stream
+        # once after a 255 reset.
         calls = {"n": 0}
         monkeypatch.setattr(
             subprocess, "Popen", self._popen_factory([255, 0], calls))
         inst = {"host": "remote", "path": "/srv/x", "orchestrator": "compose"}
         rc = direct_commands._helpers._stream_in_container(
-            "x", inst, "php maintenance/update.php")
+            "x", inst, "php maintenance/update.php", retry_on_reset=True)
         assert rc == 0
         assert calls["n"] == 2, "should re-stream once after the 255 reset"
+
+    def test_remote_does_not_retry_by_default(self, monkeypatch):
+        # Default (arbitrary, possibly non-idempotent script): a 255 reset is
+        # NOT retried — re-running could double-apply destructive work.
+        calls = {"n": 0}
+        monkeypatch.setattr(
+            subprocess, "Popen", self._popen_factory([255, 0], calls))
+        inst = {"host": "remote", "path": "/srv/x", "orchestrator": "compose"}
+        rc = direct_commands._helpers._stream_in_container(
+            "x", inst, "php maintenance/nukePage.php Foo")
+        assert rc == 255
+        assert calls["n"] == 1, "arbitrary scripts must not be retried"
 
     def test_localhost_does_not_retry(self, monkeypatch):
         calls = {"n": 0}

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -1044,29 +1044,44 @@ class TestResilientExec:
         assert "until" in poll
         assert poll.get("ignore_unreachable") is True
 
-    def test_launch_normalizes_command_whitespace(self):
+    def test_launch_collapses_only_newlines(self):
         # rx_cmd often comes from a `>-` folded scalar whose more-indented
-        # Jinja continuations preserve newlines. Under `shell` (/bin/sh -c)
-        # a bare newline is a command separator, so the launch must collapse
-        # whitespace to one line (regression for the helm `--reset-values`
-        # "not found" rc=127 break).
+        # Jinja continuations preserve newlines. Under `shell` (/bin/sh -c) a
+        # bare newline is a command separator, so the launch must fold the
+        # command onto one line (regression for the helm `--reset-values`
+        # rc=127 break) — but collapse ONLY newlines, not all whitespace, so
+        # a secret with a tab/double-space on the exec_long path isn't mangled.
         tasks = yaml.safe_load(open(self.PRIMITIVE))
         cmd = tasks[0]["ansible.builtin.shell"]["cmd"]
-        assert ".split()" in cmd and "join(' ')" in cmd, (
-            "resilient_exec launch must normalize rx_cmd whitespace so a "
-            "folded multi-line command runs as a single shell line"
+        assert "regex_replace" in cmd and r"\r\n" in cmd, (
+            "launch must collapse newline runs (regex_replace) not all "
+            "whitespace, so intra-line spacing in secrets is preserved"
+        )
+        assert ".split()" not in cmd, (
+            "split()|join collapses ALL whitespace and mangles secrets "
+            "containing tabs/double-spaces"
         )
 
     def test_folded_rx_cmds_have_no_newline_after_normalization(self):
         # Every resilient_exec caller's rx_cmd, once folded by YAML and
-        # whitespace-normalized, must be a single line.
+        # newline-collapsed, must be a single line.
+        import re
         for rel in ("helm_deploy.yml", "helm_uninstall.yml",
                     "k8s_argocd_bootstrap.yml"):
             tasks = yaml.safe_load(open(os.path.join(ORCHESTRATOR_TASKS, rel)))
             for t in self._walk(tasks):
                 rx = (t.get("vars") or {}).get("rx_cmd")
                 if rx:
-                    assert "\n" not in " ".join(rx.split()), rel
+                    assert "\n" not in re.sub(r"[\r\n]+", " ", rx).strip(), rel
+
+    def test_poll_and_cleanup_honor_no_log(self):
+        # async_status returns the job's `cmd`, so the poll + cleanup tasks
+        # must honor rx_no_log or a secret in rx_cmd (e.g. the k3s join
+        # token) leaks under -v.
+        tasks = yaml.safe_load(open(self.PRIMITIVE))
+        for name in ("Wait for completion", "Clean up async job file"):
+            t = next(x for x in tasks if str(x.get("name", "")).startswith(name))
+            assert "rx_no_log" in str(t.get("no_log", "")), name
 
     @staticmethod
     def _walk(tasks):


### PR DESCRIPTION
Closes #757. Fixes found by Comprehensive Review Round 3 in the resilient-remote-ops / backup-restore code merged since v4.1.1 (#751–#756). Main CI is green; these address correctness/security gaps unit tests and the integration suite don't reliably exercise.

## F4 — maintenance retry safety (high)
`_stream_in_container` retried **any** remote maintenance stream on an SSH reset, but `maintenance script`/`extension` run **arbitrary** operator scripts — a non-idempotent one (`nukePage.php`, `deleteBatch.php`, `importDump.php`) would be **double-applied** after a mid-run reset. Retry is now opt-in (`retry_on_reset`); only the idempotent `maintenance update` path (update.php / runJobs.php / rebuildData.php) opts in.

## F5 — token redaction (med, security)
`resilient_exec` honored `rx_no_log` on the launch + failure tasks but **not** the `async_status` poll/cleanup tasks, whose result includes the job's `cmd` — so the k3s join token could surface under `-v`. Added `no_log` to those tasks.

## F6 — compose timeout (med)
`_run_compose` remote kept the 30s `_ssh_run` cap (local 120s). `up -d` image pulls and `canasta rebuild` builds exceed it → false failure while the work kept running, and the 30s timeout returns rc 1 (not 255) so the retry never fired. Now streams with no timeout (like `cmd_scale`) and retries on a connection reset (ssh 255) on the remote path.

## F1 — secret-safe normalization (med)
The `rx_cmd` fold-normalization collapsed **all** whitespace, mangling a secret containing a tab/newline/double space on the `exec_long` path. Now collapses only newline runs (`regex_replace('[\r\n]+',' ')`), preserving intra-line spacing. Verified end-to-end.

## F2 — restore false-success window (low-med)
restore_k8s could report success if the pod died after touching the sentinel but before the rc read (empty rc → the `Fatal:` check passed). Now aborts when the exit code is unreadable.

## Testing
`make lint`, `make validate`, `make test-unit` (1149 passed) green. Updated the lifecycle/maintenance mocks for the subprocess.call/retry-opt-in changes; added regression tests for each finding (newline-only normalize, no_log on poll/cleanup, opt-in retry vs no-retry-by-default, unreadable-rc abort).
