### PR TITLE
fix: Compose delete orphaned the backup staging volume (name mismatch)

### DIFF
--- a/roles/orchestrator/tasks/destroy.yml
+++ b/roles/orchestrator/tasks/destroy.yml
@@ -14,7 +14,7 @@
 
     - name: Remove backup staging volume
       ansible.builtin.command:
-        cmd: "docker volume rm {{ instance_path | basename }}-backup"
+        cmd: "docker volume rm canasta-backup-{{ instance_path | basename }}"
       changed_when: true
       ignore_errors: true  # OK if volume doesn't exist
 

--- a/tests/unit/test_backup_volume_name_match.py
+++ b/tests/unit/test_backup_volume_name_match.py
@@ -1,0 +1,58 @@
+"""Regression test: the Compose backup staging volume is created and removed
+under the same name.
+
+run_backup.yml creates `canasta-backup-<basename>`; destroy.yml must remove
+that exact name. A mismatch (the historical bug) silently orphans the volume:
+`docker volume rm` targets a name that never existed and the real volume leaks
+across create/backup/delete cycles.
+"""
+
+import os
+import re
+
+import yaml
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+ORCHESTRATOR_TASKS = os.path.join(REPO_ROOT, "roles", "orchestrator", "tasks")
+
+
+def _tasks(filename):
+    with open(os.path.join(ORCHESTRATOR_TASKS, filename)) as f:
+        return yaml.safe_load(f)
+
+
+def _walk(tasks):
+    """Yield every task dict, descending into block/ blocks."""
+    for task in tasks:
+        yield task
+        if isinstance(task.get("block"), list):
+            yield from _walk(task["block"])
+
+
+def _created_volume_name():
+    """The volume name set_fact'd as _bvol in run_backup.yml."""
+    for task in _walk(_tasks("run_backup.yml")):
+        set_fact = task.get("ansible.builtin.set_fact") or task.get("set_fact")
+        if set_fact and "_bvol" in set_fact:
+            return set_fact["_bvol"].strip()
+    raise AssertionError("no _bvol set_fact found in run_backup.yml")
+
+
+def _removed_volume_name():
+    """The volume name targeted by `docker volume rm` in destroy.yml."""
+    for task in _walk(_tasks("destroy.yml")):
+        cmd_mod = task.get("ansible.builtin.command") or task.get("command")
+        cmd = cmd_mod.get("cmd", "") if isinstance(cmd_mod, dict) else ""
+        m = re.search(r"docker volume rm\s+(.+)$", cmd)
+        if m:
+            return m.group(1).strip()
+    raise AssertionError("no `docker volume rm` command found in destroy.yml")
+
+
+def test_backup_staging_volume_names_match():
+    assert _removed_volume_name() == _created_volume_name()
+
+
+def test_backup_staging_volume_uses_canasta_prefix():
+    assert _created_volume_name() == "canasta-backup-{{ instance_path | basename }}"


### PR DESCRIPTION
Fixes #760.

## Problem

`canasta delete` on Compose left the `canasta-backup-<id>` staging volume behind. The volume is **created** as `canasta-backup-<basename>` in `run_backup.yml` (`_bvol`), but `destroy.yml` tried to **remove** `<basename>-backup` — a name that never existed. `docker compose down -v` doesn't catch it either, since it's an externally-created named volume. Result: orphaned `canasta-backup-<id>` volumes accumulate across every create/backup/delete cycle.

## Fix

`destroy.yml` now removes the same name `run_backup.yml` creates:

```diff
-        cmd: "docker volume rm {{ instance_path | basename }}-backup"
+        cmd: "docker volume rm canasta-backup-{{ instance_path | basename }}"
```

`ignore_errors` is retained for the no-backup case (volume may not exist).

## Test

Adds `tests/unit/test_backup_volume_name_match.py`, a structural test that parses both task files and asserts the created (`_bvol`) and removed (`docker volume rm`) names match. It fails against the old code and passes after the fix, so the two files can't drift apart again — no live Docker required.

Full unit suite: 1151 passed.