### PR TITLE
Sentence-case the CLI reference section headers

### DIFF
--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -95,15 +95,15 @@ def _group_subcommands(group_name):
 
 CMD_GROUPS = [
     ("System", ["install", "doctor", "host", "storage", "argocd", "uninstall"]),
-    ("Instance Management", [
+    ("Instance management", [
         "create", "delete", "list", "status", "upgrade", "version", "config",
     ]),
-    ("Wiki Management", ["add", "remove", "import", "export"]),
-    ("Container Lifecycle", ["start", "stop", "restart", "rebuild", "scale"]),
-    ("Extensions & Skins", ["extension", "skin"]),
+    ("Wiki management", ["add", "remove", "import", "export"]),
+    ("Container lifecycle", ["start", "stop", "restart", "rebuild", "scale"]),
+    ("Extensions & skins", ["extension", "skin"]),
     ("Maintenance", ["maintenance", "sitemap"]),
     ("Security", ["crowdsec"]),
-    ("Data Protection", ["backup", "gitops"]),
+    ("Data protection", ["backup", "gitops"]),
     ("Development", ["devmode"]),
 ]
 
@@ -252,7 +252,7 @@ def _global_flags_section(global_flags):
     """
     if not global_flags:
         return []
-    lines = ["=== Global Flags ===", ""]
+    lines = ["=== Global flags ===", ""]
     lines.append('{| class="wikitable"')
     lines.append(
         "! Flag !! Shorthand !! Description "
@@ -544,7 +544,7 @@ def generate_all_pages(data):
 
     # Root page
     root_lines = [
-        "== Canasta CLI Reference ==",
+        "== Canasta CLI reference ==",
         "",
         "Ansible-based management tool for Canasta MediaWiki.",
         "",
@@ -557,7 +557,7 @@ def generate_all_pages(data):
             # or subcommand-group keys (in SUBCOMMAND_GROUPS). Render both:
             # leaf commands link their generated page; group keys link the
             # group landing page. Skipping groups blanks whole sections
-            # (Extensions & Skins, Maintenance, Security, Data Protection,
+            # (Extensions & skins, Maintenance, Security, Data protection,
             # Development are all groups).
             if name in cmd_index:
                 desc = cmd_index[name].get("description", "")
@@ -603,7 +603,7 @@ def generate_all_pages(data):
         ))
 
     # Menu page
-    menu_lines = ["* # | Canasta CLI Reference"]
+    menu_lines = ["* # | Canasta CLI reference"]
     for heading, names in CMD_GROUPS:
         menu_lines.append("** # | %s" % heading)
         for name in names:

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -253,7 +253,7 @@ class TestGlobalFlagsSection:
                 continue
             if title == wp.PAGE_PREFIX + "canasta":
                 continue  # root page has no flag table
-            if "=== Global Flags ===" not in content:
+            if "=== Global flags ===" not in content:
                 missing.append(title)
         assert not missing, (
             "pages missing Global Flags section:\n  "
@@ -271,7 +271,7 @@ class TestGlobalFlagsSection:
                              "description": "Canasta instance ID"}]},
             global_flags=wp.load_definitions()["global_flags"],
         )
-        assert "=== Global Flags ===" in page
+        assert "=== Global flags ===" in page
         assert "--help" in page
         assert "--verbose" in page
 
@@ -284,7 +284,7 @@ class TestGlobalFlagsSection:
                              "type": "string",
                              "description": "Canasta instance ID"}]}
         )
-        assert "=== Global Flags ===" not in page
+        assert "=== Global flags ===" not in page
 
 
 class TestOrchestratorColumn:
@@ -334,8 +334,8 @@ class TestOrchestratorColumn:
         orchestrator, so they show 'Both' in the column."""
         page = self._create_page()
         # The Global Flags section is the tail of the page after
-        # '=== Global Flags ==='.
-        gf = page.split("=== Global Flags ===", 1)[1]
+        # '=== Global flags ==='.
+        gf = page.split("=== Global flags ===", 1)[1]
         assert "Orchestrator" in gf
         for line in gf.splitlines():
             if "<code>--help</code>" in line or "<code>--verbose</code>" in line:
@@ -403,7 +403,7 @@ class TestSubcommandGroupPages:
         pages = self._pages()
         for group in ("host", "gitops", "config"):
             page = pages[wp.PAGE_PREFIX + "canasta " + group]
-            assert "=== Global Flags ===" in page
+            assert "=== Global flags ===" in page
             assert "<code>--help</code>" in page
             assert "<code>--verbose</code>" in page
 


### PR DESCRIPTION
## Change

The generated CLI reference used title case for its headers. This switches them to sentence case (only the first word capitalized; initialisms like `CLI` preserved):

- Root index title: `Canasta CLI Reference` → `Canasta CLI reference`
- Section headings: `Instance Management` → `Instance management`, `Wiki Management` → `Wiki management`, `Container Lifecycle` → `Container lifecycle`, `Extensions & Skins` → `Extensions & skins`, `Data Protection` → `Data protection` (single-word headings like System/Maintenance/Security/Development unchanged)
- `MediaWiki:Menu-cli-reference` title likewise
- `=== Global Flags ===` → `=== Global flags ===` on every command page, so the index and the pages it links to stay consistent

## Tests

Updated the `Global flags` assertions in `test_wiki_publish.py`; all 56 unit tests pass.

Closes #775