### PR TITLE
fix(backup): fail loudly when the K8s DB dump can't run (no silent DB-less snapshot)

### DIFF
--- a/roles/orchestrator/tasks/k8s_run_backup.yml
+++ b/roles/orchestrator/tasks/k8s_run_backup.yml
@@ -167,12 +167,31 @@
           - sh
           - -c
           - |
+            set -u
             EXCLUDE='^(information_schema|performance_schema|mysql|sys)$'
-            for db in $(mariadb -h "${MYSQL_HOST:-db}" -u "${MYSQL_USER:-root}" -p"$MYSQL_PASSWORD" \
-              -N -e "SHOW DATABASES" | grep -vE "$EXCLUDE"); do
-              mariadb-dump -h "${MYSQL_HOST:-db}" -u "${MYSQL_USER:-root}" -p"$MYSQL_PASSWORD" \
-                --single-transaction --databases "$db" \
-                > "/currentsnapshot/config/backup/db_${db}.sql"
+            # List databases first so a connection/auth failure aborts the
+            # backup loudly instead of silently saving a DB-less snapshot.
+            if ! DBLIST=$(mariadb -h "${MYSQL_HOST:-db}" -u "${MYSQL_USER:-root}" \
+                -p"$MYSQL_PASSWORD" -N -e "SHOW DATABASES"); then
+              echo "FATAL: could not list databases (DB connection or auth failed)" >&2
+              exit 1
+            fi
+            DBS=$(printf '%s\n' "$DBLIST" | grep -vE "$EXCLUDE" || true)
+            if [ -z "$DBS" ]; then
+              echo "FATAL: no user databases found to back up" >&2
+              exit 1
+            fi
+            for db in $DBS; do
+              if ! mariadb-dump -h "${MYSQL_HOST:-db}" -u "${MYSQL_USER:-root}" \
+                  -p"$MYSQL_PASSWORD" --single-transaction --databases "$db" \
+                  > "/currentsnapshot/config/backup/db_${db}.sql"; then
+                echo "FATAL: mariadb-dump failed for database '$db'" >&2
+                exit 1
+              fi
+              if [ ! -s "/currentsnapshot/config/backup/db_${db}.sql" ]; then
+                echo "FATAL: dump for database '$db' is empty" >&2
+                exit 1
+              fi
             done
         envFrom:
           - secretRef:

--- a/tests/unit/test_backup_schedule_k8s.py
+++ b/tests/unit/test_backup_schedule_k8s.py
@@ -459,6 +459,46 @@ class TestOnDemandBackupCapturesDB:
             "backup_stage_db_dumps.yml has no 'Dump each wiki database' task"
         )
 
+    def _dump_databases_script(self):
+        """The shell script of the dump-databases init container."""
+        for task in self._walk(self._load_run_backup()):
+            sf = task.get("ansible.builtin.set_fact") or task.get("set_fact")
+            if not (isinstance(sf, dict) and "_backup_init_containers" in sf):
+                continue
+            value = sf["_backup_init_containers"]
+            if not isinstance(value, list):
+                continue
+            for c in value:
+                if isinstance(c, dict) and c.get("name") == "dump-databases":
+                    cmd = c.get("command", [])
+                    return cmd[-1] if cmd else ""
+        return ""
+
+    def test_dump_databases_fails_loudly_on_db_error(self):
+        """A DB connection/auth failure must FAIL the backup, not
+        silently snapshot without the database. The original
+        'for db in $(mariadb ... SHOW DATABASES)' form swallowed the
+        failure: an empty command substitution ran the loop zero times,
+        wrote no dump, and exited 0 — producing a 'successful' snapshot
+        with no database (silent data loss)."""
+        script = self._dump_databases_script()
+        assert script, "dump-databases init container command not found"
+        assert "SHOW DATABASES" in script
+        assert "exit 1" in script, (
+            "dump-databases must exit non-zero when it cannot list or "
+            "dump the database, so the backup Job fails instead of "
+            "silently saving a snapshot without the database"
+        )
+        # Guard against the original silent-failure shape: looping
+        # directly over the command substitution runs zero times (and
+        # exits 0) when SHOW DATABASES fails.
+        normalized = " ".join(script.split())
+        assert "for db in $(mariadb" not in normalized, (
+            "dump-databases must not loop directly over "
+            "$(mariadb ... SHOW DATABASES) — a failed substitution "
+            "silently skips the dump; capture the list first and check it"
+        )
+
 
 class TestSharedBackupRBAC:
     """The SA + Role + RoleBinding live in roles/backup/tasks/


### PR DESCRIPTION
Closes #835.

## The bug (silent data loss)

On Kubernetes, the `dump-databases` init container in `k8s_run_backup.yml` looped over:

```sh
for db in $(mariadb ... -N -e "SHOW DATABASES" | grep -vE "$EXCLUDE"); do
  mariadb-dump ... --databases "$db" > "/currentsnapshot/config/backup/db_${db}.sql"
done
```

If `mariadb ... SHOW DATABASES` failed to connect or authenticate (e.g. the `canasta-<id>-backup-env` Secret's MYSQL creds drifted from the running DB after a restore/domain change), the command substitution was **empty**, the loop ran **zero times**, **no `db_*.sql`** was written, and the container **exited 0**. The restic Job then snapshotted config + secrets but **no database**, and `canasta backup create` reported success. Restoring such a snapshot brings back config but **no wiki content**.

Found in a hands-on cross-host K8s DR e2e: a backup of a heavily restored/domain-changed instance produced a snapshot with `config/`, `.env`, and `secrets-*.yaml` but no `db_main.sql`; the restore brought no content.

## The fix

List the databases up front and **abort (`exit 1`)** if:
- the `SHOW DATABASES` listing fails (connection/auth),
- there are no user databases, or
- any `mariadb-dump` fails or produces an empty file.

A failing init container now fails the backup Job, so the failure surfaces instead of producing a DB-less "successful" snapshot — mirroring Canasta's existing "restore must fail loudly" guard.

**Compose is unaffected** (audited): it dumps explicit wiki ids via `exec.yml`, and `resilient_exec` already fails the play on a non-zero rc — the bug is specific to the K8s init container, where the failure hid inside a command substitution rather than the exec rc.

## Validation

- New unit test `test_dump_databases_fails_loudly_on_db_error` (asserts the guard + that the old silent-substitution form is gone); full unit suite + lint green.
- **Live, on real hosts** (fresh k3s on `small`): a healthy `backup create` with the fixed code still succeeds and the snapshot contains `db_main.sql` (no regression).
- **Runtime fail-demo** of the extracted script: auth failure → `FATAL: could not list databases`, exit 1; dump failure → `FATAL: mariadb-dump failed`, exit 1; the old form → exit 0 silently with no dump.
