### PR TITLE
fix(gitops): route 'gitops add config/wikis.yaml' through the template reconcile

### DIFF
--- a/roles/gitops/tasks/add.yml
+++ b/roles/gitops/tasks/add.yml
@@ -2,22 +2,36 @@
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
+# config/wikis.yaml is rendered from wikis.yaml.template, so staging the
+# rendered file directly would drop a literal edit (e.g. a wiki display
+# name) on the next render and never reach other hosts. Detect an
+# explicit request for it and route it through the same reconcile the
+# no-path form uses, rather than a bare 'git add'.
+- name: Classify the add request
+  ansible.builtin.set_fact:
+    _add_all: "{{ path is not defined or path == '' }}"
+    _add_wikis: >-
+      {{ path is defined and path != ''
+         and (path | regex_replace('^\\./', '')) == 'config/wikis.yaml' }}
+
+# Explicit path other than config/wikis.yaml: stage it literally.
 - name: Stage specific file
   ansible.builtin.command:
     cmd: "git add {{ path }}"
     chdir: "{{ instance_path }}"
   register: _git_add_path
   changed_when: _git_add_path.rc == 0
-  when: path is defined and path != ''
+  when:
+    - not _add_all
+    - not _add_wikis
 
-# config/wikis.yaml is not tracked (it is rendered from
-# wikis.yaml.template). Capture any literal edits (e.g. a wiki's
-# display name) back into the template so they are staged and shared
-# rather than dropped on the next render.
+# Capture any literal config/wikis.yaml edits back into the template so
+# they are staged and shared rather than dropped on the next render.
+# Runs for the no-path form and for an explicit config/wikis.yaml.
 - name: Capture wikis.yaml edits into the gitops template
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/gitops/tasks/_reconcile_wikis_template.yml
-  when: path is not defined or path == ''
+  when: _add_all or _add_wikis
 
 # Scope with an explicit pathspec: since Git 2.0 `git add -A` ignores
 # the working directory and stages the whole tree, so chdir alone does
@@ -28,7 +42,30 @@
     chdir: "{{ instance_path }}"
   register: _git_add
   changed_when: _git_add.rc == 0
-  when: path is not defined or path == ''
+  when: _add_all
+
+# An explicit config/wikis.yaml request: the reconcile above captured the
+# edit into the template; also stage the rendered file, but only when it
+# is tracked (it is gitignored on current instances, where there is
+# nothing to stage and a bare 'git add' would error).
+- name: Check whether config/wikis.yaml is tracked
+  ansible.builtin.command:
+    cmd: "git ls-files --error-unmatch config/wikis.yaml"
+    chdir: "{{ instance_path }}"
+  register: _wikis_tracked
+  failed_when: false
+  changed_when: false
+  when: _add_wikis
+
+- name: Stage the tracked rendered wikis.yaml
+  ansible.builtin.command:
+    cmd: "git add -- config/wikis.yaml"
+    chdir: "{{ instance_path }}"
+  register: _git_add_wikis
+  changed_when: _git_add_wikis.rc == 0
+  when:
+    - _add_wikis
+    - (_wikis_tracked.rc | default(1)) == 0
 
 # wikis.yaml.template lives at the instance root, outside config/, so
 # the pathspec above does not reach it. Stage it whenever it exists (a
@@ -41,7 +78,7 @@
   register: _git_add_tmpl
   changed_when: _git_add_tmpl.rc == 0
   when:
-    - path is not defined or path == ''
+    - _add_all or _add_wikis
     - _reconcile_wikis_tmpl.stat.exists | default(false)
 
 - name: Report captured wikis.yaml edits
@@ -50,6 +87,6 @@
       Captured config/wikis.yaml edits into wikis.yaml.template
       (e.g. wiki display names). Staged for push.
   when:
-    - path is not defined or path == ''
+    - _add_all or _add_wikis
     - _reconcile_wikis_write is defined
     - _reconcile_wikis_write.changed | default(false)

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -2797,6 +2797,59 @@ def test_config_refresh_template(inst):
     )
 
 
+def test_gitops_add_wikis_yaml(inst):
+    """`gitops add config/wikis.yaml` (explicit path) must route through the
+    wikis.yaml->template reconcile, not stage the rendered file. On old code
+    the bare `git add` of the gitignored file errors; with the fix the edit
+    is captured into wikis.yaml.template."""
+    if shutil.which("git-crypt") is None:
+        raise SkipTest("git-crypt not installed")
+    import yaml
+
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir, "-e", inst.env_file,
+    )
+
+    print("Creating bare git repository...")
+    bare_repo = os.path.join(inst.work_dir, "gitops-remote.git")
+    subprocess.run(
+        ["git", "init", "--bare", bare_repo], capture_output=True, check=True,
+    )
+    key_file = os.path.join(inst.work_dir, "gitops-test.key")
+
+    print("Initializing gitops...")
+    inst.run_ok(
+        "gitops", "init", "-i", inst.id, "-n", "testhost",
+        "--repo", bare_repo, "--key", key_file,
+    )
+
+    wikis_yaml = os.path.join(inst.instance_path(), "config", "wikis.yaml")
+    template = os.path.join(inst.instance_path(), "wikis.yaml.template")
+    assert os.path.isfile(template), (
+        "gitops init should create wikis.yaml.template"
+    )
+
+    print("Editing the wiki display name directly in config/wikis.yaml...")
+    with open(wikis_yaml) as f:
+        data = yaml.safe_load(f)
+    data["wikis"][0]["name"] = "DWIM Display Name"
+    with open(wikis_yaml, "w") as f:
+        yaml.safe_dump(data, f)
+
+    print("Staging by explicit path: canasta gitops add config/wikis.yaml...")
+    inst.run_ok("gitops", "add", "-i", inst.id, "config/wikis.yaml")
+
+    print("The edit must have been captured into wikis.yaml.template...")
+    with open(template) as f:
+        tmpl = f.read()
+    assert "DWIM Display Name" in tmpl, (
+        "explicit-path gitops add did not reconcile into the template:\n%s"
+        % tmpl
+    )
+
+
 # --- Test runner ---
 
 ALL_TESTS = {
@@ -2813,6 +2866,7 @@ ALL_TESTS = {
     "backup-custom-dockerfile": test_backup_custom_dockerfile,
     "backup-missing-dockerfile": test_backup_missing_dockerfile,
     "gitops": test_gitops,
+    "gitops-add-wikis-yaml": test_gitops_add_wikis_yaml,
     "gitops-join": test_gitops_join,
     "gitops-pull-diff": test_gitops_pull_diff,
     "extension-skin": test_extension_skin,

--- a/tests/unit/test_gitops_add_scope.py
+++ b/tests/unit/test_gitops_add_scope.py
@@ -45,13 +45,10 @@ class TestGitopsAddScope:
         not rely on chdir + bare `git add -A` (which is whole-tree)."""
         tasks = _load_tasks()
         # Only the whole-tree-capable `git add -A` form is at risk of the
-        # chdir-ignored bug. Explicit single-file stages (e.g.
-        # `git add -- wikis.yaml.template`) are intentionally scoped.
-        no_path = [
-            t for t in tasks
-            if "path is not defined" in str(t.get("when", ""))
-            and ("git add -A" in _cmd(t))
-        ]
+        # chdir-ignored bug. Match it by command rather than by its `when`
+        # expression (implementation detail). Explicit single-file stages
+        # (e.g. `git add -- wikis.yaml.template`) are already scoped.
+        no_path = [t for t in tasks if "git add -A" in _cmd(t)]
         assert no_path, "add.yml lost its no-path staging task"
         for t in no_path:
             cmd = _cmd(t)


### PR DESCRIPTION
## Summary

`canasta gitops add config/wikis.yaml` did the wrong thing. `config/wikis.yaml` is rendered from `wikis.yaml.template`, but the wikis.yaml→template reconcile in `roles/gitops/tasks/add.yml` only ran for the **no-path** form. The explicit-path branch was a bare `git add {{ path }}`, so:

- on a current instance (where `config/wikis.yaml` is gitignored) it **errored** ("paths are ignored…");
- on a legacy instance that still tracks it, it staged the **rendered** file without updating the template — the literal edit (e.g. a wiki display name) was dropped on the next render and never propagated to other hosts.

Closes #864.

## Fix

Detect an explicit `config/wikis.yaml` request and route it through the same reconcile the no-path form uses: capture the edit into `wikis.yaml.template`, stage the template, and stage the rendered file only when it is tracked (so the gitignored current-instance case doesn't error). Other explicit paths and the no-path form are unchanged.

## Testing

Validated through the real `add.yml` against a registered instance + git repo (localhost harness) across all paths:

| Invocation | Result |
|---|---|
| `gitops add config/wikis.yaml` (gitignored) | reconcile → template staged; rendered file untouched |
| `gitops add config/wikis.yaml` (legacy, tracked) | reconcile → template + rendered file staged |
| `gitops add config/default.vcl` | bare `git add`, no reconcile (unchanged) |
| `gitops add` (no path) | reconcile + `git add -A -- config` + template (unchanged) |

Adds integration test `gitops-add-wikis-yaml` (fails on old code: the bare `git add` of the gitignored file errors). `make lint`/`make validate` pass.
