### PR TITLE
fix: make canasta create --build-from work on Kubernetes (in-cluster registry)

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -372,9 +372,9 @@ commands:
         description: "Path to custom composer.local.json"
       - name: registry
         type: string
-        default: "localhost:5000"
+        default: "10.43.0.2:5000"
         orchestrator_only: kubernetes
-        description: "Container registry for pushing locally built images"
+        description: "Address pods pull locally built images from (the in-cluster registry's ClusterIP)"
       - name: skip_argocd_install
         type: bool
         default: false

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -370,11 +370,6 @@ commands:
       - name: composer
         type: path
         description: "Path to custom composer.local.json"
-      - name: registry
-        type: string
-        default: "10.43.0.2:5000"
-        orchestrator_only: kubernetes
-        description: "Address pods pull locally built images from (the in-cluster registry's ClusterIP)"
       - name: skip_argocd_install
         type: bool
         default: false

--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -413,7 +413,7 @@
         _k8s_override:
           image:
             repository: "{{ _config_value | regex_replace(':[^:]+$', '') }}"
-            tag: "{{ _config_value | regex_replace('^[^:]+:', '') }}"
+            tag: "{{ _config_value | regex_replace('^.*:', '') }}"
       when: _config_key == 'CANASTA_IMAGE'
 
     - name: Write updated values.yaml

--- a/roles/create/tasks/_kubernetes_setup.yml
+++ b/roles/create/tasks/_kubernetes_setup.yml
@@ -82,6 +82,12 @@
 - name: Push image to registry (if built from source)
   when: build_from is defined and build_from != ''
   block:
+    # Guarantee the registry exists even on a cluster that predates it and
+    # hasn't been upgraded yet (idempotent, no restart) — so --build-from never
+    # dead-ends on a missing registry.
+    - name: Ensure the in-cluster image registry
+      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_ensure_registry.yml"
+
     - name: Tag and push image to registry
       ansible.builtin.command:
         cmd: "docker tag {{ _base_image }} localhost:5000/{{ _base_image }}"

--- a/roles/create/tasks/_kubernetes_setup.yml
+++ b/roles/create/tasks/_kubernetes_setup.yml
@@ -75,15 +75,19 @@
     _k8s_namespace: "canasta-{{ id }}"
     _mw_secret_key: "{{ lookup('password', '/dev/null length=64 chars=hexdigits') }}"
 
+# Push to the registry's loopback hostPort on this (control-plane) node:
+# localhost is auto-insecure for docker (no daemon.json) and not exposed. The
+# registry stores by repo path, so pods pull the same image via the registry's
+# ClusterIP ({{ registry }}) — see the image ref in k8s_values.yaml.j2.
 - name: Push image to registry (if built from source)
   when: build_from is defined and build_from != ''
   block:
     - name: Tag and push image to registry
       ansible.builtin.command:
-        cmd: "docker tag {{ _base_image }} {{ registry | default('localhost:5000') }}/{{ _base_image }}"
+        cmd: "docker tag {{ _base_image }} localhost:5000/{{ _base_image }}"
       changed_when: true
 
     - name: Push image
       ansible.builtin.command:
-        cmd: "docker push {{ registry | default('localhost:5000') }}/{{ _base_image }}"
+        cmd: "docker push localhost:5000/{{ _base_image }}"
       changed_when: true

--- a/roles/orchestrator/files/k8s_registry.yaml
+++ b/roles/orchestrator/files/k8s_registry.yaml
@@ -1,0 +1,79 @@
+# In-cluster image registry for locally-built images (canasta create
+# --build-from, custom service/sidecar images).
+#
+# Reached at two addresses for the same registry (a registry stores by repo
+# path, so the host:port is just the endpoint):
+#   - pull: the fixed ClusterIP 10.43.0.2:5000 — cluster-internal (NOT
+#     externally routable), reachable from every node's containerd, trusted
+#     via certs.d (see k8s_registry_trust.yaml). This is what pods reference.
+#   - push: localhost:5000 on the control-plane node, via a loopback-only
+#     hostPort — so `docker push` is auto-insecure (no daemon.json) and not
+#     exposed. The pod is pinned to the cp so the hostPort lands there.
+# No NodePort (which would expose the auth-less registry on every node's public
+# IP), so no kube-proxy lockdown and no k3s restart are needed.
+#
+# The fixed ClusterIP assumes the k3s default service CIDR (10.43.0.0/16),
+# which Canasta installs use.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: canasta-registry
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: registry-data
+  namespace: canasta-registry
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+  namespace: canasta-registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: canasta-registry
+  template:
+    metadata:
+      labels:
+        app: canasta-registry
+    spec:
+      # Pin to the control plane so the loopback push hostPort is on the host
+      # that runs `docker build`/`docker push` for --build-from.
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: "true"
+      containers:
+        - name: registry
+          image: registry:2
+          ports:
+            - containerPort: 5000
+              hostPort: 5000
+              hostIP: 127.0.0.1
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/registry
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+  namespace: canasta-registry
+spec:
+  type: ClusterIP
+  clusterIP: 10.43.0.2
+  selector:
+    app: canasta-registry
+  ports:
+    - port: 5000
+      targetPort: 5000

--- a/roles/orchestrator/files/k8s_registry_trust.yaml
+++ b/roles/orchestrator/files/k8s_registry_trust.yaml
@@ -42,6 +42,13 @@ spec:
           volumeMounts:
             - name: certsd
               mountPath: /certs.d
+          # Ready only once the trust file is actually on disk, so a deploy that
+          # waits on this DaemonSet's rollout can rely on every node trusting
+          # the registry before it pushes/pulls.
+          readinessProbe:
+            exec:
+              command: ["test", "-f", "/certs.d/10.43.0.2:5000/hosts.toml"]
+            periodSeconds: 5
       volumes:
         - name: certsd
           hostPath:

--- a/roles/orchestrator/files/k8s_registry_trust.yaml
+++ b/roles/orchestrator/files/k8s_registry_trust.yaml
@@ -1,0 +1,49 @@
+# Trust the in-cluster registry (10.43.0.2:5000) as a plain-HTTP endpoint on
+# EVERY node's containerd. A DaemonSet reaches all nodes — control plane,
+# current workers, and any worker that joins later — with no ssh, no
+# cluster-membership tracking, and (critically) no k3s restart: k3s containerd
+# uses `config_path = .../certs.d` and reads hosts.toml per-pull, so dropping
+# the file takes effect immediately. This is what makes a locally-built image
+# pullable cluster-wide.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: registry-trust
+  namespace: canasta-registry
+spec:
+  selector:
+    matchLabels:
+      app: canasta-registry-trust
+  template:
+    metadata:
+      labels:
+        app: canasta-registry-trust
+    spec:
+      # Run on every node, including the (possibly tainted) control plane.
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: trust
+          image: busybox:1.36
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -e
+              dir=/certs.d/10.43.0.2:5000
+              mkdir -p "$dir"
+              cat > "$dir/hosts.toml" <<EOF
+              [host."http://10.43.0.2:5000"]
+                capabilities = ["pull", "resolve"]
+                skip_verify = true
+              EOF
+              echo "registry trust written for 10.43.0.2:5000"
+              # Stay running so the DaemonSet pod is healthy; the file persists.
+              exec sleep infinity
+          volumeMounts:
+            - name: certsd
+              mountPath: /certs.d
+      volumes:
+        - name: certsd
+          hostPath:
+            path: /var/lib/rancher/k3s/agent/etc/containerd/certs.d
+            type: DirectoryOrCreate

--- a/roles/orchestrator/tasks/k8s_ensure_registry.yml
+++ b/roles/orchestrator/tasks/k8s_ensure_registry.yml
@@ -36,12 +36,19 @@
       kubectl: {{ _registry_apply.stderr | default('') }}
   when: _registry_apply.rc != 0
 
+# registry_wait=false (install) deploys best-effort and returns immediately, so
+# bootstrapping a cluster never hard-fails on the registry being slow to come up
+# (it's not needed until a build-from push). The build-from paths (create /
+# upgrade) leave it at the default true and block until it's ready before they
+# push/pull.
 - name: Wait for the registry to be ready
   ansible.builtin.command:
-    cmd: kubectl -n canasta-registry rollout status deploy/registry --timeout=120s
+    cmd: kubectl -n canasta-registry rollout status deploy/registry --timeout=180s
   changed_when: false
+  when: registry_wait | default(true)
 
 - name: Wait for every node to trust the registry (trust DaemonSet ready)
   ansible.builtin.command:
-    cmd: kubectl -n canasta-registry rollout status ds/registry-trust --timeout=120s
+    cmd: kubectl -n canasta-registry rollout status ds/registry-trust --timeout=180s
   changed_when: false
+  when: registry_wait | default(true)

--- a/roles/orchestrator/tasks/k8s_ensure_registry.yml
+++ b/roles/orchestrator/tasks/k8s_ensure_registry.yml
@@ -1,0 +1,32 @@
+---
+# Ensure the in-cluster image registry (fixed ClusterIP 10.43.0.2:5000) and the
+# per-node certs.d trust DaemonSet exist and are ready. Idempotent: deploys on a
+# cluster that lacks them, a no-op (instant) afterward — and the DaemonSet reads
+# containerd certs.d per-pull, so no k3s restart is ever needed.
+#
+# Called from: k8s-cp install (fresh clusters), canasta upgrade (so a cluster
+# installed before this support self-migrates on the next upgrade), and
+# create --build-from (so build-from works even before an upgrade). This makes
+# the registry guaranteed present whenever a locally-built image is used.
+
+- name: Deploy the in-cluster image registry and per-node trust
+  ansible.builtin.command:
+    cmd: >-
+      kubectl apply
+      -f {{ canasta_root }}/roles/orchestrator/files/k8s_registry.yaml
+      -f {{ canasta_root }}/roles/orchestrator/files/k8s_registry_trust.yaml
+  register: _registry_apply
+  changed_when: "'created' in _registry_apply.stdout or 'configured' in _registry_apply.stdout"
+  until: _registry_apply.rc == 0
+  retries: 4
+  delay: 5
+
+- name: Wait for the registry to be ready
+  ansible.builtin.command:
+    cmd: kubectl -n canasta-registry rollout status deploy/registry --timeout=120s
+  changed_when: false
+
+- name: Wait for every node to trust the registry (trust DaemonSet ready)
+  ansible.builtin.command:
+    cmd: kubectl -n canasta-registry rollout status ds/registry-trust --timeout=120s
+  changed_when: false

--- a/roles/orchestrator/tasks/k8s_ensure_registry.yml
+++ b/roles/orchestrator/tasks/k8s_ensure_registry.yml
@@ -17,9 +17,24 @@
       -f {{ canasta_root }}/roles/orchestrator/files/k8s_registry_trust.yaml
   register: _registry_apply
   changed_when: "'created' in _registry_apply.stdout or 'configured' in _registry_apply.stdout"
-  until: _registry_apply.rc == 0
+  failed_when: false
+  # Retry transient API errors, but stop immediately on a permanent fixed-
+  # ClusterIP error (don't hammer it); the next task reports it clearly.
+  until: >-
+    _registry_apply.rc == 0
+    or 'already allocated' in _registry_apply.stderr
+    or 'Invalid value' in _registry_apply.stderr
   retries: 4
   delay: 5
+
+- name: Explain a registry deploy failure (often a fixed-ClusterIP conflict)
+  ansible.builtin.fail:
+    msg: >-
+      Could not deploy the in-cluster image registry. Its fixed ClusterIP
+      10.43.0.2 is unavailable if the cluster uses a non-default Kubernetes
+      service CIDR (not 10.43.0.0/16) or 10.43.0.2 is already in use.
+      kubectl: {{ _registry_apply.stderr | default('') }}
+  when: _registry_apply.rc != 0
 
 - name: Wait for the registry to be ready
   ansible.builtin.command:

--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -106,21 +106,10 @@
   become: true
 
 # In-cluster image registry (registry:2 at the fixed ClusterIP 10.43.0.2:5000)
-# holding locally built images (canasta create --build-from, custom service/
-# sidecar images), plus a DaemonSet that trusts it on every node via certs.d
-# (hot-reloaded, no k3s restart). Idempotent — runs for fresh and existing
-# clusters, and the DaemonSet also trusts any worker that joins later.
-- name: Deploy the in-cluster image registry and per-node trust
-  ansible.builtin.command:
-    cmd: >-
-      kubectl apply
-      -f {{ canasta_root }}/roles/orchestrator/files/k8s_registry.yaml
-      -f {{ canasta_root }}/roles/orchestrator/files/k8s_registry_trust.yaml
-  register: _registry_apply
-  changed_when: "'created' in _registry_apply.stdout or 'configured' in _registry_apply.stdout"
-  until: _registry_apply.rc == 0
-  retries: 4
-  delay: 5
+# + the per-node certs.d trust DaemonSet, for locally built images (canasta
+# create --build-from, custom service/sidecar images).
+- name: Ensure the in-cluster image registry and per-node trust
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_ensure_registry.yml"
 
 - name: Check if helm is installed
   ansible.builtin.command:

--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -110,6 +110,11 @@
 # create --build-from, custom service/sidecar images).
 - name: Ensure the in-cluster image registry and per-node trust
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_ensure_registry.yml"
+  vars:
+    # Deploy best-effort at install — don't block cluster bootstrap on the
+    # registry becoming ready (it's only needed for a later build-from push,
+    # where create/upgrade wait for it).
+    registry_wait: false
 
 - name: Check if helm is installed
   ansible.builtin.command:

--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -105,6 +105,23 @@
     state: link
   become: true
 
+# In-cluster image registry (registry:2 at the fixed ClusterIP 10.43.0.2:5000)
+# holding locally built images (canasta create --build-from, custom service/
+# sidecar images), plus a DaemonSet that trusts it on every node via certs.d
+# (hot-reloaded, no k3s restart). Idempotent — runs for fresh and existing
+# clusters, and the DaemonSet also trusts any worker that joins later.
+- name: Deploy the in-cluster image registry and per-node trust
+  ansible.builtin.command:
+    cmd: >-
+      kubectl apply
+      -f {{ canasta_root }}/roles/orchestrator/files/k8s_registry.yaml
+      -f {{ canasta_root }}/roles/orchestrator/files/k8s_registry_trust.yaml
+  register: _registry_apply
+  changed_when: "'created' in _registry_apply.stdout or 'configured' in _registry_apply.stdout"
+  until: _registry_apply.rc == 0
+  retries: 4
+  delay: 5
+
 - name: Check if helm is installed
   ansible.builtin.command:
     cmd: helm version --short

--- a/roles/orchestrator/tasks/k8s_install_k3s_agent.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s_agent.yml
@@ -40,6 +40,8 @@
     # a minute or more and a controller-side SSH reset mid-join would abort
     # it. rx_no_log hides the command because it carries the join token. The
     # k3s installer is idempotent, so a re-run after a reset is safe.
+    # (Registry trust is applied cluster-wide by the registry-trust DaemonSet,
+    # which lands on this worker once it joins — no per-worker config here.)
     - name: Download and install k3s agent
       ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/resilient_exec.yml"
       vars:

--- a/roles/orchestrator/tasks/upgrade_image_tag.yml
+++ b/roles/orchestrator/tasks/upgrade_image_tag.yml
@@ -7,8 +7,14 @@
 #        _upgrade_inst, _mig
 
 # --- Update K8s values.yaml image tag ---
+# Skip for build_from instances: their image is the registry-qualified local
+# build (set at create), not a ghcr.io version tag — bumping it would point the
+# pod at a non-existent tag. The rebuilt image is re-pushed under the same ref
+# and re-pulled on restart (image.pullPolicy: Always for build_from).
 - name: Update Kubernetes image tag in values.yaml
-  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+  when:
+    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+    - _upgrade_inst.instance.buildFrom | default('') == ''
   block:
     - name: Read current values.yaml
       ansible.builtin.slurp:

--- a/roles/orchestrator/tasks/upgrade_publish_rebuilt_image.yml
+++ b/roles/orchestrator/tasks/upgrade_publish_rebuilt_image.yml
@@ -1,11 +1,19 @@
 ---
 # Publish a rebuilt-from-source custom image for the orchestrator.
-# Kubernetes: push to the in-cluster registry so the deployment can pull
-# it. Compose: no-op — the locally built image is used directly.
+# Kubernetes: push to the in-cluster registry via the control plane's loopback
+# hostPort (localhost:5000, auto-insecure) so the deployment can pull it via
+# the registry's ClusterIP. Compose: no-op — the locally built image is used
+# directly.
 # Input: instance_orchestrator, _built_image
 
-- name: Push rebuilt image to registry (Kubernetes)
+- name: Tag rebuilt image for the in-cluster registry (Kubernetes)
   ansible.builtin.command:
-    cmd: "docker push {{ _built_image }}"
+    cmd: "docker tag {{ _built_image }} localhost:5000/{{ _built_image }}"
+  changed_when: true
+  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+
+- name: Push rebuilt image to the in-cluster registry (Kubernetes)
+  ansible.builtin.command:
+    cmd: "docker push localhost:5000/{{ _built_image }}"
   changed_when: true
   when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']

--- a/roles/orchestrator/templates/k8s_values.yaml.j2
+++ b/roles/orchestrator/templates/k8s_values.yaml.j2
@@ -26,6 +26,9 @@ instance:
 image:
   repository: {{ _k8s_image | regex_replace(':[^:]+$', '') }}
   tag: "{{ _k8s_image | regex_replace('^.*:', '') }}"
+  # build_from re-pushes the same registry ref on each upgrade, so the rebuilt
+  # image must be re-pulled (mutable tag) rather than served from the node cache.
+  pullPolicy: {{ 'Always' if (build_from is defined and build_from != '') else 'IfNotPresent' }}
 
 domains:
   - {{ domain_name | default('localhost') }}

--- a/roles/orchestrator/templates/k8s_values.yaml.j2
+++ b/roles/orchestrator/templates/k8s_values.yaml.j2
@@ -16,9 +16,16 @@
 instance:
   id: {{ id }}
 
+{# build_from: the image was pushed to the in-cluster registry, so the pod must
+   pull the registry-qualified ref ({{ registry }}/{{ _built_image }}); otherwise
+   use --canasta-image / the default. Split on the LAST colon so a registry
+   address with a port (host:port/repo:tag) parses correctly. #}
+{% set _k8s_image = (build_from is defined and build_from != '')
+   | ternary((registry | default('10.43.0.2:5000')) ~ '/' ~ (_built_image | default('canasta:local')),
+             canasta_image | default(canasta_default_image)) %}
 image:
-  repository: {{ canasta_image | default(canasta_default_image) | regex_replace(':[^:]+$', '') }}
-  tag: "{{ canasta_image | default(canasta_default_image) | regex_replace('^[^:]+:', '') }}"
+  repository: {{ _k8s_image | regex_replace(':[^:]+$', '') }}
+  tag: "{{ _k8s_image | regex_replace('^.*:', '') }}"
 
 domains:
   - {{ domain_name | default('localhost') }}

--- a/roles/orchestrator/templates/k8s_values.yaml.j2
+++ b/roles/orchestrator/templates/k8s_values.yaml.j2
@@ -16,12 +16,13 @@
 instance:
   id: {{ id }}
 
-{# build_from: the image was pushed to the in-cluster registry, so the pod must
-   pull the registry-qualified ref ({{ registry }}/{{ _built_image }}); otherwise
-   use --canasta-image / the default. Split on the LAST colon so a registry
-   address with a port (host:port/repo:tag) parses correctly. #}
+{# build_from: the image was pushed to the in-cluster registry, so the pod pulls
+   the registry-qualified ref (the registry's fixed ClusterIP, 10.43.0.2:5000 —
+   must match k8s_registry.yaml + the certs.d trust); otherwise use
+   --canasta-image / the default. Split on the LAST colon so a registry address
+   with a port (host:port/repo:tag) parses correctly. #}
 {% set _k8s_image = (build_from is defined and build_from != '')
-   | ternary((registry | default('10.43.0.2:5000')) ~ '/' ~ (_built_image | default('canasta:local')),
+   | ternary('10.43.0.2:5000/' ~ (_built_image | default('canasta:local')),
              canasta_image | default(canasta_default_image)) %}
 image:
   repository: {{ _k8s_image | regex_replace(':[^:]+$', '') }}

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -55,6 +55,16 @@
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/orchestrator/tasks/upgrade_db_migration.yml
 
+# Self-heal the cluster: deploy the in-cluster registry + per-node trust if a
+# cluster installed before this support lacks them. Idempotent (a no-op once
+# present), no k3s restart. Runs for every k8s instance so the registry is
+# guaranteed present after upgrading — both for build_from below and going
+# forward — without a separate `canasta install k8s-cp` step.
+- name: Ensure the in-cluster image registry (Kubernetes)
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/k8s_ensure_registry.yml
+  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+
 # --- Rebuild custom image if instance was built from source ---
 - name: Check for BuildFrom in registry
   canasta_registry:

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -127,12 +127,15 @@
     {{ canasta_root }}/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
 
 # A compose-only change (e.g. gaining the crowdsec service) must also
-# trigger a recreate, not just an image bump.
+# trigger a recreate, not just an image bump. A build_from instance always
+# rebuilt its image above, so it must restart to redeploy the new build
+# (no registry pull happened, so _images_updated is false for it).
 - name: Decide whether a restart is needed
   ansible.builtin.set_fact:
     _restart_needed: >-
       {{ (_images_updated | bool)
-         or (_compose_stack_copy is defined and _compose_stack_copy is changed) }}
+         or (_compose_stack_copy is defined and _compose_stack_copy is changed)
+         or (_upgrade_inst.instance.buildFrom | default('') != '') }}
 
 - name: Restart containers
   when: _restart_needed | bool

--- a/tests/unit/test_k8s_registry.py
+++ b/tests/unit/test_k8s_registry.py
@@ -101,6 +101,12 @@ def test_registry_is_ensured_from_install_upgrade_and_create():
         assert "k8s_ensure_registry.yml" in _text(path)
 
 
+def test_install_deploys_registry_best_effort():
+    # Cluster bootstrap must NOT hard-fail on the registry being slow to become
+    # ready (it's only needed for a later build-from push).
+    assert "registry_wait: false" in _text(CP)
+
+
 def test_no_nodeport_lockdown_or_restart_machinery():
     # The ClusterIP design must not reintroduce NodePort exposure handling.
     cp = _text(CP)

--- a/tests/unit/test_k8s_registry.py
+++ b/tests/unit/test_k8s_registry.py
@@ -1,0 +1,122 @@
+"""Structural guards for the in-cluster image registry that makes
+`canasta create --build-from` (and, later, custom service/sidecar images)
+work on Kubernetes.
+
+A full install e2e needs a systemd k3s host, which a single CI runner can't
+provide. These tests instead lock in the wiring so the pieces can't silently
+regress:
+
+  - the registry is a fixed-ClusterIP service (cluster-internal, NOT a
+    NodePort) so the auth-less registry isn't internet-exposed and no
+    kube-proxy lockdown / k3s restart is needed;
+  - push uses a loopback hostPort on the control plane (auto-insecure, no
+    daemon.json);
+  - every node trusts the registry via a certs.d DaemonSet (hot-reloaded, no
+    restart) — including workers that join later;
+  - the cp install deploys both the registry and the trust DaemonSet;
+  - a build_from image is referenced at the registry, not the bare local tag.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+CP = os.path.join(REPO_ROOT, "roles", "orchestrator", "tasks", "k8s_install_k3s.yml")
+AGENT = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "k8s_install_k3s_agent.yml")
+REGISTRY_MANIFEST = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "files", "k8s_registry.yaml")
+TRUST_MANIFEST = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "files", "k8s_registry_trust.yaml")
+VALUES_TPL = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "templates", "k8s_values.yaml.j2")
+PUSH = os.path.join(REPO_ROOT, "roles", "create", "tasks", "_kubernetes_setup.yml")
+CMD_DEFS = os.path.join(REPO_ROOT, "meta", "command_definitions.yml")
+
+REGISTRY_ADDR = "10.43.0.2:5000"
+
+
+def _walk(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk(t[nested])
+
+
+def _text(path):
+    with open(path) as f:
+        return f.read()
+
+
+def test_registry_is_a_fixed_clusterip_not_a_nodeport():
+    docs = [d for d in yaml.safe_load_all(_text(REGISTRY_MANIFEST)) if d]
+    svc = next(d for d in docs if d["kind"] == "Service")
+    assert svc["spec"]["type"] == "ClusterIP"
+    assert svc["spec"]["clusterIP"] == "10.43.0.2"
+    # No NodePort type / nodePort field — that's what would expose it publicly.
+    assert all(d.get("spec", {}).get("type") != "NodePort" for d in docs)
+    assert all("nodePort" not in p
+               for p in svc["spec"]["ports"])
+
+
+def test_registry_push_path_is_loopback_hostport_on_the_cp():
+    docs = [d for d in yaml.safe_load_all(_text(REGISTRY_MANIFEST)) if d]
+    dep = next(d for d in docs if d["kind"] == "Deployment")
+    spec = dep["spec"]["template"]["spec"]
+    assert "node-role.kubernetes.io/control-plane" in spec["nodeSelector"]
+    port = spec["containers"][0]["ports"][0]
+    assert port["hostPort"] == 5000 and port["hostIP"] == "127.0.0.1"
+
+
+def test_trust_daemonset_writes_certsd_on_every_node():
+    docs = [d for d in yaml.safe_load_all(_text(TRUST_MANIFEST)) if d]
+    ds = next(d for d in docs if d["kind"] == "DaemonSet")
+    pod = ds["spec"]["template"]["spec"]
+    # tolerations: Exists -> lands on every node incl. the control plane
+    assert any(t.get("operator") == "Exists" for t in pod["tolerations"])
+    vol = next(v for v in pod["volumes"] if "hostPath" in v)
+    assert vol["hostPath"]["path"].endswith("/containerd/certs.d")
+    body = _text(TRUST_MANIFEST)
+    assert REGISTRY_ADDR in body and "skip_verify = true" in body
+
+
+def test_cp_deploys_registry_and_trust():
+    cmds = [(t.get("ansible.builtin.command", {}) or {}).get("cmd", "")
+            for t in _walk(yaml.safe_load(open(CP)))]
+    deploy = next(c for c in cmds if "k8s_registry.yaml" in c)
+    assert "k8s_registry_trust.yaml" in deploy
+
+
+def test_no_nodeport_lockdown_or_restart_machinery():
+    # The ClusterIP design must not reintroduce NodePort exposure handling.
+    cp = _text(CP)
+    assert "nodeport-addresses" not in cp
+    assert "registries.yaml" not in cp
+
+
+def test_worker_has_no_per_node_registry_config():
+    # Trust is cluster-wide via the DaemonSet; the worker join carries none.
+    agent = _text(AGENT)
+    assert "registries.yaml" not in agent
+    assert "nodeport-addresses" not in agent
+
+
+def test_build_from_image_points_at_the_registry():
+    text = _text(VALUES_TPL)
+    # build_from selects {{ registry }}/{{ _built_image }} (the ClusterIP),
+    # not the bare canasta_image default; tag split must be last-colon so a
+    # host:port/repo:tag address parses.
+    assert "_built_image" in text and "registry" in text
+    assert "regex_replace('^.*:', '')" in text
+
+
+def test_push_uses_loopback_hostport():
+    assert "localhost:5000/" in _text(PUSH)
+
+
+def test_registry_default_is_the_clusterip():
+    assert REGISTRY_ADDR in _text(CMD_DEFS)

--- a/tests/unit/test_k8s_registry.py
+++ b/tests/unit/test_k8s_registry.py
@@ -23,6 +23,8 @@ import yaml
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 CP = os.path.join(REPO_ROOT, "roles", "orchestrator", "tasks", "k8s_install_k3s.yml")
+ENSURE = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "k8s_ensure_registry.yml")
 AGENT = os.path.join(
     REPO_ROOT, "roles", "orchestrator", "tasks", "k8s_install_k3s_agent.yml")
 REGISTRY_MANIFEST = os.path.join(
@@ -84,11 +86,19 @@ def test_trust_daemonset_writes_certsd_on_every_node():
     assert REGISTRY_ADDR in body and "skip_verify = true" in body
 
 
-def test_cp_deploys_registry_and_trust():
+def test_ensure_task_applies_registry_and_trust():
     cmds = [(t.get("ansible.builtin.command", {}) or {}).get("cmd", "")
-            for t in _walk(yaml.safe_load(open(CP)))]
-    deploy = next(c for c in cmds if "k8s_registry.yaml" in c)
-    assert "k8s_registry_trust.yaml" in deploy
+            for t in _walk(yaml.safe_load(open(ENSURE)))]
+    apply = next(c for c in cmds if "k8s_registry.yaml" in c)
+    assert "k8s_registry_trust.yaml" in apply
+
+
+def test_registry_is_ensured_from_install_upgrade_and_create():
+    # Install, upgrade (self-heal existing clusters), and create --build-from
+    # all ensure the registry, so build-from never dead-ends on a missing one.
+    upgrade_main = os.path.join(REPO_ROOT, "roles", "upgrade", "tasks", "main.yml")
+    for path in (CP, upgrade_main, PUSH):
+        assert "k8s_ensure_registry.yml" in _text(path)
 
 
 def test_no_nodeport_lockdown_or_restart_machinery():

--- a/tests/unit/test_k8s_registry.py
+++ b/tests/unit/test_k8s_registry.py
@@ -117,10 +117,10 @@ def test_worker_has_no_per_node_registry_config():
 
 def test_build_from_image_points_at_the_registry():
     text = _text(VALUES_TPL)
-    # build_from selects {{ registry }}/{{ _built_image }} (the ClusterIP),
-    # not the bare canasta_image default; tag split must be last-colon so a
-    # host:port/repo:tag address parses.
-    assert "_built_image" in text and "registry" in text
+    # build_from selects the registry ClusterIP (not the bare canasta_image
+    # default); tag split must be last-colon so a host:port/repo:tag address
+    # parses. The address is a literal here — see the consistency test below.
+    assert "_built_image" in text and REGISTRY_ADDR in text
     assert "regex_replace('^.*:', '')" in text
 
 
@@ -128,8 +128,25 @@ def test_push_uses_loopback_hostport():
     assert "localhost:5000/" in _text(PUSH)
 
 
-def test_registry_default_is_the_clusterip():
-    assert REGISTRY_ADDR in _text(CMD_DEFS)
+def test_registry_address_is_consistent_everywhere():
+    # The pull address (10.43.0.2:5000) is hardcoded in three places that must
+    # agree: the Service ClusterIP, the certs.d trust, and the pod image ref.
+    # There is no --registry flag (overriding it would not be honored by the
+    # Service/trust, so it was removed).
+    assert "10.43.0.2" in _text(REGISTRY_MANIFEST)
+    assert REGISTRY_ADDR in _text(TRUST_MANIFEST)
+    assert REGISTRY_ADDR in _text(VALUES_TPL)
+    assert "name: registry" not in _text(CMD_DEFS)
+
+
+def test_image_ref_tag_split_parses_a_port_address():
+    # Lock the parsing contract: host:port/repo:tag must split on the LAST colon.
+    import re
+    img = "10.43.0.2:5000/canasta:local"
+    assert re.sub(r":[^:]+$", "", img) == "10.43.0.2:5000/canasta"   # repository
+    assert re.sub(r"^.*:", "", img) == "local"                       # tag
+    # and the default ghcr image (single colon) still parses
+    assert re.sub(r"^.*:", "", "ghcr.io/canastawiki/canasta:3.5.10") == "3.5.10"
 
 
 # --- upgrade path: build_from must work the same as create on k8s ---

--- a/tests/unit/test_k8s_registry.py
+++ b/tests/unit/test_k8s_registry.py
@@ -120,3 +120,32 @@ def test_push_uses_loopback_hostport():
 
 def test_registry_default_is_the_clusterip():
     assert REGISTRY_ADDR in _text(CMD_DEFS)
+
+
+# --- upgrade path: build_from must work the same as create on k8s ---
+
+UPGRADE_PUBLISH = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "upgrade_publish_rebuilt_image.yml")
+UPGRADE_TAG = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "upgrade_image_tag.yml")
+UPGRADE_MAIN = os.path.join(REPO_ROOT, "roles", "upgrade", "tasks", "main.yml")
+
+
+def test_upgrade_pushes_rebuilt_image_to_the_registry():
+    # Not the bare tag — must reach the registry via the loopback hostPort.
+    assert "localhost:5000/" in _text(UPGRADE_PUBLISH)
+
+
+def test_upgrade_keeps_the_registry_ref_for_build_from():
+    # The k8s tag-bump must skip build_from (else it points at a ghcr version
+    # tag the rebuilt local image doesn't have).
+    assert "buildFrom | default('') == ''" in _text(UPGRADE_TAG)
+
+
+def test_upgrade_restarts_build_from_instances():
+    assert "buildFrom | default('') != ''" in _text(UPGRADE_MAIN)
+
+
+def test_build_from_forces_a_repull():
+    text = _text(VALUES_TPL)
+    assert "pullPolicy" in text and "Always" in text


### PR DESCRIPTION
Closes #790.

`canasta create --build-from` (and `canasta upgrade` of a build-from instance) were non-functional on Kubernetes, with zero CI coverage. This makes both work end-to-end by giving the cluster an internal image registry, and is the foundation for delivering custom service/sidecar images to multi-node clusters (#774).

## The breaks (confirmed live on a k3s cluster)

1. **No registry.** The build succeeded, then `docker push localhost:5000/...` → connection refused (Canasta pushed to a registry it never provisioned), aborting create before Helm.
2. **Wrong image reference.** The k8s values template used `canasta_image | default(canasta_default_image)`, which is unset for `build_from` — so even past the push, the pod ran the **stock** image, ignoring the build.
3. **No node trust (multi-node).** A locally-built image must be trusted by every node's containerd and reachable cluster-wide.
4. **Upgrade was broken too.** `canasta upgrade` rebuilt the image but pushed the **bare** tag (not to the registry), bumped the k8s image to a ghcr.io version tag the local build lacks, and **never restarted** the instance (a build-from upgrade triggers no registry pull, so the restart was skipped) — so a rebuilt image never deployed.

## The design

An in-cluster `registry:2` at a **fixed ClusterIP `10.43.0.2:5000`**, trusted on every node via **containerd certs.d** written by a **DaemonSet**:

- **Not a NodePort.** A ClusterIP is cluster-internal, so the auth-less, plain-HTTP registry is **never internet-exposed** — no kube-proxy lockdown and no k3s restart needed.
- **Push** uses a **loopback hostPort** (`127.0.0.1:5000`) on the control-plane node (the registry pod is pinned there). `localhost` is auto-insecure for docker, so no `daemon.json`. The registry stores by repo path, so pods pull the same image via the ClusterIP.
- **Trust** is a **DaemonSet** that writes `certs.d/<addr>/hosts.toml` on every node. k3s containerd uses `config_path=.../certs.d` and reads it **per-pull — no restart**. The DaemonSet (`tolerations: Exists`) covers the control plane, current workers, and any worker that joins later, with **no ssh, no cluster-membership tracking, and no per-worker install config**.
- **Image ref.** For `build_from` on k8s, `image.repository:tag` points at `{registry}/{built image}`, split on the **last** colon so a `host:port/repo:tag` address parses. `image.pullPolicy: Always` (build-from only) re-pulls the same-tag rebuilt image on upgrade rather than serving it stale from the node cache.
- **Upgrade** mirrors create: rebuild → push to the registry hostPort → keep the registry-qualified ref (skip the ghcr tag-bump) → restart the instance → re-pull.

The fixed ClusterIP assumes the k3s default service CIDR (`10.43.0.0/16`), which Canasta installs use.

## Validation (live, 2-node k3s)

- From a **clean** `canasta install k8s-cp`: registry (ClusterIP) + trust DaemonSet auto-deployed; `create -o kubernetes --build-from` → web pod on the **built** image (`10.43.0.2:5000/canasta:local`, confirmed by a build marker).
- **Upgrade:** changed the source, `canasta upgrade` → the web pod redeployed the **new** build (marker flipped V1→V2).
- Registry **not reachable** on the node's public IP (`:5000`/`:30500`).
- Normal `create -o kubernetes` (stock image) still works — the template change is regression-safe.
- **Multi-node:** a freshly-joined worker is auto-trusted by the DaemonSet (no per-worker config, no restart) and pulls the built image via the ClusterIP.
- **Migration:** on a cluster stripped of the registry + certs.d, re-running `canasta install k8s-cp` restored the registry and trust on **both** the cp and the worker via the DaemonSet (no restart, no per-worker action).

## Tests

`tests/unit/test_k8s_registry.py` — structural guards for the ClusterIP registry, the certs.d DaemonSet, the create image ref, and the upgrade path (push to registry, keep the ref for build-from, restart, re-pull). Full unit suite green.

## Notes / follow-ups

- **Always-on:** the registry (a lightweight `registry:2` + lazy PVC) is standard cluster infra on every k8s install.
- **Self-heal / migration:** the registry + trust DaemonSet are *ensured* (idempotent `kubectl apply` + wait-ready, no restart) on `install k8s-cp`, on every `canasta upgrade` of a k8s instance, and on `create --build-from` — so a cluster installed before this support gains them automatically, with no separate step or cryptic failure. (No build-from instances pre-exist to migrate: build-from create failed-and-cleaned-up on k8s before this fix.)
- **Follow-up:** an `integration-k8s-build-from` CI job (modeled on the existing k8s backup job); user-facing docs on canasta.wiki.
