### PR TITLE
fix(gitops): stage wikis.yaml.template whenever it exists in gitops add

### DIFF
--- a/roles/gitops/tasks/add.yml
+++ b/roles/gitops/tasks/add.yml
@@ -31,8 +31,10 @@
   when: path is not defined or path == ''
 
 # wikis.yaml.template lives at the instance root, outside config/, so
-# the pathspec above does not reach it.
-- name: Stage reconciled wikis.yaml.template
+# the pathspec above does not reach it. Stage it whenever it exists (a
+# no-op when unchanged) so a template edit captured by an earlier
+# 'config regenerate' is not left behind on push.
+- name: Stage wikis.yaml.template
   ansible.builtin.command:
     cmd: "git add -- wikis.yaml.template"
     chdir: "{{ instance_path }}"
@@ -40,8 +42,7 @@
   changed_when: _git_add_tmpl.rc == 0
   when:
     - path is not defined or path == ''
-    - _reconcile_wikis_write is defined
-    - _reconcile_wikis_write.changed | default(false)
+    - _reconcile_wikis_tmpl.stat.exists | default(false)
 
 - name: Report captured wikis.yaml edits
   ansible.builtin.debug:

--- a/tests/unit/test_gitops_wikis_template_reconcile.py
+++ b/tests/unit/test_gitops_wikis_template_reconcile.py
@@ -97,6 +97,24 @@ class TestWiring:
         )
         assert recon_idx < stage_idx, "reconcile must run before staging config/"
 
+    def test_template_staged_whenever_it_exists_not_only_on_capture(self):
+        """A template edit captured by an earlier 'config regenerate' is
+        left unstaged unless 'gitops add' stages the template whenever it
+        exists — not only when this reconcile run changed it."""
+        raw = _flat_text(ADD_YML)
+        stage = next(
+            t for t in _walk(raw)
+            if "git add -- wikis.yaml.template" in str(
+                (t.get("ansible.builtin.command") or t.get("command") or {})
+            )
+        )
+        when = str(stage.get("when", ""))
+        assert "stat.exists" in when, "template stage must be gated on existence"
+        assert "_reconcile_wikis_write" not in when, (
+            "template stage must not be gated on whether this reconcile run "
+            "changed it, or a regenerate-then-add leaves the edit unstaged"
+        )
+
     def test_regenerate_captures_before_rerender(self):
         raw = _flat_text(REGENERATE)
         recon_idx = next(


### PR DESCRIPTION
Follow-up to #851 (#850), caught during localhost gitops validation.

## Problem

`canasta config regenerate` updates `wikis.yaml.template` on disk (capturing a `config/wikis.yaml` display-name edit) but does not stage it. A later `canasta gitops add` whose reconcile is a no-op then skipped staging that already-pending template change — because staging was gated on whether *that* reconcile run changed the file — so `canasta gitops push` dropped the edit.

Repro (on a gitops Compose instance):

1. Edit a wiki's `name` in `config/wikis.yaml`.
2. `canasta config regenerate` — template now updated on disk, unstaged.
3. `canasta gitops add` — reconcile is a no-op; template change left unstaged.
4. `canasta gitops push` — the display-name change never reaches the remote.

## Fix

Stage `wikis.yaml.template` whenever it exists (a no-op when unchanged) rather than only when the current reconcile run changed it. Adds a regression guard asserting the staging task is gated on template existence, not on `_reconcile_wikis_write.changed`.

## Validation

Confirmed live on a localhost instance with a local bare gitops repo: after `config regenerate`, `gitops add` now stages the template, `push` propagates it, and a no-op `add` still reports "No changes" with a clean tree.

- `make lint`, `make validate` pass.
- `make test-unit`: 1342 passed.
