### PR TITLE
fix(output): render list debug msg line-by-line in canasta_minimal callback

### DIFF
--- a/callback_plugins/canasta_minimal.py
+++ b/callback_plugins/canasta_minimal.py
@@ -64,6 +64,10 @@ class CallbackModule(CallbackBase):
         if hasattr(result, '_task'):
             if result._task.action in ("ansible.builtin.debug", "debug"):
                 msg = result._result.get("msg")
+                # A debug 'msg' may be a list (one element per line). Render
+                # it line-by-line rather than as a Python list repr.
+                if isinstance(msg, (list, tuple)):
+                    msg = "\n".join(str(m) for m in msg)
                 if msg and msg not in ("All items completed", "All items skipped"):
                     msg_str = str(msg)
                     if any(msg_str.startswith(p) for p in self._GREEN_PREFIXES):

--- a/tests/unit/test_canasta_minimal_callback.py
+++ b/tests/unit/test_canasta_minimal_callback.py
@@ -211,3 +211,37 @@ class TestRunnerItemOnFailed:
             _result(msg="non-zero return code"), ignore_errors=True
         )
         assert cb._captured == []
+
+
+class TestRunnerOnOkDebug:
+    """v2_runner_on_ok renders debug task 'msg' output. A list msg (one
+    element per line) must render line-by-line, not as a Python list repr.
+    """
+
+    def _debug_result(self, msg):
+        return SimpleNamespace(
+            _result={"msg": msg},
+            _task=SimpleNamespace(action="ansible.builtin.debug"),
+        )
+
+    def test_list_msg_rendered_line_by_line(self):
+        cb = _make_callback()
+        cb.v2_runner_on_ok(self._debug_result(["line one", "line two", ""]))
+        assert len(cb._captured) == 1
+        shown = cb._captured[0][0]
+        assert shown == "line one\nline two\n"
+        assert "[" not in shown and "'" not in shown
+
+    def test_string_msg_unchanged(self):
+        cb = _make_callback()
+        cb.v2_runner_on_ok(self._debug_result("just a string"))
+        assert cb._captured[0][0] == "just a string"
+
+    def test_non_debug_task_suppressed(self):
+        cb = _make_callback()
+        result = SimpleNamespace(
+            _result={"msg": ["x", "y"]},
+            _task=SimpleNamespace(action="ansible.builtin.command"),
+        )
+        cb.v2_runner_on_ok(result)
+        assert cb._captured == []


### PR DESCRIPTION
## Summary

`canasta config refresh-template` printed its drift list, diffs, and reminders as a raw Python list literal instead of clean lines:

```
$ canasta config refresh-template
['Seed files that differ from the current template:', '  config/Caddyfile.global', ..., 'Review and adopt one with: canasta config refresh-template <file> --yes']
```

Closes #862.

## Cause

The `canasta_minimal` stdout callback does `str(msg)` on a debug task's `msg`. When `msg` is a list (one element per line) — which the refresh-template drift list, per-file diff, and reminders use — `str()` renders the Python list repr. The default Ansible stdout callback pretty-prints list msgs, which is why this passed local `ansible-playbook` testing but not the real CLI (which uses `canasta_minimal`).

Latent since the feature landed (#859); the read-only no-argument path that emits the list only became reachable after the no-prompt fix (#861).

## Fix

In `canasta_minimal`'s `v2_runner_on_ok`, join a list/tuple `msg` with newlines before display, so list msgs render line-by-line. A list `msg` is a standard Ansible idiom; no command relied on the prior repr output (no other playbook emits a list msg). Adds callback unit tests.

## Testing

- Verified through the actual `canasta_minimal` callback (not just raw `ansible-playbook`): list, preview, and apply output all render as clean lines.
- `make lint`, `make validate`, `make test-unit` (1352 passed) green.
