### PR TITLE
fix(k8s): persist a readable kubeconfig mode across k3s restarts

### DIFF
--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -32,9 +32,15 @@
     # k3s API server's cert via INSTALL_K3S_EXEC="--tls-san <addr>".
     # Empty string when not provided (k3s uses its default cert SANs:
     # 127.0.0.1, the node's internal IP, kubernetes.default.*).
+    # --write-kubeconfig-mode 0644 persists a readable kubeconfig in the
+    # k3s unit, so a k3s restart doesn't revert /etc/rancher/k3s/k3s.yaml
+    # to root-only 0600 — which breaks every kubectl/helm task that runs
+    # as the non-root SSH user (the one-time chmod below only covers the
+    # fresh-install window, not subsequent restarts).
     - name: Build k3s install exec args
       ansible.builtin.set_fact:
         _k3s_install_exec: >-
+          --write-kubeconfig-mode 0644
           {{ (public_ip | default([]))
              | map('regex_replace', '^(.*)$', '--tls-san \1')
              | join(' ') }}

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -166,6 +166,21 @@ class TestHelmChart:
             "should be 3500. See #58 / #65."
         )
 
+    def test_k3s_install_persists_readable_kubeconfig_mode(self):
+        """The control-plane k3s install must pass
+        --write-kubeconfig-mode 0644 in INSTALL_K3S_EXEC so a k3s restart
+        keeps /etc/rancher/k3s/k3s.yaml readable. The one-time chmod only
+        covers the fresh-install window; k3s rewrites the file at its
+        default 0600 on every restart, which then breaks every non-root
+        kubectl/helm task (preflight, helm_deploy, sync)."""
+        with open(os.path.join(ORCHESTRATOR_TASKS, "k8s_install_k3s.yml")) as f:
+            content = f.read()
+        assert "--write-kubeconfig-mode 0644" in content, (
+            "k8s_install_k3s.yml must pass --write-kubeconfig-mode 0644 "
+            "in the k3s install exec so the kubeconfig stays readable "
+            "across k3s restarts"
+        )
+
 
 class TestExternalDatabase:
     """External DB support on the K8s path: chart gates db.enabled,


### PR DESCRIPTION
Closes #836.

After a `systemctl restart k3s`, `/etc/rancher/k3s/k3s.yaml` reverts to k3s's default `0600` root-only mode. Every canasta K8s task that runs `kubectl`/`helm` as the non-root SSH user (preflight, `helm_deploy`, `k8s_sync_config`) then fails with "permission denied" / "Cannot reach Kubernetes cluster" — even though the cluster is healthy. The install's one-time `chmod 0644` only covers the fresh-install window.

Pass `--write-kubeconfig-mode 0644` in `INSTALL_K3S_EXEC` so the readable mode is baked into the k3s unit and survives restarts. Control-plane only (the agent writes no kubeconfig).

Found in a hands-on K8s DR e2e (a reflexive `k3s restart` triggered it). Structural unit test + lint green.
