### PR TITLE
fix(sidecars): tear down sidecar containers on compose delete

### DIFF
--- a/roles/orchestrator/tasks/destroy.yml
+++ b/roles/orchestrator/tasks/destroy.yml
@@ -6,8 +6,11 @@
   when: instance_orchestrator | default('compose') == 'compose'
   block:
     - name: Destroy containers and volumes
+      # --remove-orphans sweeps containers not in the default compose files,
+      # notably app sidecars (created via the docker-compose.sidecars.yml -f
+      # layer), so a full teardown leaves nothing behind.
       ansible.builtin.command:
-        cmd: "docker compose down -v"
+        cmd: "docker compose down -v --remove-orphans"
         chdir: "{{ instance_path }}"
       changed_when: true
       ignore_errors: true  # OK if containers already removed

--- a/tests/unit/test_sidecar_render_wiring.py
+++ b/tests/unit/test_sidecar_render_wiring.py
@@ -12,6 +12,7 @@ import os
 ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 START = os.path.join(ROOT, "roles", "orchestrator", "tasks", "start.yml")
 STOP = os.path.join(ROOT, "roles", "orchestrator", "tasks", "stop.yml")
+DESTROY = os.path.join(ROOT, "roles", "orchestrator", "tasks", "destroy.yml")
 HELM = os.path.join(ROOT, "roles", "orchestrator", "tasks", "helm_deploy.yml")
 CHART = os.path.join(ROOT, "roles", "orchestrator", "files", "helm", "canasta")
 TPL = os.path.join(CHART, "templates", "sidecars.yaml")
@@ -42,6 +43,13 @@ def test_compose_layer_added_before_user_override():
 def test_stop_includes_sidecar_layer_for_teardown():
     body = _text(STOP)
     assert "docker-compose.sidecars.yml" in body
+
+
+def test_destroy_removes_sidecar_orphans():
+    # delete uses a bare `down` (no sidecar -f layer), so it must pass
+    # --remove-orphans or the sidecar container survives deletion.
+    body = _text(DESTROY)
+    assert "down -v --remove-orphans" in body
 
 
 def test_scale_up_is_generalized_to_all():


### PR DESCRIPTION
Closes #818.

`canasta delete` ran `docker compose down -v` without the sidecar `-f` layer, so app sidecars (created via `docker-compose.sidecars.yml`) were treated as orphans and left running after the instance was deleted — reproduced live (`<id>-cache-1` survived a delete).

Adds `--remove-orphans` to the destroy `down` so a full teardown sweeps any container not in the default compose files (notably sidecars), and also catches the case where `sidecars.yaml` was already removed. Plus a structural guard.

Full unit suite green (1296), lint clean.