### PR TITLE
maintenance exec: add --stdin-file to pipe a file to the command

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1307,9 +1307,15 @@ commands:
 
       With no arguments and no --service flag, lists the running services.
       The default service is "web" (the MediaWiki container).
+
+      Use --stdin-file to feed a file to the command's standard input — for
+      example, piping wikitext to `maintenance/run.php edit <page>`. The
+      file is read on the controller, so it works for local, remote, and
+      Kubernetes targets alike. Content is read as text (UTF-8).
     examples:
       - "canasta maintenance exec -- ls /var/www/mediawiki"
       - "canasta maintenance exec -s db -- mariadb-admin ping -h localhost"
+      - "canasta maintenance exec --stdin-file page.txt -- php run.php edit 'Main Page'"
     playbook: maintenance_exec.yml
     parameters:
       - name: id
@@ -1324,6 +1330,9 @@ commands:
         short: w
         type: string
         description: "Wiki ID"
+      - name: stdin_file
+        type: path
+        description: "File fed to the command's standard input (e.g. wikitext for an edit), read as UTF-8 on the controller."
       - name: exec_args
         type: string
         positional: true

--- a/roles/maintenance/tasks/exec.yml
+++ b/roles/maintenance/tasks/exec.yml
@@ -34,6 +34,7 @@
   vars:
     exec_service: "{{ service | default('web') }}"
     exec_command: "{{ exec_args }}"
+    exec_stdin: "{{ stdin_file | default('') }}"
   when: (exec_args | default('')) != ''
 
 - name: Display output

--- a/roles/orchestrator/tasks/exec.yml
+++ b/roles/orchestrator/tasks/exec.yml
@@ -8,6 +8,9 @@
 #   instance_orchestrator (str) - compose or kubernetes
 #   exec_service (str) - service name (default: web)
 #   exec_command (str) - command to run
+#   exec_stdin (str, optional) - path to a file (on the controller) whose
+#     contents are fed to the command's stdin. Read as UTF-8 text. Ignored
+#     on the long/detached path. Compose pipes via `exec -T`; K8s adds `-i`.
 #   exec_no_log (bool, optional) - suppress command in output
 #   exec_long (bool, optional) - run detached + polled for long commands
 #     (update.php on a big wiki, a large mysqldump) so a controller-side
@@ -43,7 +46,7 @@
     - name: Build K8s exec command
       ansible.builtin.set_fact:
         _exec_full_cmd: >-
-          kubectl exec {{ _k8s_pod_name }}
+          kubectl exec {{ '-i ' if (exec_stdin | default('')) | length > 0 else '' }}{{ _k8s_pod_name }}
           -n {{ _k8s_namespace }} --
           /bin/bash -c {{ exec_command | quote }}
         _exec_chdir: null
@@ -57,6 +60,13 @@
   ansible.builtin.shell:
     cmd: "{{ _exec_full_cmd }}"
     chdir: "{{ _exec_chdir | default(omit) }}"
+    # Read on the controller (lookup runs there), so the content travels
+    # with the task and reaches the command regardless of delegation.
+    # Gated on the current call's exec_stdin, not a persisted fact.
+    stdin: >-
+      {{ lookup('file', exec_stdin)
+         if (exec_stdin | default('')) | length > 0
+         else omit }}
   register: exec_result
   changed_when: false
   no_log: "{{ exec_no_log | default(false) }}"

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -333,6 +333,38 @@ class TestBuildAnsibleArgs:
         extra = self._get_vars(result)
         assert extra["id"] == "mysite"
 
+    def test_maintenance_exec_stdin_file_path_abspath(self, data):
+        """--stdin-file is a local path: resolved to an absolute path so the
+        controller-side lookup('file', ...) finds it regardless of cwd."""
+        import os
+        from argparse import Namespace
+        args = Namespace(
+            command="maintenance_exec", host=None, verbose=False,
+            id="mysite", service=None, wiki=None,
+            stdin_file="page.wikitext", exec_args=["php", "run.php", "edit"],
+        )
+        result = canasta_cli.build_ansible_args(
+            "ap", "maintenance_exec", args, data
+        )
+        extra = self._get_vars(result)
+        assert extra["stdin_file"] == os.path.abspath(
+            os.path.expanduser("page.wikitext")
+        )
+
+    def test_maintenance_exec_stdin_file_omitted(self, data):
+        """No --stdin-file: the stdin_file var is absent (the play omits it)."""
+        from argparse import Namespace
+        args = Namespace(
+            command="maintenance_exec", host=None, verbose=False,
+            id="mysite", service=None, wiki=None,
+            stdin_file=None, exec_args=["ls", "/var/www/mediawiki"],
+        )
+        result = canasta_cli.build_ansible_args(
+            "ap", "maintenance_exec", args, data
+        )
+        extra = self._get_vars(result)
+        assert "stdin_file" not in extra
+
     def test_host_name_param(self, data):
         """host_name parameter (with long: name) is passed correctly."""
         from argparse import Namespace


### PR DESCRIPTION
Closes #767.

## What

Adds a `--stdin-file <FILE>` flag to `canasta maintenance exec` that feeds
a file's contents to the executed command's standard input.

```
canasta maintenance exec -i mysite --stdin-file page.txt -- \
  php maintenance/run.php edit --user=WikiSysop 'Main Page'
```

## How

- The file is read on the controller via `lookup('file', …)`, so the
  content travels with the task and reaches the container regardless of
  delegation — local, remote (`--host`), or Kubernetes.
- Compose already runs `docker compose exec -T`, which pipes stdin. The
  K8s path now adds `-i` to `kubectl exec` only when a file is supplied.
- The shell exec gates stdin on the current call's `exec_stdin` input
  rather than a persisted fact, so a prior exec can't leak its input
  into a later stdin-less exec (this primitive is included in many flows).
- `--stdin-file` is ignored on the long/detached exec path; that path is
  for big batch jobs (update.php, mysqldump), not stdin-driven commands.

## Why

Lets tooling write wiki pages via `maintenance/run.php edit <page>` (which
reads content from stdin) through the CLI instead of raw `docker exec -i`,
which only works on the Docker host. Motivating consumer: a declarative
wiki-application deployer that installs starter content this way.

## Tests

- New unit tests cover the param plumbing (local path resolved to an
  absolute path; omitted when not supplied).
- `make validate`, `make lint`, and the full unit suite (1159 tests) pass.

## Notes

Generated command docs (`docs/commands/*.md`) are gitignored build
artifacts; run `make docs` to regenerate the `maintenance exec` page.