### PR TITLE
Dedup canasta.py ↔ Ansible-layer logic: registry resolution + param validation (#773)

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -160,6 +160,114 @@ _VALIDATORS = {
 }
 
 
+# Parameter validation runs at two layers by design. These functions are
+# the CLI's fast-fail half: they run after argparse but before any Ansible
+# work, so a typo (comma-vs-period domain, a missing required_unless
+# partner) fails in milliseconds instead of after Argo CD/helm/image-pull
+# steps have already done work. The playbook re-validates the same
+# command_definitions.yml metadata in roles/common/tasks/validate_params.yml
+# so values that bypass the CLI (CANASTA_FORCE_ANSIBLE, Molecule, a raw
+# ansible-playbook run) are still caught. Both layers read the same
+# definition fields; neither is authoritative alone. Each function returns
+# a list of (exit_code, message) so the caller decides how to surface them.
+
+
+def _validate_required_unless(cmd_def, get_value):
+    """Flag params whose required_unless partner is also unset."""
+    errors = []
+    for param in cmd_def.get("parameters", []):
+        ru = param.get("required_unless")
+        if not ru:
+            continue
+        if not get_value(param["name"]) and not get_value(ru):
+            errors.append((
+                1,
+                "Error: --%s is required unless --%s is provided"
+                % (param["name"].replace("_", "-"), ru.replace("_", "-")),
+            ))
+    return errors
+
+
+def _validate_orchestrator_only(cmd_def, get_value):
+    """Flag params restricted to one orchestrator when another is selected."""
+    errors = []
+    orchestrator = get_value("orchestrator")
+    if not orchestrator:
+        return errors
+    for param in cmd_def.get("parameters", []):
+        orch_only = param.get("orchestrator_only")
+        if not orch_only:
+            continue
+        value = get_value(param["name"])
+        if value is None or value == param.get("default"):
+            continue
+        if orchestrator != orch_only:
+            errors.append((
+                1,
+                "Error: --%s can only be used with --orchestrator %s"
+                % (param["name"].replace("_", "-"), orch_only),
+            ))
+    return errors
+
+
+def _validate_named_validators(cmd_def, get_value, validators=None):
+    """Check params tagged `validator: <name>` against the named regex.
+
+    An unknown validator name is a bug in command_definitions.yml, not a
+    user error, so it surfaces as an internal error (exit 2).
+    """
+    if validators is None:
+        validators = _VALIDATORS
+    errors = []
+    for param in cmd_def.get("parameters", []):
+        validator_name = param.get("validator")
+        if not validator_name:
+            continue
+        value = get_value(param["name"])
+        if value is None or value == "":
+            continue
+        validator = validators.get(validator_name)
+        if validator is None:
+            errors.append((
+                2,
+                "Internal error: parameter '%s' references unknown "
+                "validator '%s'" % (param["name"], validator_name),
+            ))
+            continue
+        regex, error_template = validator[0], validator[1]
+        hint_fn = validator[2] if len(validator) > 2 else None
+        if not regex.match(str(value)):
+            hint = hint_fn(value) if hint_fn else ""
+            errors.append((
+                1,
+                "Error: --%s %r %s%s"
+                % (
+                    param["name"].replace("_", "-"),
+                    str(value),
+                    error_template,
+                    hint,
+                ),
+            ))
+    return errors
+
+
+def collect_cli_param_errors(cmd_def, args):
+    """Run the CLI-layer parameter validations and return a list of
+    (exit_code, message) tuples, in evaluation order. Empty when valid.
+
+    `args` is the parsed argparse Namespace; orchestrator-alias
+    normalization (k8s -> kubernetes) is expected to have run already.
+    """
+    def get_value(name):
+        return getattr(args, name, None)
+
+    return (
+        _validate_required_unless(cmd_def, get_value)
+        + _validate_orchestrator_only(cmd_def, get_value)
+        + _validate_named_validators(cmd_def, get_value)
+    )
+
+
 def load_definitions():
     """Load command definitions from YAML."""
     try:
@@ -1384,84 +1492,13 @@ def main():
     if getattr(args, "orchestrator", None) == "k8s":
         args.orchestrator = "kubernetes"
 
-    # Validate required_unless parameters early, before spinning up
-    # Ansible. Mirrors the check in roles/common/tasks/validate_params.yml
-    # so the user sees the same message at parse time instead of waiting
-    # for the playbook to load.
-    for param in cmd_def.get("parameters", []):
-        ru = param.get("required_unless")
-        if not ru:
-            continue
-        own_value = getattr(args, param["name"], None)
-        other_value = getattr(args, ru, None)
-        if not own_value and not other_value:
-            print(
-                "Error: --%s is required unless --%s is provided"
-                % (
-                    param["name"].replace("_", "-"),
-                    ru.replace("_", "-"),
-                ),
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-    # Validate orchestrator-specific parameters.
-    # If a parameter has orchestrator_only set, reject it when the user
-    # selected a different orchestrator.
-    orchestrator = getattr(args, "orchestrator", None)
-    if orchestrator:
-        for param in cmd_def.get("parameters", []):
-            orch_only = param.get("orchestrator_only")
-            if not orch_only:
-                continue
-            value = getattr(args, param["name"], None)
-            if value is None or value == param.get("default"):
-                continue
-            if orchestrator != orch_only:
-                print(
-                    "Error: --%s can only be used with "
-                    "--orchestrator %s"
-                    % (param["name"].replace("_", "-"), orch_only),
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-
-    # Validate parameters tagged with `validator: <name>` against a
-    # named regex. Catches typos (e.g. comma-vs-period in domain names)
-    # before any Ansible work is done — much cheaper than the same
-    # check failing at the end of the create pipeline.
-    for param in cmd_def.get("parameters", []):
-        validator_name = param.get("validator")
-        if not validator_name:
-            continue
-        value = getattr(args, param["name"], None)
-        if value is None or value == "":
-            continue
-        validator = _VALIDATORS.get(validator_name)
-        if validator is None:
-            # Unknown validator name in command_definitions.yml is a
-            # bug in the YAML, not a user error — surface loudly.
-            print(
-                "Internal error: parameter '%s' references unknown "
-                "validator '%s'" % (param["name"], validator_name),
-                file=sys.stderr,
-            )
-            sys.exit(2)
-        regex, error_template = validator[0], validator[1]
-        hint_fn = validator[2] if len(validator) > 2 else None
-        if not regex.match(str(value)):
-            hint = hint_fn(value) if hint_fn else ""
-            print(
-                "Error: --%s %r %s%s"
-                % (
-                    param["name"].replace("_", "-"),
-                    str(value),
-                    error_template,
-                    hint,
-                ),
-                file=sys.stderr,
-            )
-            sys.exit(1)
+    # CLI-layer parameter validation (required_unless, orchestrator_only,
+    # named regex validators). Runs before Ansible so typos fail in
+    # milliseconds; the playbook re-validates the same metadata as a
+    # backstop. Exit on the first error in evaluation order.
+    for code, message in collect_cli_param_errors(cmd_def, args):
+        print(message, file=sys.stderr)
+        sys.exit(code)
 
     # Interactive exec: bypass Ansible for TTY support.
     if command_name == "maintenance_exec":

--- a/canasta.py
+++ b/canasta.py
@@ -23,6 +23,14 @@ DEFINITIONS_PATH = os.path.join(SCRIPT_DIR, "meta", "command_definitions.yml")
 CANASTA_YML = os.path.join(SCRIPT_DIR, "canasta.yml")
 ANSIBLE_CFG = os.path.join(SCRIPT_DIR, "ansible.cfg")
 
+# Registry-location and lookup helpers are shared with the
+# canasta_registry Ansible module (which reads/writes conf.json), so the
+# CLI and the module never disagree about where the registry lives. The
+# helpers live under the role's module_utils dir; append it to the path
+# so `import canasta_config` resolves the same file Ansible ships.
+sys.path.append(os.path.join(SCRIPT_DIR, "roles", "common", "module_utils"))
+import canasta_config  # noqa: E402
+
 # Ensure Ansible uses the repo's config regardless of working directory
 os.environ.setdefault("ANSIBLE_CONFIG", ANSIBLE_CFG)
 
@@ -644,29 +652,15 @@ def add_params_to_parser(parser, params):
 def get_config_dir():
     """Return the user config directory (where conf.json lives).
 
-    Mirrors canasta_registry.py logic.
+    Delegates to the shared helper so the CLI resolves the same location
+    the canasta_registry module writes to.
     """
-    override = os.environ.get("CANASTA_CONFIG_DIR")
-    if override:
-        return override
-    if os.geteuid() == 0:
-        return "/etc/canasta"
-    import platform
-    if platform.system() == "Darwin":
-        base = os.path.join(
-            os.path.expanduser("~"), "Library", "Application Support"
-        )
-    else:
-        base = os.environ.get(
-            "XDG_CONFIG_HOME",
-            os.path.join(os.path.expanduser("~"), ".config"),
-        )
-    return os.path.join(base, "canasta")
+    return canasta_config.get_config_dir()
 
 
 def get_config_file_path():
     """Return the path to conf.json."""
-    return os.path.join(get_config_dir(), "conf.json")
+    return canasta_config.config_path(get_config_dir())
 
 
 def resolve_instance(instance_id=None):
@@ -678,9 +672,7 @@ def resolve_instance(instance_id=None):
     if not os.path.isfile(conf_file):
         print("Error: no registry found at %s" % conf_file, file=sys.stderr)
         sys.exit(1)
-    with open(conf_file) as f:
-        data = json.load(f)
-    instances = data.get("Instances", {})
+    instances = canasta_config.read_config(get_config_dir()).get("Instances", {})
 
     if instance_id:
         if instance_id not in instances:
@@ -696,16 +688,11 @@ def resolve_instance(instance_id=None):
     # Walk up from cwd to find a matching instance path. Honor
     # CANASTA_HOST_PWD (the dockerized CLI passes the host's working
     # directory there) before falling back to the process cwd.
-    search = os.path.abspath(os.environ.get("CANASTA_HOST_PWD") or os.getcwd())
-    while True:
-        for iid, inst in instances.items():
-            if os.path.abspath(inst.get("path", "")) == search:
-                inst["id"] = iid
-                return inst
-        parent = os.path.dirname(search)
-        if parent == search:
-            break
-        search = parent
+    search = os.environ.get("CANASTA_HOST_PWD") or os.getcwd()
+    iid, inst = canasta_config.find_by_path(instances, search)
+    if iid is not None:
+        inst["id"] = iid
+        return inst
 
     print(
         "Error: no instance found for current directory", file=sys.stderr

--- a/roles/common/library/canasta_registry.py
+++ b/roles/common/library/canasta_registry.py
@@ -79,78 +79,26 @@ options:
 
 import json
 import os
-import platform
-import pwd
 
 from ansible.module_utils.basic import AnsibleModule
 
+# Registry location and lookup helpers are shared with the canasta.py CLI
+# wrapper so the two never disagree about where conf.json lives.
+from ansible.module_utils.canasta_config import (
+    config_path,
+    find_by_path,
+    get_config_dir,
+    is_root,
+    read_config,
+    write_config,
+)
 
-CONFIG_FILENAME = "conf.json"
-
-
-def get_config_dir(override=None):
-    """Determine the config directory using the platform's conventional
-    per-user config location:
-    - macOS: ~/Library/Application Support/canasta
-    - Linux: $XDG_CONFIG_HOME/canasta or ~/.config/canasta
-    """
-    if override:
-        return override
-    env_dir = os.environ.get("CANASTA_CONFIG_DIR")
-    if env_dir:
-        return env_dir
-    if is_root():
-        return "/etc/canasta"
-    if platform.system() == "Darwin":
-        config_home = os.path.join(
-            os.path.expanduser("~"), "Library", "Application Support"
-        )
-    else:
-        config_home = os.environ.get(
-            "XDG_CONFIG_HOME",
-            os.path.join(os.path.expanduser("~"), ".config"),
-        )
-    return os.path.join(config_home, "canasta")
-
-
-def is_root():
-    """Check if running as root."""
-    try:
-        return pwd.getpwuid(os.getuid()).pw_name == "root"
-    except (KeyError, AttributeError):
-        return os.getuid() == 0
-
-
-def config_path(config_dir):
-    """Return the full path to conf.json."""
-    return os.path.join(config_dir, CONFIG_FILENAME)
-
-
-def read_config(config_dir):
-    """Read and return the registry config, creating it if needed."""
-    path = config_path(config_dir)
-    if not os.path.exists(path):
-        return {"Instances": {}}
-    with open(path, "r") as f:
-        content = f.read().strip()
-    if not content:
-        return {"Instances": {}}
-    data = json.loads(content)
-    # Migrate legacy "Installations" key
-    if "Installations" in data and "Instances" not in data:
-        data["Instances"] = data.pop("Installations")
-    if "Instances" not in data:
-        data["Instances"] = {}
-    return data
-
-
-def write_config(config_dir, data):
-    """Write the registry config to conf.json."""
-    os.makedirs(config_dir, mode=0o755, exist_ok=True)
-    path = config_path(config_dir)
-    with open(path, "w") as f:
-        json.dump(data, f, indent=4)
-        f.write("\n")
+# Re-exported for backwards compatibility with importers/tests that
+# referenced canasta_registry.* before the helpers were extracted.
+__all__ = [
+    "config_path", "find_by_path", "get_config_dir", "is_root",
+    "read_config", "write_config", "instance_to_dict", "run_module",
+]
 
 
 def instance_to_dict(instance):
@@ -175,20 +123,6 @@ def instance_to_dict(instance):
     if instance.get("dockerHost"):
         result["dockerHost"] = instance["dockerHost"]
     return result
-
-
-def find_by_path(instances, search_path):
-    """Walk up from search_path to find a matching instance."""
-    search_path = os.path.abspath(search_path)
-    while True:
-        for inst_id, inst in instances.items():
-            if os.path.abspath(inst.get("path", "")) == search_path:
-                return inst_id, inst
-        parent = os.path.dirname(search_path)
-        if parent == search_path:
-            break
-        search_path = parent
-    return None, None
 
 
 def run_module():

--- a/roles/common/module_utils/canasta_config.py
+++ b/roles/common/module_utils/canasta_config.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""Shared registry-location and lookup helpers for Canasta.
+
+The instance registry (conf.json) lives in a platform-specific per-user
+config directory. Two callers need identical logic for *where* that file
+is and *how* to find an instance by path:
+
+  * the canasta_registry Ansible module, which reads and writes it, and
+  * the canasta.py CLI wrapper, which must resolve an instance before
+    handing off to ansible-playbook.
+
+Pre-extraction each side carried its own copy; canasta.py's even had a
+"Mirrors canasta_registry.py logic" comment. Two hand-synced copies of
+the registry's location are how the CLI and the module silently end up
+disagreeing about where conf.json is. This module is the single source.
+
+The canasta_* Ansible modules import it via
+`from ansible.module_utils.canasta_config import ...` (the role's
+module_utils dir is on the loader path via ansible.cfg). canasta.py
+imports it directly off the same directory. Pure stdlib so both import
+paths work without Ansible loaded.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+import os
+import platform
+import pwd
+
+
+CONFIG_FILENAME = "conf.json"
+
+
+def is_root():
+    """Return True when running as root."""
+    try:
+        return pwd.getpwuid(os.getuid()).pw_name == "root"
+    except (KeyError, AttributeError):
+        return os.getuid() == 0
+
+
+def get_config_dir(override=None):
+    """Return the directory holding conf.json, by convention:
+    - explicit override / $CANASTA_CONFIG_DIR (test isolation) win
+    - root: /etc/canasta
+    - macOS: ~/Library/Application Support/canasta
+    - Linux: $XDG_CONFIG_HOME/canasta or ~/.config/canasta
+    """
+    if override:
+        return override
+    env_dir = os.environ.get("CANASTA_CONFIG_DIR")
+    if env_dir:
+        return env_dir
+    if is_root():
+        return "/etc/canasta"
+    if platform.system() == "Darwin":
+        config_home = os.path.join(
+            os.path.expanduser("~"), "Library", "Application Support"
+        )
+    else:
+        config_home = os.environ.get(
+            "XDG_CONFIG_HOME",
+            os.path.join(os.path.expanduser("~"), ".config"),
+        )
+    return os.path.join(config_home, "canasta")
+
+
+def config_path(config_dir):
+    """Return the full path to conf.json inside config_dir."""
+    return os.path.join(config_dir, CONFIG_FILENAME)
+
+
+def read_config(config_dir):
+    """Read and return the registry dict, normalizing the schema.
+
+    A missing or empty file yields {"Instances": {}}. The legacy
+    "Installations" key is migrated to "Instances".
+    """
+    path = config_path(config_dir)
+    if not os.path.exists(path):
+        return {"Instances": {}}
+    with open(path, "r") as f:
+        content = f.read().strip()
+    if not content:
+        return {"Instances": {}}
+    data = json.loads(content)
+    if "Installations" in data and "Instances" not in data:
+        data["Instances"] = data.pop("Installations")
+    if "Instances" not in data:
+        data["Instances"] = {}
+    return data
+
+
+def write_config(config_dir, data):
+    """Write the registry dict to conf.json, creating config_dir."""
+    os.makedirs(config_dir, mode=0o755, exist_ok=True)
+    path = config_path(config_dir)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=4)
+        f.write("\n")
+
+
+def find_by_path(instances, search_path):
+    """Walk up from search_path; return (id, instance) of the registered
+    instance whose `path` matches, or (None, None)."""
+    search_path = os.path.abspath(search_path)
+    while True:
+        for inst_id, inst in instances.items():
+            if os.path.abspath(inst.get("path", "")) == search_path:
+                return inst_id, inst
+        parent = os.path.dirname(search_path)
+        if parent == search_path:
+            break
+        search_path = parent
+    return None, None

--- a/roles/common/tasks/validate_params.yml
+++ b/roles/common/tasks/validate_params.yml
@@ -1,6 +1,14 @@
 ---
 # Validate command parameters against the command definition.
 # Expects: command (str), canasta_commands (dict from command_definitions.yml)
+#
+# This is the playbook-layer half of a two-layer check. canasta.py runs
+# the same metadata-driven validations (required_unless etc.) at the CLI
+# so typos fail fast; this task re-validates so values that bypass the CLI
+# (CANASTA_FORCE_ANSIBLE, Molecule, a raw ansible-playbook run) are still
+# caught. Both read the same command_definitions.yml fields — keep the
+# rules (not the messages) in step. See collect_cli_param_errors in
+# canasta.py for the CLI side.
 
 - name: Look up command definition
   ansible.builtin.set_fact:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.join(ROLES_DIR, "extensions_skins", "library"))
 import importlib  # noqa: E402
 _module_utils_dir = os.path.join(ROLES_DIR, "common", "module_utils")
 sys.path.insert(0, _module_utils_dir)
-for _name in ("canasta_validate",):
+for _name in ("canasta_validate", "canasta_config"):
     _mod = importlib.import_module(_name)
     sys.modules.setdefault("ansible.module_utils.%s" % _name, _mod)
 

--- a/tests/unit/test_canasta_config.py
+++ b/tests/unit/test_canasta_config.py
@@ -1,0 +1,106 @@
+"""Tests for the shared canasta_config module_util.
+
+config-dir resolution, conf.json read/write, and path lookup live here
+so the canasta_registry Ansible module and the canasta.py CLI wrapper
+share one implementation (and can never disagree about where the
+registry lives). These were previously part of test_canasta_registry;
+they moved with the code.
+"""
+
+import json
+import os
+
+import canasta_config
+
+
+class TestGetConfigDir:
+    def test_override(self):
+        assert canasta_config.get_config_dir("/custom/path") == "/custom/path"
+
+    def test_env_variable(self, monkeypatch, tmp_dir):
+        monkeypatch.setenv("CANASTA_CONFIG_DIR", tmp_dir)
+        assert canasta_config.get_config_dir() == tmp_dir
+
+    def test_default_non_root_linux(self, monkeypatch, tmp_dir):
+        monkeypatch.delenv("CANASTA_CONFIG_DIR", raising=False)
+        monkeypatch.setattr(canasta_config, "is_root", lambda: False)
+        monkeypatch.setattr("platform.system", lambda: "Linux")
+        monkeypatch.setenv("XDG_CONFIG_HOME", tmp_dir)
+        assert canasta_config.get_config_dir() == os.path.join(tmp_dir, "canasta")
+
+    def test_default_non_root_macos(self, monkeypatch):
+        monkeypatch.delenv("CANASTA_CONFIG_DIR", raising=False)
+        monkeypatch.setattr(canasta_config, "is_root", lambda: False)
+        monkeypatch.setattr("platform.system", lambda: "Darwin")
+        expected = os.path.join(
+            os.path.expanduser("~"),
+            "Library", "Application Support", "canasta",
+        )
+        assert canasta_config.get_config_dir() == expected
+
+    def test_default_root(self, monkeypatch):
+        monkeypatch.delenv("CANASTA_CONFIG_DIR", raising=False)
+        monkeypatch.setattr(canasta_config, "is_root", lambda: True)
+        assert canasta_config.get_config_dir() == "/etc/canasta"
+
+
+class TestConfigPath:
+    def test_config_path(self):
+        assert canasta_config.config_path("/etc/canasta") == "/etc/canasta/conf.json"
+
+
+class TestReadConfig:
+    def test_missing_file_returns_empty(self, tmp_dir):
+        result = canasta_config.read_config(tmp_dir)
+        assert result == {"Instances": {}}
+
+    def test_reads_existing_config(self, sample_config):
+        config_dir, expected = sample_config
+        result = canasta_config.read_config(config_dir)
+        assert "mysite" in result["Instances"]
+        assert "devsite" in result["Instances"]
+
+    def test_migrates_legacy_installations_key(self, tmp_dir):
+        legacy = {"Installations": {"old": {"id": "old", "path": "/old", "orchestrator": "compose"}}}
+        with open(os.path.join(tmp_dir, "conf.json"), "w") as f:
+            json.dump(legacy, f)
+        result = canasta_config.read_config(tmp_dir)
+        assert "old" in result["Instances"]
+        assert "Installations" not in result
+
+
+class TestWriteConfig:
+    def test_creates_directory_and_file(self, tmp_dir):
+        config_dir = os.path.join(tmp_dir, "new_dir")
+        canasta_config.write_config(config_dir, {"Instances": {}})
+        assert os.path.exists(os.path.join(config_dir, "conf.json"))
+
+    def test_writes_valid_json(self, tmp_dir):
+        data = {"Instances": {"test": {"id": "test", "path": "/test", "orchestrator": "compose"}}}
+        canasta_config.write_config(tmp_dir, data)
+        with open(os.path.join(tmp_dir, "conf.json")) as f:
+            loaded = json.load(f)
+        assert loaded["Instances"]["test"]["id"] == "test"
+
+
+class TestFindByPath:
+    def test_exact_match(self, sample_config):
+        config_dir, data = sample_config
+        instances = data["Instances"]
+        mysite_path = instances["mysite"]["path"]
+        found_id, found_inst = canasta_config.find_by_path(instances, mysite_path)
+        assert found_id == "mysite"
+
+    def test_subdirectory_match(self, sample_config):
+        config_dir, data = sample_config
+        instances = data["Instances"]
+        sub_path = os.path.join(instances["mysite"]["path"], "config", "settings")
+        os.makedirs(sub_path, exist_ok=True)
+        found_id, _ = canasta_config.find_by_path(instances, sub_path)
+        assert found_id == "mysite"
+
+    def test_no_match(self, sample_config):
+        _, data = sample_config
+        found_id, found_inst = canasta_config.find_by_path(data["Instances"], "/nonexistent")
+        assert found_id is None
+        assert found_inst is None

--- a/tests/unit/test_canasta_registry.py
+++ b/tests/unit/test_canasta_registry.py
@@ -7,69 +7,16 @@ import canasta_registry
 from mock_ansible import run_module_with_params
 
 
-class TestGetConfigDir:
-    def test_override(self):
-        assert canasta_registry.get_config_dir("/custom/path") == "/custom/path"
+class TestSharedHelpersReExported:
+    """The registry-location helpers now live in the shared canasta_config
+    module_util; canasta_registry re-exports them. Their behavior is tested
+    in test_canasta_config; this just guards the re-export so existing
+    `canasta_registry.<helper>` references keep resolving."""
 
-    def test_env_variable(self, monkeypatch, tmp_dir):
-        monkeypatch.setenv("CANASTA_CONFIG_DIR", tmp_dir)
-        assert canasta_registry.get_config_dir() == tmp_dir
-
-    def test_default_non_root_linux(self, monkeypatch, tmp_dir):
-        monkeypatch.delenv("CANASTA_CONFIG_DIR", raising=False)
-        monkeypatch.setattr(canasta_registry, "is_root", lambda: False)
-        monkeypatch.setattr("platform.system", lambda: "Linux")
-        monkeypatch.setenv("XDG_CONFIG_HOME", tmp_dir)
-        assert canasta_registry.get_config_dir() == os.path.join(tmp_dir, "canasta")
-
-    def test_default_non_root_macos(self, monkeypatch):
-        monkeypatch.delenv("CANASTA_CONFIG_DIR", raising=False)
-        monkeypatch.setattr(canasta_registry, "is_root", lambda: False)
-        monkeypatch.setattr("platform.system", lambda: "Darwin")
-        expected = os.path.join(
-            os.path.expanduser("~"),
-            "Library", "Application Support", "canasta",
-        )
-        assert canasta_registry.get_config_dir() == expected
-
-    def test_default_root(self, monkeypatch):
-        monkeypatch.delenv("CANASTA_CONFIG_DIR", raising=False)
-        monkeypatch.setattr(canasta_registry, "is_root", lambda: True)
-        assert canasta_registry.get_config_dir() == "/etc/canasta"
-
-
-class TestReadConfig:
-    def test_missing_file_returns_empty(self, tmp_dir):
-        result = canasta_registry.read_config(tmp_dir)
-        assert result == {"Instances": {}}
-
-    def test_reads_existing_config(self, sample_config):
-        config_dir, expected = sample_config
-        result = canasta_registry.read_config(config_dir)
-        assert "mysite" in result["Instances"]
-        assert "devsite" in result["Instances"]
-
-    def test_migrates_legacy_installations_key(self, tmp_dir):
-        legacy = {"Installations": {"old": {"id": "old", "path": "/old", "orchestrator": "compose"}}}
-        with open(os.path.join(tmp_dir, "conf.json"), "w") as f:
-            json.dump(legacy, f)
-        result = canasta_registry.read_config(tmp_dir)
-        assert "old" in result["Instances"]
-        assert "Installations" not in result
-
-
-class TestWriteConfig:
-    def test_creates_directory_and_file(self, tmp_dir):
-        config_dir = os.path.join(tmp_dir, "new_dir")
-        canasta_registry.write_config(config_dir, {"Instances": {}})
-        assert os.path.exists(os.path.join(config_dir, "conf.json"))
-
-    def test_writes_valid_json(self, tmp_dir):
-        data = {"Instances": {"test": {"id": "test", "path": "/test", "orchestrator": "compose"}}}
-        canasta_registry.write_config(tmp_dir, data)
-        with open(os.path.join(tmp_dir, "conf.json")) as f:
-            loaded = json.load(f)
-        assert loaded["Instances"]["test"]["id"] == "test"
+    def test_helpers_importable_from_registry(self):
+        for name in ("get_config_dir", "is_root", "config_path",
+                     "read_config", "write_config", "find_by_path"):
+            assert callable(getattr(canasta_registry, name))
 
 
 class TestInstanceToDict:

--- a/tests/unit/test_cli_param_validation.py
+++ b/tests/unit/test_cli_param_validation.py
@@ -1,0 +1,166 @@
+"""Tests for canasta.py's CLI-layer parameter validation.
+
+These validations (required_unless, orchestrator_only, named regex
+validators) run after argparse but before any Ansible work so typos fail
+in milliseconds. They were extracted out of main() into testable helpers;
+this exercises them directly. The playbook re-validates the same
+command_definitions.yml metadata in roles/common/tasks/validate_params.yml
+(the two-layer design) — TestRequiredUnlessParity guards that the two
+layers stay driven by the same field.
+"""
+
+import argparse
+import os
+import sys
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+sys.path.insert(0, REPO_ROOT)
+
+import canasta  # noqa: E402
+
+
+def _args(**kw):
+    return argparse.Namespace(**kw)
+
+
+class TestRequiredUnless:
+    CMD = {"parameters": [
+        {"name": "repo", "required_unless": "envfile"},
+        {"name": "envfile"},
+    ]}
+
+    def test_neither_set_fails(self):
+        errs = canasta._validate_required_unless(
+            self.CMD, lambda n: getattr(_args(repo=None, envfile=None), n, None))
+        assert errs == [
+            (1, "Error: --repo is required unless --envfile is provided")]
+
+    def test_partner_set_passes(self):
+        vals = {"repo": None, "envfile": "/tmp/x.env"}
+        errs = canasta._validate_required_unless(self.CMD, lambda n: vals.get(n))
+        assert errs == []
+
+    def test_own_set_passes(self):
+        vals = {"repo": "git@example.com:r.git", "envfile": None}
+        errs = canasta._validate_required_unless(self.CMD, lambda n: vals.get(n))
+        assert errs == []
+
+    def test_hyphenates_names_in_message(self):
+        cmd = {"parameters": [{"name": "global_settings",
+                               "required_unless": "wiki_name"}]}
+        vals = {"global_settings": None, "wiki_name": None}
+        errs = canasta._validate_required_unless(cmd, lambda n: vals.get(n))
+        assert errs[0][1] == (
+            "Error: --global-settings is required unless "
+            "--wiki-name is provided")
+
+
+class TestOrchestratorOnly:
+    CMD = {"parameters": [
+        {"name": "registry", "orchestrator_only": "kubernetes"},
+    ]}
+
+    def test_wrong_orchestrator_fails(self):
+        vals = {"orchestrator": "compose", "registry": "localhost:5000"}
+        errs = canasta._validate_orchestrator_only(self.CMD, lambda n: vals.get(n))
+        assert errs == [
+            (1, "Error: --registry can only be used with "
+                "--orchestrator kubernetes")]
+
+    def test_matching_orchestrator_passes(self):
+        vals = {"orchestrator": "kubernetes", "registry": "localhost:5000"}
+        errs = canasta._validate_orchestrator_only(self.CMD, lambda n: vals.get(n))
+        assert errs == []
+
+    def test_no_orchestrator_selected_skips(self):
+        vals = {"orchestrator": None, "registry": "localhost:5000"}
+        errs = canasta._validate_orchestrator_only(self.CMD, lambda n: vals.get(n))
+        assert errs == []
+
+    def test_default_value_skips(self):
+        cmd = {"parameters": [
+            {"name": "registry", "orchestrator_only": "kubernetes",
+             "default": "none"}]}
+        vals = {"orchestrator": "compose", "registry": "none"}
+        errs = canasta._validate_orchestrator_only(cmd, lambda n: vals.get(n))
+        assert errs == []
+
+
+class TestNamedValidators:
+    CMD = {"parameters": [{"name": "domain_name", "validator": "hostname"}]}
+
+    def test_valid_hostname_passes(self):
+        vals = {"domain_name": "example.com"}
+        errs = canasta._validate_named_validators(self.CMD, lambda n: vals.get(n))
+        assert errs == []
+
+    def test_invalid_hostname_fails_with_hint(self):
+        vals = {"domain_name": "example.com:8443"}
+        errs = canasta._validate_named_validators(self.CMD, lambda n: vals.get(n))
+        assert len(errs) == 1
+        code, msg = errs[0]
+        assert code == 1
+        assert "is not a valid hostname" in msg
+        assert "HTTP_PORT/HTTPS_PORT" in msg
+
+    def test_empty_value_skips(self):
+        vals = {"domain_name": ""}
+        errs = canasta._validate_named_validators(self.CMD, lambda n: vals.get(n))
+        assert errs == []
+
+    def test_unknown_validator_is_internal_error(self):
+        cmd = {"parameters": [{"name": "x", "validator": "nope"}]}
+        vals = {"x": "whatever"}
+        errs = canasta._validate_named_validators(cmd, lambda n: vals.get(n))
+        assert errs == [
+            (2, "Internal error: parameter 'x' references unknown "
+                "validator 'nope'")]
+
+
+class TestCollectOrderAndExitCodes:
+    def test_required_unless_reported_before_validator(self):
+        # required_unless is evaluated before the named validators, so when
+        # an unrelated param is missing its partner AND another param has a
+        # bad value, the missing-partner error is first — that's what
+        # main() exits on. (A single param can't trigger both: required_unless
+        # fires only on an empty value, which the validators skip.)
+        cmd = {"parameters": [
+            {"name": "domain_name", "validator": "hostname"},
+            {"name": "repo", "required_unless": "envfile"},
+            {"name": "envfile"},
+        ]}
+        args = _args(domain_name="bad:8443", repo=None, envfile=None,
+                     orchestrator=None)
+        errs = canasta.collect_cli_param_errors(cmd, args)
+        assert errs[0] == (
+            1, "Error: --repo is required unless --envfile is provided")
+        # the validator error is still collected, just after it
+        assert any("is not a valid hostname" in m for _, m in errs)
+
+    def test_all_valid_returns_empty(self):
+        cmd = {"parameters": [{"name": "domain_name", "validator": "hostname"}]}
+        args = _args(domain_name="example.com", orchestrator=None)
+        assert canasta.collect_cli_param_errors(cmd, args) == []
+
+
+class TestRequiredUnlessParity:
+    """Both validation layers must be driven by the same metadata field.
+
+    canasta.py keys off param['required_unless']; validate_params.yml's
+    'Check required parameters' task keys off `item.required_unless`. If
+    either side renamed the field the two layers would silently diverge.
+    This asserts the Ansible task still references the same field name the
+    CLI helper reads.
+    """
+
+    def test_ansible_layer_uses_required_unless_field(self):
+        path = os.path.join(
+            REPO_ROOT, "roles", "common", "tasks", "validate_params.yml")
+        with open(path) as f:
+            tasks = yaml.safe_load(f)
+        required_task = next(
+            t for t in tasks if t.get("name") == "Check required parameters")
+        rendered = yaml.safe_dump(required_task)
+        assert "required_unless" in rendered


### PR DESCRIPTION
Addresses items **3 and 4** of #773 — the two Python↔Python duplications
the issue flagged as "do these first." Two focused commits; no behavior
change for end users.

## #3 — share registry-location helpers (commit 1)

`canasta.py` re-implemented `get_config_dir` / conf.json reading /
find-by-path that already lived in the `canasta_registry` Ansible module,
kept in sync by hand (its `get_config_dir` even carried a "Mirrors
canasta_registry.py logic" comment).

**The two copies had diverged in a way that matters:** `canasta.py`
detected root with `os.geteuid()==0` while the module used a name-based
`is_root()`, so the CLI and the module could resolve `conf.json` to
*different directories*.

- New `roles/common/module_utils/canasta_config.py` is the single source
  for `is_root`, `get_config_dir`, `config_path`, `read_config`,
  `write_config`, `find_by_path`.
- `canasta_registry` imports and re-exports them; `canasta.py` imports the
  same module off the role's `module_utils` dir.
- Helper tests move to `test_canasta_config.py`; `test_canasta_registry`
  keeps a re-export smoke check plus its module-specific coverage.

## #4 — extract CLI-layer param validation into tested helpers (commit 2)

`main()` carried three inline validation blocks (`required_unless`,
`orchestrator_only`, named regex validators), one with a misleading
"Mirrors the check in validate_params.yml" comment that read as a
hand-sync obligation.

- Pulled into module-level helpers behind `collect_cli_param_errors()`,
  each returning `(exit_code, message)`; `main()` just prints and exits on
  the first error.
- **No behavior change** — same messages, same exit codes (2 for an
  unknown validator name, 1 otherwise), same evaluation order.
- The misleading comment is replaced with an accurate description of the
  deliberate two-layer design (CLI fast-fail + playbook backstop, both
  driven by the same `command_definitions.yml` fields);
  `validate_params.yml` gains a reciprocal note. A parity test guards that
  both layers stay keyed on `required_unless`.

## Deferred

Items **1** (container exec) and **2** (k8s pod resolution) are
Python↔Ansible and left for follow-up per the issue's "choose per
appetite." Note: item 2 has **already silently diverged** — filed
separately as #777.

## Testing

- `make test-unit` — 1185 passed
- `ruff check .` — clean
- `make validate` — 77 commands, 60 playbooks
- Manually verified `create` still rejects a bad `--domain-name` (exit 1,
  identical message) and a missing `required_unless` partner (exit 1).