### PR TITLE
fix(gitops): make K8s gitops join work (four bugs)

### DIFF
--- a/roles/gitops/tasks/join_kubernetes.yml
+++ b/roles/gitops/tasks/join_kubernetes.yml
@@ -58,15 +58,41 @@
     _ssh_key_path: "{{ key }}.ssh"
     _ssh_key_target_path: "{{ instance_path }}/.gitops-deploy-key"
 
-- name: Read SSH deploy key from controller
-  ansible.builtin.slurp:
-    src: "{{ _ssh_key_path }}"
-  register: _gitops_ssh_key
-  delegate_to: localhost
-  vars:
-    ansible_connection: local
-    ansible_python_interpreter: "{{ ansible_playbook_python }}"
-  no_log: true
+# The deploy key lives on the controller, but by this point resolve_instance
+# has switched the play's connection to the instance host. delegate_to:
+# localhost + vars: ansible_connection: local does NOT reliably override that
+# host-level switch, so the slurp would run on the target and fail to find the
+# controller path (silently — no_log + the minimal stdout callback hide it).
+# Use the save/switch-to-local/restore dance instead, the same shape
+# init_kubernetes.yml uses for its controller-side key work.
+- name: Save connection state before controller-side key read
+  ansible.builtin.set_fact:
+    _gjk_saved:
+      host: "{{ ansible_host | default('localhost') }}"
+      conn: "{{ ansible_connection | default('local') }}"
+      user: "{{ ansible_user | default('') }}"
+      python: "{{ ansible_python_interpreter | default(ansible_playbook_python) }}"
+
+- block:
+    - name: Switch to local for SSH key read
+      ansible.builtin.set_fact:
+        ansible_host: "localhost"
+        ansible_connection: "local"
+        ansible_user: ""
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
+
+    - name: Read SSH deploy key from controller
+      ansible.builtin.slurp:
+        src: "{{ _ssh_key_path }}"
+      register: _gitops_ssh_key
+      no_log: true
+  always:
+    - name: Restore connection state after key read
+      ansible.builtin.set_fact:
+        ansible_host: "{{ _gjk_saved.host }}"
+        ansible_connection: "{{ _gjk_saved.conn }}"
+        ansible_user: "{{ _gjk_saved.user }}"
+        ansible_python_interpreter: "{{ _gjk_saved.python }}"
 
 - name: Stage SSH deploy private key on target for git operations
   ansible.builtin.copy:
@@ -139,11 +165,16 @@
 # owned files (#571). Materialize .gitattributes first so git-crypt
 # decrypts hosts/** on checkout, then rewrite only the files that differ
 # and surface a permission failure as an actionable message.
+# Compose gitops repos carry a .gitattributes that drives git-crypt
+# decryption on checkout. K8s gitops repos are cleartext (secrets live in
+# K8s Secrets, not the repo), so they have no .gitattributes — make this a
+# no-op there rather than a hard failure on a missing pathspec.
 - name: Materialize .gitattributes so git-crypt filters apply on checkout
   ansible.builtin.command:
     cmd: "git checkout HEAD -- .gitattributes"
     chdir: "{{ instance_path }}"
   changed_when: true
+  failed_when: false
 
 - name: Find tracked files whose content differs from the repo
   ansible.builtin.command:
@@ -287,6 +318,29 @@
     dest: "{{ instance_path }}/argocd/application.yaml"
     mode: "0644"
 
+# Argo CD on the new host needs the deploy key to clone the repo, just as
+# init creates it on the first host. Without this, the Application can't
+# authenticate (it falls back to a non-existent SSH agent) and never syncs.
+- name: Create or update Argo CD repo credential Secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "canasta-{{ instance_id }}-repo"
+        namespace: "{{ argocd_namespace | default('argocd') }}"
+        labels:
+          argocd.argoproj.io/secret-type: repository
+          app.kubernetes.io/managed-by: canasta-cli
+          app.kubernetes.io/instance: "{{ instance_id }}"
+      type: Opaque
+      stringData:
+        type: git
+        url: "{{ repo }}"
+        sshPrivateKey: "{{ _gitops_ssh_key.content | b64decode }}"
+  no_log: true
+
 - name: Apply Argo CD Application to cluster
   kubernetes.core.k8s:
     state: present
@@ -311,10 +365,16 @@
   changed_when: false
   failed_when: false
 
+# The commit runs on the target host, which usually has no git identity
+# configured (unlike init, which commits on the controller). Set the
+# identity inline so the commit never aborts with "Author identity
+# unknown" — overridable by --git-user-name / --git-user-email.
 - name: Commit
   ansible.builtin.command:
     cmd: >-
       git -c commit.gpgsign=false
+      -c user.name={{ (git_user_name | default('Canasta GitOps', true)) | quote }}
+      -c user.email={{ (git_user_email | default('canasta-gitops@' ~ host_name, true)) | quote }}
       commit -m 'Add environment {{ host_name }}'
     chdir: "{{ instance_path }}"
   changed_when: true

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -1296,3 +1296,62 @@ class TestGitopsInitNonInteractive:
             "init must fail fast (not hang) in --non-interactive mode when "
             "the deploy key is not yet authorized"
         )
+
+
+class TestGitopsJoinK8sWorks:
+    """gitops join was broken on Kubernetes (it assumed Compose/git-crypt
+    and committed on the controller). These guard the four fixes that make
+    a cross-host re-attach actually work end-to-end."""
+
+    JOIN_K8S = os.path.join(GITOPS_TASKS, "join_kubernetes.yml")
+
+    def _content(self):
+        with open(self.JOIN_K8S) as f:
+            return f.read()
+
+    def test_reads_deploy_key_via_connection_switch(self):
+        """The controller-local key read must use the save/switch-to-local/
+        restore dance, not delegate_to+vars (which doesn't override the
+        connection switch to the instance host, so the slurp runs on the
+        target and fails)."""
+        c = self._content()
+        assert "Switch to local for SSH key read" in c, (
+            "the key read must switch the connection to local"
+        )
+        i = c.find("Read SSH deploy key from controller")
+        seg = c[i:i + 400]
+        assert "delegate_to: localhost" not in seg, (
+            "the key read must not rely on delegate_to+vars (unreliable "
+            "after the connection switch); use the switch-to-local dance"
+        )
+
+    def test_gitattributes_materialize_is_non_fatal(self):
+        """K8s gitops repos are cleartext (no git-crypt / no .gitattributes),
+        so the .gitattributes checkout must not hard-fail."""
+        c = self._content()
+        i = c.find("git checkout HEAD -- .gitattributes")
+        assert i >= 0, "join still materializes .gitattributes"
+        assert "failed_when: false" in c[i:i + 200], (
+            ".gitattributes materialize must be non-fatal (absent on K8s)"
+        )
+
+    def test_commit_sets_inline_identity(self):
+        """The commit runs on the target host (no git identity); it must set
+        user.name/user.email inline so it doesn't abort 'Author identity
+        unknown'."""
+        c = self._content()
+        i = c.find("commit -m 'Add environment")
+        seg = c[max(0, i - 200):i]
+        assert "user.name=" in seg and "user.email=" in seg, (
+            "the join commit must set an inline git identity"
+        )
+
+    def test_creates_argocd_repo_credential_secret(self):
+        """Argo CD on the new host needs the deploy key to clone the repo;
+        the join must create the repository Secret (like init)."""
+        c = self._content()
+        assert "argocd.argoproj.io/secret-type: repository" in c, (
+            "join must create the Argo CD repo-credential Secret so the "
+            "new host's Argo can authenticate to the repo"
+        )
+        assert "sshPrivateKey:" in c


### PR DESCRIPTION
Closes #848.

`canasta gitops join` was **never functional on Kubernetes** — it assumed the Compose/git-crypt flow and committed on the controller, so it failed at the first K8s-specific step. Worse, the failures were **invisible**: the `canasta_minimal` stdout callback + `no_log` hid them, so the command just exited 2 with no output (that's the "silent exit 2" of #848). Running with `--verbose` surfaced four distinct bugs, fixed here:

1. **Deploy-key read** — use the save/switch-to-local/restore connection dance. `delegate_to: localhost` + `vars: ansible_connection: local` does **not** reliably override the connection switch `resolve_instance` makes to the instance host, so the controller-local key slurp ran on the target and failed `File not found`.
2. **`.gitattributes` materialize** — made non-fatal. K8s gitops repos are cleartext (no git-crypt), so there's no `.gitattributes`; a hard `git checkout HEAD -- .gitattributes` aborted on a missing pathspec.
3. **Commit identity** — set inline `user.name`/`user.email` on the commit. It runs on the *target* host (init commits on the controller), which usually has no git identity → `Author identity unknown`. Overridable by `--git-user-name`/`--git-user-email`.
4. **Argo CD repo-credential Secret** — create it on the new host (only `init` did). Without it the new host's Argo CD can't authenticate to the repo and the Application never syncs.

## Validation

- New structural unit tests for all four fixes; full suite + lint green.
- **Live, on real hosts:** a second host joined an existing **GitHub-backed** gitops farm — the repo gained its `hosts/bigdst/` entry, the join completed `failed=0`, and the new host's Argo CD Application reached **`Synced`**.

## Follow-ups noted (not in this PR)
- The `canasta_minimal` stdout callback **swallows fatal task errors** in non-verbose mode — a non-zero exit with no diagnostic. Worth surfacing errors always.
- `gitops join --ssh-key <controller-path>` still misuses the controller path for target-side git ops (use without `--ssh-key`, which defaults to the staged key).
- `render_kubernetes.yml` logs a scary (ignored) `[ERROR]` when `hosts/_shared/vars.yaml` is absent.
