### PR TITLE
fix: K8s delete no longer times out on slow multi-node NFS teardown

### DIFF
--- a/roles/orchestrator/tasks/helm_uninstall.yml
+++ b/roles/orchestrator/tasks/helm_uninstall.yml
@@ -2,17 +2,20 @@
 # Uninstall the Canasta Helm release and clean up.
 # Input: instance_id, _k8s_namespace
 
-# Launched detached and polled (resilient_exec) so a controller-side SSH
-# reset during the wait doesn't abort an uninstall still progressing on the
-# target. rx_fail is false because uninstalling an already-absent release
-# returns non-zero — harmless, matching the prior ignore_errors.
+# No --wait: helm uninstall removes the release record and triggers resource
+# deletion; the namespace delete below waits for full teardown. With --wait,
+# on a multi-node NFS instance the uninstall could exceed its async window
+# (slow pod termination / NFS unmount) and the timed-out async_status task
+# would abort the whole delete BEFORE the namespace was removed — leaking the
+# namespace + PVCs while the instance was already deregistered. rx_fail is
+# false because uninstalling an already-absent release returns non-zero.
 - name: Uninstall Canasta Helm release
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/resilient_exec.yml"
   vars:
     rx_name: "uninstall Helm release canasta-{{ instance_id }}"
-    rx_async: 300
+    rx_async: 120
     rx_fail: false
-    rx_cmd: "helm uninstall canasta-{{ instance_id }} -n {{ _k8s_namespace }} --wait"
+    rx_cmd: "helm uninstall canasta-{{ instance_id }} -n {{ _k8s_namespace }}"
 
 - name: Delete Ansible-managed resources
   kubernetes.core.k8s:
@@ -30,19 +33,27 @@
     - { kind: ConfigMap, name: "canasta-{{ instance_id }}-db-config" }
   ignore_errors: true  # OK if resources already deleted
 
-# Wait for the namespace to fully terminate before returning. Without
-# this, deletion is async and an immediate `canasta create` races the
-# still-Terminating namespace and fails its stale-namespace guard.
-# Namespace teardown (finalizers, PVC/pod cleanup) can take minutes, so
-# this is launched detached and polled (resilient_exec): a controller-side
-# reset during the wait must not leave the caller believing it failed while
-# k8s is still terminating it. --ignore-not-found keeps a re-run idempotent.
-- name: Delete namespace
-  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/resilient_exec.yml"
-  vars:
-    rx_name: "delete namespace {{ _k8s_namespace }}"
-    rx_async: 360
-    rx_cmd: >-
-      kubectl delete namespace {{ _k8s_namespace }}
-      --ignore-not-found=true --wait=true --timeout=300s
+# Request deletion without a held --wait, then poll until the namespace is
+# fully gone with short `kubectl get` calls. A single held `kubectl delete
+# --wait` (or wrapping one in an async window) aborts the whole delete when
+# termination is slow — e.g. NFS PVC/pod cleanup on a multi-node cluster —
+# leaving the namespace behind. Polling tolerates a slow teardown and a
+# transient SSH reset (each poll is a brief connection). We still wait for
+# full termination so an immediate same-id re-create doesn't race the stale
+# Terminating namespace. --ignore-not-found keeps the request idempotent.
+- name: Request namespace deletion
+  ansible.builtin.command:
+    cmd: "kubectl delete namespace {{ _k8s_namespace }} --ignore-not-found=true --wait=false"
+  changed_when: true
+  when: delete_namespace | default(true) | bool
+
+- name: Wait for namespace to be fully gone
+  ansible.builtin.command:
+    cmd: "kubectl get namespace {{ _k8s_namespace }} -o name"
+  register: _ns_gone
+  changed_when: false
+  failed_when: false
+  retries: 120
+  delay: 5
+  until: _ns_gone.rc != 0
   when: delete_namespace | default(true) | bool

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -1008,20 +1008,31 @@ class TestK8sDeleteWaitsForNamespace:
     returning — otherwise an immediate re-create races the still-Terminating
     namespace and fails the stale-namespace guard (#684)."""
 
-    def test_namespace_deletion_waits(self):
+    def test_namespace_deletion_requests_then_polls_until_gone(self):
+        # #762: a single held `kubectl delete --wait` aborts the whole delete
+        # when termination is slow (NFS on multi-node), leaking the namespace.
+        # Issue the delete (--wait=false), then poll until it's gone — still
+        # waiting for full termination so delete->re-create doesn't race.
         with open(os.path.join(ORCHESTRATOR_TASKS, "helm_uninstall.yml")) as f:
             tasks = yaml.safe_load(f)
-        ns = next(t for t in tasks if t.get("name") == "Delete namespace")
-        # Deletion runs via resilient_exec (launch detached + poll) so a
-        # controller-side SSH reset during the wait can't abort it, but the
-        # kubectl command still waits for the namespace to fully terminate.
-        assert "resilient_exec.yml" in ns["ansible.builtin.include_tasks"]
-        cmd = ns["vars"]["rx_cmd"]
-        assert "kubectl delete namespace" in cmd
-        assert "--wait=true" in cmd
-        assert "--timeout=300s" in cmd, (
-            "namespace deletion must wait, so delete->create does not race"
-        )
+        req = next(t for t in tasks if t.get("name") == "Request namespace deletion")
+        assert "--wait=false" in req["ansible.builtin.command"]["cmd"]
+        assert "--ignore-not-found" in req["ansible.builtin.command"]["cmd"]
+
+        wait = next(t for t in tasks if t.get("name") == "Wait for namespace to be fully gone")
+        assert "kubectl get namespace" in wait["ansible.builtin.command"]["cmd"]
+        assert wait["until"] == "_ns_gone.rc != 0"  # NotFound == gone
+        assert int(wait["retries"]) * int(wait["delay"]) >= 300
+
+    def test_helm_uninstall_drops_wait(self):
+        # The helm uninstall must NOT use --wait: with --wait its async window
+        # could time out on slow multi-node NFS teardown and abort the delete
+        # before the namespace was removed (#762). Teardown is handled by the
+        # namespace delete + poll above.
+        with open(os.path.join(ORCHESTRATOR_TASKS, "helm_uninstall.yml")) as f:
+            tasks = yaml.safe_load(f)
+        un = next(t for t in tasks if t.get("name") == "Uninstall Canasta Helm release")
+        assert "--wait" not in un["vars"]["rx_cmd"]
 
 
 class TestResilientExec:


### PR DESCRIPTION
Fixes #762. Found and re-tested in a hands-on multi-node K8s e2e (cp `big` + worker `small`, NFS RWX PVCs).

## Problem
`canasta delete` ran `helm uninstall --wait` and `kubectl delete namespace --wait`, each wrapped in a fixed `resilient_exec` async window. On a multi-node NFS instance, slow pod termination / NFS unmount made the helm uninstall exceed its 300s window. A timed-out `async_status` task fails **regardless of `rx_fail`** (it only gates the separate "Report failure" task), so the play aborted **before** the namespace delete — leaking the `canasta-<id>` namespace + PVCs while the instance was already deregistered. Operator saw `Error: Timeout exceeded` and a half-removed instance.

## Fix
- **helm uninstall: drop `--wait`** (and lower its async window). The release record is removed quickly; resource teardown is handled by the namespace delete below — no reason to block on a slow `--wait`.
- **namespace delete: request + poll-until-gone** instead of a single held `--wait`. Issue `kubectl delete namespace --ignore-not-found=true --wait=false`, then poll `kubectl get namespace` (short calls, `retries:120 delay:5` = up to 10 min) until it's NotFound. This tolerates slow NFS teardown and a transient SSH reset without aborting, and still waits for full termination so a same-id re-create doesn't race the stale Terminating namespace.

## Live re-test (the fix)
Created a fresh K8s instance on big/small, then `canasta delete` with this code:
- `Instance 'e2ek8s2' deleted.` in **82s** (no timeout; pre-fix it aborted at ~300s+)
- `canasta-e2ek8s2` namespace: **fully gone**
- Argo CD: **untouched** (ns Active, 7 pods)
- registry: empty

## Testing
`make lint`, `make validate`, `make test-unit` (1152 passed). Updated `TestK8sDeleteWaitsForNamespace` to assert request+poll-until-gone and that the helm uninstall drops `--wait`.
