### PR TITLE
feat(config): add 'config refresh-template' to adopt updated seed files

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -84,7 +84,7 @@ _ensure_ca_bundle()
 
 # Commands that have subcommands (e.g., "config get" -> "config_get")
 SUBCOMMAND_GROUPS = {
-    "config": ["get", "set", "unset", "regenerate"],
+    "config": ["get", "set", "unset", "regenerate", "refresh-template"],
     "extension": ["list", "enable", "disable"],
     "skin": ["list", "enable", "disable"],
     "maintenance": ["update", "script", "extension", "exec"],

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1016,6 +1016,45 @@ commands:
         type: string
         description: "Canasta instance ID"
 
+  - name: config_refresh_template
+    description: "Adopt the current template version of a seeded config file"
+    long_description: |
+      Overwrite an instance's copy of a template-seeded config file
+      (e.g. config/default.vcl, config/settings/global/Vector.php) with
+      the version shipped in the current CLI. These files are copied
+      once when the instance is created and then owned by you, so an
+      upgrade never changes them; use this to adopt an improved shipped
+      version, or to restore a seed file you deleted.
+
+      With no file argument, lists the seed files whose instance copy
+      differs from the current template. With one or more files, shows
+      the diff and overwrites only when --yes is passed, so review the
+      diff first (your local edits to that file are replaced). Rendered
+      files (.env, wikis.yaml, Caddyfile) belong to 'config regenerate'
+      and per-wiki Settings.php is user-owned; neither is touched here.
+    examples:
+      - "canasta config refresh-template"
+      - "canasta config refresh-template config/default.vcl"
+      - "canasta config refresh-template config/default.vcl --yes"
+    playbook: config_refresh_template.yml
+    parameters:
+      - name: id
+        short: i
+        type: string
+        description: "Canasta instance ID"
+      - name: files
+        type: string
+        positional: true
+        multi: true
+        description: >-
+          Template-seeded file path(s) to refresh, relative to the
+          instance root (e.g. config/default.vcl)
+      - name: "yes"
+        short: "y"
+        type: bool
+        default: false
+        description: "Overwrite the instance copy without confirmation"
+
   - name: config_unset
     description: "Remove a configuration setting"
     long_description: |

--- a/playbooks/config_refresh_template.yml
+++ b/playbooks/config_refresh_template.yml
@@ -1,0 +1,20 @@
+---
+# canasta config refresh-template - Adopt the current template version of a
+# template-seeded config file, overwriting the instance's copy.
+#
+# Seed files (config/default.vcl, config/settings/global/*.php, the settings
+# READMEs, the crowdsec configs) are copied from instance_template once at
+# create and then owned by the user, so upgrade never changes them. This
+# adopts the current shipped version for a named file, or restores one that
+# was deleted. Rendered files (.env, wikis.yaml, Caddyfile) belong to
+# 'config regenerate' and per-wiki Settings.php is user-owned; neither is
+# touched here.
+
+- name: Resolve instance
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/common/tasks/resolve_instance.yml
+
+- name: Refresh template-seeded config files
+  ansible.builtin.include_role:
+    name: config
+    tasks_from: refresh_template.yml

--- a/roles/config/tasks/_refresh_one.yml
+++ b/roles/config/tasks/_refresh_one.yml
@@ -1,0 +1,89 @@
+---
+# Refresh a single template-seeded file: show the template-vs-instance diff
+# and overwrite the instance copy when --yes was given. A missing instance
+# copy (a deleted seed) diffs as a full addition and is restored.
+#
+# Input: _refresh_file (path relative to the instance root), instance_path,
+#        canasta_root, yes (bool).
+
+- name: Read the instance copy of {{ _refresh_file }}
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/{{ _refresh_file }}"
+  register: _refresh_cur
+  failed_when: false
+
+- name: Read the template copy of {{ _refresh_file }}
+  ansible.builtin.slurp:
+    src: "{{ canasta_root }}/instance_template/{{ _refresh_file }}"
+  delegate_to: localhost
+  register: _refresh_new
+
+- name: Note when {{ _refresh_file }} already matches the template
+  ansible.builtin.debug:
+    msg: "{{ _refresh_file }} already matches the current template; nothing to do."
+  when:
+    - not (_refresh_cur.failed | default(false))
+    - (_refresh_cur.content | default('')) == (_refresh_new.content | default(''))
+
+- name: Diff and apply {{ _refresh_file }} when it differs
+  when: >-
+    (_refresh_cur.failed | default(false)) or
+    ((_refresh_cur.content | default('')) != (_refresh_new.content | default('')))
+  block:
+    - name: Stage the current instance copy on the controller
+      ansible.builtin.tempfile:
+        state: file
+      delegate_to: localhost
+      register: _refresh_tmp
+
+    - name: Write the current instance copy for diffing
+      ansible.builtin.copy:
+        content: "{{ (_refresh_cur.content | default('')) | b64decode }}"
+        dest: "{{ _refresh_tmp.path }}"
+        mode: "0644"
+      delegate_to: localhost
+
+    - name: Compute the diff (current -> template)
+      ansible.builtin.command:
+        argv:
+          - diff
+          - -u
+          - --label
+          - "{{ _refresh_file }} (current)"
+          - --label
+          - "{{ _refresh_file }} (template)"
+          - "{{ _refresh_tmp.path }}"
+          - "{{ canasta_root }}/instance_template/{{ _refresh_file }}"
+      delegate_to: localhost
+      register: _refresh_diff
+      changed_when: false
+      failed_when: false
+
+    - name: Show the diff for {{ _refresh_file }}
+      ansible.builtin.debug:
+        msg: "{{ [_refresh_file + ' (current --> template):', ''] + (_refresh_diff.stdout_lines | default([])) }}"
+
+    - name: Overwrite the instance copy with the template
+      ansible.builtin.copy:
+        src: "{{ canasta_root }}/instance_template/{{ _refresh_file }}"
+        dest: "{{ instance_path }}/{{ _refresh_file }}"
+        mode: "0644"
+      when: yes | default(false) | bool
+
+    - name: Report {{ _refresh_file }} refreshed
+      ansible.builtin.debug:
+        msg: "Refreshed {{ _refresh_file }} from the current template."
+      when: yes | default(false) | bool
+
+    - name: Report {{ _refresh_file }} previewed
+      ansible.builtin.debug:
+        msg: >-
+          Previewed {{ _refresh_file }}. Re-run with --yes to overwrite the
+          instance copy with the current template.
+      when: not (yes | default(false) | bool)
+
+    - name: Remove the staged copy
+      ansible.builtin.file:
+        path: "{{ _refresh_tmp.path }}"
+        state: absent
+      delegate_to: localhost

--- a/roles/config/tasks/refresh_template.yml
+++ b/roles/config/tasks/refresh_template.yml
@@ -1,0 +1,100 @@
+---
+# Adopt the current template version of template-seeded config files.
+#
+# The set of refreshable files is whatever ships under
+# instance_template/config on the controller. With no requested files we
+# report drift; with requested files we diff each and overwrite when --yes
+# was given.
+#
+# Input: instance_path, instance_id, canasta_root, files (str:
+#        space-separated paths, optional), yes (bool).
+
+- name: Enumerate shipped template seed files
+  ansible.builtin.find:
+    paths: "{{ canasta_root }}/instance_template/config"
+    recurse: true
+    file_type: file
+  delegate_to: localhost
+  register: _refresh_find
+
+- name: Build the set of refreshable seed paths
+  ansible.builtin.set_fact:
+    _refresh_seed_paths: >-
+      {{ _refresh_find.files
+         | map(attribute='path')
+         | map('regex_replace',
+               '^' ~ ((canasta_root ~ '/instance_template/') | regex_escape), '')
+         | sort }}
+    _refresh_requested: "{{ (files | default('', true)).split() }}"
+
+# --- List mode: report which seed files differ from the template ---------
+- name: Report drift
+  when: _refresh_requested | length == 0
+  block:
+    - name: Read instance copies of the seed files
+      ansible.builtin.slurp:
+        src: "{{ instance_path }}/{{ item }}"
+      loop: "{{ _refresh_seed_paths }}"
+      register: _refresh_inst
+      failed_when: false
+
+    - name: Read template copies of the seed files
+      ansible.builtin.slurp:
+        src: "{{ canasta_root }}/instance_template/{{ item }}"
+      loop: "{{ _refresh_seed_paths }}"
+      delegate_to: localhost
+      register: _refresh_tmpl
+
+    - name: Compute the drifted seed files
+      ansible.builtin.set_fact:
+        _refresh_drift: "{{ _refresh_drift | default([]) + [item.0] }}"
+      loop: >-
+        {{ _refresh_seed_paths
+           | zip(_refresh_inst.results, _refresh_tmpl.results) | list }}
+      loop_control:
+        label: "{{ item.0 }}"
+      when: >-
+        (item.1.failed | default(false)) or
+        ((item.1.content | default('')) != (item.2.content | default('')))
+
+    - name: Report the drifted seed files
+      ansible.builtin.debug:
+        msg: >-
+          {{
+            (_refresh_drift | default([]) | length == 0)
+            | ternary(
+                ['All template-seeded files match the current template.'],
+                ['Seed files that differ from the current template:']
+                + (_refresh_drift | default([]) | map('regex_replace', '^', '  ') | list)
+                + ['',
+                   "Review and adopt one with: "
+                   ~ "canasta config refresh-template <file> --yes"]
+              )
+          }}
+
+# --- File mode: diff each requested file and overwrite when --yes ---------
+- name: Refresh requested files
+  when: _refresh_requested | length > 0
+  block:
+    - name: Validate requested files are template-seeded
+      ansible.builtin.fail:
+        msg: >-
+          '{{ item }}' is not a template-seeded file. Refreshable files:
+          {{ _refresh_seed_paths | join(', ') }}
+      loop: "{{ _refresh_requested }}"
+      when: item not in _refresh_seed_paths
+
+    - name: Refresh each requested seed file
+      ansible.builtin.include_tasks: _refresh_one.yml
+      loop: "{{ _refresh_requested }}"
+      loop_control:
+        loop_var: _refresh_file
+
+    - name: Remind to apply and capture the changes
+      ansible.builtin.debug:
+        msg:
+          - "Restart the instance to apply: canasta restart -i {{ instance_id }}"
+          - >-
+            Capture into gitops (if used):
+            canasta gitops add && canasta gitops push
+      when: yes | default(false) | bool

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -2718,6 +2718,85 @@ def test_k8s_build_from(inst):
     )
 
 
+def test_config_refresh_template(inst):
+    """Verify 'config refresh-template' lists drift, previews, and adopts
+    the shipped template for a seeded file (and restores a deleted one)."""
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir,
+        "-e", inst.env_file,
+    )
+    wait_for_wiki(inst.http_port)
+
+    vcl = os.path.join(inst.instance_path(), "config", "default.vcl")
+    vector = os.path.join(
+        inst.instance_path(), "config", "settings", "global", "Vector.php",
+    )
+    tmpl_vcl = os.path.join(
+        REPO_ROOT, "instance_template", "config", "default.vcl",
+    )
+    tmpl_vector = os.path.join(
+        REPO_ROOT, "instance_template", "config", "settings", "global",
+        "Vector.php",
+    )
+
+    # Drift one seed file (local edit) and delete another.
+    marker = "# CANASTA_TEST_REFRESH_MARKER"
+    print("Drifting default.vcl and deleting Vector.php...")
+    with open(vcl, "a") as f:
+        f.write("\n%s\n" % marker)
+    os.remove(vector)
+
+    print("Listing drift (no file argument)...")
+    out = inst.run_ok("config", "refresh-template", "-i", inst.id)
+    assert "config/default.vcl" in out, (
+        "drift list should flag default.vcl:\n%s" % out
+    )
+    assert "config/settings/global/Vector.php" in out, (
+        "drift list should flag the deleted Vector.php:\n%s" % out
+    )
+
+    print("Previewing default.vcl (no --yes must not change it)...")
+    out = inst.run_ok(
+        "config", "refresh-template", "-i", inst.id, "config/default.vcl",
+    )
+    assert "--yes" in out, (
+        "preview should tell the user to re-run with --yes:\n%s" % out
+    )
+    with open(vcl) as f:
+        assert marker in f.read(), "preview must not modify the instance copy"
+
+    print("Adopting the template for both files with --yes...")
+    inst.run_ok(
+        "config", "refresh-template", "-i", inst.id,
+        "config/default.vcl", "config/settings/global/Vector.php", "--yes",
+    )
+    with open(vcl) as f, open(tmpl_vcl) as t:
+        assert f.read() == t.read(), "default.vcl should match the template"
+    assert os.path.isfile(vector), "deleted Vector.php should be restored"
+    with open(vector) as f, open(tmpl_vector) as t:
+        assert f.read() == t.read(), "restored Vector.php should match template"
+
+    print("A second --yes run is a no-op (already matches)...")
+    out = inst.run_ok(
+        "config", "refresh-template", "-i", inst.id,
+        "config/default.vcl", "--yes",
+    )
+    assert "already matches" in out, (
+        "an unchanged file should report already matching:\n%s" % out
+    )
+
+    print("A non-template path is rejected...")
+    out, rc = inst.run(
+        "config", "refresh-template", "-i", inst.id, "config/../.env",
+    )
+    assert rc != 0, "refreshing a non-template path should fail"
+    assert "not a template-seeded file" in out, (
+        "rejection should explain why:\n%s" % out
+    )
+
+
 # --- Test runner ---
 
 ALL_TESTS = {
@@ -2739,6 +2818,7 @@ ALL_TESTS = {
     "extension-skin": test_extension_skin,
     "wiki-farm": test_wiki_farm,
     "config-side-effects": test_config_side_effects,
+    "config-refresh-template": test_config_refresh_template,
     "version": test_version,
     "doctor": test_doctor,
     "host-management": test_host_management,


### PR DESCRIPTION
## Summary

Adds `canasta config refresh-template [<file>...]` so users can adopt the current shipped version of a template-seeded config file, or restore one they deleted.

Closes #858.

## Background

Template-seeded config files — `config/default.vcl`, `config/settings/global/{DefaultSettings,Vector,CanastaFooterIcon}.php`, the settings `README`s, the crowdsec configs — are copied from `instance_template/` to the instance **once at create** (`roles/create/tasks/main.yml`, `force: false`) and are user-owned thereafter. Each file's header invites editing/deletion (delete `Vector.php` to drop Vector, edit `DefaultSettings.php` to change wiki defaults, etc.).

`canasta upgrade` is intentionally no-clobber on these (only `docker-compose.yml` is force-refreshed). That is correct — auto-overwriting would clobber deliberate user choices. But the consequence is that an instance which never customized a seed file is frozen on its create-time version forever, with no supported way to adopt an improved shipped version (a caching fix in `default.vcl`, a security tweak in `DefaultSettings.php`) or to restore a seed file that was deleted. The committed gitops HEAD is the *old* template, so `git restore` reverts to old rather than adopting new.

This is distinct from `config regenerate` (which owns *rendered* files: `.env`, `wikis.yaml`, `Caddyfile`) and from per-wiki `Settings.php` (genuinely user-owned, no shipped template).

## Behavior

- **No argument** — list the template-seeded files whose instance copy differs from the current template (read-only).
- **With a file** — show the `current → template` diff and stop (preview).
- **With `--yes`** — overwrite the instance copy with the shipped template.

Restricted to files shipped under `instance_template/config/`, so path traversal, `.env`, `wikis.yaml`, and per-wiki `Settings.php` are rejected. A missing instance copy (deleted seed) diffs as a full addition and is restored. After applying, it reminds to restart and (for gitops instances) `gitops add`/`push`.

Lives on `canasta config` (sibling to `config regenerate`), not `upgrade` (wrong semantics, heavyweight) and not `gitops` (the source is `instance_template/`, not the repo).

## Changes

- `meta/command_definitions.yml` — `config_refresh_template` definition (positional-multi `files`, `--yes`)
- `canasta.py` — `refresh-template` added to the `config` subcommand group
- `playbooks/config_refresh_template.yml`, `roles/config/tasks/refresh_template.yml`, `roles/config/tasks/_refresh_one.yml`

## Testing

- `make validate`, `make lint`, `make test-unit` (1347 passed) green.
- Live-validated against a fake instance directory: drift listing (modified file + deleted seed), preview-without-modifying, apply-overwrites, restore-deleted-seed, invalid/traversal path rejection, and already-matching no-op.
