### PR TITLE
feat(sidecars): sidecars.yaml storage module + `canasta sidecar` commands (1/3)

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -106,6 +106,7 @@ SUBCOMMAND_GROUPS = {
     "storage": ["setup", "list"],
     "host": ["add", "remove", "list"],
     "argocd": ["ui", "password", "apps"],
+    "sidecar": ["add", "list", "remove"],
 }
 
 # Nested subcommand groups (backup schedule set|list|remove)

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -2600,7 +2600,8 @@ commands:
         type: string
         multi: true
         description: "Container port the sidecar listens on (repeatable)"
-      - name: command
+      - name: sidecar_command
+        long: command
         type: string
         description: "Override command (a string)"
       - name: env

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -243,6 +243,17 @@ command_groups:
       pod CIDRs (override with `CADDY_TRUSTED_PROXY_CIDRS`) so it attributes
       decisions to the real client IP rather than the ingress.
 
+  - name: sidecar
+    description: "Manage app sidecars for a Canasta instance"
+    long_description: |
+      Declare and manage app sidecars — companion services the wiki talks
+      to (e.g. a cache or a parsing service) — in `config/sidecars.yaml`.
+      Sidecars are declared once and deploy the same way on Docker Compose
+      and Kubernetes. Subcommands add, list, and remove sidecar
+      declarations; run `canasta restart` to apply. For richer sidecars
+      (mounted config files, dependencies, healthchecks), edit
+      `config/sidecars.yaml` directly.
+
 commands:
   # ---------------------------------------------------------------------------
   # Instance lifecycle
@@ -2552,3 +2563,95 @@ commands:
         short: H
         type: string
         description: "Target host (default: localhost)"
+
+  - name: sidecar_add
+    description: "Add an app sidecar to config/sidecars.yaml"
+    long_description: |
+      Declare an app sidecar in `config/sidecars.yaml`, then run
+      `canasta restart` to deploy it. Covers the common fields; for
+      richer sidecars (mounted config files, dependencies, healthchecks)
+      edit `config/sidecars.yaml` directly.
+    examples:
+      - "canasta sidecar add -i mywiki --name cache --image redis:7-alpine --port 6379"
+      - "canasta sidecar add -i mywiki --name cache --image redis:7-alpine --volume data:/data:1Gi"
+    playbook: sidecar_add.yml
+    parameters:
+      - name: id
+        short: i
+        type: string
+        description: "Canasta instance ID"
+      - name: path
+        short: p
+        type: string
+        description: "Path to the Canasta instance directory"
+      - name: sidecar_name
+        long: name
+        short: n
+        type: string
+        required: true
+        description: "Sidecar name (a DNS label; becomes a service + hostname)"
+      - name: image
+        type: string
+        description: "Image reference (mutually exclusive with --build)"
+      - name: build
+        type: string
+        description: "Build context path (mutually exclusive with --image)"
+      - name: port
+        type: string
+        multi: true
+        description: "Container port the sidecar listens on (repeatable)"
+      - name: command
+        type: string
+        description: "Override command (a string)"
+      - name: env
+        type: string
+        multi: true
+        description: "Environment entry as KEY=VALUE (repeatable)"
+      - name: volume
+        type: string
+        multi: true
+        description: >-
+          Volume as NAME:MOUNTPATH (ephemeral) or NAME:MOUNTPATH:SIZE
+          (persistent); repeatable
+
+  - name: sidecar_list
+    description: "List app sidecars declared for a Canasta instance"
+    long_description: |
+      List the sidecars declared in `config/sidecars.yaml`, with their
+      image (or build context) and ports.
+    examples:
+      - "canasta sidecar list -i mywiki"
+    playbook: sidecar_list.yml
+    parameters:
+      - name: id
+        short: i
+        type: string
+        description: "Canasta instance ID"
+      - name: path
+        short: p
+        type: string
+        description: "Path to the Canasta instance directory"
+
+  - name: sidecar_remove
+    description: "Remove an app sidecar from config/sidecars.yaml"
+    long_description: |
+      Remove a sidecar declaration from `config/sidecars.yaml`, then run
+      `canasta restart` to tear it down.
+    examples:
+      - "canasta sidecar remove -i mywiki --name cache"
+    playbook: sidecar_remove.yml
+    parameters:
+      - name: id
+        short: i
+        type: string
+        description: "Canasta instance ID"
+      - name: path
+        short: p
+        type: string
+        description: "Path to the Canasta instance directory"
+      - name: sidecar_name
+        long: name
+        short: n
+        type: string
+        required: true
+        description: "Name of the sidecar to remove"

--- a/playbooks/sidecar_add.yml
+++ b/playbooks/sidecar_add.yml
@@ -13,7 +13,7 @@
     image: "{{ image | default(omit) }}"
     build: "{{ build | default(omit) }}"
     ports: "{{ port | default(omit) }}"
-    command: "{{ command | default(omit) }}"
+    command: "{{ sidecar_command | default(omit) }}"
     env: "{{ env | default(omit) }}"
     volumes: "{{ volume | default(omit) }}"
   register: _sidecar_add

--- a/playbooks/sidecar_add.yml
+++ b/playbooks/sidecar_add.yml
@@ -1,0 +1,25 @@
+---
+# canasta sidecar add - Add an app sidecar to config/sidecars.yaml.
+
+- name: Resolve instance
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/common/tasks/resolve_instance.yml
+
+- name: Add sidecar to config/sidecars.yaml
+  canasta_sidecars_yaml:
+    instance_path: "{{ instance_path }}"
+    state: add
+    name: "{{ sidecar_name }}"
+    image: "{{ image | default(omit) }}"
+    build: "{{ build | default(omit) }}"
+    ports: "{{ port | default(omit) }}"
+    command: "{{ command | default(omit) }}"
+    env: "{{ env | default(omit) }}"
+    volumes: "{{ volume | default(omit) }}"
+  register: _sidecar_add
+
+- name: Report
+  ansible.builtin.debug:
+    msg: >-
+      Sidecar '{{ sidecar_name }}' added to config/sidecars.yaml.
+      Run 'canasta restart' to deploy it.

--- a/playbooks/sidecar_list.yml
+++ b/playbooks/sidecar_list.yml
@@ -1,0 +1,27 @@
+---
+# canasta sidecar list - List app sidecars declared for an instance.
+
+- name: Resolve instance
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/common/tasks/resolve_instance.yml
+
+- name: Read sidecars from config/sidecars.yaml
+  canasta_sidecars_yaml:
+    instance_path: "{{ instance_path }}"
+    state: list
+  register: _sidecar_list
+
+- name: Report when no sidecars are declared
+  ansible.builtin.debug:
+    msg: "No sidecars declared for this instance."
+  when: _sidecar_list.sidecars | length == 0
+
+- name: List declared sidecars
+  ansible.builtin.debug:
+    msg: >-
+      {{ item.name }} — {{ item.image | default('build: ' ~ (item.build | default('?'))) }}{{
+        (' — ports ' ~ (item.ports | join(','))) if (item.ports is defined) else '' }}
+  loop: "{{ _sidecar_list.sidecars }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: _sidecar_list.sidecars | length > 0

--- a/playbooks/sidecar_remove.yml
+++ b/playbooks/sidecar_remove.yml
@@ -1,0 +1,31 @@
+---
+# canasta sidecar remove - Remove an app sidecar from config/sidecars.yaml.
+
+- name: Resolve instance
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/common/tasks/resolve_instance.yml
+
+- name: Check the sidecar exists
+  canasta_sidecars_yaml:
+    instance_path: "{{ instance_path }}"
+    state: query
+    name: "{{ sidecar_name }}"
+  register: _sidecar_check
+
+- name: Fail if the sidecar does not exist
+  ansible.builtin.fail:
+    msg: "No sidecar named '{{ sidecar_name }}' in config/sidecars.yaml."
+  when: not _sidecar_check.exists
+
+- name: Remove sidecar from config/sidecars.yaml
+  canasta_sidecars_yaml:
+    instance_path: "{{ instance_path }}"
+    state: remove
+    name: "{{ sidecar_name }}"
+  register: _sidecar_remove
+
+- name: Report
+  ansible.builtin.debug:
+    msg: >-
+      Sidecar '{{ sidecar_name }}' removed from config/sidecars.yaml.
+      Run 'canasta restart' to tear it down.

--- a/roles/common/library/canasta_sidecars_yaml.py
+++ b/roles/common/library/canasta_sidecars_yaml.py
@@ -1,0 +1,287 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""Ansible module for managing Canasta sidecars.yaml files.
+
+Provides CRUD + validation on `config/sidecars.yaml`, the instance file
+that declares app sidecars (companion services the wiki talks to). This
+module only reads/writes/validates the declaration; rendering it into
+runtime artifacts (a Compose override layer / Helm values) is separate.
+"""
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: canasta_sidecars_yaml
+short_description: Manage Canasta sidecars.yaml
+description:
+  - Read, add, remove, and validate app sidecars in config/sidecars.yaml.
+options:
+  instance_path:
+    description: Path to the Canasta instance directory.
+    type: str
+    required: true
+  state:
+    description: Action to perform.
+    type: str
+    choices: [read, list, add, remove, query, validate]
+    default: read
+  name:
+    description: Sidecar name (a DNS label; becomes a service + hostname).
+    type: str
+  image:
+    description: Image reference (mutually exclusive with build).
+    type: str
+  build:
+    description: Build context path (mutually exclusive with image).
+    type: str
+  ports:
+    description: Container ports the sidecar listens on.
+    type: list
+    elements: int
+  command:
+    description: Override command (a string; ${VAR} resolved at render time).
+    type: str
+  env:
+    description: Environment entries as 'KEY=VALUE' strings.
+    type: list
+    elements: str
+  volumes:
+    description: >-
+      Volume specs as 'NAME:MOUNTPATH' (ephemeral) or 'NAME:MOUNTPATH:SIZE'
+      (persistent).
+    type: list
+    elements: str
+"""
+
+import os
+
+import yaml
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.canasta_validate import (
+    validate_sidecar_name,
+)
+
+
+def sidecars_yaml_path(instance_path):
+    """Return the path to config/sidecars.yaml, guarded against traversal."""
+    path = os.path.join(instance_path, "config", "sidecars.yaml")
+    real_path = os.path.realpath(path)
+    real_base = os.path.realpath(instance_path)
+    if not real_path.startswith(real_base + os.sep):
+        raise ValueError(
+            "sidecars.yaml path '%s' escapes instance directory '%s'"
+            % (real_path, real_base)
+        )
+    return path
+
+
+def read_sidecars(instance_path):
+    """Read sidecars.yaml and return the list of sidecar dicts."""
+    path = sidecars_yaml_path(instance_path)
+    if not os.path.exists(path):
+        return []
+    with open(path, "r") as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("sidecars", [])
+
+
+def write_sidecars(instance_path, sidecars):
+    """Write the sidecars list to sidecars.yaml."""
+    path = sidecars_yaml_path(instance_path)
+    os.makedirs(os.path.dirname(path), mode=0o755, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump({"sidecars": sidecars}, f,
+                  default_flow_style=False, sort_keys=False)
+
+
+def sidecar_names(sidecars):
+    return [s.get("name") for s in sidecars if isinstance(s, dict)]
+
+
+def sidecar_exists(sidecars, name):
+    return name in sidecar_names(sidecars)
+
+
+def parse_env(items):
+    """['KEY=VALUE', ...] -> {'KEY': 'VALUE', ...}."""
+    out = {}
+    for item in items or []:
+        if "=" not in item:
+            raise ValueError("env '%s' must be KEY=VALUE" % item)
+        key, value = item.split("=", 1)
+        out[key] = value
+    return out
+
+
+def parse_volumes(items):
+    """'NAME:MOUNTPATH' -> ephemeral; 'NAME:MOUNTPATH:SIZE' -> persistent."""
+    out = []
+    for item in items or []:
+        parts = item.split(":")
+        if len(parts) == 2:
+            out.append({"name": parts[0], "mountPath": parts[1],
+                        "persistent": False})
+        elif len(parts) == 3:
+            out.append({"name": parts[0], "mountPath": parts[1],
+                        "persistent": True, "size": parts[2]})
+        else:
+            raise ValueError(
+                "volume '%s' must be NAME:MOUNTPATH or NAME:MOUNTPATH:SIZE"
+                % item
+            )
+    return out
+
+
+def build_sidecar(name, image=None, build=None, ports=None,
+                  command=None, env=None, volumes=None):
+    """Construct a sidecar dict from CLI params, omitting unset fields."""
+    sidecar = {"name": name}
+    if build:
+        sidecar["build"] = build
+    else:
+        sidecar["image"] = image
+    if ports:
+        sidecar["ports"] = [int(p) for p in ports]
+    if command:
+        sidecar["command"] = command
+    env_dict = parse_env(env)
+    if env_dict:
+        sidecar["env"] = env_dict
+    volume_list = parse_volumes(volumes)
+    if volume_list:
+        sidecar["volumes"] = volume_list
+    return sidecar
+
+
+def validate_sidecars(sidecars):
+    """Return None if every entry is valid, else an error string."""
+    seen = set()
+    for sidecar in sidecars:
+        if not isinstance(sidecar, dict):
+            return "each sidecar must be a mapping"
+        name = sidecar.get("name")
+        err = validate_sidecar_name(name or "")
+        if err:
+            return err
+        if name in seen:
+            return "duplicate sidecar name '%s'" % name
+        seen.add(name)
+        has_image = bool(sidecar.get("image"))
+        has_build = bool(sidecar.get("build"))
+        if not has_image and not has_build:
+            return "sidecar '%s' must set either image or build" % name
+        if has_image and has_build:
+            return "sidecar '%s' cannot set both image and build" % name
+    return None
+
+
+def run_module():
+    module_args = dict(
+        instance_path=dict(type="str", required=True),
+        state=dict(type="str", default="read",
+                   choices=["read", "list", "add", "remove", "query",
+                            "validate"]),
+        name=dict(type="str", required=False),
+        image=dict(type="str", required=False),
+        build=dict(type="str", required=False),
+        ports=dict(type="list", elements="int", required=False),
+        command=dict(type="str", required=False),
+        env=dict(type="list", elements="str", required=False),
+        volumes=dict(type="list", elements="str", required=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    instance_path = module.params["instance_path"]
+    state = module.params["state"]
+    name = module.params.get("name")
+
+    result = {"changed": False}
+
+    if state in ("read", "list"):
+        sidecars = read_sidecars(instance_path)
+        result["sidecars"] = sidecars
+        result["names"] = sidecar_names(sidecars)
+
+    elif state == "query":
+        if not name:
+            module.fail_json(msg="name is required for query")
+            return
+        sidecars = read_sidecars(instance_path)
+        result["exists"] = sidecar_exists(sidecars, name)
+        for sidecar in sidecars:
+            if sidecar.get("name") == name:
+                result["sidecar"] = sidecar
+                break
+
+    elif state == "add":
+        if not name:
+            module.fail_json(msg="name is required for add")
+            return
+        err = validate_sidecar_name(name)
+        if err:
+            module.fail_json(msg=err)
+            return
+        image = module.params.get("image")
+        build = module.params.get("build")
+        if not image and not build:
+            module.fail_json(msg="one of image or build is required for add")
+            return
+        if image and build:
+            module.fail_json(msg="image and build are mutually exclusive")
+            return
+        sidecars = read_sidecars(instance_path)
+        if sidecar_exists(sidecars, name):
+            module.fail_json(msg="sidecar '%s' already exists" % name)
+            return
+        try:
+            sidecar = build_sidecar(
+                name, image, build,
+                module.params.get("ports"), module.params.get("command"),
+                module.params.get("env"), module.params.get("volumes"),
+            )
+        except ValueError as exc:
+            module.fail_json(msg=str(exc))
+            return
+        sidecars.append(sidecar)
+        if not module.check_mode:
+            write_sidecars(instance_path, sidecars)
+        result["changed"] = True
+        result["sidecar"] = sidecar
+
+    elif state == "remove":
+        if not name:
+            module.fail_json(msg="name is required for remove")
+            return
+        sidecars = read_sidecars(instance_path)
+        remaining = [s for s in sidecars if s.get("name") != name]
+        result["changed"] = len(remaining) != len(sidecars)
+        result["removed"] = result["changed"]
+        if result["changed"] and not module.check_mode:
+            write_sidecars(instance_path, remaining)
+
+    elif state == "validate":
+        sidecars = read_sidecars(instance_path)
+        err = validate_sidecars(sidecars)
+        if err:
+            module.fail_json(msg=err)
+            return
+        result["valid"] = True
+        result["count"] = len(sidecars)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/common/module_utils/canasta_validate.py
+++ b/roles/common/module_utils/canasta_validate.py
@@ -14,6 +14,8 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import re
+
 
 # Wiki IDs that collide with paths the canasta image expects
 # canasta-controlled (the `wikis/` mount, the `images/` images dir,
@@ -32,5 +34,40 @@ def validate_wiki_id(value):
     if value in RESERVED_WIKI_IDS:
         return "wiki ID '%s' is reserved (cannot be: %s)" % (
             value, ", ".join(RESERVED_WIKI_IDS),
+        )
+    return None
+
+
+# Sidecar names that collide with the stack's own services. A sidecar
+# becomes a Compose service, a k8s object name, and a DNS hostname, so a
+# clash with one of these would override / collide with a core component
+# (catastrophic, not a benign clash).
+RESERVED_SIDECAR_NAMES = [
+    "web", "db", "caddy", "varnish", "crowdsec", "elasticsearch",
+    "jobrunner", "logstash", "opensearch", "opensearch-dashboards",
+    "mediawiki", "registry",
+]
+
+# DNS label: lowercase alphanumeric and hyphens, no leading/trailing
+# hyphen, 1-63 chars. Unlike a wiki ID, a sidecar name MAY contain
+# hyphens (e.g. `receipt-scanner`) since it is used as a DNS name.
+_SIDECAR_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
+
+
+def validate_sidecar_name(value):
+    """Return None if `value` is a valid sidecar name, otherwise an error
+    string suitable for `module.fail_json(msg=...)`."""
+    if not value:
+        return "sidecar name cannot be empty"
+    if len(value) > 63:
+        return "sidecar name '%s' is too long (max 63 characters)" % value
+    if not _SIDECAR_NAME_RE.match(value):
+        return (
+            "sidecar name '%s' is invalid: use lowercase letters, digits, and "
+            "hyphens (a DNS label — no leading/trailing hyphen)" % value
+        )
+    if value in RESERVED_SIDECAR_NAMES:
+        return "sidecar name '%s' is reserved (cannot be: %s)" % (
+            value, ", ".join(RESERVED_SIDECAR_NAMES),
         )
     return None

--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -101,6 +101,7 @@ CMD_GROUPS = [
     ("Wiki management", ["add", "remove", "import", "export"]),
     ("Container lifecycle", ["start", "stop", "restart", "rebuild", "scale"]),
     ("Extensions & skins", ["extension", "skin"]),
+    ("App sidecars", ["sidecar"]),
     ("Maintenance", ["maintenance", "sitemap"]),
     ("Security", ["crowdsec"]),
     ("Data protection", ["backup", "gitops"]),

--- a/tests/unit/test_canasta_sidecars_yaml.py
+++ b/tests/unit/test_canasta_sidecars_yaml.py
@@ -200,6 +200,18 @@ class TestCommandWiring:
         with open(os.path.join(REPO, "canasta.py")) as f:
             assert '"sidecar": ["add", "list", "remove"]' in f.read()
 
+    def test_no_param_dest_collides_with_dispatch_var(self):
+        # A param internally named 'command' clobbers canasta.py's top-level
+        # subparser dest='command' (the dispatch variable), breaking the
+        # whole subcommand. The override-command flag must use a distinct
+        # internal name (sidecar_command) with `long: command`.
+        with open(os.path.join(REPO, "meta", "command_definitions.yml")) as f:
+            defs = yaml.safe_load(f)
+        add = next(c for c in defs["commands"] if c["name"] == "sidecar_add")
+        dests = {p["name"] for p in add["parameters"]}
+        assert "command" not in dests
+        assert "sidecar_command" in dests
+
     def test_command_defs_and_playbooks_exist(self):
         with open(os.path.join(REPO, "meta", "command_definitions.yml")) as f:
             defs = yaml.safe_load(f)

--- a/tests/unit/test_canasta_sidecars_yaml.py
+++ b/tests/unit/test_canasta_sidecars_yaml.py
@@ -1,0 +1,213 @@
+"""Tests for the canasta_sidecars_yaml module + sidecar-name validation.
+
+Covers config/sidecars.yaml CRUD (the storage foundation for the sidecar
+primitive) and the validation that keeps a sidecar name from colliding with
+a core stack service.
+"""
+
+import os
+
+import pytest
+import yaml
+
+import canasta_sidecars_yaml
+from mock_ansible import run_module_with_params
+
+REPO = os.path.join(os.path.dirname(__file__), "..", "..")
+_v = canasta_sidecars_yaml.validate_sidecar_name
+
+
+class TestValidateSidecarName:
+    def test_valid_simple(self):
+        assert _v("cache") is None
+
+    def test_valid_with_hyphen(self):
+        # Unlike a wiki ID, a sidecar name may contain hyphens (DNS label).
+        assert _v("receipt-scanner") is None
+
+    def test_empty(self):
+        assert "empty" in _v("")
+
+    def test_uppercase_rejected(self):
+        assert _v("Cache") is not None
+
+    def test_leading_hyphen_rejected(self):
+        assert _v("-cache") is not None
+
+    def test_trailing_hyphen_rejected(self):
+        assert _v("cache-") is not None
+
+    def test_underscore_rejected(self):
+        assert _v("my_cache") is not None
+
+    def test_too_long(self):
+        assert "too long" in _v("a" * 64)
+
+    def test_reserved_web(self):
+        assert "reserved" in _v("web")
+
+    def test_reserved_db(self):
+        assert "reserved" in _v("db")
+
+    def test_reserved_caddy(self):
+        assert _v("caddy") is not None
+
+
+class TestParseHelpers:
+    def test_parse_env(self):
+        assert canasta_sidecars_yaml.parse_env(["A=1", "B=x=y"]) == {
+            "A": "1", "B": "x=y"}
+
+    def test_parse_env_bad(self):
+        with pytest.raises(ValueError):
+            canasta_sidecars_yaml.parse_env(["NOEQUALS"])
+
+    def test_parse_volumes_ephemeral(self):
+        assert canasta_sidecars_yaml.parse_volumes(["t:/tmp"]) == [
+            {"name": "t", "mountPath": "/tmp", "persistent": False}]
+
+    def test_parse_volumes_persistent(self):
+        assert canasta_sidecars_yaml.parse_volumes(["data:/data:1Gi"]) == [
+            {"name": "data", "mountPath": "/data",
+             "persistent": True, "size": "1Gi"}]
+
+    def test_parse_volumes_bad(self):
+        with pytest.raises(ValueError):
+            canasta_sidecars_yaml.parse_volumes(["justone"])
+
+    def test_build_sidecar_image_omits_empty(self):
+        assert canasta_sidecars_yaml.build_sidecar("cache", image="redis:7") == {
+            "name": "cache", "image": "redis:7"}
+
+    def test_build_sidecar_build_excludes_image(self):
+        sidecar = canasta_sidecars_yaml.build_sidecar("c", build="./c")
+        assert sidecar == {"name": "c", "build": "./c"}
+
+    def test_build_sidecar_full(self):
+        sidecar = canasta_sidecars_yaml.build_sidecar(
+            "cache", image="redis:7", ports=["6379"], command="redis-server",
+            env=["A=1"], volumes=["data:/data:1Gi"])
+        assert sidecar["ports"] == [6379]
+        assert sidecar["env"] == {"A": "1"}
+        assert sidecar["volumes"][0]["persistent"] is True
+
+
+class TestValidateSidecars:
+    def test_ok(self):
+        assert canasta_sidecars_yaml.validate_sidecars(
+            [{"name": "cache", "image": "redis:7"}]) is None
+
+    def test_duplicate(self):
+        err = canasta_sidecars_yaml.validate_sidecars(
+            [{"name": "c", "image": "i"}, {"name": "c", "image": "j"}])
+        assert "duplicate" in err
+
+    def test_missing_image_and_build(self):
+        err = canasta_sidecars_yaml.validate_sidecars([{"name": "c"}])
+        assert "image or build" in err
+
+    def test_both_image_and_build(self):
+        err = canasta_sidecars_yaml.validate_sidecars(
+            [{"name": "c", "image": "i", "build": "./c"}])
+        assert "cannot set both" in err
+
+    def test_reserved_name(self):
+        err = canasta_sidecars_yaml.validate_sidecars(
+            [{"name": "web", "image": "i"}])
+        assert "reserved" in err
+
+
+def _add(inst, **extra):
+    params = {"instance_path": inst, "state": "add", "name": "cache",
+              "image": "redis:7-alpine"}
+    params.update(extra)
+    return run_module_with_params(canasta_sidecars_yaml, params)
+
+
+class TestModuleStates:
+    def test_add_writes_file(self, tmp_dir):
+        result, failed, _ = _add(tmp_dir)
+        assert not failed and result["changed"] is True
+        path = os.path.join(tmp_dir, "config", "sidecars.yaml")
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert data["sidecars"][0]["name"] == "cache"
+
+    def test_add_duplicate_fails(self, tmp_dir):
+        _add(tmp_dir)
+        _, failed, msg = _add(tmp_dir)
+        assert failed and "already exists" in msg
+
+    def test_add_reserved_fails(self, tmp_dir):
+        _, failed, msg = run_module_with_params(canasta_sidecars_yaml, {
+            "instance_path": tmp_dir, "state": "add",
+            "name": "web", "image": "i"})
+        assert failed and "reserved" in msg
+
+    def test_add_requires_image_or_build(self, tmp_dir):
+        _, failed, msg = run_module_with_params(canasta_sidecars_yaml, {
+            "instance_path": tmp_dir, "state": "add", "name": "cache"})
+        assert failed and "image or build" in msg
+
+    def test_add_image_and_build_mutually_exclusive(self, tmp_dir):
+        _, failed, msg = run_module_with_params(canasta_sidecars_yaml, {
+            "instance_path": tmp_dir, "state": "add", "name": "cache",
+            "image": "i", "build": "./c"})
+        assert failed and "mutually exclusive" in msg
+
+    def test_list_after_add(self, tmp_dir):
+        _add(tmp_dir, ports=["6379"])
+        result, failed, _ = run_module_with_params(canasta_sidecars_yaml, {
+            "instance_path": tmp_dir, "state": "list"})
+        assert not failed and result["names"] == ["cache"]
+
+    def test_query_exists_and_absent(self, tmp_dir):
+        _add(tmp_dir)
+        present, _, _ = run_module_with_params(canasta_sidecars_yaml, {
+            "instance_path": tmp_dir, "state": "query", "name": "cache"})
+        absent, _, _ = run_module_with_params(canasta_sidecars_yaml, {
+            "instance_path": tmp_dir, "state": "query", "name": "nope"})
+        assert present["exists"] is True and absent["exists"] is False
+
+    def test_remove(self, tmp_dir):
+        _add(tmp_dir)
+        result, failed, _ = run_module_with_params(canasta_sidecars_yaml, {
+            "instance_path": tmp_dir, "state": "remove", "name": "cache"})
+        assert not failed and result["changed"] is True
+        gone, _, _ = run_module_with_params(canasta_sidecars_yaml, {
+            "instance_path": tmp_dir, "state": "query", "name": "cache"})
+        assert gone["exists"] is False
+
+    def test_remove_absent_no_change(self, tmp_dir):
+        result, failed, _ = run_module_with_params(canasta_sidecars_yaml, {
+            "instance_path": tmp_dir, "state": "remove", "name": "nope"})
+        assert not failed and result["changed"] is False
+
+    def test_validate_ok(self, tmp_dir):
+        _add(tmp_dir)
+        result, failed, _ = run_module_with_params(canasta_sidecars_yaml, {
+            "instance_path": tmp_dir, "state": "validate"})
+        assert not failed and result["valid"] is True
+
+    def test_read_empty_instance(self, tmp_dir):
+        result, failed, _ = run_module_with_params(canasta_sidecars_yaml, {
+            "instance_path": tmp_dir, "state": "read"})
+        assert not failed and result["sidecars"] == []
+
+
+class TestCommandWiring:
+    def test_group_registered_in_cli(self):
+        with open(os.path.join(REPO, "canasta.py")) as f:
+            assert '"sidecar": ["add", "list", "remove"]' in f.read()
+
+    def test_command_defs_and_playbooks_exist(self):
+        with open(os.path.join(REPO, "meta", "command_definitions.yml")) as f:
+            defs = yaml.safe_load(f)
+        names = {c["name"] for c in defs["commands"]}
+        groups = {g["name"] for g in defs["command_groups"]}
+        assert "sidecar" in groups
+        for cmd in ("sidecar_add", "sidecar_list", "sidecar_remove"):
+            assert cmd in names
+        for playbook in ("sidecar_add.yml", "sidecar_list.yml",
+                         "sidecar_remove.yml"):
+            assert os.path.exists(os.path.join(REPO, "playbooks", playbook))


### PR DESCRIPTION
## Summary
**PR 1 of 3** for the orchestrator-agnostic sidecar primitive (#774). Adds the foundation: a `config/sidecars.yaml` storage module, the `canasta sidecar` command group, and validation.

## What's included
- **Storage module** `canasta_sidecars_yaml` — read/list/add/remove/query/validate, mirroring `canasta_wikis_yaml`.
- **Validation** `validate_sidecar_name` + `RESERVED_SIDECAR_NAMES`: rejects names that collide with core services (`web`/`db`/`caddy`/`varnish`/`crowdsec`/`elasticsearch`/`jobrunner`/…) and enforces a DNS-label format (hyphens allowed, unlike wiki IDs).
- **Commands** `canasta sidecar add|list|remove` — a new subcommand group in `canasta.py` + `meta/command_definitions.yml` + playbooks.
- Docs-index "App sidecars" group; 37 unit tests.

## ⚠️ Runtime behavior / sequencing
This PR is **plumbing only**. The commands read/write/validate `config/sidecars.yaml` — **nothing renders that file into a running container yet**. The rendering (Compose `-f` layer + Helm Deployment/Service/PVC/ConfigMap templates) lands in **the follow-up PR (2/3)**, which must merge before a release ships these commands. The help text references "Run `canasta restart` to deploy it," which only holds once 2/3 is in — **do not cut a release with this PR alone.**

`import` is deferred to a fast-follow; richer sidecars (mounted config files, dependencies, healthchecks) are hand-authored in `config/sidecars.yaml` for now.

## Tests
- 37 new unit tests (validation, parse/build, CRUD module states, command wiring); full suite **1256 passing**.
- `validate_definitions` (80 commands ↔ 63 playbooks), yamllint --strict, ruff F401 clean; docs gen produces the three `CLI:` pages.

Closes #807. Part of #774.