### PR TITLE
Fix root CLI:Canasta reference page dropping all subcommand groups

### DIFF
--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -540,6 +540,7 @@ def generate_all_pages(data):
     """Generate all wiki pages from command definitions."""
     pages = []
     cmd_index = {c["name"]: c for c in data["commands"]}
+    group_index = {g["name"]: g for g in data.get("command_groups", [])}
 
     # Root page
     root_lines = [
@@ -552,13 +553,24 @@ def generate_all_pages(data):
         root_lines.append("=== %s ===" % heading)
         root_lines.append("")
         for name in names:
+            # CMD_GROUPS entries are either leaf commands (in cmd_index)
+            # or subcommand-group keys (in SUBCOMMAND_GROUPS). Render both:
+            # leaf commands link their generated page; group keys link the
+            # group landing page. Skipping groups blanks whole sections
+            # (Extensions & Skins, Maintenance, Security, Data Protection,
+            # Development are all groups).
             if name in cmd_index:
-                cmd = cmd_index[name]
+                desc = cmd_index[name].get("description", "")
                 link = cmd_page_title(name)
-                root_lines.append(
-                    "* [[%s|canasta %s]] — %s"
-                    % (link, name, cmd.get("description", ""))
-                )
+            elif name in SUBCOMMAND_GROUPS:
+                desc = group_index.get(name, {}).get("description", "")
+                link = cmd_page_title(name)
+            else:
+                continue
+            sep = " — " + _backticks_to_code(desc) if desc else ""
+            root_lines.append(
+                "* [[%s|canasta %s]]%s" % (link, name, sep)
+            )
         root_lines.append("")
     root_lines.append("{{Reference Manual}}")
     pages.append((PAGE_PREFIX + "canasta", "\n".join(root_lines)))
@@ -580,7 +592,6 @@ def generate_all_pages(data):
     # command set. Description and synopsis come from `command_groups:`
     # in command_definitions.yml; missing entries fall back to a generic
     # "Manage canasta <group>" stub.
-    group_index = {g["name"]: g for g in data.get("command_groups", [])}
     for group_name in _all_group_names():
         group_def = group_index.get(group_name, {})
         pages.append((

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -152,6 +152,52 @@ class TestMenuCoverage:
                 )
 
 
+class TestRootPageCoverage:
+    """The root CLI:canasta page must link to every CMD_GROUPS entry,
+    including subcommand groups. The earlier bug was that the root
+    generator only rendered leaf commands found in cmd_index and
+    silently dropped every subcommand-group name, blanking whole
+    sections (Extensions & Skins, Maintenance, Security, Data
+    Protection, Development are all groups)."""
+
+    def _root_content(self):
+        data = wp.load_definitions()
+        for title, content in wp.generate_all_pages(data):
+            if title == wp.PAGE_PREFIX + "canasta":
+                return content
+        raise AssertionError("root page not emitted")
+
+    def test_every_cmd_group_entry_is_linked(self):
+        root = self._root_content()
+        missing = []
+        for _heading, names in wp.CMD_GROUPS:
+            for name in names:
+                if name in wp.SUBCOMMAND_GROUPS or _has_command(name):
+                    if "|canasta %s]]" % name not in root:
+                        missing.append(name)
+        assert not missing, (
+            "root page missing entries:\n  " + "\n  ".join(missing)
+        )
+
+    def test_no_section_is_empty(self):
+        root = self._root_content()
+        lines = root.splitlines()
+        for i, line in enumerate(lines):
+            if line.startswith("=== ") and line.endswith(" ==="):
+                rest = [
+                    ln for ln in lines[i + 1:]
+                    if ln.strip() and not ln.startswith("{{")
+                ]
+                assert rest and rest[0].startswith("* "), (
+                    "section %r has no command entries" % line
+                )
+
+
+def _has_command(name):
+    data = wp.load_definitions()
+    return any(c["name"] == name for c in data["commands"])
+
+
 class TestCwdResolutionFootnote:
     """Non-required -i flags get a cwd-resolution footnote in the
     flags table. Required -i (create) does not, because there's no


### PR DESCRIPTION
## Problem

The generated `CLI:Canasta` reference index — published by `scripts/wiki_publish.py` and linked from the breadcrumb on every command page — only listed leaf commands. The root-page generator in `generate_all_pages` rendered a name only when it was found in `cmd_index`, silently skipping every subcommand-group name (`host`, `storage`, `argocd`, `config`, `extension`, `skin`, `maintenance`, `sitemap`, `crowdsec`, `backup`, `gitops`, `devmode`).

This blanked five entire sections (Extensions & Skins, Maintenance, Security, Data Protection, Development) and dropped `host`/`storage`/`argocd`/`config` from the populated sections. Because the page is republished on every run, the script was actively overwriting the live index with the broken version.

The menu generator (`MediaWiki:Menu-cli-reference`) already handled both leaves and groups — only the root page had the gap.

## Fix

Render subcommand-group entries on the root page too, linking each to its `CLI:canasta <group>` landing page with the description from `command_groups:`, mirroring the menu generator. `group_index` is now built once and reused.

## Tests

Added `TestRootPageCoverage`:
- every `CMD_GROUPS` entry (leaf **or** group) is linked from the root page
- no section is left empty

All 56 unit tests in `test_wiki_publish.py` pass.

Closes #769