### PR TITLE
fix(storage): verify the NFS server is reachable when --server is used

### DIFF
--- a/playbooks/storage_setup_nfs.yml
+++ b/playbooks/storage_setup_nfs.yml
@@ -75,6 +75,31 @@
     msg: "Either --server or --install-server is required."
   when: _nfs_server is not defined or _nfs_server == ''
 
+# With --server (pointing at a pre-existing NFS server) it's easy to
+# target a host that has no NFS server running — the StorageClass is then
+# created pointing at a dead endpoint and the failure only surfaces much
+# later as instance pods stuck on unmountable content PVCs. Probe the NFS
+# port up front and fail with an actionable message. Skipped for
+# --install-server, which sets up the server on this host above.
+- name: Verify the provided NFS server is reachable on the NFS port
+  ansible.builtin.wait_for:
+    host: "{{ _nfs_server }}"
+    port: 2049
+    timeout: 5
+  register: _nfs_reachable
+  ignore_errors: true
+  when: not (install_server | default(false) | bool)
+
+- name: Fail if the provided NFS server is unreachable
+  ansible.builtin.fail:
+    msg: >-
+      NFS server '{{ _nfs_server }}' is not reachable on port 2049. Check
+      the --server address and that its NFS export is running, or use
+      --install-server to set up an NFS server on this host.
+  when:
+    - not (install_server | default(false) | bool)
+    - _nfs_reachable.failed | default(false)
+
 - name: Add NFS CSI driver Helm repository
   kubernetes.core.helm_repository:
     name: csi-driver-nfs

--- a/tests/unit/test_storage_setup_nfs.py
+++ b/tests/unit/test_storage_setup_nfs.py
@@ -1,0 +1,48 @@
+"""Structural test for the storage-setup-nfs server reachability check."""
+
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+NFS_PLAYBOOK = os.path.join(REPO_ROOT, "playbooks", "storage_setup_nfs.yml")
+
+
+class TestNfsServerReachabilityCheck:
+    """`storage setup nfs --server <addr>` points the StorageClass at a
+    pre-existing NFS server. If that server isn't actually running, the
+    StorageClass is dead and instance pods later hang on unmountable
+    content PVCs. The playbook must probe the NFS port up front and fail
+    with an actionable message — and only for --server, not the
+    --install-server path (which sets the server up locally)."""
+
+    def _tasks(self):
+        with open(NFS_PLAYBOOK) as f:
+            return yaml.safe_load(f)
+
+    def test_probes_nfs_port_2049_gated_on_provided_server(self):
+        probe = None
+        for t in self._tasks():
+            wf = t.get("ansible.builtin.wait_for") or t.get("wait_for")
+            if isinstance(wf, dict) and wf.get("port") == 2049:
+                probe = t
+        assert probe is not None, (
+            "storage_setup_nfs.yml must wait_for the NFS server on port "
+            "2049 when --server is provided"
+        )
+        assert "install_server" in str(probe.get("when", "")), (
+            "the NFS-port probe must be gated on (not install_server) so "
+            "it runs only for --server"
+        )
+
+    def test_fails_with_actionable_message(self):
+        with open(NFS_PLAYBOOK) as f:
+            content = f.read()
+        assert "not reachable on port 2049" in content, (
+            "must fail with a clear message when the NFS server is "
+            "unreachable"
+        )
+        assert "--install-server" in content, (
+            "the failure message should point users to --install-server"
+        )


### PR DESCRIPTION
Closes #838.

`canasta storage setup nfs --server <addr>` configures the CSI driver + a StorageClass pointing at a *pre-existing* NFS server, but never checks one is running. On a fresh host with no NFS server (where the user wanted `--install-server`), this silently yields a StorageClass that can't provision — content PVCs never bind and instance pods hang, surfacing only later as "deployment exceeded its progress deadline".

Probe the NFS port (2049) up front when `--server` is given and fail with an actionable message pointing to `--install-server`. The `--install-server` path is unaffected (it sets the server up on this host first).

Found in a hands-on K8s DR e2e (used `--server` on a fresh cp; `create` hung on the web rollout). Structural unit test + lint green.
