### PR TITLE
fix(sidecars): read sidecar add --file on the controller, not the target host

### DIFF
--- a/playbooks/sidecar_add.yml
+++ b/playbooks/sidecar_add.yml
@@ -6,21 +6,19 @@
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/common/tasks/resolve_instance.yml
 
-# The file is a controller-side path (where the CLI runs), so read it on the
-# controller rather than the target host.
-- name: Read the sidecar definition file
-  ansible.builtin.slurp:
-    src: "{{ file }}"
-  delegate_to: localhost
-  vars:
-    ansible_connection: local
-  register: _sidecar_file
+# The file is a controller-side path (where the CLI runs). A lookup always
+# runs on the controller, regardless of the connection resolve_instance
+# switched to for a remote (-H) instance — unlike a delegated slurp, which
+# can read the wrong host.
+- name: Read the sidecar definition file (on the controller)
+  ansible.builtin.set_fact:
+    _sidecar_defs: "{{ lookup('file', file) }}"
 
 - name: Import sidecar definitions into config/sidecars.yaml
   canasta_sidecars_yaml:
     instance_path: "{{ instance_path }}"
     state: import
-    definitions: "{{ _sidecar_file.content | b64decode }}"
+    definitions: "{{ _sidecar_defs }}"
   register: _sidecar_import
 
 - name: Report

--- a/tests/unit/test_canasta_sidecars_yaml.py
+++ b/tests/unit/test_canasta_sidecars_yaml.py
@@ -209,6 +209,15 @@ class TestCommandWiring:
             dests = {p["name"] for p in entry.get("parameters", [])}
             assert "command" not in dests
 
+    def test_add_file_read_on_controller_not_target(self):
+        # `--file` is a controller-side path. A delegated slurp can read the
+        # wrong host after resolve_instance switches the connection for a
+        # remote (-H) instance; a lookup always runs on the controller.
+        with open(os.path.join(REPO, "playbooks", "sidecar_add.yml")) as f:
+            body = f.read()
+        assert "lookup('file', file)" in body
+        assert "ansible.builtin.slurp" not in body
+
     def test_command_defs_and_playbooks_exist(self):
         with open(os.path.join(REPO, "meta", "command_definitions.yml")) as f:
             defs = yaml.safe_load(f)


### PR DESCRIPTION
Closes #828.

`canasta sidecar add --file` failed for a remote (`-H`) instance with `File not found`, even though the file was on the controller. The slurp that read it ran on the **target host** (after `resolve_instance` switched the connection — the hazard `resolve_instance.yml` documents), where the controller-side path doesn't exist.

Fix: read the file with `lookup('file', file)`, which always runs on the controller regardless of the play's connection. Local instances were unaffected.

Found in a hands-on multi-node k8s e2e (declaring a `build:` sidecar from a file on a remote instance). Structural guard added; full unit suite + lint/validate green.