### PR TITLE
fix: maintenance exec --stdin-file (direct-exec path: stdin + quoting)

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -744,12 +744,17 @@ def handle_interactive_exec(args):
       - -s given, no command -> interactive /bin/bash in that service
       - -s given, with command -> exec in that service
     """
+    import shlex
     service = getattr(args, "service", None) or ""
     exec_args = getattr(args, "exec_args", None) or []
     if isinstance(exec_args, list):
         command = exec_args
     else:
-        command = exec_args.split() if exec_args else []
+        # exec_args arrives as a string when main() collected it from a `--`
+        # passthrough. Split it like a shell would so quoted arguments (a
+        # --summary with spaces, a page title with spaces) survive as single
+        # argv elements — a naive .split() would shred them on whitespace.
+        command = shlex.split(exec_args) if exec_args else []
 
     # No service flag AND no command -> list services (let Ansible handle it)
     if not service and not command:

--- a/canasta.py
+++ b/canasta.py
@@ -713,6 +713,28 @@ def resolve_instance(instance_id=None):
     sys.exit(1)
 
 
+def _redirect_stdin_from_file(path):
+    """Point fd 0 at `path` so the about-to-be-exec'd command reads it as
+    stdin. Used by `maintenance exec --stdin-file`. No-op when path is unset.
+
+    This runs in the direct-exec path (handle_interactive_exec os.execvp's
+    docker/kubectl/ssh, replacing this process), so there is no shell to do
+    a `< file` redirect — we dup the file onto stdin ourselves.
+    """
+    if not path:
+        return
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError as exc:
+        print(
+            "Error: cannot read --stdin-file '%s': %s" % (path, exc),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    os.dup2(fd, 0)
+    os.close(fd)
+
+
 def handle_interactive_exec(args):
     """Handle maintenance exec by running docker/kubectl exec directly.
 
@@ -759,8 +781,14 @@ def handle_interactive_exec(args):
             )
             sys.exit(1)
         pod = result.stdout.strip()
-        exec_args = ["kubectl", "exec", "-it", pod, "-n", ns, "--"]
+        # With --stdin-file the exec is non-interactive: keep stdin open
+        # (-i) but drop the TTY (-t), which would otherwise mangle a piped
+        # payload. Without it, preserve the interactive -it behavior.
+        stdin_file = getattr(args, "stdin_file", None)
+        tty_flags = "-i" if stdin_file else "-it"
+        exec_args = ["kubectl", "exec", tty_flags, pod, "-n", ns, "--"]
         exec_args.extend(command)
+        _redirect_stdin_from_file(stdin_file)
         try:
             os.execvp("kubectl", exec_args)
         except FileNotFoundError:
@@ -768,23 +796,33 @@ def handle_interactive_exec(args):
             sys.exit(1)
     else:
         host = inst.get("host", "localhost")
-        docker_cmd = (
-            ["docker", "compose", "exec", service] + command
-        )
+        # With --stdin-file the exec must be non-interactive so the piped
+        # payload reaches the command: `docker compose exec -T` (no TTY).
+        # Without it, omit -T to preserve the interactive shell behavior.
+        stdin_file = getattr(args, "stdin_file", None)
+        docker_cmd = ["docker", "compose", "exec"]
+        if stdin_file:
+            docker_cmd.append("-T")
+        docker_cmd += [service] + command
         if host and host != "localhost":
-            # Run via SSH on the remote host
+            # Run via SSH on the remote host. ssh forwards our stdin to the
+            # remote command, so the --stdin-file payload (dup'd onto fd 0
+            # below) flows through to `docker compose exec -T`. Use -T (no
+            # remote TTY) when piping; -t for interactive sessions.
             import shlex
             remote_cmd = "cd %s && %s" % (
                 shlex.quote(inst["path"]),
                 " ".join(shlex.quote(a) for a in docker_cmd),
             )
             try:
-                ssh_args = ["ssh", "-t", "-o", "LogLevel=ERROR"]
+                ssh_args = ["ssh", "-T" if stdin_file else "-t",
+                            "-o", "LogLevel=ERROR"]
                 # Include any custom SSH args (e.g. from ANSIBLE_SSH_ARGS)
                 extra_ssh = os.environ.get("ANSIBLE_SSH_ARGS", "")
                 if extra_ssh:
                     ssh_args.extend(extra_ssh.split())
                 ssh_args.extend([host, remote_cmd])
+                _redirect_stdin_from_file(stdin_file)
                 os.execvp("ssh", ssh_args)
             except FileNotFoundError:
                 print("Error: ssh not found on PATH", file=sys.stderr)
@@ -799,6 +837,7 @@ def handle_interactive_exec(args):
                 )
                 sys.exit(1)
             try:
+                _redirect_stdin_from_file(stdin_file)
                 os.execvp("docker", docker_cmd)
             except FileNotFoundError:
                 print("Error: docker not found on PATH", file=sys.stderr)

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -1551,3 +1551,52 @@ class TestNestedGroupHelp:
         assert "backup schedule" in out
         for sub in ("set", "list", "remove"):
             assert sub in out
+
+
+class TestHandleInteractiveExecStdin:
+    """maintenance exec --stdin-file must make the direct exec non-interactive
+    (so a piped payload survives) and redirect the file onto stdin. This path
+    bypasses Ansible, so the wiring lives in handle_interactive_exec."""
+
+    def _run(self, monkeypatch, stdin_file, orchestrator="compose"):
+        from argparse import Namespace
+        calls = {}
+        monkeypatch.setattr(canasta_cli, "resolve_instance", lambda _id: {
+            "id": "rsdev", "orchestrator": orchestrator,
+            "host": "localhost", "path": "/tmp/inst",
+        })
+        monkeypatch.setattr(canasta_cli.os, "chdir", lambda p: None)
+        monkeypatch.setattr(
+            canasta_cli, "_redirect_stdin_from_file",
+            lambda p: calls.__setitem__("redirect", p))
+        monkeypatch.setattr(
+            canasta_cli.os, "execvp",
+            lambda f, argv: calls.__setitem__("execvp", (f, list(argv))))
+        if orchestrator in ("kubernetes", "k8s"):
+            monkeypatch.setattr(
+                canasta_cli.subprocess, "run",
+                lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="pod-1"))
+        args = Namespace(id="rsdev", service=None,
+                         exec_args=["php", "edit"], stdin_file=stdin_file)
+        canasta_cli.handle_interactive_exec(args)
+        return calls
+
+    def test_compose_stdin_file_adds_T_and_redirects(self, monkeypatch):
+        calls = self._run(monkeypatch, "/tmp/page.txt")
+        binary, argv = calls["execvp"]
+        assert binary == "docker"
+        assert argv[:4] == ["docker", "compose", "exec", "-T"]
+        assert calls["redirect"] == "/tmp/page.txt"
+
+    def test_compose_without_stdin_file_stays_interactive(self, monkeypatch):
+        calls = self._run(monkeypatch, None)
+        _binary, argv = calls["execvp"]
+        assert "-T" not in argv
+        assert calls["redirect"] is None
+
+    def test_k8s_stdin_file_drops_tty(self, monkeypatch):
+        calls = self._run(monkeypatch, "/tmp/page.txt", orchestrator="k8s")
+        binary, argv = calls["execvp"]
+        assert binary == "kubectl"
+        assert "-i" in argv and "-it" not in argv
+        assert calls["redirect"] == "/tmp/page.txt"

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -1600,3 +1600,27 @@ class TestHandleInteractiveExecStdin:
         assert binary == "kubectl"
         assert "-i" in argv and "-it" not in argv
         assert calls["redirect"] == "/tmp/page.txt"
+
+    def test_string_exec_args_preserves_quoting(self, monkeypatch):
+        """A `--` passthrough arrives as one string; quoted args (a spaced
+        --summary, a page title with spaces) must survive as single argv
+        elements. Regression: a naive .split() shredded them on whitespace,
+        so edit.php wrote to a page titled "'--summary=Initial"."""
+        from argparse import Namespace
+        calls = {}
+        monkeypatch.setattr(canasta_cli, "resolve_instance", lambda _id: {
+            "id": "x", "orchestrator": "compose",
+            "host": "localhost", "path": "/tmp/i"})
+        monkeypatch.setattr(canasta_cli.os, "chdir", lambda p: None)
+        monkeypatch.setattr(
+            canasta_cli, "_redirect_stdin_from_file", lambda p: None)
+        monkeypatch.setattr(
+            canasta_cli.os, "execvp",
+            lambda f, argv: calls.__setitem__("argv", list(argv)))
+        args = Namespace(
+            id="x", service=None, stdin_file=None,
+            exec_args="php edit '--summary=a b' 'Template:Page Name'")
+        canasta_cli.handle_interactive_exec(args)
+        argv = calls["argv"]
+        assert "--summary=a b" in argv
+        assert "Template:Page Name" in argv


### PR DESCRIPTION
Closes #770.

`canasta maintenance exec <cmd>` runs through `handle_interactive_exec`,
which execs docker/kubectl/ssh directly via `os.execvp` — it never reaches
the Ansible exec path where #768 wired `--stdin-file`. Two fixes there:

## 1. --stdin-file now takes effect (`e57fe7a`)
- Compose: add `-T` (no TTY) so a pipe survives; `dup2` the file onto fd 0.
- K8s: `kubectl exec -i` (drop the TTY) + `dup2`.
- Remote: `ssh -T` + `dup2`; ssh forwards stdin to `docker compose exec -T`.
- Interactive behavior (no `--stdin-file`) is unchanged (`-it`/`-t`).

## 2. Quoted args survive (`a29f225`)
The direct path split the `--` passthrough with a naive `str.split()`,
shredding quoted tokens on whitespace. Use `shlex.split` so a spaced
`--summary` or a page title with spaces stays one argv element.

## Why both, found together
A live deploy importing starter pages via `run.php edit` (content on stdin):
with bug 1 the pages imported empty; once stdin flowed, bug 2 wrote them to
a page titled `'--summary=Initial`. Fixed, the import lands correctly and
`cargoRecreateData` builds the tables.

## Tests
+4 regression tests over `handle_interactive_exec` (stdin `-T`/`-i` flags,
the stdin redirect, and quote preservation). `make validate`, `make lint`,
and the full unit suite (1163 tests) pass.

## Note
These two bugs both stem from `maintenance exec` having a second,
Ansible-bypassing code path that re-implements the orchestrator dispatch.
Consolidating the direct and Ansible exec paths (keeping `os.execvp` only
for genuinely interactive sessions) would prevent this class of drift — a
worthwhile follow-up, out of scope here.