### PR TITLE
fix: tear down containers for deactivated feature profiles

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -311,6 +311,21 @@ _MANAGED_PROFILES = [
     ("crowdsec", "CANASTA_ENABLE_CROWDSEC", "false"),
 ]
 
+# Service names declared under each managed profile, used to tear down
+# containers left running when a feature flag is turned off. internal-db
+# (the db service) is intentionally absent so a database is never
+# auto-removed. Must match the `profiles:` keys in
+# roles/orchestrator/files/compose/docker-compose.yml and the
+# _profile_services map in sync_compose_profiles.yml.
+_MANAGED_PROFILE_SERVICES = {
+    "observable": [
+        "opensearch", "logstash", "opensearch-dashboards", "observable-init",
+    ],
+    "elasticsearch": ["elasticsearch"],
+    "varnish": ["varnish"],
+    "crowdsec": ["crowdsec"],
+}
+
 # Plugin-enabled Caddy image the caddy service runs when a feature needs
 # a Caddy plugin: CrowdSec (the bouncer) or a provider trusted-proxy mode
 # (caddy-cdn-ranges). Kept in sync with the literal in
@@ -386,6 +401,27 @@ def _sync_compose_profiles(inst):
             new_entries, "CANASTA_CADDY_IMAGE", desired_caddy_image,
         )
     _write_env_content(path, host, _entries_to_content(new_entries))
+
+    # A feature flag flipped off drops its profile from COMPOSE_PROFILES, but
+    # docker compose up/down only act on active profiles — a container still
+    # running under the now-inactive profile is an untouched orphan. Stop and
+    # remove those containers so disabling a feature tears it down. Mirrors
+    # the teardown in sync_compose_profiles.yml.
+    if profiles_changed:
+        removed = [
+            p for p in current if p in managed_names and p not in desired
+        ]
+        stale_services = [
+            svc for p in removed for svc in _MANAGED_PROFILE_SERVICES[p]
+        ]
+        if stale_services:
+            profile_flags = []
+            for p in removed:
+                profile_flags += ["--profile", p]
+            _run_compose(
+                inst.get("id"), inst,
+                profile_flags + ["rm", "-sf"] + stale_services,
+            )
 
 
 def _dump_compose_failure(inst):

--- a/roles/orchestrator/tasks/sync_compose_profiles.yml
+++ b/roles/orchestrator/tasks/sync_compose_profiles.yml
@@ -33,6 +33,48 @@
     value: "{{ _desired_profiles | join(',') }}"
   when: _desired_profiles | sort != _current_profiles | sort
 
+# A feature flag flipped off (e.g. CANASTA_ENABLE_ELASTICSEARCH=false) drops
+# its profile from COMPOSE_PROFILES, but `docker compose up`/`down` only act
+# on active profiles — a container already running under the now-inactive
+# profile is treated as an orphan and left running. Stop and remove those
+# containers so disabling a feature actually tears it down. Scoped to the
+# managed feature profiles; internal-db is intentionally excluded so a
+# database container is never auto-removed. The service lists must match the
+# `profiles:` keys in roles/orchestrator/files/compose/docker-compose.yml.
+- name: Tear down containers for deactivated feature profiles
+  vars:
+    _profile_services:
+      observable: [opensearch, logstash, opensearch-dashboards, observable-init]
+      elasticsearch: [elasticsearch]
+      varnish: [varnish]
+      crowdsec: [crowdsec]
+    _removed_profiles: >-
+      {{ _current_profiles | difference(_desired_profiles)
+         | select('in', _profile_services.keys() | list) | list }}
+  when: _removed_profiles | length > 0
+  block:
+    - name: Check for docker-compose.override.yml (profile teardown)
+      ansible.builtin.stat:
+        path: "{{ instance_path }}/docker-compose.override.yml"
+      register: _teardown_override
+
+    - name: Build compose file arguments for profile teardown
+      ansible.builtin.set_fact:
+        _teardown_compose_files: >-
+          {{ ['-f', 'docker-compose.yml'] +
+             (_teardown_override.stat.exists | ternary(['-f', 'docker-compose.override.yml'], [])) +
+             ((instance_devmode | default(false) | bool) | ternary(['-f', 'docker-compose.dev.yml'], [])) }}
+
+    - name: Stop and remove containers for deactivated profiles
+      ansible.builtin.command:
+        cmd: >-
+          docker compose {{ _teardown_compose_files | join(' ') }}
+          {{ _removed_profiles | map('regex_replace', '^', '--profile ') | join(' ') }}
+          rm -sf
+          {{ _removed_profiles | map('extract', _profile_services) | flatten | join(' ') }}
+        chdir: "{{ instance_path }}"
+      changed_when: true
+
 # The caddy service runs the plugin image when a plugin feature is on:
 # CrowdSec (the bouncer), or a provider trusted-proxy mode
 # (cloudflare/imperva, which need caddy-cdn-ranges). An explicit CIDR list

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1455,6 +1455,19 @@ class TestSyncComposeProfiles:
     def _inst(self, tmp_path):
         return {"path": str(tmp_path), "host": "localhost"}
 
+    @pytest.fixture(autouse=True)
+    def _stub_run_compose(self, monkeypatch):
+        """Record (don't execute) the teardown `docker compose` calls so the
+        sync tests never shell out to a real docker."""
+        self.compose_calls = []
+        monkeypatch.setattr(
+            direct_commands._helpers,
+            "_run_compose",
+            lambda inst_id, inst, action_args: (
+                self.compose_calls.append(action_args) or 0
+            ),
+        )
+
     def test_adds_elasticsearch_when_flag_true(self, tmp_path):
         # User toggled CANASTA_ENABLE_ELASTICSEARCH=true by hand-editing
         # .env. COMPOSE_PROFILES hasn't been updated. _sync should fix it.
@@ -1515,6 +1528,72 @@ class TestSyncComposeProfiles:
         # If _sync wrote the file, mtime would update. The guard in
         # _sync (sorted(desired) == sorted(current)) must prevent that.
         assert env_path.stat().st_mtime_ns == original_mtime
+
+    def test_deactivated_profile_tears_down_its_container(self, tmp_path):
+        # elasticsearch was active; the flag is now false. The profile is
+        # dropped AND its orphaned container must be stopped and removed.
+        (tmp_path / ".env").write_text(
+            "CANASTA_ENABLE_ELASTICSEARCH=false\n"
+            "CANASTA_ENABLE_VARNISH=true\n"
+            "COMPOSE_PROFILES=elasticsearch,varnish\n"
+        )
+        direct_commands._sync_compose_profiles(self._inst(tmp_path))
+        assert len(self.compose_calls) == 1
+        argv = self.compose_calls[0]
+        assert argv[:2] == ["--profile", "elasticsearch"]
+        assert argv[2:4] == ["rm", "-sf"]
+        assert "elasticsearch" in argv[4:]
+        # varnish stays active, so it is never torn down.
+        assert "varnish" not in argv
+
+    def test_deactivated_observable_removes_all_its_services(self, tmp_path):
+        # The observable profile maps to four services; all must be named.
+        (tmp_path / ".env").write_text(
+            "CANASTA_ENABLE_OBSERVABILITY=false\n"
+            "CANASTA_ENABLE_VARNISH=true\n"
+            "COMPOSE_PROFILES=observable,varnish\n"
+        )
+        direct_commands._sync_compose_profiles(self._inst(tmp_path))
+        assert len(self.compose_calls) == 1
+        named = self.compose_calls[0][self.compose_calls[0].index("-sf") + 1:]
+        assert sorted(named) == sorted(
+            direct_commands._helpers._MANAGED_PROFILE_SERVICES["observable"]
+        )
+
+    def test_no_teardown_when_nothing_deactivated(self, tmp_path):
+        # Adding a profile (or steady state) must not tear anything down.
+        (tmp_path / ".env").write_text(
+            "CANASTA_ENABLE_ELASTICSEARCH=true\n"
+            "CANASTA_ENABLE_VARNISH=true\n"
+            "COMPOSE_PROFILES=varnish\n"
+        )
+        direct_commands._sync_compose_profiles(self._inst(tmp_path))
+        assert self.compose_calls == []
+
+    def test_profile_service_map_matches_bundled_compose(self):
+        # The teardown map must list exactly the services each managed
+        # profile owns in the bundled compose file; drift would orphan a
+        # container or name a non-existent service.
+        import yaml
+
+        compose_path = os.path.join(
+            REPO_ROOT, "roles", "orchestrator", "files", "compose",
+            "docker-compose.yml",
+        )
+        with open(compose_path) as f:
+            services = yaml.safe_load(f)["services"]
+
+        expected = {}
+        for name, spec in services.items():
+            for profile in (spec.get("profiles") or []):
+                expected.setdefault(profile, []).append(name)
+
+        for profile, names in (
+            direct_commands._helpers._MANAGED_PROFILE_SERVICES.items()
+        ):
+            assert sorted(expected.get(profile, [])) == sorted(names), (
+                "profile %r services drifted from docker-compose.yml" % profile
+            )
 
     def test_no_env_file_is_a_noop(self, tmp_path):
         # Nothing to sync; must not create a file or raise.


### PR DESCRIPTION
Fixes #786.

## Problem

Disabling a Docker Compose feature flag left its container running. For example:

```
canasta config set CANASTA_ENABLE_ELASTICSEARCH=false
```

drops `elasticsearch` from `COMPOSE_PROFILES` and restarts the instance, but the running `*-elasticsearch-1` container keeps running. `docker compose up`/`down` only act on active profiles, and the sync strips the profile **before** the `down` runs — so `down` never sees the now-inactive service, and without `--remove-orphans` the container survives as an orphan. The same gap affects a plain `start`/`restart` after the flag is off, and the other profile-gated features (`observable`, `varnish`, `crowdsec`).

## Fix

After re-syncing `COMPOSE_PROFILES`, both profile-sync layers now tear down containers for any feature profile that was just deactivated:

- `roles/orchestrator/tasks/sync_compose_profiles.yml` — the Ansible `config set` path
- `direct_commands/_helpers.py` — the Python `start`/`restart` fast-path

The teardown runs `docker compose --profile <removed> rm -sf <services>`. Passing `--profile <removed>` explicitly re-recognizes the just-disabled service for that single `rm`, even though it is already gone from `COMPOSE_PROFILES`. `internal-db` is intentionally excluded so a database container is never auto-removed.

## Tests

- Stubbed `_run_compose` in the sync tests so they never shell out to a real docker.
- New cases: deactivating `elasticsearch` tears down its container; `observable` removes all four of its services; adding a profile / steady state tears down nothing.
- Parity guard: `_MANAGED_PROFILE_SERVICES` must exactly match the `profiles:` keys in the bundled `docker-compose.yml`, so the map can't silently drift.

`make test-unit` (1199 passed), `make validate`, and `make lint` all pass.