### PR TITLE
Fix gitops add (no path) to stage only config/, not the whole tree

### DIFF
--- a/roles/gitops/tasks/add.yml
+++ b/roles/gitops/tasks/add.yml
@@ -10,10 +10,13 @@
   changed_when: _git_add_path.rc == 0
   when: path is defined and path != ''
 
+# Scope with an explicit pathspec: since Git 2.0 `git add -A` ignores
+# the working directory and stages the whole tree, so chdir alone does
+# not limit it to config/.
 - name: Stage all changes under config/
   ansible.builtin.command:
-    cmd: "git add -A"
-    chdir: "{{ instance_path }}/config"
+    cmd: "git add -A -- config"
+    chdir: "{{ instance_path }}"
   register: _git_add
   changed_when: _git_add.rc == 0
   when: path is not defined or path == ''

--- a/tests/unit/test_gitops_add_scope.py
+++ b/tests/unit/test_gitops_add_scope.py
@@ -1,0 +1,62 @@
+"""Regression guard for 'canasta gitops add' (no path).
+
+The no-path form is meant to stage only changes under config/. It used
+to run `git add -A` after chdir-ing into config/, but since Git 2.0
+`git add -A` with no pathspec stages the WHOLE working tree regardless
+of the current directory — so it also swept in extensions/, untracked
+host files (hosts/hosts.yaml), public_assets/, etc.
+
+The fix scopes the add with an explicit `config` pathspec. This test
+asserts the no-path staging command carries that pathspec, so a revert
+to the bare whole-tree form is caught.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+ADD_YML = os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "add.yml")
+
+
+def _walk_tasks(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk_tasks(t[nested])
+
+
+def _load_tasks():
+    with open(ADD_YML) as f:
+        return list(_walk_tasks(yaml.safe_load(f)))
+
+
+def _cmd(task):
+    c = task.get("ansible.builtin.command") or task.get("command") or {}
+    return c.get("cmd", "") if isinstance(c, dict) else str(c)
+
+
+class TestGitopsAddScope:
+    def test_no_path_add_is_scoped_to_config(self):
+        """The no-path staging command must name `config` as a pathspec,
+        not rely on chdir + bare `git add -A` (which is whole-tree)."""
+        tasks = _load_tasks()
+        no_path = [
+            t for t in tasks
+            if "path is not defined" in str(t.get("when", ""))
+            and ("git add" in _cmd(t))
+        ]
+        assert no_path, "add.yml lost its no-path staging task"
+        for t in no_path:
+            cmd = _cmd(t)
+            # A bare `git add -A` (the buggy form) has no pathspec, so
+            # `config` would only appear in chdir — assert it's in the cmd.
+            tokens = cmd.split()
+            assert "config" in tokens, (
+                "no-path 'gitops add' must stage with a `config` pathspec "
+                "(e.g. `git add -A -- config`), not bare `git add -A`; got: %r"
+                % cmd
+            )


### PR DESCRIPTION
Fixes #782.

## Problem

`canasta gitops add` with no path argument is meant to stage only changes under `config/`, but it ran `git add -A` after chdir-ing into `config/`. Since Git 2.0, `git add -A` with no pathspec stages the **entire working tree** regardless of the current directory, so it also swept in `extensions/` (incl. submodule pointer changes), untracked host files (`hosts/hosts.yaml`), `public_assets/`, `docker-compose.override.yml.example`, etc. — which could then be committed and pushed unintentionally.

## Change

`roles/gitops/tasks/add.yml`: the no-path form now runs `git add -A -- config` from the instance root (explicit pathspec), so it stages additions, modifications, deletions, and untracked files **under config/ only**. The path-form (`canasta gitops add <path>`) was already correctly scoped and is unchanged.

## Testing

- New structural regression guard `tests/unit/test_gitops_add_scope.py` asserting the no-path staging command carries a `config` pathspec (so a revert to the bare whole-tree form is caught).
- Behavior verified in a scratch repo: `git add -A -- config` from the repo root stages only `config/` paths.
- `make lint`, `make validate`, `make test-unit` (1192 passed).