### PR TITLE
fix(k8s): apply the backup-env Secret before backup/restore Jobs

### DIFF
--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -78,6 +78,13 @@
     wait: true
     wait_timeout: 60
 
+# Refresh the backup-env Secret from .env so the restore pod's restic +
+# DB creds are current even after `config set --no-restart`. The full
+# k8s_sync_config runs later in this file, but the restore pod needs the
+# Secret now.
+- name: Apply backup-env Secret before the restore pod
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_apply_backup_env_secret.yml"
+
 - name: Create restore pod
   kubernetes.core.k8s:
     state: present

--- a/roles/orchestrator/tasks/k8s_apply_backup_env_secret.yml
+++ b/roles/orchestrator/tasks/k8s_apply_backup_env_secret.yml
@@ -1,0 +1,41 @@
+---
+# Refresh the canasta-<id>-backup-env Secret from the instance's .env so
+# the backup/restore Job always sees the current RESTIC_* / cloud-backend /
+# MYSQL creds. k8s_sync_config.yml normally builds this Secret, but it only
+# runs on a start/restart — `config set --no-restart` updates .env and skips
+# it, leaving the Secret stale so the next backup/restore Job fails (restic:
+# "Please specify repository location"). Applying it here, right before the
+# Job, makes backup/restore self-sufficient. Mirrors the Secret in
+# k8s_sync_config.yml.
+#
+# Input: instance_path, instance_id
+
+- name: Read .env for backup-env Secret
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read_all
+  register: _be_env
+  no_log: true
+
+- name: Build backup-env Secret data
+  ansible.builtin.set_fact:
+    _be_env_data: >-
+      {{ _be_env.variables | default({}) | dict2items
+         | selectattr('key', 'match',
+             '^(RESTIC_|AWS_|B2_|AZURE_|GOOGLE_|OS_|ST_|MYSQL_HOST$|MYSQL_USER$|MYSQL_PASSWORD$)')
+         | items2dict }}
+  no_log: true
+
+- name: Apply backup-env Secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "canasta-{{ instance_id }}-backup-env"
+        namespace: "canasta-{{ instance_id }}"
+      type: Opaque
+      stringData: "{{ _be_env_data }}"
+  when: _be_env_data | length > 0
+  no_log: true

--- a/roles/orchestrator/tasks/k8s_run_backup.yml
+++ b/roles/orchestrator/tasks/k8s_run_backup.yml
@@ -225,6 +225,12 @@
           - name: dumps
             mountPath: /currentsnapshot/config/backup
 
+# Refresh the backup-env Secret from .env so the Job's restic + DB creds
+# are current even after `config set --no-restart` (which skips the sync
+# that normally rebuilds it).
+- name: Apply backup-env Secret before the backup Job
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_apply_backup_env_secret.yml"
+
 - name: Create restic Job
   kubernetes.core.k8s:
     state: present

--- a/tests/unit/test_backup_schedule_k8s.py
+++ b/tests/unit/test_backup_schedule_k8s.py
@@ -926,3 +926,51 @@ class TestK8sBackupLocalRepoNodeAffinity:
         # cloud-backend restore stays node-agnostic.
         r = self._read(self.RESTORE)
         assert "if (_restore_local_repo | bool) else {}" in r
+
+
+class TestBackupEnvSecretAppliedBeforeJob:
+    """`config set RESTIC_* --no-restart` updates .env but skips the
+    k8s_sync_config that rebuilds the canasta-<id>-backup-env Secret. So
+    backup/restore must re-apply that Secret from .env right before
+    launching their Job/pod — otherwise restic fails with 'Please specify
+    repository location'."""
+
+    APPLY_SECRET = os.path.join(
+        REPO_ROOT, "roles", "orchestrator", "tasks",
+        "k8s_apply_backup_env_secret.yml",
+    )
+    RUN_BACKUP = os.path.join(
+        REPO_ROOT, "roles", "orchestrator", "tasks", "k8s_run_backup.yml",
+    )
+    RESTORE_K8S = os.path.join(
+        REPO_ROOT, "roles", "backup", "tasks", "restore_k8s.yml",
+    )
+
+    def test_apply_secret_task_exists_and_builds_secret(self):
+        assert os.path.isfile(self.APPLY_SECRET), (
+            "k8s_apply_backup_env_secret.yml must exist"
+        )
+        with open(self.APPLY_SECRET) as f:
+            content = f.read()
+        assert "-backup-env" in content, "must apply the backup-env Secret"
+        assert "RESTIC_" in content, "must filter RESTIC_* (and friends)"
+
+    def test_backup_applies_secret_before_job(self):
+        with open(self.RUN_BACKUP) as f:
+            content = f.read()
+        i = content.find("k8s_apply_backup_env_secret.yml")
+        j = content.find("Create restic Job")
+        assert 0 <= i < j, (
+            "k8s_run_backup.yml must apply the backup-env Secret before "
+            "creating the restic Job"
+        )
+
+    def test_restore_applies_secret_before_pod(self):
+        with open(self.RESTORE_K8S) as f:
+            content = f.read()
+        i = content.find("k8s_apply_backup_env_secret.yml")
+        j = content.find("Create restore pod")
+        assert 0 <= i < j, (
+            "restore_k8s.yml must apply the backup-env Secret before "
+            "creating the restore pod"
+        )


### PR DESCRIPTION
Closes #837.

On K8s, restic + DB creds reach the backup/restore Job via the `canasta-<id>-backup-env` Secret, which only `k8s_sync_config` rebuilds — and only on a start/restart. `canasta config set RESTIC_* --no-restart` updates `.env` but skips that sync, so the Secret goes stale and the next backup/restore fails inside the Job with `Fatal: Please specify repository location`. `restore_k8s.yml` does run `k8s_sync_config`, but only *after* the restore pod — too late.

Extract the Secret build+apply into `k8s_apply_backup_env_secret.yml` and include it right before the restic Job (`k8s_run_backup.yml`) and the restore pod (`restore_k8s.yml`), so both are self-sufficient regardless of a prior start.

Found in a hands-on K8s DR e2e (restore failed exactly this way after a `--no-restart` restic config). Structural unit tests + lint green.
