### PR TITLE
fix(sidecars): deploy compose sidecars via canasta start/stop/restart

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -110,6 +110,35 @@ def _read_env_content(path, host):
     return content if rc == 0 else ""
 
 
+def _instance_has_sidecars(inst):
+    """True if the instance declares app sidecars in config/sidecars.yaml.
+
+    The Ansible start/stop path renders the sidecar override layer and
+    includes it in the compose -f list; this fast direct path does not, so
+    the lifecycle commands fall back to Ansible when sidecars exist."""
+    path = inst.get("path", "")
+    host = inst.get("host") or "localhost"
+    sidecars_path = os.path.join(path, "config", "sidecars.yaml")
+    if _is_localhost(host):
+        try:
+            with open(sidecars_path) as f:
+                content = f.read()
+        except OSError:
+            return False
+    else:
+        rc, content = _ssh_run(
+            host, "cat %s 2>/dev/null" % _shell_quote(sidecars_path))
+        if rc != 0:
+            return False
+    if not (content or "").strip():
+        return False
+    try:
+        data = yaml.safe_load(content) or {}
+    except yaml.YAMLError:
+        return False
+    return bool(data.get("sidecars"))
+
+
 def _lint_env_content(content):
     """Find .env hygiene problems that survive read-time quote-stripping but
     reach `docker --env-file` literally: quoted values and CRLF endings.

--- a/direct_commands/lifecycle.py
+++ b/direct_commands/lifecycle.py
@@ -18,6 +18,8 @@ def cmd_start(args):
         # these are multi-step controller-to-remote operations that
         # need Ansible.
         return _helpers.FALLBACK
+    if _helpers._instance_has_sidecars(inst):
+        return _helpers.FALLBACK  # Ansible renders + layers the sidecars.
     _helpers._sync_compose_profiles(inst)
     rc = _helpers._run_compose(inst_id, inst, ["up", "-d"])
     if rc != 0:
@@ -34,6 +36,8 @@ def cmd_stop(args):
         # (where the cluster kubeconfig lives), not the controller.
         # Ansible resolves the host and switches the connection.
         return _helpers.FALLBACK
+    if _helpers._instance_has_sidecars(inst):
+        return _helpers.FALLBACK  # Ansible includes the sidecar -f layer.
     return _helpers._run_compose(inst_id, inst, ["down"])
 
 
@@ -43,6 +47,8 @@ def cmd_restart(args):
     if inst.get("orchestrator", "compose") in ("kubernetes", "k8s"):
         # K8s restart needs Ansible for the start half (helm deploy).
         return _helpers.FALLBACK
+    if _helpers._instance_has_sidecars(inst):
+        return _helpers.FALLBACK  # Ansible renders + layers the sidecars.
     rc = _helpers._run_compose(inst_id, inst, ["down"])
     if rc != 0:
         return rc

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1275,6 +1275,40 @@ class TestLifecycleCommands:
         args = type("Args", (), {"id": "k8s-site"})()
         assert direct_commands.cmd_stop(args) is direct_commands.FALLBACK
 
+    def _compose_inst(self, tmp_path, sidecars_yaml):
+        site = tmp_path / "scsite"
+        (site / "config").mkdir(parents=True)
+        (site / "config" / "sidecars.yaml").write_text(sidecars_yaml)
+        return str(site)
+
+    def test_lifecycle_falls_back_when_sidecars_declared(
+            self, tmp_path, monkeypatch):
+        # A compose instance with sidecars must defer start/stop/restart to
+        # Ansible, which renders the sidecar override layer; the fast direct
+        # path doesn't render it.
+        path = self._compose_inst(
+            tmp_path, "sidecars:\n  - name: cache\n    image: redis:7\n")
+        monkeypatch.setattr(
+            direct_commands._helpers, "_resolve_instance",
+            lambda args: ("scsite", {"path": path, "orchestrator": "compose"}))
+        args = type("Args", (), {"id": "scsite"})()
+        assert direct_commands.cmd_start(args) is direct_commands.FALLBACK
+        assert direct_commands.cmd_stop(args) is direct_commands.FALLBACK
+        assert direct_commands.cmd_restart(args) is direct_commands.FALLBACK
+
+    def test_no_fallback_when_sidecars_empty(self, tmp_path, monkeypatch):
+        # An empty sidecars list keeps the fast direct path.
+        path = self._compose_inst(tmp_path, "sidecars: []\n")
+        monkeypatch.setattr(
+            direct_commands._helpers, "_resolve_instance",
+            lambda args: ("scsite", {"path": path, "orchestrator": "compose"}))
+        monkeypatch.setattr(
+            direct_commands._helpers, "_sync_compose_profiles", lambda inst: None)
+        monkeypatch.setattr(
+            direct_commands._helpers, "_run_compose", lambda *a, **kw: 0)
+        args = type("Args", (), {"id": "scsite"})()
+        assert direct_commands.cmd_start(args) == 0
+
     def test_start_runs_up(self, monkeypatch):
         captured_cmds = []
 


### PR DESCRIPTION
## Summary
Fixes a gap in #814: **Compose sidecars are never deployed by `canasta start`/`stop`/`restart`.**

Those lifecycle commands run as pure-Python **direct commands** for Compose (`direct_commands/lifecycle.py`) to skip the ~3-5s ansible startup. That fast path runs `docker compose` directly and **bypasses the Ansible `start.yml`/`stop.yml`** where #814 put the sidecar render + `-f` layering — so `config/sidecars.yaml` is never rendered into `docker-compose.sidecars.yml` and the sidecar container is never brought up. (K8s was unaffected: it already returns FALLBACK to Ansible.)

**Repro (pre-fix):** `canasta create -o compose`; `canasta sidecar add … --name cache --image redis:7-alpine --port 6379`; `canasta restart` → no `docker-compose.sidecars.yml`, no `cache` container.

## Fix
`cmd_start`/`cmd_stop`/`cmd_restart` fall back to Ansible when the instance declares sidecars (the Ansible path renders + layers them). The fast direct path stays for the common sidecar-less case. Adds `_instance_has_sidecars` (handles local and remote/ssh instances) and tests.

## Validation
- Unit: 1295 passing (2 new fallback tests; existing compose direct-path tests unaffected — they use sidecar-less instances).
- **Live (Compose, localhost):** `canasta sidecar add` → `canasta restart` now renders `docker-compose.sidecars.yml` and brings up the `cache` sidecar, reachable from `web` (`redis-cli -h cache ping`, TCP to `:6379`). A clean `canasta stop` tears it down; `canasta start` redeploys it fresh.

Closes #816.