### PR TITLE
Fix gitops push to publish unpushed commits, not just staged changes

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -2147,10 +2147,12 @@ commands:
   - name: gitops_push
     description: "Push configuration changes to the git repository"
     long_description: |
-      Commit staged changes and push to the remote repository. Files
-      must be staged first using `canasta gitops add`. When
-      `pull_requests` is enabled in `hosts.yaml`, creates a branch
-      and opens a pull request instead of pushing directly to main.
+      Commit staged changes and push to the remote repository. Stage
+      changes first with `canasta gitops add`; commits already made by
+      other commands (such as `canasta gitops fix-submodules`) are also
+      pushed even when nothing is staged. When `pull_requests` is enabled
+      in `hosts.yaml`, creates a branch and opens a pull request instead
+      of pushing directly to main.
     examples:
       - "canasta gitops push"
       - "canasta gitops push -m 'Add docs wiki'"

--- a/roles/gitops/tasks/push_compose.yml
+++ b/roles/gitops/tasks/push_compose.yml
@@ -155,16 +155,31 @@
     chdir: "{{ instance_path }}"
   register: _push_staged
   changed_when: false
-  ignore_errors: true  # rc=1 means there are changes
+  ignore_errors: true  # rc=1 means there are staged changes
+
+# Commits already made (e.g. by 'canasta gitops fix-submodules') must
+# still be pushed even when nothing is staged.
+- name: Count unpushed commits
+  ansible.builtin.command:
+    cmd: "git rev-list --count @{upstream}..HEAD"
+    chdir: "{{ instance_path }}"
+  register: _push_unpushed
+  changed_when: false
+  ignore_errors: true  # no upstream configured -> treat as none
+
+- name: Determine what there is to push
+  ansible.builtin.set_fact:
+    _push_has_staged: "{{ _push_staged.rc != 0 }}"
+    _push_has_unpushed: "{{ (_push_unpushed.stdout | default('0', true) | trim | int) > 0 }}"
 
 - name: Report no changes
   ansible.builtin.debug:
     msg: "No changes to push."
-  when: _push_staged.rc == 0
+  when: not _push_has_staged and not _push_has_unpushed
 
-- name: End play if nothing staged
+- name: End play if nothing to push
   ansible.builtin.meta: end_play
-  when: _push_staged.rc == 0
+  when: not _push_has_staged and not _push_has_unpushed
 
 # --- Direct push (default) ---
 - name: Direct push to main
@@ -177,6 +192,7 @@
           commit -m "{{ message | default('Configuration update') }}"
         chdir: "{{ instance_path }}"
       changed_when: true
+      when: _push_has_staged
 
     - name: Push to main
       ansible.builtin.command:
@@ -211,6 +227,7 @@
         chdir: "{{ instance_path }}"
       register: _pr_commit
       changed_when: true
+      when: _push_has_staged
 
     - name: Push feature branch
       ansible.builtin.command:

--- a/tests/unit/test_gitops_push_unpushed.py
+++ b/tests/unit/test_gitops_push_unpushed.py
@@ -1,0 +1,91 @@
+"""Regression guards for 'canasta gitops push'.
+
+push_compose.yml used to end the play whenever nothing was staged,
+so a commit already made by another command (e.g. 'canasta gitops
+fix-submodules', which commits the .gitmodules registration directly)
+could never be pushed — the operator had to fall back to a bare
+'git push origin main'.
+
+These tests parse push_compose.yml and assert that push fires on
+unpushed commits as well as staged changes, and that the commit step
+is guarded so it never runs against an empty index.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+PUSH_COMPOSE = os.path.join(
+    REPO_ROOT, "roles", "gitops", "tasks", "push_compose.yml",
+)
+
+
+def _walk_tasks(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk_tasks(t[nested])
+
+
+def _load_tasks():
+    with open(PUSH_COMPOSE) as f:
+        return list(_walk_tasks(yaml.safe_load(f)))
+
+
+def _when_str(task):
+    when = task.get("when", "")
+    if isinstance(when, list):
+        return " ".join(str(c) for c in when)
+    return str(when)
+
+
+def _task_by_name(tasks, name):
+    return [t for t in tasks if t.get("name") == name]
+
+
+class TestPushPublishesUnpushedCommits:
+    def test_counts_unpushed_commits(self):
+        """An explicit task must count commits ahead of the upstream so
+        push isn't gated solely on the staging area."""
+        tasks = _load_tasks()
+        cmds = [
+            (t.get("ansible.builtin.command") or t.get("command") or {})
+            for t in tasks
+        ]
+        cmds = [c.get("cmd", "") if isinstance(c, dict) else str(c) for c in cmds]
+        assert any(
+            "rev-list" in c and "@{upstream}..HEAD" in c for c in cmds
+        ), "push_compose.yml must count unpushed commits via git rev-list @{upstream}..HEAD"
+
+    def test_end_play_considers_unpushed_not_just_staged(self):
+        """The early-exit must require BOTH no staged changes AND no
+        unpushed commits — otherwise an already-made commit is stranded."""
+        tasks = _load_tasks()
+        end_tasks = [
+            t for t in tasks
+            if (t.get("ansible.builtin.meta") or t.get("meta")) == "end_play"
+        ]
+        assert end_tasks, "push_compose.yml lost its end_play guard"
+        for t in end_tasks:
+            when = _when_str(t)
+            assert "_push_has_unpushed" in when and "_push_has_staged" in when, (
+                "end_play must gate on both _push_has_staged and "
+                "_push_has_unpushed, not staged changes alone"
+            )
+
+    def test_commit_steps_are_guarded_on_staged(self):
+        """'Commit staged changes' must only run when something is
+        staged; otherwise an unpushed-only push commits an empty index
+        and fails."""
+        tasks = _load_tasks()
+        commit_tasks = _task_by_name(tasks, "Commit staged changes")
+        assert commit_tasks, "push_compose.yml lost its commit task(s)"
+        for t in commit_tasks:
+            assert "_push_has_staged" in _when_str(t), (
+                "each 'Commit staged changes' task must be guarded by "
+                "when: _push_has_staged"
+            )


### PR DESCRIPTION
Fixes #780.

## Problem

`canasta gitops push` ended the play whenever the index was empty (`git diff --cached --quiet`), so a commit already made by another command — notably `canasta gitops fix-submodules`, which commits the `.gitmodules` registration directly — could never be pushed. The branch would sit *ahead of remote by 1 commit* and the operator had to fall back to a bare `git push origin main`.

## Change

`roles/gitops/tasks/push_compose.yml`:
- Count commits ahead of `@{upstream}` (`git rev-list --count @{upstream}..HEAD`); treat a missing upstream as zero.
- Proceed when there are **staged changes OR unpushed commits**; only early-exit when neither exists.
- Guard each `Commit staged changes` step with `when: _push_has_staged` so it never commits an empty index (covers both the direct-push and PR-mode paths; a pre-existing commit rides onto the PR branch).

This mirrors the ahead-of-remote computation `gitops status` already uses, and makes the documented "after fixing, run `canasta gitops push`" workflow actually work.

## Also

- `meta/command_definitions.yml`: clarify `gitops_push` help — already-made commits are pushed even when nothing is staged.
- `tests/unit/test_gitops_push_unpushed.py`: structural regression guard (counts unpushed via `rev-list @{upstream}..HEAD`; `end_play` gates on both conditions; commit steps guarded).

## Testing

`make lint`, `make validate`, `make docs`, `make test-unit` (1194 passed).