### PR TITLE
fix: repair integration tests + scrub stale K8s-CronJob references after #826

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -285,7 +285,7 @@ jobs:
           k8s-crowdsec
         timeout-minutes: 35
 
-  # Separate job (own runner) so the K8s backup Jobs/CronJob run against a
+  # Separate job (own runner) so the K8s backup Jobs run against a
   # fresh single-node cluster with their own time budget, in parallel with
   # the other k8s jobs rather than serializing behind them.
   integration-k8s-backup:

--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -133,14 +133,15 @@ def _parse_doctor(stdout, hostname):
         "OK" if gitcrypt == "OK" else "not installed"))
 
     lines.append("")
-    # Host crontab is only relevant for Compose `canasta backup schedule`.
-    # On Kubernetes, scheduled backups run as a CronJob in-cluster and
-    # don't depend on host crontab.
-    lines.append("Scheduled backups, Compose only (optional):")
+    # Backup scheduling writes a host crontab entry on the host where the
+    # instance runs — the local/remote host for Compose, the control-plane
+    # node for Kubernetes — so crontab is needed there for both orchestrators.
+    lines.append("Scheduled backups (optional):")
     lines.append("  crontab:         %s" % (
         "OK" if crontab == "OK"
-        else "not installed (install cron to use canasta backup schedule "
-             "on Compose; K8s uses an in-cluster CronJob instead)"))
+        else "not installed (install cron to use 'canasta backup schedule'; "
+             "the schedule is a host crontab entry on the instance's host, "
+             "including the control-plane node for Kubernetes)"))
     # Scheduled backups run `canasta backup create` on the host via the
     # crontab, so a runnable canasta must exist there (any flavor —
     # native or docker). BROKEN = the command exists but doesn't run.

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -140,32 +140,32 @@ command_groups:
   - name: backup_schedule
     description: "Manage scheduled backups"
     long_description: |
-      Manage recurring backup schedules. The implementation differs
-      by orchestrator:
+      Manage recurring backup schedules. Scheduling is the same on both
+      orchestrators: a crontab entry on the host where the instance runs
+      — the local or remote host for Compose, the control-plane node for
+      Kubernetes (the same host the instance's other commands run on).
+      The entry runs `canasta backup create -i <id> --tag scheduled` on
+      the schedule, which performs the backup the orchestrator-native
+      way: a Compose container, or an in-cluster restic Job for
+      Kubernetes. Output goes to `backup.log` in the instance directory;
+      failures are visible there and via `tail -F`.
 
-      **Compose** instances use a host crontab entry that runs
-      `canasta backup create -i <id> --tag scheduled` on the schedule.
-      Output goes to `backup.log` in the instance directory; failures
-      are visible there and via `tail -F`. Requires the `cron` package
-      on the host (Debian: `apt install cron`).
+      That host therefore needs the `cron` package (Debian:
+      `apt install cron`) and a runnable `canasta` — the cron entry calls
+      `canasta backup create`. `canasta backup schedule set` fails with
+      guidance if either is missing on a remote / control-plane host. The
+      schedule is also persisted to `config/backup-schedule.yml`, so it
+      is captured by backups and re-materialized on restore.
 
-      **Kubernetes** instances use a `CronJob` named
-      `canasta-backup-<id>` in the instance namespace. The Job pod
-      runs a `dump-databases` init container (mariadb-dump for every
-      DB on the configured `MYSQL_HOST`) followed by a `restic`
-      container that snapshots the instance's PVCs. Both containers
-      `envFrom` a `canasta-<id>-backup-env` Secret that's synced from
-      the instance's `.env` and contains restic + cloud-backend
-      credentials (`RESTIC_*`, `AWS_*`, `B2_*`, `AZURE_*`,
-      `GOOGLE_*`, `OS_*`, `ST_*`) plus `MYSQL_HOST` / `MYSQL_USER`
-      / `MYSQL_PASSWORD`. The CronJob keeps the last 3 successful
-      and 7 failed Jobs for post-mortem.
-
-      When a scheduled K8s backup fails, the operator finds it via
-      `kubectl get jobs -n canasta-<id>` (status `Failed`) and
-      `kubectl logs -n canasta-<id> job/<name>` for the dump or
-      restic error. Watch out for the failed-history limit cycling
-      old failures off the cluster after seven runs.
+      For Kubernetes, the in-cluster backup Job runs a `dump-databases`
+      init container (mariadb-dump for every DB on the configured
+      `MYSQL_HOST`) followed by a `restic` container that snapshots the
+      instance's PVCs. Both `envFrom` a `canasta-<id>-backup-env` Secret
+      synced from the instance's `.env`, containing restic + cloud-backend
+      credentials (`RESTIC_*`, `AWS_*`, `B2_*`, `AZURE_*`, `GOOGLE_*`,
+      `OS_*`, `ST_*`) plus `MYSQL_HOST` / `MYSQL_USER` / `MYSQL_PASSWORD`.
+      Find a failed run via `kubectl get jobs -n canasta-<id>` (status
+      `Failed`) and `kubectl logs -n canasta-<id> job/<name>`.
 
   - name: gitops
     description: "Git-based configuration management"
@@ -1889,28 +1889,22 @@ commands:
       expression follows the standard 5-field format
       `minute hour day-of-month month day-of-week`.
 
-      On **Compose**, this writes a host crontab entry that runs
-      `canasta backup create -i <id> --tag scheduled` on the
-      schedule. Output goes to `backup.log` in the instance
-      directory.
+      This writes a crontab entry on the host where the instance runs
+      (the instance's host for Compose, the control-plane node for
+      Kubernetes) that runs `canasta backup create -i <id> --tag
+      scheduled` on the schedule; output goes to `backup.log` in the
+      instance directory. `canasta` must be installed on that host — on a
+      remote or Kubernetes instance, set it up first with
+      `canasta install canasta -H <host>`.
 
-      On **Kubernetes**, this creates a `CronJob` named
-      `canasta-backup-<id>` in the instance namespace. The Job pod
-      runs `mariadb-dump` per database followed by `restic backup`
-      against the configured `RESTIC_REPOSITORY`. Both steps consume
-      credentials via the `canasta-<id>-backup-env` Secret —
-      including any cloud-backend env (`AWS_*`, `B2_*`, `AZURE_*`,
-      `GOOGLE_*`) the user set in `.env`. To inspect the rendered
-      schedule and resources, use `kubectl get cronjob
-      canasta-backup-<id> -n canasta-<id> -o yaml`.
+      Use `--purge-older-than` to chain `canasta backup purge
+      --keep-within <duration>` after each backup, so old snapshots are
+      pruned without a separate maintenance run.
 
-      Use `--purge-older-than` to chain `restic forget --prune
-      --keep-within <duration>` after each backup, so old snapshots
-      are pruned without a separate maintenance run.
-
-      Setting a new schedule replaces the existing one in place
-      (same crontab entry name on Compose, same CronJob name on
-      Kubernetes); duplicates aren't created.
+      The schedule is persisted to `config/backup-schedule.yml` (captured
+      by backups, re-materialized on restore). Setting a new schedule
+      replaces the existing crontab entry in place; duplicates aren't
+      created.
     examples:
       - "canasta backup schedule set '0 2 * * *'"
       - "canasta backup schedule set '0 3 * * *' --purge-older-than 30d"
@@ -1935,13 +1929,11 @@ commands:
       Show the current backup schedule for this instance, if one
       exists.
 
-      On Compose, queries the host crontab and parses the
-      `canasta backup create -i <id>` entry. On Kubernetes, queries
-      the `canasta-backup-<id>` CronJob in the instance namespace.
-      Reports the schedule expression and whether a `--purge-older-
-      than` is wired in. "No backup schedule found" means no entry
-      exists for this instance on the orchestrator's native
-      scheduling surface.
+      Reads the crontab on the host where the instance runs (the
+      control-plane node for Kubernetes) and parses the
+      `canasta backup create -i <id>` entry, reporting the schedule
+      expression and whether a `--purge-older-than` is wired in. "No
+      backup schedule found" means no entry exists for this instance.
     examples:
       - "canasta backup schedule list"
     playbook: backup_schedule_list.yml
@@ -1954,10 +1946,11 @@ commands:
   - name: backup_schedule_remove
     description: "Remove a scheduled backup"
     long_description: |
-      Remove the recurring backup schedule for this instance. On
-      Compose this deletes the host crontab entry; on Kubernetes
-      this deletes the `canasta-backup-<id>` CronJob. A Job that's
-      already running at the moment the schedule is removed
+      Remove the recurring backup schedule for this instance — deletes
+      the crontab entry on the host where the instance runs (the
+      control-plane node for Kubernetes) and clears
+      `config/backup-schedule.yml` so it isn't re-materialized on
+      restore. A backup already running when the schedule is removed
       finishes naturally — only future firings stop.
     examples:
       - "canasta backup schedule remove"

--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -112,7 +112,7 @@
             # canasta-<id>-backup-env carries every cloud-backend
             # credential restic might need (RESTIC_*, AWS_*, B2_*,
             # AZURE_*, GOOGLE_*, OS_*, ST_*) — same Secret the on-
-            # demand backup Job and scheduled CronJob use (#497).
+            # demand and scheduled backup Jobs use (#497).
             envFrom:
               - secretRef:
                   name: "canasta-{{ instance_id }}-backup-env"

--- a/roles/backup/tasks/schedule_list.yml
+++ b/roles/backup/tasks/schedule_list.yml
@@ -3,8 +3,8 @@
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/common/tasks/resolve_instance.yml
 
-# The orchestrator owns how a schedule is read back and displayed (host
-# crontab vs Kubernetes CronJob); dispatch unconditionally.
+# Scheduling is a host crontab entry on the host where the instance runs
+# (the cp node for K8s); the orchestrator task reads it back uniformly.
 - name: Display backup schedule
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/orchestrator/tasks/backup_schedule_list.yml

--- a/roles/backup/tasks/schedule_remove.yml
+++ b/roles/backup/tasks/schedule_remove.yml
@@ -2,8 +2,8 @@
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
-# The orchestrator owns how a schedule is removed (host crontab vs
-# Kubernetes CronJob); dispatch unconditionally.
+# Scheduling is a host crontab entry on the host where the instance runs
+# (the cp node for K8s); the orchestrator task removes it uniformly.
 - name: Remove backup schedule
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/orchestrator/tasks/backup_schedule_remove.yml

--- a/roles/backup/tasks/schedule_set.yml
+++ b/roles/backup/tasks/schedule_set.yml
@@ -7,8 +7,8 @@
     msg: "Cron expression must have exactly 5 fields (minute hour day month weekday), got: '{{ cron_expression }}'"
   when: cron_expression.split() | length != 5
 
-# The orchestrator owns how a schedule is installed (host crontab vs
-# Kubernetes CronJob); dispatch unconditionally.
+# Scheduling is a host crontab entry on the host where the instance runs
+# (the cp node for K8s); the orchestrator task installs it uniformly.
 - name: Install backup schedule
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/orchestrator/tasks/backup_schedule_set.yml

--- a/roles/orchestrator/tasks/k8s_sync_config.yml
+++ b/roles/orchestrator/tasks/k8s_sync_config.yml
@@ -224,9 +224,9 @@
           whitelists.yaml: "{{ _sync_crowdsec_whitelists.content | b64decode }}"
 
 # --- Backup environment Secret ---
-# The on-demand backup Job (k8s_run_backup.yml) and the scheduled
-# CronJob (roles/backup/tasks/schedule_set.yml) both need restic +
-# DB env to land on the backup containers. Build a single Secret
+# The backup Job (k8s_run_backup.yml) needs restic + DB env to land on
+# the backup containers (scheduled runs go through the same Job via the
+# host crontab). Build a single Secret
 # from .env so envFrom: secretRef gives both flows everything they
 # need — including cloud-backend creds (#497) and external-DB
 # host/user (#498) — without per-task plumbing.

--- a/tests/integration/remote/Dockerfile
+++ b/tests/integration/remote/Dockerfile
@@ -27,8 +27,17 @@ RUN install -m 0755 -d /etc/apt/keyrings \
     && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin \
     && rm -rf /var/lib/apt/lists/*
 
-# Create testuser with sudo (no password)
-RUN useradd -m -s /bin/bash testuser \
+# Create testuser as a faithful canasta account — a member of every group
+# 'canasta doctor' expects: www-data (Canasta containers write files as
+# www-data) and canasta (upgrade self-update), plus docker. www-data MUST
+# be gid 33 to match the Canasta web image's www-data, which chowns the
+# bind-mounted config/; otherwise testuser can't write the group-writable
+# config files (e.g. config/backup-schedule.yml written by 'backup
+# schedule set'). Passwordless sudo for install steps.
+RUN groupadd -f -g 33 www-data \
+    && groupadd -f canasta \
+    && groupadd -f docker \
+    && useradd -m -s /bin/bash -G www-data,canasta,docker testuser \
     && echo "testuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Prepare SSH

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -1520,9 +1520,10 @@ def test_k8s_backup(inst):
 
     Exercises the runtime backup path that previously had only unit
     coverage: a local (hostPath) restic repo, the on-demand backup Job
-    with its dump-databases init container, and the schedule CronJob
+    with its dump-databases init container, and the host-crontab schedule
     lifecycle. Restore is covered by the Compose backup test; here the
-    focus is that the K8s Job/CronJob machinery actually runs.
+    focus is that the K8s backup Job machinery and host-crontab scheduling
+    actually run.
     """
     result = subprocess.run(["kubectl", "cluster-info"], capture_output=True)
     if result.returncode != 0:

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -1578,14 +1578,25 @@ def test_k8s_backup(inst):
             "Snapshot tag not found in list output:\n%s" % output
         )
 
-        print("Setting a backup schedule (CronJob)...")
+        print("Setting a backup schedule (host crontab on the cp node)...")
         inst.run_ok("backup", "schedule", "set", "-i", inst.id, "0 3 * * *")
-        result = subprocess.run(
-            ["kubectl", "get", "cronjob", cronjob, "-n", ns],
-            capture_output=True, text=True,
+        # Scheduling is a host crontab entry now, not an in-cluster CronJob.
+        # The CI runner is the single-node control plane, so the entry lands
+        # in its crontab.
+        marker = "canasta-backup-%s" % inst.id
+        crontab = subprocess.run(
+            ["crontab", "-l"], capture_output=True, text=True,
         )
-        assert result.returncode == 0, (
-            "CronJob %s not created: %s" % (cronjob, result.stderr)
+        assert marker in crontab.stdout, (
+            "crontab entry %s not written:\n%s" % (marker, crontab.stdout)
+        )
+        no_cronjob = subprocess.run(
+            ["kubectl", "get", "cronjob", cronjob, "-n", ns],
+            capture_output=True,
+        )
+        assert no_cronjob.returncode != 0, (
+            "an in-cluster CronJob was created; scheduling should use the "
+            "host crontab"
         )
 
         print("Listing the backup schedule...")
@@ -1596,15 +1607,12 @@ def test_k8s_backup(inst):
 
         print("Removing the backup schedule...")
         inst.run_ok("backup", "schedule", "remove", "-i", inst.id)
-        for _ in range(6):
-            result = subprocess.run(
-                ["kubectl", "get", "cronjob", cronjob, "-n", ns],
-                capture_output=True,
-            )
-            if result.returncode != 0:
-                break
-            time.sleep(2)
-        assert result.returncode != 0, "CronJob still present after remove"
+        crontab = subprocess.run(
+            ["crontab", "-l"], capture_output=True, text=True,
+        )
+        assert marker not in crontab.stdout, (
+            "crontab entry still present after remove:\n%s" % crontab.stdout
+        )
     finally:
         # The hostPath repo lives on the node (created by the Job as root);
         # cleanup() removes the instance but not this path.

--- a/tests/unit/test_backup_restic_host.py
+++ b/tests/unit/test_backup_restic_host.py
@@ -6,10 +6,10 @@ parent ("no parent snapshot found, will read all files") and
 `forget --group-by host,paths` puts each snapshot in its own group,
 defeating incremental backups and retention grouping.
 
-create.yml feeds both the Compose and K8s on-demand backups (and the
-Compose scheduled backup, which runs `canasta backup create`); the K8s
-CronJob builds its own restic command in schedule_set.yml. Both must pin
---host to the instance id (stable within each instance's own repo).
+create.yml feeds the Compose and K8s on-demand backups; scheduled backups
+(both orchestrators) run `canasta backup create` via the host crontab, so
+they share this path. It must pin --host to the instance id (stable within
+each instance's own repo).
 
 Pure YAML-structure parsing, mirroring test_backup_schedule_compose.py.
 """

--- a/tests/unit/test_backup_schedule_k8s.py
+++ b/tests/unit/test_backup_schedule_k8s.py
@@ -1,9 +1,9 @@
 """Structural tests for K8s backup-scheduling tasks.
 
-These exercise YAML structure rather than runtime behavior — the
-playbook file is parsed, the CronJob block is located, and we
-assert that field-name conventions and K8s-side defaults are in
-place. They guard against regressions that show up only in
+These exercise YAML structure rather than runtime behavior — the K8s
+backup task files (k8s_run_backup.yml, restore_k8s.yml, the shared RBAC)
+are parsed and we assert that field-name conventions and K8s-side defaults
+are in place. They guard against regressions that show up only in
 production (slow failure feedback, missing history, etc.).
 
 End-to-end behavior is covered separately on a real cluster (see
@@ -15,14 +15,6 @@ import os
 import yaml
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
-SCHEDULE_SET = os.path.join(
-    REPO_ROOT, "roles", "orchestrator", "tasks", "backup_schedule_set.yml",
-)
-
-
-def _load_tasks():
-    with open(SCHEDULE_SET) as f:
-        return yaml.safe_load(f)
 
 
 def _walk_tasks(tasks):
@@ -88,9 +80,9 @@ class TestK8sSecretBackupRBAC:
     only the two Secret names we dump, only `get` verb, namespace-
     local. Least-privilege RBAC.
 
-    Source of truth is roles/backup/tasks/_k8s_backup_rbac.yml — both
-    the CronJob path (schedule_set.yml) and the on-demand path
-    (k8s_run_backup.yml) include this file (#513 refactor)."""
+    Source of truth is roles/backup/tasks/_k8s_backup_rbac.yml — the
+    on-demand backup path (k8s_run_backup.yml) includes this file
+    (#513 refactor)."""
 
     SHARED_RBAC_PATH = os.path.join(
         REPO_ROOT, "roles", "backup", "tasks", "_k8s_backup_rbac.yml",
@@ -110,14 +102,14 @@ class TestK8sSecretBackupRBAC:
     def test_serviceaccount_created(self):
         sas = list(self._find_resources("ServiceAccount"))
         assert len(sas) >= 1, (
-            "schedule_set.yml must create a ServiceAccount for the "
+            "the shared RBAC file must create a ServiceAccount for the "
             "backup Pod (#510)"
         )
 
     def test_role_grants_only_get_on_named_secrets(self):
         roles = list(self._find_resources("Role"))
         assert len(roles) >= 1, (
-            "schedule_set.yml must create a Role granting Secret read "
+            "the shared RBAC file must create a Role granting Secret read "
             "to the backup ServiceAccount (#510)"
         )
         rules = roles[0]["rules"]
@@ -400,8 +392,7 @@ class TestOnDemandBackupCapturesDB:
                     )
                     assert "dump-secrets" in names, (
                         "Backup-op init containers must include "
-                        "dump-secrets (matches scheduled CronJob, "
-                        "consolidates with #510)"
+                        "dump-secrets (#510)"
                     )
                     found_backup_op_conditional = True
         assert found_default_empty, (
@@ -418,7 +409,7 @@ class TestOnDemandBackupCapturesDB:
     def test_dumps_volume_added_for_backup_ops(self):
         """The dumps emptyDir + mount-on-mount under
         /currentsnapshot/config/backup must exist when backup-op,
-        matching the schedule_set.yml CronJob's pattern."""
+        matching the on-demand backup Job's pattern."""
         with open(self.K8S_RUN_BACKUP) as f:
             content = f.read()
         # Both the volume and the mount point must be added together
@@ -471,9 +462,8 @@ class TestOnDemandBackupCapturesDB:
 
 class TestSharedBackupRBAC:
     """The SA + Role + RoleBinding live in roles/backup/tasks/
-    _k8s_backup_rbac.yml so the CronJob (schedule_set.yml) and the
-    on-demand Job (k8s_run_backup.yml) stay in lockstep. Schedule_set
-    must include the shared file (refactored per #513)."""
+    _k8s_backup_rbac.yml so the on-demand backup Job (k8s_run_backup.yml)
+    gets least-privilege RBAC (refactored per #513)."""
 
     SHARED_RBAC = os.path.join(
         REPO_ROOT, "roles", "backup", "tasks", "_k8s_backup_rbac.yml",
@@ -632,13 +622,9 @@ class TestDiffComposeMatchRegex:
 class TestDumpSecretsStripsEphemeralMetadata:
     """`kubectl get secret -o yaml` emits resourceVersion, uid, and
     creationTimestamp. `kubectl apply -f` then refuses to apply,
-    erroring with 'object has been modified'. Both dump-secrets init
-    containers (scheduled CronJob + on-demand Job) must strip those
-    fields with sed."""
+    erroring with 'object has been modified'. The dump-secrets init
+    container (on-demand backup Job) must strip those fields with sed."""
 
-    SCHEDULE_SET = os.path.join(
-        REPO_ROOT, "roles", "orchestrator", "tasks", "backup_schedule_set.yml",
-    )
     K8S_RUN_BACKUP = os.path.join(
         REPO_ROOT, "roles", "orchestrator", "tasks", "k8s_run_backup.yml",
     )
@@ -850,8 +836,8 @@ class TestK8sRestoreUsesWebPodForDbImport:
 
 class TestK8sBackupLocalRepoNodeAffinity:
     """#749: a local-path restic repo is a node-local hostPath, so the
-    restore Pod and scheduled CronJob must pin to one node (the
-    control-plane). The backup Job additionally hostPath-mounts the cp
+    restore Pod must pin to one node (the control-plane). The backup Job
+    additionally hostPath-mounts the cp
     node's config/ and .env (so it captures the full on-disk config, not
     the web-config ConfigMap subset), so it pins to the control-plane
     unconditionally — there's no cloud-unpinned exception for it. The


### PR DESCRIPTION
Closes #833.

Repairs the two push-to-main integration jobs that went red after #826 (run 27917625459), and scrubs the stale K8s-`CronJob` references #826 left behind. **No canasta runtime change.**

## Make CI green

**Remote Host** — #826's schedule persistence writes `config/backup-schedule.yml`. On a running instance `config/` is `www-data`-owned, mode `0775` (group-writable), so the canasta account must be in the `www-data` group to write it — enforced by `canasta doctor` — but the test's `testuser` wasn't. Make the fixture a faithful canasta account: `testuser` in **`www-data` (gid 33, matching the web image)**, `canasta`, and `docker` groups. (#826's `copy`/`file: absent` were correct all along; the dir is group-writable.)

**K8s Backup** — the test asserted `backup schedule set` creates an in-cluster `CronJob`, which #826 removed (scheduling is a host crontab on the cp node now). Now asserts the cp-node crontab entry is written + **no CronJob** is created, gone after `remove`.

## Scrub stale CronJob references (#826 fallout)

`grep CronJob` surfaced stale references everywhere #826 didn't update:
- `command_definitions.yml` — the `backup_schedule` group + set/list/remove help described a K8s CronJob; rewritten to the unified host-crontab model (host crontab on the instance's host — cp node for K8s — running `canasta backup create`, persisted to `config/backup-schedule.yml`). Surfaces via `--help` + the CLI: wiki.
- `direct_commands/doctor.py` — crontab section no longer claims K8s uses a CronJob.
- Stale comments in `schedule_set`/`remove`/`list`, `restore_k8s`, `k8s_sync_config`, and the K8s test docstrings.
- Dead code from #826's test pruning: module `SCHEDULE_SET` + `_load_tasks` and a dead class `SCHEDULE_SET` attr.

A repo-wide `grep CronJob` is now clean (only the legitimate negative assertion + explanatory comment remain).

## Verification

Unit + lint + validate green (1317 tests). The remote and K8s backup jobs can't run on macOS (native-Linux-Docker / k3s) and run push-to-main only, so they verify on merge — but the fix is test/doc-only and matches the ground-truth `config/` perms (`0775 www-data:www-data`) and the documented `doctor` group requirement.
