### PR TITLE
feat(upgrade): refresh gitops .gitignore from gitignore.default

### DIFF
--- a/roles/gitops/tasks/refresh_gitignore.yml
+++ b/roles/gitops/tasks/refresh_gitignore.yml
@@ -1,0 +1,40 @@
+---
+# Ensure the instance .gitignore carries the current shipped ignore rules
+# (roles/gitops/files/gitignore.default). New rules added in later
+# releases are appended; user-added lines and existing ordering are
+# preserved (idempotent). Only the rule lines are reconciled — comments
+# and blank lines in gitignore.default are layout, not rules.
+#
+# Gitops-only: .gitignore is written by 'gitops init', so this no-ops when
+# the gitops marker or the .gitignore is absent.
+#
+# Input: instance_path, canasta_root.
+
+- name: Stat gitops marker and .gitignore
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/{{ item }}"
+  loop:
+    - .gitops-host
+    - .gitignore
+  register: _gi_stats
+
+- name: Refresh managed ignore rules
+  when:
+    - _gi_stats.results[0].stat.exists | default(false)
+    - _gi_stats.results[1].stat.exists | default(false)
+  block:
+    - name: Read the shipped ignore rules
+      ansible.builtin.set_fact:
+        _gi_shipped_rules: >-
+          {{ lookup('file', canasta_root ~ '/roles/gitops/files/gitignore.default').splitlines()
+             | map('trim')
+             | reject('match', '^#')
+             | reject('equalto', '')
+             | list }}
+
+    - name: Ensure each shipped ignore rule is present
+      ansible.builtin.lineinfile:
+        path: "{{ instance_path }}/.gitignore"
+        line: "{{ item }}"
+        state: present
+      loop: "{{ _gi_shipped_rules }}"

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -106,6 +106,15 @@
     name: orchestrator
     tasks_from: init_config.yml
 
+# Bring a gitops instance's .gitignore current with the shipped rules.
+# Like the managed compose stack files above, .gitignore is CLI-managed
+# scaffolding; unlike them it was never refreshed after 'gitops init', so
+# ignore rules added in later releases never reached existing instances.
+# No-ops on non-gitops instances.
+- name: Refresh gitops .gitignore (managed ignore rules)
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/gitops/tasks/refresh_gitignore.yml
+
 # --- Bump configured image tag (orchestrator-specific) ---
 # K8s updates values.yaml image.tag; Compose updates CANASTA_IMAGE in .env.
 - name: Update configured image tag

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -2797,6 +2797,56 @@ def test_config_refresh_template(inst):
     )
 
 
+def test_upgrade_refreshes_gitignore(inst):
+    """canasta upgrade backfills new managed ignore rules into a gitops
+    instance's .gitignore while preserving user-added lines."""
+    if shutil.which("git-crypt") is None:
+        raise SkipTest("git-crypt not installed")
+
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir, "-e", inst.env_file,
+    )
+
+    print("Creating bare git repository...")
+    bare_repo = os.path.join(inst.work_dir, "gitops-remote.git")
+    subprocess.run(
+        ["git", "init", "--bare", bare_repo], capture_output=True, check=True,
+    )
+    key_file = os.path.join(inst.work_dir, "gitops-test.key")
+
+    print("Initializing gitops...")
+    inst.run_ok(
+        "gitops", "init", "-i", inst.id, "-n", "testhost",
+        "--repo", bare_repo, "--key", key_file,
+    )
+
+    gi = os.path.join(inst.instance_path(), ".gitignore")
+    print("Simulating a stale .gitignore (drop a managed rule, add a user "
+          "line)...")
+    with open(gi) as f:
+        lines = [ln for ln in f.read().splitlines()
+                 if ln.strip() != "config/wikis.yaml"]
+    lines.append("my-custom-ignore.txt")
+    with open(gi, "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+    print("Upgrading...")
+    inst.run_ok("upgrade")
+
+    with open(gi) as f:
+        result = f.read().splitlines()
+    assert "config/wikis.yaml" in result, (
+        "upgrade should restore the dropped managed ignore rule:\n%s"
+        % "\n".join(result)
+    )
+    assert "my-custom-ignore.txt" in result, (
+        "upgrade must preserve user-added .gitignore lines:\n%s"
+        % "\n".join(result)
+    )
+
+
 # --- Test runner ---
 
 ALL_TESTS = {
@@ -2807,6 +2857,7 @@ ALL_TESTS = {
     "lifecycle": test_lifecycle,
     "import": test_import_export,
     "upgrade": test_upgrade,
+    "upgrade-refreshes-gitignore": test_upgrade_refreshes_gitignore,
     "upgrade-backfill-hosts-yaml": test_upgrade_backfill_hosts_yaml,
     "backup": test_backup,
     "backup-advanced": test_backup_advanced,


### PR DESCRIPTION
## Summary

A gitops instance's `.gitignore` is written once at `gitops init` (from `roles/gitops/files/gitignore.default`) and never refreshed. Ignore rules added in later releases — `config/wikis.yaml`, `config/default.vcl`, `config/settings/global/README`, etc. — never reach existing instances, which is why an older instance ends up tracking files that current instances ignore. `canasta upgrade` already force-refreshes other CLI-managed scaffolding (`docker-compose.yml`); `.gitignore` was left out.

Closes #865.

## Fix

`roles/gitops/tasks/refresh_gitignore.yml` ensures every shipped rule from `gitignore.default` is present in the instance `.gitignore`: appends missing rules, preserves user-added lines and ordering, idempotent. Gitops-only — gated on the gitops marker and an existing `.gitignore`, so it no-ops on non-gitops instances. Called from `upgrade` right after orchestrator config init.

## Caveat (intentional)

Refreshing rules only affects ignores going forward — git keeps tracking files that are already committed even once they're ignored. Untracking those (`git rm --cached`) is a deliberate, destructive step and is **not** part of this automatic refresh.

## Testing

Localhost harness against the real task:

- stale `.gitignore` → all shipped rules appended, user lines (`# my custom ignores`, `secret-notes.txt`) preserved; second run idempotent (`changed=0`).
- non-gitops (no marker) and gitops-without-`.gitignore` → skipped, no file created.

Adds integration test `upgrade-refreshes-gitignore` (drops a managed rule + adds a user line, runs `canasta upgrade`, asserts the rule is restored and the user line survives). `make lint`/`make validate`/`make test-unit` (1352) pass.
