### PR TITLE
test: add k8s build-from integration coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -190,7 +190,7 @@ jobs:
     name: "Integration: Kubernetes"
     if: github.event_name != 'pull_request'  # See #67
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -229,6 +229,14 @@ jobs:
           .venv/bin/python tests/integration/run_tests.py
           k8s-lifecycle
         timeout-minutes: 20
+      # Reuse the same bootstrapped cluster (k8s-lifecycle deletes its instance
+      # on cleanup, and the in-cluster registry was deployed at install) so this
+      # adds only the build/push/pull path, not a second k3s bootstrap.
+      - name: Run K8s build-from test
+        run: >-
+          .venv/bin/python tests/integration/run_tests.py
+          k8s-build-from
+        timeout-minutes: 18
 
   # Separate job (own runner) so the CrowdSec enable — which drives several
   # Helm rollouts — gets a fresh, unloaded node and its own time budget rather

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -2625,10 +2625,95 @@ def test_k8s_crowdsec(inst):
     assert result.returncode != 0, "Namespace still exists after delete"
 
 
+def test_k8s_build_from(inst):
+    """`create -o kubernetes --build-from`: the custom image is built, pushed to
+    the in-cluster registry, and the web pod runs it from the registry ref.
+
+    Guards the #790 fix end to end: without it the pod silently ran the stock
+    ghcr image (wrong image ref) or never pulled (no registry). The build is a
+    single FROM-stock layer plus a marker file, so the test exercises the
+    build -> push -> pull delivery path without a heavyweight image build.
+    """
+    result = subprocess.run(["kubectl", "cluster-info"], capture_output=True)
+    if result.returncode != 0:
+        raise SkipTest("kubectl not available or cluster not reachable")
+    result = subprocess.run(["helm", "version", "--short"], capture_output=True)
+    if result.returncode != 0:
+        raise SkipTest("helm not installed")
+
+    # Trivial build-from source: a Canasta image identical to stock plus a marker
+    # layer. canasta create --build-from runs `docker build` on <src>/Canasta.
+    src_root = os.path.join(inst.work_dir, "bfsrc")
+    src = os.path.join(src_root, "Canasta")
+    os.makedirs(src, exist_ok=True)
+    with open(os.path.join(src, "Dockerfile"), "w") as f:
+        f.write(
+            "FROM ghcr.io/canastawiki/canasta:latest\n"
+            "RUN echo build-from-ci > /tmp/canasta-build-from-ci\n"
+        )
+
+    print("Creating Kubernetes instance from source (--build-from)...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir,
+        "--orchestrator", "kubernetes",
+        "--build-from", src_root,
+        "--skip-argocd-install",
+    )
+
+    print("Verifying instance registered...")
+    output = inst.run_ok("list")
+    assert inst.id in output, "instance not in list: %s" % output
+    assert "KUBERNETES" in output, "instance not K8s: %s" % output
+
+    namespace = "canasta-%s" % inst.id
+
+    print("Verifying the web deployment runs the in-cluster registry image...")
+    image = subprocess.run(
+        ["kubectl", "-n", namespace, "get",
+         "deployment/canasta-%s-web" % inst.id,
+         "-o", "jsonpath={.spec.template.spec.containers[0].image}"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    assert image == "10.43.0.2:5000/canasta:local", (
+        "web image is %r, expected the in-cluster registry ref "
+        "(build_from image-ref fix)" % image
+    )
+
+    print("Verifying the web pod pulled the image and is running...")
+    result = subprocess.run(
+        ["kubectl", "get", "pods", "-n", namespace,
+         "-l", "app.kubernetes.io/component=web",
+         "-o", "jsonpath={.items[0].metadata.name}"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0 and result.stdout, (
+        "could not find web pod (pull/registry failure?): %s" % result.stderr
+    )
+    web_pod = result.stdout.strip()
+    phase = subprocess.run(
+        ["kubectl", "get", "pod", web_pod, "-n", namespace,
+         "-o", "jsonpath={.status.phase}"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    assert phase == "Running", "web pod not Running (phase=%s)" % phase
+
+    print("Confirming the running pod is the built image (marker layer)...")
+    marker = subprocess.run(
+        ["kubectl", "exec", "-n", namespace, web_pod, "--",
+         "cat", "/tmp/canasta-build-from-ci"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    assert marker == "build-from-ci", (
+        "marker missing; pod is not the built image: %r" % marker
+    )
+
+
 # --- Test runner ---
 
 ALL_TESTS = {
     "k8s-lifecycle": test_k8s_lifecycle,
+    "k8s-build-from": test_k8s_build_from,
     "k8s-crowdsec": test_k8s_crowdsec,
     "k8s-backup": test_k8s_backup,
     "lifecycle": test_lifecycle,


### PR DESCRIPTION
## Summary

Adds an integration test for `canasta create --build-from` on Kubernetes, the path fixed in #791. That fix landed with no automated coverage, and the K8s integration jobs are PR-gated (`if: github.event_name != 'pull_request'`), so a regression in the build → push → pull delivery path would not be caught by PR checks.

## What it does

`test_k8s_build_from` (`k8s-build-from`):
- Builds a trivial custom image (`FROM ghcr.io/canastawiki/canasta:latest` + a marker file).
- Runs `canasta create -o kubernetes --build-from … --skip-argocd-install`.
- Asserts: instance registered as KUBERNETES; the web deployment image is the in-cluster registry ref `10.43.0.2:5000/canasta:local`; the web pod is `Running` (pulled from the registry); and the marker file is present in the pod (proves the *built* image runs, not the stock ghcr image).

The step is folded into the existing **Integration: Kubernetes** job to reuse the bootstrapped cluster — the in-cluster registry is deployed at install, and `k8s-lifecycle` deletes its instance on cleanup — so it adds only the build/push/pull path rather than a second k3s bootstrap. The job's `timeout-minutes` is bumped 25 → 35 to fit both steps; overall suite wall-clock is unchanged (this job stays under the Features bottleneck).

## Validation

Like the rest of the integration suite, this test runs only on push-to-main / `workflow_dispatch`, not on the PR itself — so PR checks here are Unit/Lint only. The new test was validated live end-to-end on a real two-node k3s cluster: all four assertions passed and the instance was cleaned up (`1 passed, 0 failed, 0 skipped`).

Closes #800