### PR TITLE
fix(backup): make schedule commands work under canasta-docker

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -17,6 +17,13 @@
 
 set -euo pipefail
 
+# Absolute path of this wrapper on the host, passed into the container as
+# CANASTA_CLI_BIN so playbooks that schedule work via cron (e.g. 'backup
+# schedule set') bake a fully-qualified host command — cron's PATH is
+# minimal and won't find a bare 'canasta'.
+CANASTA_CLI_BIN="$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")"
+export CANASTA_CLI_BIN
+
 # `canasta install` provisions software ON THE HOST — k3s as a systemd
 # unit, the docker engine package, etc. That work can't run inside the
 # canasta-ansible container, which has no systemd and no privilege over
@@ -675,6 +682,30 @@ if [[ "$HAS_CREATE" == "true" ]] && [[ "$HAS_PATH" == "false" ]] && [[ "$HAS_HOS
     EXTRA_ARGS=(-p "$(pwd)")
 fi
 
+# Scheduled backups (Compose) live in the host crontab, which a throwaway
+# container can't write. For a local 'backup schedule set/list/remove',
+# dump the host crontab to a host-mounted file the container edits, then
+# install it back after the run (see the dispatch at the end). K8s
+# schedules (CronJobs) and remote (-H) instances leave this file untouched
+# and run through the container/ansible unchanged.
+SCHEDULE_CRONTAB_FILE=""
+_sched_pprev=""
+_sched_prev=""
+for _arg in "$@"; do
+    case "$_arg" in -*) continue ;; esac
+    if [[ "$_sched_pprev" == "backup" && "$_sched_prev" == "schedule" ]]; then
+        case "$_arg" in
+            set|list|remove)
+                [[ "$HAS_HOST" == "false" ]] \
+                    && SCHEDULE_CRONTAB_FILE="$CONFIG_DIR/.host-crontab"
+                ;;
+        esac
+        break
+    fi
+    _sched_pprev="$_sched_prev"
+    _sched_prev="$_arg"
+done
+
 # Allocate a TTY when stdin is a terminal (needed for interactive exec).
 DOCKER_RUN_FLAGS=(-i)
 if [[ -t 0 ]]; then
@@ -687,6 +718,12 @@ fi
 # release (semver tag) from a dev build (':latest').
 DOCKER_RUN_FLAGS+=(-e CANASTA_RUN_MODE=docker)
 DOCKER_RUN_FLAGS+=(-e "CANASTA_CLI_IMAGE_TAG=${IMAGE##*:}")
+DOCKER_RUN_FLAGS+=(-e "CANASTA_CLI_BIN=$CANASTA_CLI_BIN")
+# Tell the playbook to edit this mounted file instead of the (unreachable)
+# host crontab; the dispatch below installs it on the host afterward.
+if [[ -n "$SCHEDULE_CRONTAB_FILE" ]]; then
+    DOCKER_RUN_FLAGS+=(-e "CANASTA_HOST_CRONTAB=$SCHEDULE_CRONTAB_FILE")
+fi
 
 # Detect if `docker` is actually a podman shim (e.g. the podman-docker
 # package on Debian/Fedora installs /usr/bin/docker as a wrapper that
@@ -711,6 +748,32 @@ if [[ -n "${CANASTA_DOCKER_DRY_RUN:-}" ]]; then
         printf '%s\n' "$a"
     done
     exit 0
+fi
+
+# Local 'backup schedule' commands: hand the container a snapshot of the
+# host crontab to edit, then install whatever it wrote back. Bypasses
+# 'exec' so we regain control after the container exits. A run that
+# leaves the file unchanged (K8s schedule, or 'list') installs nothing.
+if [[ -n "$SCHEDULE_CRONTAB_FILE" ]]; then
+    crontab -l > "$SCHEDULE_CRONTAB_FILE" 2>/dev/null || : > "$SCHEDULE_CRONTAB_FILE"
+    _crontab_before="$(cksum < "$SCHEDULE_CRONTAB_FILE")"
+    _sched_rc=0
+    docker run ${ENGINE_OPTS[@]+"${ENGINE_OPTS[@]}"} --rm "${DOCKER_RUN_FLAGS[@]}" \
+        "${MOUNTS[@]}" \
+        "$IMAGE" "$@" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} || _sched_rc=$?
+    _crontab_after="$(cksum < "$SCHEDULE_CRONTAB_FILE")"
+    if [[ "$_sched_rc" -eq 0 && "$_crontab_before" != "$_crontab_after" ]]; then
+        if command -v crontab >/dev/null 2>&1; then
+            crontab "$SCHEDULE_CRONTAB_FILE"
+        else
+            echo "Error: scheduled backups need the 'crontab' command on" \
+                 "this host. Install the cron package (e.g. 'apt install" \
+                 "cron')." >&2
+            _sched_rc=1
+        fi
+    fi
+    rm -f "$SCHEDULE_CRONTAB_FILE"
+    exit "$_sched_rc"
 fi
 
 exec docker run ${ENGINE_OPTS[@]+"${ENGINE_OPTS[@]}"} --rm "${DOCKER_RUN_FLAGS[@]}" \

--- a/canasta-native
+++ b/canasta-native
@@ -16,6 +16,11 @@ while [[ -L "$SOURCE" ]]; do
 done
 SCRIPT_DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
 
+# Record this wrapper's absolute path so downstream tooling (e.g. the
+# crontab entry written by 'backup schedule set') can re-invoke the CLI
+# with a fully-qualified path, independent of cron's minimal PATH.
+export CANASTA_CLI_BIN="${SCRIPT_DIR}/$(basename "$SOURCE")"
+
 if [[ -x "${SCRIPT_DIR}/.venv/bin/python" ]]; then
     exec "${SCRIPT_DIR}/.venv/bin/python" "${SCRIPT_DIR}/canasta.py" "$@"
 else

--- a/canasta.py
+++ b/canasta.py
@@ -1212,6 +1212,15 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
     if host_value:
         extra_vars["target_host"] = host_value
 
+    # The wrapper records its own absolute path in CANASTA_CLI_BIN so
+    # playbooks that re-invoke the CLI (e.g. the crontab entry written by
+    # 'backup schedule set') can use a fully-qualified path rather than
+    # relying on a minimal cron PATH. Absent when canasta.py is run
+    # directly without a wrapper.
+    cli_bin = os.environ.get("CANASTA_CLI_BIN")
+    if cli_bin:
+        extra_vars["canasta_cli_bin"] = cli_bin
+
     if args.verbose:
         extra_vars["verbose"] = "true"
     else:

--- a/roles/orchestrator/tasks/backup_schedule_list.yml
+++ b/roles/orchestrator/tasks/backup_schedule_list.yml
@@ -9,12 +9,23 @@
 - name: List schedule (Compose)
   when: instance_orchestrator | default('compose') == 'compose'
   block:
-    - name: List cron jobs for this instance
+    # A local containerized run reads the host crontab file the wrapper
+    # mounted (CANASTA_HOST_CRONTAB); native and remote read the live
+    # crontab (remote over the connection resolve_instance switched to).
+    - name: Select crontab source
+      ansible.builtin.set_fact:
+        _sched_use_file: >-
+          {{ (lookup('env', 'CANASTA_HOST_CRONTAB') != '')
+             and (target_host is not defined)
+             and (_instance_host | default('localhost') == 'localhost') }}
+
+    - name: List cron jobs for this instance (native / remote)
       ansible.builtin.command:
         cmd: "crontab -l"
       register: _cron_list
       changed_when: false
       failed_when: false  # rc=1 when crontab is empty; we handle missing binary below
+      when: not _sched_use_file
 
     - name: Fail if crontab command is missing
       ansible.builtin.fail:
@@ -22,17 +33,32 @@
           The 'crontab' command is not available on this host. Install
           the cron package (e.g. 'apt install cron') to use backup
           schedules.
-      when: _cron_list.rc is not defined
+      when:
+        - not _sched_use_file
+        - _cron_list.rc is not defined
 
-    # Ansible's cron module writes two lines to the crontab: a
-    # '#Ansible: <name>' comment and the actual cron entry. Match the
-    # command line (which contains 'canasta backup create -i <id> '),
-    # not the comment (which contains 'canasta-backup-<id>'). The
-    # trailing space anchors the match so 'foo' doesn't match 'foo2'.
+    - name: Read the host crontab file (containerized CLI)
+      ansible.builtin.slurp:
+        src: "{{ lookup('env', 'CANASTA_HOST_CRONTAB') }}"
+      register: _cron_slurp
+      when: _sched_use_file
+
+    - name: Normalize crontab lines
+      ansible.builtin.set_fact:
+        _crontab_lines: >-
+          {{ (_cron_slurp.content | b64decode).splitlines()
+             if _sched_use_file
+             else (_cron_list.stdout_lines | default([])) }}
+
+    # Both the cron module ('#Ansible: <name>' + entry) and the
+    # containerized blockinfile path ('# BEGIN/END <name>' + entry) write
+    # the same job line. Match that line (it contains 'canasta backup
+    # create -i <id> '), not the marker comment. The trailing space
+    # anchors the match so 'foo' doesn't match 'foo2'.
     - name: Filter backup schedule
       ansible.builtin.set_fact:
         _schedule_lines: >-
-          {{ _cron_list.stdout_lines | default([])
+          {{ _crontab_lines | default([])
              | select('search', 'canasta backup create -i ' + instance_id + ' ')
              | list }}
 

--- a/roles/orchestrator/tasks/backup_schedule_remove.yml
+++ b/roles/orchestrator/tasks/backup_schedule_remove.yml
@@ -4,10 +4,30 @@
 # Input: instance_id, instance_orchestrator
 
 - name: Remove backup schedule (Compose)
-  ansible.builtin.cron:
-    name: "canasta-backup-{{ instance_id }}"
-    state: absent
   when: instance_orchestrator | default('compose') == 'compose'
+  block:
+    # A local containerized run edits the host crontab file the wrapper
+    # mounted (CANASTA_HOST_CRONTAB); native and remote edit the live
+    # crontab (remote over the connection resolve_instance switched to).
+    - name: Select crontab target
+      ansible.builtin.set_fact:
+        _sched_use_file: >-
+          {{ (lookup('env', 'CANASTA_HOST_CRONTAB') != '')
+             and (target_host is not defined)
+             and (_instance_host | default('localhost') == 'localhost') }}
+
+    - name: Remove cron schedule (native / remote)
+      ansible.builtin.cron:
+        name: "canasta-backup-{{ instance_id }}"
+        state: absent
+      when: not _sched_use_file
+
+    - name: Remove cron schedule from the host crontab file
+      ansible.builtin.blockinfile:
+        path: "{{ lookup('env', 'CANASTA_HOST_CRONTAB') }}"
+        marker: "# {mark} canasta-backup-{{ instance_id }}"
+        state: absent
+      when: _sched_use_file
 
 - name: Remove backup schedule (Kubernetes)
   kubernetes.core.k8s:

--- a/roles/orchestrator/tasks/backup_schedule_set.yml
+++ b/roles/orchestrator/tasks/backup_schedule_set.yml
@@ -8,35 +8,69 @@
 - name: Set backup schedule (Compose)
   when: instance_orchestrator | default('compose') == 'compose'
   block:
-    # The host crontab runs 'canasta backup create' on this host, so a
-    # runnable 'canasta' must exist here. Any flavor satisfies it
-    # (canasta-native or canasta-docker) — we only check that the command
-    # runs. Also, cron's PATH is minimal (typically /usr/bin:/bin) and
-    # usually excludes /usr/local/bin where canasta lives, so we resolve
-    # the absolute path now and bake it into the crontab.
-    - name: Resolve canasta executable on the host
+    # Cron runs 'canasta backup create' on the target host. cron's PATH
+    # is minimal (often /usr/bin:/bin) and usually excludes
+    # /usr/local/bin, so the entry needs an absolute path to canasta.
+    #
+    # Three layouts, by how the crontab is reached:
+    #  - Local native: Ansible runs on the host, so edit the live crontab
+    #    directly (cron module) using the absolute path the wrapper
+    #    recorded in canasta_cli_bin.
+    #  - Local containerized (canasta-docker): Ansible runs in a throwaway
+    #    container that can't touch the host crontab, so the wrapper dumps
+    #    it to the host-mounted file named by CANASTA_HOST_CRONTAB before
+    #    the run and re-installs it after. Here we just edit that file.
+    #  - Remote (--host, or an instance the registry pins to another host):
+    #    the crontab lives on the remote, where resolve_instance has
+    #    already switched the connection, so resolve canasta there and
+    #    fail if it isn't installed.
+    - name: Classify the schedule target
+      ansible.builtin.set_fact:
+        # Local only when neither --host nor a registry-pinned host sends
+        # the connection to another machine.
+        _sched_is_local: >-
+          {{ (target_host is not defined)
+             and (_instance_host | default('localhost') == 'localhost') }}
+        _host_crontab_file: "{{ lookup('env', 'CANASTA_HOST_CRONTAB') }}"
+
+    - name: Resolve canasta on the target host
       ansible.builtin.shell: command -v canasta
-      register: _host_canasta
+      register: _remote_canasta
       changed_when: false
       failed_when: false
+      when: not _sched_is_local
 
-    - name: Require a runnable canasta on the host for scheduled backups
+    - name: Require canasta on the target host for scheduled backups
       ansible.builtin.fail:
         msg: >-
-          Scheduled backups run 'canasta backup create' on this host via
-          crontab, but no 'canasta' executable was found here. Install it
-          first — 'canasta install canasta -H <host>' (or install
-          canasta-docker) — then re-run 'canasta backup schedule set'.
-      when: _host_canasta.rc != 0 or (_host_canasta.stdout | trim) == ''
+          No 'canasta' executable found on
+          {{ target_host | default(_instance_host) }}. Install it there
+          first, then re-run 'canasta backup schedule set'.
+      when:
+        - not _sched_is_local
+        - _remote_canasta.rc != 0 or (_remote_canasta.stdout | trim) == ''
+
+    # Local uses the wrapper's recorded path; remote uses what we just
+    # resolved over SSH. Falls back to a bare 'canasta' only when the
+    # CLI was run directly without the wrapper — rare, and local-only.
+    - name: Select the canasta command for cron
+      ansible.builtin.set_fact:
+        _canasta_bin: >-
+          {{ (canasta_cli_bin | default('canasta'))
+             if _sched_is_local
+             else (_remote_canasta.stdout | default('') | trim) }}
+        # Edit the mounted host crontab file only for a local
+        # containerized run; everything else edits the live crontab.
+        _sched_use_file: "{{ _sched_is_local and _host_crontab_file != '' }}"
 
     - name: Build backup command for cron
       ansible.builtin.set_fact:
         _cron_base: >-
-          {{ _host_canasta.stdout | trim }} backup create
+          {{ _canasta_bin }} backup create
           -i {{ instance_id }} --tag scheduled
         _cron_purge: >-
           {{ (purge_older_than is defined and purge_older_than != '')
-             | ternary('&& ' + (_host_canasta.stdout | trim)
+             | ternary('&& ' + _canasta_bin
              + ' backup purge -i ' + instance_id + ' --keep-within ' + (purge_older_than | default('')), '') }}
         _cron_log: '>> "{{ instance_path }}/backup.log" 2>&1'
 
@@ -44,6 +78,7 @@
       ansible.builtin.set_fact:
         _cron_cmd: "{{ (_cron_base + ' ' + _cron_purge + ' ' + _cron_log) | regex_replace('\\s+', ' ') | trim }}"
 
+    # Native / remote: edit the live crontab via the cron module.
     - name: Set cron schedule
       ansible.builtin.cron:
         name: "canasta-backup-{{ instance_id }}"
@@ -53,6 +88,19 @@
         day: "{{ cron_expression.split()[2] }}"
         month: "{{ cron_expression.split()[3] }}"
         weekday: "{{ cron_expression.split()[4] }}"
+      when: not _sched_use_file
+
+    # Containerized CLI: edit the host crontab file the wrapper mounted;
+    # the wrapper installs it on the host after this container exits. The
+    # BEGIN/END marker block replaces any prior entry for this instance,
+    # mirroring the cron module's replace-by-name behavior.
+    - name: Set cron schedule in the host crontab file
+      ansible.builtin.blockinfile:
+        path: "{{ _host_crontab_file }}"
+        create: true
+        marker: "# {mark} canasta-backup-{{ instance_id }}"
+        block: "{{ cron_expression }} {{ _cron_cmd }}"
+      when: _sched_use_file
 
 # --- Kubernetes: CronJob ---
 - name: Set backup schedule (Kubernetes)

--- a/tests/unit/test_backup_schedule_compose.py
+++ b/tests/unit/test_backup_schedule_compose.py
@@ -73,3 +73,83 @@ class TestComposeSchedulePurgeFlag:
 
     def test_schedule_uses_restic_native_keep_within(self):
         assert _compose_purge_flag() == "--keep-within"
+
+
+def _compose_tasks():
+    """Every task in the Compose branch of schedule_set.yml."""
+    with open(SCHEDULE_SET) as f:
+        tasks = yaml.safe_load(f)
+    for task in _walk_tasks(tasks):
+        name = (task.get("name") or "").lower()
+        if "compose" in name and "block" in task:
+            return list(_walk_tasks(task["block"]))
+    raise AssertionError("no Compose block found in schedule_set.yml")
+
+
+class TestComposeScheduleCanastaResolution:
+    """The local (no --host) path must not gate on probing the host for a
+    'canasta' executable — canasta is necessarily installed locally (it's
+    running now). The probe + fail belongs only to the remote path."""
+
+    def test_no_unconditional_local_canasta_probe(self):
+        for task in _compose_tasks():
+            shell = task.get("ansible.builtin.shell") or task.get("shell")
+            if shell and "command -v canasta" in str(shell):
+                # The probe must be skipped for local targets (it fails
+                # inside the canasta-docker container, which has no
+                # 'canasta' on PATH).
+                when = task.get("when")
+                when_text = " ".join(when) if isinstance(when, list) else str(when)
+                assert "_sched_is_local" in when_text, (
+                    "local schedule set must not probe the host for canasta"
+                )
+
+    def test_cron_command_uses_wrapper_recorded_path(self):
+        for task in _compose_tasks():
+            sf = task.get("ansible.builtin.set_fact") or task.get("set_fact")
+            if isinstance(sf, dict) and "_canasta_bin" in sf:
+                assert "canasta_cli_bin" in sf["_canasta_bin"], (
+                    "local cron must reuse the wrapper's canasta_cli_bin path"
+                )
+                return
+        raise AssertionError("schedule_set.yml has no _canasta_bin set_fact")
+
+    def test_containerized_local_writes_host_crontab_file(self):
+        """The containerized CLI can't reach the live host crontab, so it
+        edits the wrapper-mounted file (CANASTA_HOST_CRONTAB) via
+        blockinfile instead of the cron module."""
+        blockinfile = [
+            (t.get("ansible.builtin.blockinfile") or t.get("blockinfile"))
+            for t in _compose_tasks()
+            if (t.get("ansible.builtin.blockinfile") or t.get("blockinfile"))
+        ]
+        assert blockinfile, "no blockinfile task for the host crontab file"
+        assert "_host_crontab_file" in str(blockinfile[0].get("path")), (
+            "blockinfile must target the wrapper-provided host crontab file"
+        )
+
+    def test_native_and_host_file_paths_are_mutually_exclusive(self):
+        """The cron module (native/remote) and blockinfile (local
+        containerized) paths are gated on the same _sched_use_file flag,
+        so exactly one runs."""
+        cron = [t for t in _compose_tasks()
+                if (t.get("ansible.builtin.cron") or t.get("cron"))]
+        bf = [t for t in _compose_tasks()
+              if (t.get("ansible.builtin.blockinfile") or t.get("blockinfile"))]
+        assert cron and bf
+        assert str(cron[0].get("when")).strip() == "not _sched_use_file"
+        assert str(bf[0].get("when")).strip() == "_sched_use_file"
+
+    def test_host_file_path_requires_local_target(self):
+        """The local classification must consider the instance's registry
+        host, not merely the absence of --host — resolve_instance switches
+        the connection to a registry-pinned remote host even without
+        --host."""
+        for task in _compose_tasks():
+            sf = task.get("ansible.builtin.set_fact") or task.get("set_fact")
+            if isinstance(sf, dict) and "_sched_is_local" in sf:
+                assert "_instance_host" in sf["_sched_is_local"], (
+                    "local classification must consider _instance_host"
+                )
+                return
+        raise AssertionError("no _sched_is_local classification found")

--- a/tests/unit/test_canasta_docker.py
+++ b/tests/unit/test_canasta_docker.py
@@ -530,3 +530,58 @@ class TestPasswdEntryUsesHostUsername:
             "(%r) — got %r in entry %r"
             % (host_username, username, my_entry)
         )
+
+
+def assert_no_env_key(argv, key):
+    """Assert no `-e KEY=...` appears in the docker run argv."""
+    for i, a in enumerate(argv):
+        if a == "-e" and i + 1 < len(argv) and argv[i + 1].startswith(key + "="):
+            raise AssertionError(
+                "did not expect -e %s=... in argv:\n%s" % (key, "\n".join(argv))
+            )
+
+
+class TestBackupScheduleCrontabWiring:
+    """Local 'backup schedule' commands need the host crontab mediated by
+    the wrapper, since the container can't reach it. The wrapper passes
+    CANASTA_HOST_CRONTAB (the mounted file the playbook edits) and always
+    passes CANASTA_CLI_BIN (the host path baked into the cron entry)."""
+
+    def test_cli_bin_always_passed(self):
+        argv, _ = run_dry(["doctor"])
+        # Path is host-specific; assert the key is present with some value.
+        assert any(
+            a == "-e" and argv[i + 1].startswith("CANASTA_CLI_BIN=/")
+            for i, a in enumerate(argv[:-1])
+        ), "CANASTA_CLI_BIN should be passed into the container"
+
+    def test_host_crontab_passed_for_local_schedule_set(self):
+        config_dir = tempfile.mkdtemp(prefix="cd-", dir="/tmp")
+        _run_dry_tmpdirs.append(config_dir)
+        argv, _ = run_dry(
+            ["backup", "schedule", "set", "0 5 * * *"],
+            env={"CANASTA_CONFIG_DIR": config_dir},
+        )
+        assert_env_var(argv, "CANASTA_HOST_CRONTAB", config_dir + "/.host-crontab")
+
+    def test_host_crontab_passed_for_local_schedule_list_and_remove(self):
+        for action in ("list", "remove"):
+            config_dir = tempfile.mkdtemp(prefix="cd-", dir="/tmp")
+            _run_dry_tmpdirs.append(config_dir)
+            argv, _ = run_dry(
+                ["backup", "schedule", action],
+                env={"CANASTA_CONFIG_DIR": config_dir},
+            )
+            assert_env_var(
+                argv, "CANASTA_HOST_CRONTAB", config_dir + "/.host-crontab"
+            )
+
+    def test_host_crontab_not_passed_for_remote_schedule(self):
+        # --host targets a remote crontab over SSH; the container handles it.
+        argv, _ = run_dry(["--host", "prod1", "backup", "schedule",
+                           "set", "0 5 * * *"])
+        assert_no_env_key(argv, "CANASTA_HOST_CRONTAB")
+
+    def test_host_crontab_not_passed_for_non_schedule_commands(self):
+        argv, _ = run_dry(["backup", "create", "-i", "x"])
+        assert_no_env_key(argv, "CANASTA_HOST_CRONTAB")


### PR DESCRIPTION
Fixes #812.

## Problem

`canasta backup schedule set/list/remove` was non-functional under the `canasta-docker` wrapper for local Compose instances. Scheduled backups (Compose) are a host crontab entry, but under `canasta-docker` Ansible runs inside a throwaway `--rm` container with no host crontab access and no `crontab` binary:

- `set` wrote a crontab entry inside the container, which vanished on exit — the schedule never took effect.
- `list` read the empty container crontab and always reported "No backup schedule found".
- `remove` was a no-op.
- The preflight failed confusingly — it ran `command -v canasta` inside the container (which has `canasta.py` but no `canasta` on `PATH`), so it claimed "no 'canasta' executable was found here" while a `canasta` command was clearly running, and pointed at a remote-host install (`-H <host>`) irrelevant to a local run.

## Fix

Keep the cron logic in the playbook (built-in `cron`/`blockinfile`/`slurp`); the thin `canasta-docker` wrapper mediates only the host crontab I/O.

- For a local `backup schedule` command, the wrapper dumps the host crontab to a mounted file (`CANASTA_HOST_CRONTAB`) **before** the `docker run` and installs it back **after** the container exits — but only if the container changed it (so `list` and K8s instances install nothing).
- The playbook edits that mounted file via `blockinfile`/`slurp` for a local-containerized target, and edits the live crontab via the `cron` module otherwise.
- Both wrappers record their absolute host path as `CANASTA_CLI_BIN`, forwarded by `canasta.py`, so cron entries are fully-qualified (cron's `PATH` is minimal).
- Local vs remote is keyed on the registry-recorded `_instance_host`, not merely the absence of `-H` — `resolve_instance` switches the connection to a registry-pinned remote host even without `-H`.

### Behavior

| Invocation | Crontab written | How |
| --- | --- | --- |
| native, local | host crontab | `cron` module on host |
| docker, local | host crontab | `blockinfile` → wrapper installs |
| `-H` / registry-remote (either mode) | remote crontab | `cron` module over SSH |
| K8s (either mode) | CronJob in-cluster | unchanged |

## Testing

- `make lint` + `make validate` clean; full unit suite passes (1229, +18 new).
- New unit coverage: playbook gating (`tests/unit/test_backup_schedule_compose.py`) and wrapper env-wiring (`tests/unit/test_canasta_docker.py`).
- Live Ansible e2e: docker-path `set` → `list` → `remove` against a mounted crontab file — preserves unrelated entries, `list` reads it back with the purge note, `remove` cleans only the canasta block.
- Verified the wrapper's dump → run → install dispatch with fakes (installs on change, no-ops on `list`).

## Follow-up

The schedule lives only in the crontab/CronJob and isn't captured by backup, so a restore to a new host loses it — tracked separately in #811.
