### PR TITLE
docs: guard docs/ against hand-written prose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,8 @@ The publisher writes pages under the `CLI:` namespace plus `MediaWiki:Menu-cli-r
 - Run `make test-unit && make validate` before opening a PR.
 - Follow the existing commit-message style (`git log` for examples).
 
-## Design documents
+## Documentation
 
-Design docs live in `docs/`; user-facing guides live on canasta.wiki — e.g. [Help:Multi-node Kubernetes](https://canasta.wiki/wiki/Help:Multi-node_Kubernetes) for multi-node K8s deployments.
+Narrative documentation — user-facing guides, conceptual pages, and design notes — lives on canasta.wiki, not in this repository. See [Help:About the user guide](https://canasta.wiki/wiki/Help:About_the_user_guide) for the structure, and e.g. [Help:Multi-node Kubernetes](https://canasta.wiki/wiki/Help:Multi-node_Kubernetes) for multi-node K8s deployments.
+
+The `docs/` directory holds only the auto-generated CLI command reference (`docs/commands/*.md`, produced by `make docs` from `meta/command_definitions.yml` and git-ignored). Do not add hand-written Markdown there — see [docs/README.md](docs/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,18 @@
+# docs/
+
+This directory holds **only** the auto-generated CLI command reference, under
+`commands/`. Those files are produced from `meta/command_definitions.yml` by
+`scripts/generate_docs.py` (run `make docs`) and are git-ignored — do not edit
+them by hand or commit them.
+
+## Do not add prose documentation here
+
+User-facing guides, conceptual documentation, and how-tos live on the Canasta
+documentation wiki, **not** in this repository:
+
+- <https://canasta.wiki/wiki/Help:About_the_user_guide>
+
+If you want to document a configuration pattern, workflow, or troubleshooting
+tip, add or update the relevant `Help:` page there instead of placing a Markdown
+file in this directory. A file added here will not be discoverable by users and
+will drift out of sync with the wiki.


### PR DESCRIPTION
## Summary

`docs/` is a build-output directory only — it holds the auto-generated CLI command reference (`docs/commands/*.md` from `make docs`, git-ignored except `.gitkeep`). This adds a guard so contributors don't drop prose documentation there (which isn't user-discoverable and drifts from the wiki).

- **`docs/README.md`** (new) — states the directory holds only the generated command reference and that narrative docs belong on canasta.wiki.
- **`CONTRIBUTING.md`** — reworks the stale "Design docs live in `docs/`" line to match reality: narrative documentation (user-facing and design) lives on canasta.wiki; `docs/` is generated output only.

Documentation/guardrail only — no code changes.

## Context

Prompted by #796, which added a Cloudflare guide as `docs/cloudflare-tls-pattern.md`. That content now lives on canasta.wiki at [Help:Using Canasta with Cloudflare](https://canasta.wiki/wiki/Help:Using_Canasta_with_Cloudflare), and #796 has been closed.

## Testing

- `make test-unit` — 1215 passed
- `make validate` — passed

Closes #798