### PR TITLE
feat(gitops): flag uncaptured config/wikis.yaml edits in gitops status

### DIFF
--- a/direct_commands/__init__.py
+++ b/direct_commands/__init__.py
@@ -133,6 +133,7 @@ from .gitops import (  # noqa: F401
     _parse_gitops_diff,
     _parse_gitops_status,
     _parse_gitops_status_k8s,
+    _wikis_uncaptured_edit,
 )
 from .extension_skin import cmd_extension_list, cmd_skin_list  # noqa: F401
 from .backup import cmd_backup_list  # noqa: F401

--- a/direct_commands/gitops.py
+++ b/direct_commands/gitops.py
@@ -49,8 +49,49 @@ def _gitops_status_script(path, ssh_key=None):
         "git diff --name-only 2>/dev/null; "
         "echo '%(d)s'; "
         "git fetch 2>/dev/null; "
-        "git rev-list --left-right --count HEAD...@{upstream} 2>/dev/null || echo '0\t0'"
+        "git rev-list --left-right --count HEAD...@{upstream} 2>/dev/null || echo '0\t0'; "
+        "echo '%(d)s'; "
+        "cat config/wikis.yaml 2>/dev/null; "
+        "echo '%(d)s'; "
+        "cat wikis.yaml.template 2>/dev/null"
     ) % {"p": qp, "d": d, "ssh": _git_ssh_env_prefix(ssh_key)}
+
+
+_URL_LINE_RE = re.compile(r"^[ \t]*url:.*$", re.MULTILINE)
+
+
+def _wikis_uncaptured_edit(live_raw, tmpl_raw):
+    """True if config/wikis.yaml has literal edits not yet in the template.
+
+    config/wikis.yaml is rendered from wikis.yaml.template, so a direct
+    edit to a literal field (e.g. a wiki's display name) is gitignored and
+    invisible to git status until 'gitops add' reconciles it. Compare the
+    two per wiki id, ignoring the host-specific url (a {{placeholder}} in
+    the template), so the advisory fires only on a genuine uncaptured edit.
+    Returns False when either file is absent or unparseable (e.g. non-gitops
+    or K8s gitops, which has no wikis.yaml.template).
+    """
+    if not (live_raw or "").strip() or not (tmpl_raw or "").strip():
+        return False
+    # The template's `url:` lines hold {{placeholder}} values that are not
+    # valid YAML, so strip url lines from both before parsing. url is
+    # host-specific and excluded from the comparison anyway.
+    live_clean = _URL_LINE_RE.sub("", live_raw)
+    tmpl_clean = _URL_LINE_RE.sub("", tmpl_raw)
+    try:
+        live = yaml.safe_load(live_clean) or {}
+        tmpl = yaml.safe_load(tmpl_clean) or {}
+    except yaml.YAMLError:
+        return False
+
+    def _by_id(doc):
+        out = {}
+        for w in (doc.get("wikis") or []) if isinstance(doc, dict) else []:
+            if isinstance(w, dict) and "id" in w:
+                out[w["id"]] = {k: v for k, v in w.items() if k != "url"}
+        return out
+
+    return _by_id(live) != _by_id(tmpl)
 
 
 def _parse_gitops_status(stdout, instance_id):
@@ -82,6 +123,10 @@ def _parse_gitops_status(stdout, instance_id):
     staged = staged_raw.split("\n") if staged_raw else []
     unstaged = unstaged_raw.split("\n") if unstaged_raw else []
 
+    live_wikis_raw = parts[7] if len(parts) > 7 else ""
+    tmpl_wikis_raw = parts[8] if len(parts) > 8 else ""
+    wikis_drift = _wikis_uncaptured_edit(live_wikis_raw, tmpl_wikis_raw)
+
     try:
         revcount_parts = revcount_raw.split("\t")
         ahead = int(revcount_parts[0])
@@ -111,7 +156,12 @@ def _parse_gitops_status(stdout, instance_id):
             lines.append("  %s" % f)
         lines.append("")
 
-    if not staged and not unstaged:
+    if wikis_drift:
+        lines.append("Uncaptured config/wikis.yaml edits (e.g. wiki display name):")
+        lines.append("  run 'canasta gitops add' to capture and stage them.")
+        lines.append("")
+
+    if not staged and not unstaged and not wikis_drift:
         lines.append("No changes.")
         lines.append("")
 

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1909,9 +1909,10 @@ class TestHostRemove:
 class TestParseGitopsStatus:
     def _make_output(self, hostname="myhost", hosts_yaml="MISSING",
                      commit="abc1234", applied="abc1234",
-                     staged="", unstaged="", revcount="0\t0"):
+                     staged="", unstaged="", revcount="0\t0",
+                     wikis=None, template=None):
         d = direct_commands._SENTINEL
-        return (
+        out = (
             hostname + "\n" + d + "\n"
             + hosts_yaml + "\n" + d + "\n"
             + commit + "\n" + d + "\n"
@@ -1920,6 +1921,12 @@ class TestParseGitopsStatus:
             + unstaged + "\n" + d + "\n"
             + revcount + "\n"
         )
+        if wikis is not None or template is not None:
+            out += (
+                d + "\n" + (wikis or "") + "\n"
+                + d + "\n" + (template or "")
+            )
+        return out
 
     def test_basic_status(self):
         out = self._make_output()
@@ -1963,6 +1970,50 @@ class TestParseGitopsStatus:
         out = self._make_output(hostname="MISSING")
         result = direct_commands._parse_gitops_status(out, "mysite")
         assert "Host:           unknown" in result
+
+    # Uncaptured config/wikis.yaml edits (e.g. a display name edited
+    # directly in the gitignored rendered file) are invisible to git
+    # status; status must flag them with a hint to run 'gitops add'.
+    _LIVE = "wikis:\n- id: main\n  url: localhost:8090\n  name: Conservation Wiki\n"
+    _TMPL_STALE = (
+        "wikis:\n  - id: main\n    url: {{wiki_url_main}}\n    name: \"main\"\n"
+    )
+    _TMPL_OK = (
+        "wikis:\n  - id: main\n    url: {{wiki_url_main}}\n"
+        "    name: \"Conservation Wiki\"\n"
+    )
+
+    def test_uncaptured_wikis_edit_flagged(self):
+        out = self._make_output(wikis=self._LIVE, template=self._TMPL_STALE)
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "Uncaptured config/wikis.yaml edits" in result
+        assert "canasta gitops add" in result
+        # Must not also claim there is nothing to do.
+        assert "No changes." not in result
+
+    def test_captured_wikis_no_advisory(self):
+        out = self._make_output(wikis=self._LIVE, template=self._TMPL_OK)
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "Uncaptured config/wikis.yaml edits" not in result
+        assert "No changes." in result
+
+    def test_no_template_no_advisory(self):
+        """Non-gitops / K8s gitops has no wikis.yaml.template — never flag."""
+        out = self._make_output(wikis=self._LIVE, template="")
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "Uncaptured config/wikis.yaml edits" not in result
+
+    def test_legacy_output_without_wikis_sections(self):
+        """Output predating the wikis sections must parse unchanged."""
+        out = self._make_output()
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "No changes." in result
+        assert "Uncaptured config/wikis.yaml edits" not in result
+
+    def test_script_reads_wikis_and_template(self):
+        script = direct_commands._gitops_status_script("/srv/mysite")
+        assert "cat config/wikis.yaml" in script
+        assert "cat wikis.yaml.template" in script
 
 
 class TestCmdGitopsStatus:


### PR DESCRIPTION
Fixes #854. Follow-up to #851/#853.

## Problem

`canasta gitops status` reported "No changes." even when `config/wikis.yaml` had an uncaptured literal edit (e.g. a wiki's display name / `$wgSitename`). Because `config/wikis.yaml` is gitignored (rendered from `wikis.yaml.template`), a direct edit is invisible to the git-based status until `canasta gitops add` reconciles it — so the edit read as if it were lost.

## Fix

`gitops status` now reads `config/wikis.yaml` and `wikis.yaml.template` (two extra sections in the batched status script) and compares their literal fields per wiki id, ignoring the host-specific `url` placeholder. On a mismatch it prints:

```
Uncaptured config/wikis.yaml edits (e.g. wiki display name):
  run 'canasta gitops add' to capture and stage them.
```

- Read-only (no file mutation in `status`).
- Compose-only: K8s gitops has no `wikis.yaml.template`, so the advisory never fires there.
- The template's `url: {{...}}` placeholders are not valid YAML, so `url` lines are stripped before parsing (url is excluded from the comparison anyway).

## Validation

Live on a localhost instance with a local bare gitops repo:

| State | `gitops status` |
|---|---|
| Clean | `No changes.` |
| After editing `name` (uncaptured) | advisory shown, no "No changes." |
| After `gitops add` | advisory gone; template staged for push |

- `make lint`, `make validate` pass.
- `make test-unit`: 1347 passed (8 new — drift flagged/not-flagged, no-template, legacy-output back-compat, script reads the files).
