### PR TITLE
fix(create): support podman < 4.4 for host-gateway extra_hosts

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -229,7 +229,21 @@ with open(dst, 'w') as f:
 PYEOF
         fi
         if [[ -f "$CANASTA_KUBE_CONFIG" ]]; then
-            MOUNTS+=(--add-host=host.docker.internal:host-gateway)
+            # "host-gateway" is understood by Docker and podman >= 4.4 but
+            # rejected by podman < 4.4; fall back to the bridge gateway IP
+            # there so `--add-host` doesn't abort the run.
+            host_gw="host-gateway"
+            if command -v podman &>/dev/null; then
+                pv="$(podman --version 2>/dev/null | awk '{print $3}')"
+                if [[ -n "$pv" \
+                    && "$(printf '%s\n4.4.0\n' "$pv" | sort -V | head -n1)" == "$pv" \
+                    && "$pv" != "4.4.0" ]]; then
+                    gw="$(podman network inspect podman \
+                        --format '{{range .Subnets}}{{.Gateway}}{{end}}' 2>/dev/null)"
+                    [[ -n "$gw" ]] && host_gw="$gw"
+                fi
+            fi
+            MOUNTS+=(--add-host=host.docker.internal:"$host_gw")
         fi
     fi
     if [[ -f "$CANASTA_KUBE_CONFIG" ]]; then

--- a/roles/create/tasks/_env_update.yml
+++ b/roles/create/tasks/_env_update.yml
@@ -55,6 +55,18 @@
     - { key: "CANASTA_IMAGE", value: "{{ _base_image }}" }
   no_log: true
 
+# Pin the literal bridge-gateway IP for podman < 4.4, which can't resolve
+# the "host-gateway" magic value in docker-compose.yml's extra_hosts. The
+# fact is only set (non-empty) by _preflight.yml on such hosts, so this
+# is naturally a no-op for Docker and podman >= 4.4.
+- name: Pin HOST_GATEWAY for podman < 4.4
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: set
+    key: HOST_GATEWAY
+    value: "{{ _host_gateway_fallback }}"
+  when: _host_gateway_fallback | default('') | length > 0
+
 - name: Set WIKI_DB_PASSWORD for non-root user
   canasta_env:
     path: "{{ instance_path }}/.env"

--- a/roles/create/tasks/_preflight.yml
+++ b/roles/create/tasks/_preflight.yml
@@ -173,3 +173,33 @@
   when:
     - orchestrator | default('compose') == 'compose'
     - _mem_check.rc | default(0) != 0
+
+# Compose-only host-gateway compatibility probe. The web service maps
+# gateway.docker.internal to the magic "host-gateway" value, which
+# podman only learned in 4.4 — on podman < 4.4, `compose up` aborts with
+# "invalid IP address in add-host: host-gateway". When the target runs an
+# older podman, resolve the bridge gateway IP ourselves so _env_update.yml
+# can pin HOST_GATEWAY in .env. The probe stays empty (and HOST_GATEWAY
+# unset, so the magic value is used) for Docker and podman >= 4.4.
+- name: Probe podman version for host-gateway support (Compose only)
+  ansible.builtin.shell:
+    cmd: |
+      {% raw %}set -o pipefail
+      command -v podman >/dev/null 2>&1 || exit 0
+      ver=$(podman --version 2>/dev/null | awk '{print $3}')
+      [ -n "$ver" ] || exit 0
+      # Emit the bridge gateway only when podman is older than 4.4.0.
+      if [ "$(printf '%s\n4.4.0\n' "$ver" | sort -V | head -n1)" = "$ver" ] \
+         && [ "$ver" != "4.4.0" ]; then
+          podman network inspect podman \
+              --format '{{range .Subnets}}{{.Gateway}}{{end}}' 2>/dev/null
+      fi{% endraw %}
+  register: _host_gateway_probe
+  changed_when: false
+  failed_when: false
+  when: orchestrator | default('compose') == 'compose'
+
+- name: Record host-gateway fallback IP (Compose only)
+  ansible.builtin.set_fact:
+    _host_gateway_fallback: "{{ _host_gateway_probe.stdout | default('') | trim }}"
+  when: orchestrator | default('compose') == 'compose'

--- a/roles/orchestrator/files/compose/docker-compose.yml
+++ b/roles/orchestrator/files/compose/docker-compose.yml
@@ -53,7 +53,12 @@ services:
     restart: unless-stopped
     logging: *default-logging
     extra_hosts:
-      - "gateway.docker.internal:host-gateway"
+      # "host-gateway" is a magic value resolved by the container engine.
+      # Docker and podman >= 4.4 understand it; podman < 4.4 rejects it.
+      # create's preflight sets HOST_GATEWAY to a literal bridge-gateway
+      # IP on those older podman hosts; everywhere else it is unset and
+      # the magic value is used.
+      - "gateway.docker.internal:${HOST_GATEWAY:-host-gateway}"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary

`canasta create` on Compose fails on podman < 4.4 (e.g. Debian 12's 4.3.1) with:

```
Error: invalid IP address in add-host: "host-gateway"
```

podman only learned the `host-gateway` magic value in 4.4, but the generated `docker-compose.yml` and the `canasta-docker` kubeconfig path both hard-code it.

## Fix

Keep the portable `host-gateway` token everywhere it's supported (Docker, podman ≥ 4.4) and only substitute a resolved literal IP on podman < 4.4:

- **`docker-compose.yml`** — the web service's `extra_hosts` now uses `${HOST_GATEWAY:-host-gateway}`. Unset means the magic value (current behavior).
- **`_preflight.yml`** — on Compose targets, probe the podman version; when it's < 4.4, resolve the bridge gateway IP (`podman network inspect podman --format '{{range .Subnets}}{{.Gateway}}{{end}}'`) into a fact. Empty for Docker and podman ≥ 4.4.
- **`_env_update.yml`** — pin `HOST_GATEWAY` in `.env` only when that fact is non-empty (a data condition, so it's a no-op on Docker / modern podman).
- **`canasta-docker`** — the same podman < 4.4 fallback for the `--add-host` in the dockerized-CLI kubeconfig path.

The probe is best-effort (`failed_when: false`): a Docker-only host, a missing `podman` binary, or an unexpected network layout all leave `HOST_GATEWAY` unset and fall back to today's behavior.

## Testing

- `make lint`, `make validate`, and the full unit suite (1215 tests) pass.
- Version-comparison logic verified across 4.3.1 / 4.3.0 / 3.4.4 / 4.4.0 / 4.4.1 / 4.5.0 / 5.0.0.
- The Jinja `{% raw %}` block was confirmed to preserve the Go-template braces in the rendered shell command.

Not yet exercised live on a podman < 4.4 host; the resolution command mirrors the workaround proven in the issue.

Closes #797
