### PR TITLE
fix(config): make refresh-template read-only by default (no prompt before listing/preview)

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -1397,6 +1397,23 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
     return ansible_args
 
 
+def should_prompt_confirmation(cmd_def, yes_passed):
+    """Whether to show the generic destructive-confirmation prompt.
+
+    The net fires for a command that declares a "yes" parameter and was
+    invoked without --yes. A command that is read-only unless an explicit
+    write flag is given (so prompting before it has done anything is
+    wrong) opts out with 'self_confirm: true' and does its own gating in
+    the playbook.
+    """
+    if cmd_def.get("self_confirm"):
+        return False
+    has_yes_param = any(
+        p["name"] == "yes" for p in cmd_def.get("parameters", [])
+    )
+    return has_yes_param and not yes_passed
+
+
 def main():
     data = load_definitions()
     parser = build_parser(data)
@@ -1546,10 +1563,8 @@ def main():
     # Interactive confirmation for destructive commands.
     # If the command defines a "yes" parameter and the user did not pass it,
     # prompt interactively rather than making them re-run with --yes.
-    has_yes_param = any(
-        p["name"] == "yes" for p in cmd_def.get("parameters", [])
-    )
-    if has_yes_param and not getattr(args, "yes", False):
+    # Commands that are read-only by default opt out with 'self_confirm'.
+    if should_prompt_confirmation(cmd_def, getattr(args, "yes", False)):
         description = cmd_def.get("description", command_name)
         instance_id = getattr(args, "id", None)
         host = getattr(args, "host", None)

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1017,7 +1017,7 @@ commands:
         description: "Canasta instance ID"
 
   - name: config_refresh_template
-    description: "Adopt the current template version of a seeded config file"
+    description: "List, diff, or adopt template versions of seeded config files"
     long_description: |
       Overwrite an instance's copy of a template-seeded config file
       (e.g. config/default.vcl, config/settings/global/Vector.php) with
@@ -1026,17 +1026,22 @@ commands:
       upgrade never changes them; use this to adopt an improved shipped
       version, or to restore a seed file you deleted.
 
-      With no file argument, lists the seed files whose instance copy
-      differs from the current template. With one or more files, shows
-      the diff and overwrites only when --yes is passed, so review the
-      diff first (your local edits to that file are replaced). Rendered
-      files (.env, wikis.yaml, Caddyfile) belong to 'config regenerate'
-      and per-wiki Settings.php is user-owned; neither is touched here.
+      This command is read-only unless --yes is given. With no file
+      argument it lists the seed files whose instance copy differs from
+      the current template. With one or more files it shows the diff but
+      changes nothing; add --yes to overwrite, so review the diff first
+      (your local edits to that file are replaced). Rendered files (.env,
+      wikis.yaml, Caddyfile) belong to 'config regenerate' and per-wiki
+      Settings.php is user-owned; neither is touched here.
     examples:
       - "canasta config refresh-template"
       - "canasta config refresh-template config/default.vcl"
       - "canasta config refresh-template config/default.vcl --yes"
     playbook: config_refresh_template.yml
+    # Read-only by default (lists drift / previews a diff); only --yes
+    # writes. Opt out of the generic destructive-confirmation prompt so
+    # the no-arg and preview invocations don't ask before doing nothing.
+    self_confirm: true
     parameters:
       - name: id
         short: i
@@ -1053,7 +1058,7 @@ commands:
         short: "y"
         type: bool
         default: false
-        description: "Overwrite the instance copy without confirmation"
+        description: "Overwrite the instance copy (without this, only previews the diff)"
 
   - name: config_unset
     description: "Remove a configuration setting"

--- a/roles/config/tasks/_refresh_one.yml
+++ b/roles/config/tasks/_refresh_one.yml
@@ -78,8 +78,8 @@
     - name: Report {{ _refresh_file }} previewed
       ansible.builtin.debug:
         msg: >-
-          Previewed {{ _refresh_file }}. Re-run with --yes to overwrite the
-          instance copy with the current template.
+          Previewed {{ _refresh_file }} (no changes made). Re-run with --yes
+          to overwrite the instance copy with the current template.
       when: not (yes | default(false) | bool)
 
     - name: Remove the staged copy

--- a/roles/config/tasks/refresh_template.yml
+++ b/roles/config/tasks/refresh_template.yml
@@ -72,7 +72,7 @@
               )
           }}
 
-# --- File mode: diff each requested file and overwrite when --yes ---------
+# --- File mode: diff each requested file and overwrite when --yes -------
 - name: Refresh requested files
   when: _refresh_requested | length > 0
   block:

--- a/tests/unit/test_validate_definitions.py
+++ b/tests/unit/test_validate_definitions.py
@@ -201,3 +201,56 @@ class TestDescriptionLint:
             "the YAML `default:` field — remove from the description:\n  "
             + "\n  ".join(offenders)
         )
+
+
+class TestAutoConfirmInvariant:
+    """canasta.py auto-prompts 'Continue? [y/N]' for any command whose
+    parameters include one named 'yes' (the destructive-confirmation net).
+    A command that is read-only unless --yes is given (so prompting before
+    it has done anything is wrong) must opt out with 'self_confirm: true'
+    and gate writes itself — e.g. 'config refresh-template' with no args
+    lists drift and must not prompt first.
+    """
+
+    def _real_commands(self):
+        repo_root = os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.abspath(__file__))
+        ))
+        defn_path = os.path.join(
+            repo_root, "meta", "command_definitions.yml",
+        )
+        with open(defn_path) as f:
+            return yaml.safe_load(f).get("commands", [])
+
+    def _canasta(self):
+        repo_root = os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.abspath(__file__))
+        ))
+        if repo_root not in sys.path:
+            sys.path.insert(0, repo_root)
+        import canasta
+        return canasta
+
+    def test_refresh_template_opts_out_of_auto_confirm(self):
+        cmd = next(
+            c for c in self._real_commands()
+            if c["name"] == "config_refresh_template"
+        )
+        assert cmd.get("self_confirm") is True, (
+            "config_refresh_template defines a 'yes' parameter, so it must "
+            "set 'self_confirm: true' or canasta.py's auto-confirm prompt "
+            "fires on its read-only no-arg/preview modes."
+        )
+
+    def test_self_confirm_suppresses_the_prompt(self):
+        canasta = self._canasta()
+        yes_cmd = {"parameters": [{"name": "yes"}]}
+        # A plain destructive command (e.g. delete) still prompts.
+        assert canasta.should_prompt_confirmation(yes_cmd, False) is True
+        assert canasta.should_prompt_confirmation(yes_cmd, True) is False
+        # self_confirm opts out entirely.
+        optout = dict(yes_cmd, self_confirm=True)
+        assert canasta.should_prompt_confirmation(optout, False) is False
+        # No 'yes' parameter -> never prompts.
+        assert canasta.should_prompt_confirmation({"parameters": []}, False) \
+            is False


### PR DESCRIPTION
## Summary

Fixes a UX bug in `canasta config refresh-template` (added in #859): it prompted for confirmation before doing anything, even on its read-only modes.

Closes #860.

## Symptom

```
$ canasta config refresh-template
Adopt the current template version of a seeded config file. Continue? [y/N] n
Operation cancelled.
```

The no-argument form was meant to list template-seeded files that differ from the current template (read-only), and a file argument was meant to show the diff and change nothing until confirmed. Instead every invocation hit a confirmation prompt first.

## Cause

canasta.py has a generic destructive-confirmation net: any command whose parameters include one named `yes` gets a `"<description>. Continue? [y/N]"` prompt when `--yes` is not passed, and confirming force-sets `--yes`. `config_refresh_template` defines a `yes` parameter, so the net fired on the read-only no-arg and preview invocations — and confirming bypassed the intended preview.

The bug shipped because the logic was validated by running the Ansible role directly; it was never exercised through the canasta.py wrapper (the integration test that would have caught it runs Docker-only / push-to-main).

## Fix

Add an opt-out rather than removing the familiar `-y/--yes` flag: a command can set `self_confirm: true` to skip the generic prompt and gate writes itself. `config_refresh_template` sets it, so it keeps `-y/--yes` (consistent with the rest of the CLI) while staying read-only unless `--yes` is given:

- no arguments → list seed files that differ from the template
- a file → show its diff, change nothing
- `--yes` → overwrite

When there is nothing to change it reports (e.g. `All template-seeded files match the current template.`) and exits without asking.

## Changes

- `canasta.py` — extract `should_prompt_confirmation(cmd_def, yes_passed)`, honoring `self_confirm`
- `meta/command_definitions.yml` — `config_refresh_template` sets `self_confirm: true`; keeps the `yes` parameter
- `roles/config/tasks/refresh_template.yml`, `_refresh_one.yml` — messaging back to `--yes`
- tests — unit tests for `should_prompt_confirmation` and an invariant that the command opts out of the net; integration test uses `--yes`

## Testing

- Verified through the real canasta.py wrapper: the no-argument form no longer prompts (goes straight to instance resolution).
- All playbook modes confirmed via a local harness: list, no-diff ("already matches" / "All ... match"), preview-without-changing, apply, restore-deleted-seed, invalid-path rejection.
- `make validate`, `make lint`, `make test-unit` (1349 passed) green.
