### PR TITLE
feat(sidecars): canasta sidecar add declares full sidecars from a YAML file

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -2565,15 +2565,20 @@ commands:
         description: "Target host (default: localhost)"
 
   - name: sidecar_add
-    description: "Add an app sidecar to config/sidecars.yaml"
+    description: "Add app sidecar(s) to config/sidecars.yaml from a YAML file"
     long_description: |
-      Declare an app sidecar in `config/sidecars.yaml`, then run
-      `canasta restart` to deploy it. Covers the common fields; for
-      richer sidecars (mounted config files, dependencies, healthchecks)
-      edit `config/sidecars.yaml` directly.
+      Declare app sidecar(s) in `config/sidecars.yaml` from a YAML file of
+      full definitions — a single sidecar mapping, a list, or a `sidecars:`
+      list — then run `canasta restart` to deploy them. The file uses the
+      orchestrator-agnostic sidecar schema (name, image/build, ports, command,
+      env, volumes, files, depends_on, healthcheck, resources), so it renders
+      identically on Compose and Kubernetes.
+
+      To migrate an existing `docker-compose.override.yml`, use
+      `canasta sidecar migrate` instead, which translates its sidecar
+      services into this schema.
     examples:
-      - "canasta sidecar add -i mywiki --name cache --image redis:7-alpine --port 6379"
-      - "canasta sidecar add -i mywiki --name cache --image redis:7-alpine --volume data:/data:1Gi"
+      - "canasta sidecar add -i mywiki --file sidecars.yaml"
     playbook: sidecar_add.yml
     parameters:
       - name: id
@@ -2584,36 +2589,13 @@ commands:
         short: p
         type: string
         description: "Path to the Canasta instance directory"
-      - name: sidecar_name
-        long: name
-        short: n
+      - name: file
+        short: f
         type: string
         required: true
-        description: "Sidecar name (a DNS label; becomes a service + hostname)"
-      - name: image
-        type: string
-        description: "Image reference (mutually exclusive with --build)"
-      - name: build
-        type: string
-        description: "Build context path (mutually exclusive with --image)"
-      - name: port
-        type: string
-        multi: true
-        description: "Container port the sidecar listens on (repeatable)"
-      - name: sidecar_command
-        long: command
-        type: string
-        description: "Override command (a string)"
-      - name: env
-        type: string
-        multi: true
-        description: "Environment entry as KEY=VALUE (repeatable)"
-      - name: volume
-        type: string
-        multi: true
         description: >-
-          Volume as NAME:MOUNTPATH (ephemeral) or NAME:MOUNTPATH:SIZE
-          (persistent); repeatable
+          Path to a YAML file of full sidecar definition(s) (the
+          orchestrator-agnostic sidecar schema)
 
   - name: sidecar_list
     description: "List app sidecars declared for a Canasta instance"

--- a/playbooks/sidecar_add.yml
+++ b/playbooks/sidecar_add.yml
@@ -1,25 +1,30 @@
 ---
-# canasta sidecar add - Add an app sidecar to config/sidecars.yaml.
+# canasta sidecar add - Declare app sidecar(s) in config/sidecars.yaml from a
+# YAML file of full definitions (the orchestrator-agnostic sidecar schema).
 
 - name: Resolve instance
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/common/tasks/resolve_instance.yml
 
-- name: Add sidecar to config/sidecars.yaml
+# The file is a controller-side path (where the CLI runs), so read it on the
+# controller rather than the target host.
+- name: Read the sidecar definition file
+  ansible.builtin.slurp:
+    src: "{{ file }}"
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  register: _sidecar_file
+
+- name: Import sidecar definitions into config/sidecars.yaml
   canasta_sidecars_yaml:
     instance_path: "{{ instance_path }}"
-    state: add
-    name: "{{ sidecar_name }}"
-    image: "{{ image | default(omit) }}"
-    build: "{{ build | default(omit) }}"
-    ports: "{{ port | default(omit) }}"
-    command: "{{ sidecar_command | default(omit) }}"
-    env: "{{ env | default(omit) }}"
-    volumes: "{{ volume | default(omit) }}"
-  register: _sidecar_add
+    state: import
+    definitions: "{{ _sidecar_file.content | b64decode }}"
+  register: _sidecar_import
 
 - name: Report
   ansible.builtin.debug:
     msg: >-
-      Sidecar '{{ sidecar_name }}' added to config/sidecars.yaml.
-      Run 'canasta restart' to deploy it.
+      Sidecar(s) {{ _sidecar_import.names | join(', ') }} added to
+      config/sidecars.yaml. Run 'canasta restart' to deploy them.

--- a/roles/common/library/canasta_sidecars_yaml.py
+++ b/roles/common/library/canasta_sidecars_yaml.py
@@ -17,7 +17,7 @@ DOCUMENTATION = r"""
 module: canasta_sidecars_yaml
 short_description: Manage Canasta sidecars.yaml
 description:
-  - Read, add, remove, and validate app sidecars in config/sidecars.yaml.
+  - Read, import, remove, and validate app sidecars in config/sidecars.yaml.
 options:
   instance_path:
     description: Path to the Canasta instance directory.
@@ -26,34 +26,16 @@ options:
   state:
     description: Action to perform.
     type: str
-    choices: [read, list, add, remove, query, validate]
+    choices: [read, list, remove, query, validate, import]
     default: read
   name:
-    description: Sidecar name (a DNS label; becomes a service + hostname).
+    description: Sidecar name (a DNS label); for query/remove.
     type: str
-  image:
-    description: Image reference (mutually exclusive with build).
-    type: str
-  build:
-    description: Build context path (mutually exclusive with image).
-    type: str
-  ports:
-    description: Container ports the sidecar listens on.
-    type: list
-    elements: int
-  command:
-    description: Override command (a string; ${VAR} resolved at render time).
-    type: str
-  env:
-    description: Environment entries as 'KEY=VALUE' strings.
-    type: list
-    elements: str
-  volumes:
+  definitions:
     description: >-
-      Volume specs as 'NAME:MOUNTPATH' (ephemeral) or 'NAME:MOUNTPATH:SIZE'
-      (persistent).
-    type: list
-    elements: str
+      YAML document of full sidecar definition(s) for import — a single
+      sidecar mapping, a list, or a 'sidecars:' list.
+    type: str
 """
 
 import os
@@ -106,55 +88,21 @@ def sidecar_exists(sidecars, name):
     return name in sidecar_names(sidecars)
 
 
-def parse_env(items):
-    """['KEY=VALUE', ...] -> {'KEY': 'VALUE', ...}."""
-    out = {}
-    for item in items or []:
-        if "=" not in item:
-            raise ValueError("env '%s' must be KEY=VALUE" % item)
-        key, value = item.split("=", 1)
-        out[key] = value
-    return out
-
-
-def parse_volumes(items):
-    """'NAME:MOUNTPATH' -> ephemeral; 'NAME:MOUNTPATH:SIZE' -> persistent."""
-    out = []
-    for item in items or []:
-        parts = item.split(":")
-        if len(parts) == 2:
-            out.append({"name": parts[0], "mountPath": parts[1],
-                        "persistent": False})
-        elif len(parts) == 3:
-            out.append({"name": parts[0], "mountPath": parts[1],
-                        "persistent": True, "size": parts[2]})
-        else:
-            raise ValueError(
-                "volume '%s' must be NAME:MOUNTPATH or NAME:MOUNTPATH:SIZE"
-                % item
-            )
-    return out
-
-
-def build_sidecar(name, image=None, build=None, ports=None,
-                  command=None, env=None, volumes=None):
-    """Construct a sidecar dict from CLI params, omitting unset fields."""
-    sidecar = {"name": name}
-    if build:
-        sidecar["build"] = build
-    else:
-        sidecar["image"] = image
-    if ports:
-        sidecar["ports"] = [int(p) for p in ports]
-    if command:
-        sidecar["command"] = command
-    env_dict = parse_env(env)
-    if env_dict:
-        sidecar["env"] = env_dict
-    volume_list = parse_volumes(volumes)
-    if volume_list:
-        sidecar["volumes"] = volume_list
-    return sidecar
+def parse_sidecar_definitions(content):
+    """Parse a YAML document of sidecar definition(s) into a list. Accepts a
+    `sidecars:` mapping, a bare list, or a single sidecar mapping."""
+    data = yaml.safe_load(content)
+    if data is None:
+        return []
+    if isinstance(data, dict) and "sidecars" in data:
+        data = data["sidecars"]
+    if isinstance(data, dict):
+        data = [data]
+    if not isinstance(data, list):
+        raise ValueError(
+            "sidecar file must be a sidecar mapping, a list of sidecars, "
+            "or a 'sidecars:' list")
+    return data
 
 
 def validate_sidecars(sidecars):
@@ -183,15 +131,10 @@ def run_module():
     module_args = dict(
         instance_path=dict(type="str", required=True),
         state=dict(type="str", default="read",
-                   choices=["read", "list", "add", "remove", "query",
-                            "validate"]),
+                   choices=["read", "list", "remove", "query",
+                            "validate", "import"]),
         name=dict(type="str", required=False),
-        image=dict(type="str", required=False),
-        build=dict(type="str", required=False),
-        ports=dict(type="list", elements="int", required=False),
-        command=dict(type="str", required=False),
-        env=dict(type="list", elements="str", required=False),
-        volumes=dict(type="list", elements="str", required=False),
+        definitions=dict(type="str", required=False),
     )
 
     module = AnsibleModule(
@@ -221,40 +164,41 @@ def run_module():
                 result["sidecar"] = sidecar
                 break
 
-    elif state == "add":
-        if not name:
-            module.fail_json(msg="name is required for add")
+    elif state == "import":
+        content = module.params.get("definitions")
+        if not content:
+            module.fail_json(msg="definitions is required for import")
             return
-        err = validate_sidecar_name(name)
+        try:
+            incoming = parse_sidecar_definitions(content)
+        except (yaml.YAMLError, ValueError) as exc:
+            module.fail_json(msg="invalid sidecar file: %s" % exc)
+            return
+        for sidecar in incoming:
+            if isinstance(sidecar, dict) and sidecar.get("ports"):
+                try:
+                    sidecar["ports"] = [int(p) for p in sidecar["ports"]]
+                except (TypeError, ValueError):
+                    module.fail_json(
+                        msg="sidecar '%s' has non-numeric ports"
+                        % sidecar.get("name"))
+                    return
+        err = validate_sidecars(incoming)
         if err:
             module.fail_json(msg=err)
             return
-        image = module.params.get("image")
-        build = module.params.get("build")
-        if not image and not build:
-            module.fail_json(msg="one of image or build is required for add")
-            return
-        if image and build:
-            module.fail_json(msg="image and build are mutually exclusive")
-            return
         sidecars = read_sidecars(instance_path)
-        if sidecar_exists(sidecars, name):
-            module.fail_json(msg="sidecar '%s' already exists" % name)
+        existing = set(sidecar_names(sidecars))
+        dupes = [s["name"] for s in incoming if s["name"] in existing]
+        if dupes:
+            module.fail_json(
+                msg="sidecar(s) already exist: %s" % ", ".join(dupes))
             return
-        try:
-            sidecar = build_sidecar(
-                name, image, build,
-                module.params.get("ports"), module.params.get("command"),
-                module.params.get("env"), module.params.get("volumes"),
-            )
-        except ValueError as exc:
-            module.fail_json(msg=str(exc))
-            return
-        sidecars.append(sidecar)
-        if not module.check_mode:
+        sidecars.extend(incoming)
+        if incoming and not module.check_mode:
             write_sidecars(instance_path, sidecars)
-        result["changed"] = True
-        result["sidecar"] = sidecar
+        result["changed"] = bool(incoming)
+        result["names"] = [s["name"] for s in incoming]
 
     elif state == "remove":
         if not name:

--- a/tests/unit/test_canasta_sidecars_yaml.py
+++ b/tests/unit/test_canasta_sidecars_yaml.py
@@ -53,45 +53,6 @@ class TestValidateSidecarName:
         assert _v("caddy") is not None
 
 
-class TestParseHelpers:
-    def test_parse_env(self):
-        assert canasta_sidecars_yaml.parse_env(["A=1", "B=x=y"]) == {
-            "A": "1", "B": "x=y"}
-
-    def test_parse_env_bad(self):
-        with pytest.raises(ValueError):
-            canasta_sidecars_yaml.parse_env(["NOEQUALS"])
-
-    def test_parse_volumes_ephemeral(self):
-        assert canasta_sidecars_yaml.parse_volumes(["t:/tmp"]) == [
-            {"name": "t", "mountPath": "/tmp", "persistent": False}]
-
-    def test_parse_volumes_persistent(self):
-        assert canasta_sidecars_yaml.parse_volumes(["data:/data:1Gi"]) == [
-            {"name": "data", "mountPath": "/data",
-             "persistent": True, "size": "1Gi"}]
-
-    def test_parse_volumes_bad(self):
-        with pytest.raises(ValueError):
-            canasta_sidecars_yaml.parse_volumes(["justone"])
-
-    def test_build_sidecar_image_omits_empty(self):
-        assert canasta_sidecars_yaml.build_sidecar("cache", image="redis:7") == {
-            "name": "cache", "image": "redis:7"}
-
-    def test_build_sidecar_build_excludes_image(self):
-        sidecar = canasta_sidecars_yaml.build_sidecar("c", build="./c")
-        assert sidecar == {"name": "c", "build": "./c"}
-
-    def test_build_sidecar_full(self):
-        sidecar = canasta_sidecars_yaml.build_sidecar(
-            "cache", image="redis:7", ports=["6379"], command="redis-server",
-            env=["A=1"], volumes=["data:/data:1Gi"])
-        assert sidecar["ports"] == [6379]
-        assert sidecar["env"] == {"A": "1"}
-        assert sidecar["volumes"][0]["persistent"] is True
-
-
 class TestValidateSidecars:
     def test_ok(self):
         assert canasta_sidecars_yaml.validate_sidecars(
@@ -118,43 +79,13 @@ class TestValidateSidecars:
 
 
 def _add(inst, **extra):
-    params = {"instance_path": inst, "state": "add", "name": "cache",
-              "image": "redis:7-alpine"}
-    params.update(extra)
-    return run_module_with_params(canasta_sidecars_yaml, params)
+    """Seed a 'cache' sidecar via import (used by list/query/remove tests)."""
+    return run_module_with_params(canasta_sidecars_yaml, {
+        "instance_path": inst, "state": "import",
+        "definitions": "name: cache\nimage: redis:7-alpine\n"})
 
 
 class TestModuleStates:
-    def test_add_writes_file(self, tmp_dir):
-        result, failed, _ = _add(tmp_dir)
-        assert not failed and result["changed"] is True
-        path = os.path.join(tmp_dir, "config", "sidecars.yaml")
-        with open(path) as f:
-            data = yaml.safe_load(f)
-        assert data["sidecars"][0]["name"] == "cache"
-
-    def test_add_duplicate_fails(self, tmp_dir):
-        _add(tmp_dir)
-        _, failed, msg = _add(tmp_dir)
-        assert failed and "already exists" in msg
-
-    def test_add_reserved_fails(self, tmp_dir):
-        _, failed, msg = run_module_with_params(canasta_sidecars_yaml, {
-            "instance_path": tmp_dir, "state": "add",
-            "name": "web", "image": "i"})
-        assert failed and "reserved" in msg
-
-    def test_add_requires_image_or_build(self, tmp_dir):
-        _, failed, msg = run_module_with_params(canasta_sidecars_yaml, {
-            "instance_path": tmp_dir, "state": "add", "name": "cache"})
-        assert failed and "image or build" in msg
-
-    def test_add_image_and_build_mutually_exclusive(self, tmp_dir):
-        _, failed, msg = run_module_with_params(canasta_sidecars_yaml, {
-            "instance_path": tmp_dir, "state": "add", "name": "cache",
-            "image": "i", "build": "./c"})
-        assert failed and "mutually exclusive" in msg
-
     def test_list_after_add(self, tmp_dir):
         _add(tmp_dir, ports=["6379"])
         result, failed, _ = run_module_with_params(canasta_sidecars_yaml, {
@@ -195,6 +126,73 @@ class TestModuleStates:
         assert not failed and result["sidecars"] == []
 
 
+class TestParseSidecarDefinitions:
+    _p = staticmethod(canasta_sidecars_yaml.parse_sidecar_definitions)
+
+    def test_single_mapping(self):
+        assert self._p("name: cache\nimage: redis:7\n") == [
+            {"name": "cache", "image": "redis:7"}]
+
+    def test_bare_list(self):
+        out = self._p("- {name: a, image: i}\n- {name: b, image: j}\n")
+        assert [s["name"] for s in out] == ["a", "b"]
+
+    def test_sidecars_key(self):
+        out = self._p("sidecars:\n  - {name: a, image: i}\n")
+        assert out == [{"name": "a", "image": "i"}]
+
+    def test_empty(self):
+        assert self._p("") == []
+
+    def test_scalar_rejected(self):
+        with pytest.raises(ValueError):
+            self._p("just-a-string")
+
+
+class TestImportState:
+    def _import(self, inst, text):
+        return run_module_with_params(canasta_sidecars_yaml, {
+            "instance_path": inst, "state": "import", "definitions": text})
+
+    def test_import_full_sidecar(self, tmp_dir):
+        text = ("sidecars:\n"
+                "  - name: citation\n"
+                "    image: example/citoid:1.0\n"
+                "    ports: [1970]\n"
+                "    healthcheck: {path: /_info, port: 1970}\n"
+                "    depends_on: [translator]\n")
+        result, failed, _ = self._import(tmp_dir, text)
+        assert not failed and result["changed"] is True
+        assert result["names"] == ["citation"]
+        sc = canasta_sidecars_yaml.read_sidecars(tmp_dir)[0]
+        # Rich fields the flag-based add can't express survive the round-trip.
+        assert sc["healthcheck"] == {"path": "/_info", "port": 1970}
+        assert sc["depends_on"] == ["translator"]
+        assert sc["ports"] == [1970]
+
+    def test_import_multiple(self, tmp_dir):
+        text = "- {name: a, image: i}\n- {name: b, image: j}\n"
+        result, failed, _ = self._import(tmp_dir, text)
+        assert not failed and result["names"] == ["a", "b"]
+
+    def test_import_dup_with_existing_fails(self, tmp_dir):
+        _add(tmp_dir)  # adds 'cache'
+        _, failed, msg = self._import(tmp_dir, "name: cache\nimage: redis:7\n")
+        assert failed and "already exist" in msg
+
+    def test_import_reserved_name_fails(self, tmp_dir):
+        _, failed, msg = self._import(tmp_dir, "name: web\nimage: i\n")
+        assert failed and "reserved" in msg
+
+    def test_import_missing_image_and_build_fails(self, tmp_dir):
+        _, failed, msg = self._import(tmp_dir, "name: c\n")
+        assert failed and "image or build" in msg
+
+    def test_import_invalid_yaml_fails(self, tmp_dir):
+        _, failed, msg = self._import(tmp_dir, "name: c\n  bad: [unclosed")
+        assert failed and "invalid sidecar file" in msg
+
+
 class TestCommandWiring:
     def test_group_registered_in_cli(self):
         with open(os.path.join(REPO, "canasta.py")) as f:
@@ -203,14 +201,13 @@ class TestCommandWiring:
     def test_no_param_dest_collides_with_dispatch_var(self):
         # A param internally named 'command' clobbers canasta.py's top-level
         # subparser dest='command' (the dispatch variable), breaking the
-        # whole subcommand. The override-command flag must use a distinct
-        # internal name (sidecar_command) with `long: command`.
+        # whole subcommand. No sidecar param may use that internal name.
         with open(os.path.join(REPO, "meta", "command_definitions.yml")) as f:
             defs = yaml.safe_load(f)
-        add = next(c for c in defs["commands"] if c["name"] == "sidecar_add")
-        dests = {p["name"] for p in add["parameters"]}
-        assert "command" not in dests
-        assert "sidecar_command" in dests
+        for cmd in ("sidecar_add", "sidecar_list", "sidecar_remove"):
+            entry = next(c for c in defs["commands"] if c["name"] == cmd)
+            dests = {p["name"] for p in entry.get("parameters", [])}
+            assert "command" not in dests
 
     def test_command_defs_and_playbooks_exist(self):
         with open(os.path.join(REPO, "meta", "command_definitions.yml")) as f:


### PR DESCRIPTION
Closes #821.

`canasta sidecar add` took sidecar fields as individual flags, which can only express a **lossy subset** of the schema — no `healthcheck`, `files`, `depends_on`, or `resources`. This makes `add` **file-only** instead:

```
canasta sidecar add -i mywiki --file sidecars.yaml
```

The file is a YAML document of full sidecar definition(s) — a single mapping, a bare list, or a `sidecars:` list — in the **orchestrator-agnostic schema**. Each entry is validated (DNS-label name, not reserved; image XOR build) and merged into `config/sidecars.yaml`, rejecting duplicates. One input mode, no ambiguity; the file renders identically on Compose and Kubernetes.

## Changes
- New `import` state on `canasta_sidecars_yaml` + `parse_sidecar_definitions` (accepts a mapping, a list, or a `sidecars:` list).
- Removed the field-flag path end-to-end (the `add` state and `build_sidecar`/`parse_env`/`parse_volumes`) — no dead code left. Validation (reserved/name/image-xor-build/duplicate) retained via the `import` state.
- `sidecar add` now takes only `-i/-p` and a required `-f/--file`.

## Out of scope
Translating a legacy `docker-compose.override.yml` into the schema is a separate `canasta sidecar migrate` command (to follow) — it must *move* services (write to `sidecars.yaml`, remove from the override) so a left-behind override entry can't shadow the migrated sidecar.

## Testing
Unit tests for the parser and `import` state (single/list/`sidecars:`-key, duplicate, reserved, invalid YAML, full-fidelity round-trip). Full suite green (1302), lint + validate clean. **Live-validated on Compose** via canasta-native: a file-defined `healthcheck` round-trips into `config/sidecars.yaml`, renders into the compose layer, and the sidecar deploys healthy and is reachable from web by name.