### PR TITLE
fix(k8s): stage registry manifests on the host before kubectl apply

### DIFF
--- a/roles/orchestrator/tasks/k8s_ensure_registry.yml
+++ b/roles/orchestrator/tasks/k8s_ensure_registry.yml
@@ -9,12 +9,25 @@
 # create --build-from (so build-from works even before an upgrade). This makes
 # the registry guaranteed present whenever a locally-built image is used.
 
+# kubectl runs on the instance's host, so the manifests must be there — the
+# canasta_root path is the controller's and doesn't exist on a remote host.
+# Stage them on the host first (copy reads the controller src, writes the host
+# dest, local or remote).
+- name: Stage the registry manifests on the host
+  ansible.builtin.copy:
+    src: "{{ canasta_root }}/roles/orchestrator/files/{{ item }}"
+    dest: "/tmp/{{ item }}"
+    mode: "0644"
+  loop:
+    - k8s_registry.yaml
+    - k8s_registry_trust.yaml
+
 - name: Deploy the in-cluster image registry and per-node trust
   ansible.builtin.command:
     cmd: >-
       kubectl apply
-      -f {{ canasta_root }}/roles/orchestrator/files/k8s_registry.yaml
-      -f {{ canasta_root }}/roles/orchestrator/files/k8s_registry_trust.yaml
+      -f /tmp/k8s_registry.yaml
+      -f /tmp/k8s_registry_trust.yaml
   register: _registry_apply
   changed_when: "'created' in _registry_apply.stdout or 'configured' in _registry_apply.stdout"
   failed_when: false

--- a/tests/unit/test_k8s_registry.py
+++ b/tests/unit/test_k8s_registry.py
@@ -93,6 +93,18 @@ def test_ensure_task_applies_registry_and_trust():
     assert "k8s_registry_trust.yaml" in apply
 
 
+def test_ensure_stages_manifests_on_host_before_apply():
+    # kubectl runs on the instance's host, where the controller's canasta_root
+    # path doesn't exist — copy the manifests to the host first, then apply the
+    # host-local copies, so a remote (-H) host works.
+    body = _text(ENSURE)
+    assert "ansible.builtin.copy" in body
+    assert body.index("ansible.builtin.copy") < body.index("kubectl apply")
+    assert "-f /tmp/k8s_registry.yaml" in body
+    assert "{{ canasta_root }}/roles/orchestrator/files/k8s_registry.yaml" \
+        not in body
+
+
 def test_registry_is_ensured_from_install_upgrade_and_create():
     # Install, upgrade (self-heal existing clusters), and create --build-from
     # all ensure the registry, so build-from never dead-ends on a missing one.


### PR DESCRIPTION
Closes #829.

`k8s_ensure_registry` ran `kubectl apply -f {{ canasta_root }}/...` on the instance's host, but `canasta_root` is the **controller's** checkout path. When the controller isn't the host (e.g. a laptop driving a remote cp via `-H`/`canasta-native`), that path doesn't exist on the host and the apply fails (`the path ... does not exist`) — blocking registry-ensure on a remote cluster, including the #819 `build:` sidecar delivery and `create --build-from`.

Fix: stage the two manifests on the host with `copy` (reads the controller `src`, writes the host `dest`), then `kubectl apply` the host-local copies. Works identically local and remote.

Found in the same multi-node k8s e2e validating the #819 `build:` delivery (the registry was already up; the redundant re-apply failed on the controller path). Structural guard added; full suite + lint/validate green.