### PR TITLE
fix(gitops): make wiki display name edits durable under gitops

### DIFF
--- a/playbooks/config_regenerate.yml
+++ b/playbooks/config_regenerate.yml
@@ -19,6 +19,14 @@
     path: "{{ instance_path }}/.gitops-host"
   register: _regen_gitops_stat
 
+# Capture literal config/wikis.yaml edits (e.g. display names) into
+# wikis.yaml.template before re-rendering, so regenerate preserves them
+# instead of overwriting them with the template's stale values.
+- name: Capture wikis.yaml edits into the gitops template
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/gitops/tasks/_reconcile_wikis_template.yml
+  when: _regen_gitops_stat.stat.exists | default(false)
+
 # The orchestrator owns the compose-vs-K8s decision (K8s gitops uses a
 # different layout); dispatch.
 - name: Re-render gitops templates

--- a/roles/gitops/tasks/_reconcile_wikis_template.yml
+++ b/roles/gitops/tasks/_reconcile_wikis_template.yml
@@ -1,0 +1,51 @@
+---
+# Regenerate wikis.yaml.template from the live config/wikis.yaml.
+#
+# Host-specific fields (url) are rewritten as {{wiki_url_<id>}}
+# placeholders; shared literal fields (name) are copied through. This
+# captures a display name edited directly in config/wikis.yaml into the
+# tracked canonical source, so it survives the next render and reaches
+# other hosts, instead of being silently dropped.
+#
+# Only Compose gitops instances use wikis.yaml.template, so by default
+# this acts only when that template already exists (a no-op on K8s
+# gitops and non-gitops instances). Pass reconcile_create=true at init
+# time to create the template when it does not yet exist.
+#
+# Input: instance_path. Optional: reconcile_create (default false).
+# Output: _reconcile_wikis_write (the template copy result; only
+#         defined when the reconcile block ran).
+
+- name: Stat live wikis.yaml for template reconcile
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/config/wikis.yaml"
+  register: _reconcile_wikis_src
+
+- name: Stat existing wikis.yaml.template
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/wikis.yaml.template"
+  register: _reconcile_wikis_tmpl
+
+- name: Reconcile wikis.yaml.template from live wikis.yaml
+  when:
+    - _reconcile_wikis_src.stat.exists
+    - _reconcile_wikis_tmpl.stat.exists or (reconcile_create | default(false) | bool)
+  block:
+    - name: Read live wikis.yaml for template reconcile
+      canasta_wikis_yaml:
+        instance_path: "{{ instance_path }}"
+        state: read
+      register: _reconcile_wikis_data
+
+    - name: Write wikis.yaml.template from live wikis.yaml
+      ansible.builtin.copy:
+        content: |
+          wikis:
+          {% for w in _reconcile_wikis_data.wikis | default([]) %}
+            - id: {{ w.id }}
+              url: {{ '{{' }}wiki_url_{{ w.id }}{{ '}}' }}
+              name: "{{ w.name | default(w.id) }}"
+          {% endfor %}
+        dest: "{{ instance_path }}/wikis.yaml.template"
+        mode: "0644"
+      register: _reconcile_wikis_write

--- a/roles/gitops/tasks/add.yml
+++ b/roles/gitops/tasks/add.yml
@@ -10,6 +10,15 @@
   changed_when: _git_add_path.rc == 0
   when: path is defined and path != ''
 
+# config/wikis.yaml is not tracked (it is rendered from
+# wikis.yaml.template). Capture any literal edits (e.g. a wiki's
+# display name) back into the template so they are staged and shared
+# rather than dropped on the next render.
+- name: Capture wikis.yaml edits into the gitops template
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/gitops/tasks/_reconcile_wikis_template.yml
+  when: path is not defined or path == ''
+
 # Scope with an explicit pathspec: since Git 2.0 `git add -A` ignores
 # the working directory and stages the whole tree, so chdir alone does
 # not limit it to config/.
@@ -20,3 +29,26 @@
   register: _git_add
   changed_when: _git_add.rc == 0
   when: path is not defined or path == ''
+
+# wikis.yaml.template lives at the instance root, outside config/, so
+# the pathspec above does not reach it.
+- name: Stage reconciled wikis.yaml.template
+  ansible.builtin.command:
+    cmd: "git add -- wikis.yaml.template"
+    chdir: "{{ instance_path }}"
+  register: _git_add_tmpl
+  changed_when: _git_add_tmpl.rc == 0
+  when:
+    - path is not defined or path == ''
+    - _reconcile_wikis_write is defined
+    - _reconcile_wikis_write.changed | default(false)
+
+- name: Report captured wikis.yaml edits
+  ansible.builtin.debug:
+    msg: >-
+      Captured config/wikis.yaml edits into wikis.yaml.template
+      (e.g. wiki display names). Staged for push.
+  when:
+    - path is not defined or path == ''
+    - _reconcile_wikis_write is defined
+    - _reconcile_wikis_write.changed | default(false)

--- a/roles/gitops/tasks/init_compose.yml
+++ b/roles/gitops/tasks/init_compose.yml
@@ -235,30 +235,11 @@
     dest: "{{ instance_path }}/env.template"
     mode: "0644"
 
-- name: Check if wikis.yaml exists
-  ansible.builtin.stat:
-    path: "{{ instance_path }}/config/wikis.yaml"
-  register: _gitops_wikis_check
-
-- name: Read wikis for template generation
-  canasta_wikis_yaml:
-    instance_path: "{{ instance_path }}"
-    state: read
-  register: _gitops_wikis_data
-  when: _gitops_wikis_check.stat.exists
-
 - name: Generate wikis.yaml.template with URL placeholders
-  ansible.builtin.copy:
-    content: |
-      wikis:
-      {% for w in _gitops_wikis_data.wikis | default([]) %}
-        - id: {{ w.id }}
-          url: {{ '{{' }}wiki_url_{{ w.id }}{{ '}}' }}
-          name: "{{ w.name }}"
-      {% endfor %}
-    dest: "{{ instance_path }}/wikis.yaml.template"
-    mode: "0644"
-  when: _gitops_wikis_check.stat.exists
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/gitops/tasks/_reconcile_wikis_template.yml
+  vars:
+    reconcile_create: true
 
 # --- Step 10: Create hosts.yaml ---
 - name: Create hosts directory

--- a/tests/unit/test_gitops_add_scope.py
+++ b/tests/unit/test_gitops_add_scope.py
@@ -44,10 +44,13 @@ class TestGitopsAddScope:
         """The no-path staging command must name `config` as a pathspec,
         not rely on chdir + bare `git add -A` (which is whole-tree)."""
         tasks = _load_tasks()
+        # Only the whole-tree-capable `git add -A` form is at risk of the
+        # chdir-ignored bug. Explicit single-file stages (e.g.
+        # `git add -- wikis.yaml.template`) are intentionally scoped.
         no_path = [
             t for t in tasks
             if "path is not defined" in str(t.get("when", ""))
-            and ("git add" in _cmd(t))
+            and ("git add -A" in _cmd(t))
         ]
         assert no_path, "add.yml lost its no-path staging task"
         for t in no_path:

--- a/tests/unit/test_gitops_wikis_template_reconcile.py
+++ b/tests/unit/test_gitops_wikis_template_reconcile.py
@@ -1,0 +1,116 @@
+"""Guards for capturing config/wikis.yaml edits into wikis.yaml.template.
+
+config/wikis.yaml is a rendered file (gitignored); wikis.yaml.template is
+the tracked source. A display name edited directly in config/wikis.yaml
+must be captured back into the template, or it is dropped on the next
+render and never reaches other hosts. A shared reconcile task does that
+capture; these tests assert it exists, keeps `name` a literal while
+`url` stays a placeholder, and is wired into init, `gitops add`, and
+`config regenerate` in the right order.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+GITOPS_TASKS = os.path.join(REPO_ROOT, "roles", "gitops", "tasks")
+RECONCILE = os.path.join(GITOPS_TASKS, "_reconcile_wikis_template.yml")
+INIT_COMPOSE = os.path.join(GITOPS_TASKS, "init_compose.yml")
+ADD_YML = os.path.join(GITOPS_TASKS, "add.yml")
+REGENERATE = os.path.join(REPO_ROOT, "playbooks", "config_regenerate.yml")
+
+RECONCILE_INCLUDE = "_reconcile_wikis_template.yml"
+
+
+def _walk(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk(t[nested])
+
+
+def _load(path):
+    with open(path) as f:
+        return list(_walk(yaml.safe_load(f)))
+
+
+def _include_path(task):
+    inc = task.get("ansible.builtin.include_tasks") or task.get("include_tasks") or ""
+    return inc if isinstance(inc, str) else str(inc)
+
+
+def _flat_text(path):
+    """Top-level task index of each task, for ordering assertions."""
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+class TestReconcileTask:
+    def test_template_keeps_url_placeholder_and_name_literal(self):
+        with open(RECONCILE) as f:
+            content = f.read()
+        # url is host-specific -> placeholder; name is shared -> literal.
+        assert "wiki_url_{{ w.id }}" in content, "url must stay a placeholder"
+        assert 'name: "{{ w.name | default(w.id) }}"' in content, (
+            "name must be copied through as a literal so display-name edits "
+            "are captured"
+        )
+
+    def test_acts_only_when_template_exists_or_creating(self):
+        """Must no-op on K8s/non-gitops (no template) unless reconcile_create."""
+        with open(RECONCILE) as f:
+            content = f.read()
+        assert "_reconcile_wikis_tmpl.stat.exists" in content
+        assert "reconcile_create" in content
+
+
+class TestWiring:
+    def test_init_uses_shared_reconcile_not_a_second_generator(self):
+        with open(INIT_COMPOSE) as f:
+            text = f.read()
+        assert RECONCILE_INCLUDE in text, "init must use the shared reconcile task"
+        # No second inline generator writing the template (drift risk).
+        assert text.count("dest: \"{{ instance_path }}/wikis.yaml.template\"") == 0, (
+            "init must not inline a second wikis.yaml.template generator"
+        )
+
+    def test_add_reconciles_before_staging_and_stages_template(self):
+        raw = _flat_text(ADD_YML)
+        names_in_order = [t.get("name", "") for t in raw if isinstance(t, dict)]
+        cmds = " ".join(str(t) for t in raw)
+        # reconcile include present
+        assert any(RECONCILE_INCLUDE in _include_path(t) for t in _walk(raw))
+        # template explicitly staged (it lives outside config/)
+        assert "git add -- wikis.yaml.template" in cmds
+        # reconcile must come before the config staging
+        recon_idx = next(
+            i for i, t in enumerate(raw)
+            if isinstance(t, dict) and RECONCILE_INCLUDE in _include_path(t)
+        )
+        stage_idx = next(
+            i for i, t in enumerate(raw)
+            if isinstance(t, dict) and "git add -A -- config" in str(t)
+        )
+        assert recon_idx < stage_idx, "reconcile must run before staging config/"
+
+    def test_regenerate_captures_before_rerender(self):
+        raw = _flat_text(REGENERATE)
+        recon_idx = next(
+            (i for i, t in enumerate(raw)
+             if isinstance(t, dict) and RECONCILE_INCLUDE in _include_path(t)),
+            None,
+        )
+        render_idx = next(
+            (i for i, t in enumerate(raw)
+             if isinstance(t, dict) and "render_gitops_config.yml" in _include_path(t)),
+            None,
+        )
+        assert recon_idx is not None, "regenerate must capture wikis.yaml edits"
+        assert render_idx is not None
+        assert recon_idx < render_idx, (
+            "capture must run before re-render or regenerate clobbers the edit"
+        )


### PR DESCRIPTION
Fixes #850.

## Problem

A wiki's display name (`$wgSitename`) comes from the `name` field of each entry in `config/wikis.yaml` (`FarmConfigLoader.php`). But under gitops, `config/wikis.yaml` is **gitignored** and rendered from `wikis.yaml.template`. So editing `name` directly in `config/wikis.yaml`:

1. Shows nothing in `canasta gitops status` / `git status` (untracked) — the edit looks lost.
2. Doesn't propagate to other hosts (the tracked template keeps the old literal).
3. Is silently reverted on the next `config regenerate` / `gitops pull`.

Same class as #575 (config edits not durable under gitops), but for a *shared literal* field (`name`) rather than a *host-specific placeholder* (`url`): in `wikis.yaml.template`, `url` is a `{{wiki_url_<id>}}` placeholder while `name` was a literal baked in once at `gitops init` and never updated again.

## Fix

Capture literal `config/wikis.yaml` edits back into the canonical `wikis.yaml.template`, at the existing choke points — **no new command**:

- **New shared task** `roles/gitops/tasks/_reconcile_wikis_template.yml` — re-derives the template from live `config/wikis.yaml` (`url` → placeholder, `name` → literal). Idempotent; acts only on Compose gitops instances (where the template exists). `reconcile_create: true` creates it at init.
- **`gitops add`** — reconcile before staging, stage the root-level template (`git add -A -- config` can't reach it), and report what was captured. So `edit → add → push` works and is visible.
- **`config regenerate`** — capture *before* re-render, so it cannot clobber a pending edit regardless of command order.
- **`gitops init`** — now uses the shared task instead of a duplicate inline generator; collapsing the two eliminates the drift that was the root cause.

`gitops pull` keeps remote-wins semantics (renders inline, no capture), so a local hand-edit never overrides what was pulled.

## Tests

- `make lint`, `make validate` pass.
- `make test-unit`: 1338 passed (5 new).
- New `tests/unit/test_gitops_wikis_template_reconcile.py`: placeholder-vs-literal split + reconcile ordering at all three wiring points.
- Tightened the existing `test_gitops_add_scope.py` guard to target the whole-tree `git add -A` form (the explicit single-file template stage is intentionally scoped).

## Follow-up (not in this PR)

`gitops status` could proactively flag uncaptured `config/wikis.yaml` literal edits for users who run `status` before `add`. This PR makes the supported workflow correct and visible at the add/push stage.
