### PR TITLE
feat(gitops): require >=1 file for 'gitops add' and accept multiple files

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -704,7 +704,9 @@ def add_params_to_parser(parser, params):
             elif param.get("multi"):
                 parser.add_argument(
                     name,
-                    nargs="*",
+                    # `required: true` on a positional multi means at least
+                    # one value must be given (argparse errors on none).
+                    nargs="+" if required else "*",
                     default=default,
                     help=desc,
                     metavar=name.upper(),

--- a/direct_commands/gitops.py
+++ b/direct_commands/gitops.py
@@ -158,7 +158,10 @@ def _parse_gitops_status(stdout, instance_id):
 
     if wikis_drift:
         lines.append("Uncaptured config/wikis.yaml edits (e.g. wiki display name):")
-        lines.append("  run 'canasta gitops add' to capture and stage them.")
+        lines.append(
+            "  run 'canasta gitops add config/wikis.yaml' to capture and "
+            "stage them."
+        )
         lines.append("")
 
     if not staged and not unstaged and not wikis_drift:

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -2160,22 +2160,27 @@ commands:
   - name: gitops_add
     description: "Add configuration changes to git"
     long_description: |
-      Stage configuration changes for the next gitops push. If a file
-      path is given, stage just that path. Without a path, stage all
-      changes under the config directory (existing behavior).
+      Stage one or more files for the next gitops push. Each path is
+      relative to the instance root. At least one file is required.
+
+      Staging config/wikis.yaml captures its literal edits (e.g. a wiki
+      display name) into wikis.yaml.template rather than the rendered
+      file, so they survive the next render and reach other hosts.
     examples:
-      - "canasta gitops add extensions/WikiWorks/LocalSettings.php"
-      - "canasta gitops add"
+      - "canasta gitops add config/wikis.yaml"
+      - "canasta gitops add extensions/WikiWorks/LocalSettings.php config/default.vcl"
     playbook: gitops_add.yml
     parameters:
       - name: id
         short: i
         type: string
         description: "Canasta instance ID"
-      - name: path
+      - name: files
         type: string
         positional: true
-        description: "File path to stage (relative to instance root)"
+        multi: true
+        required: true
+        description: "File path(s) to stage (relative to instance root)"
 
   - name: gitops_rm
     description: "Remove configuration from git tracking"

--- a/roles/gitops/tasks/add.yml
+++ b/roles/gitops/tasks/add.yml
@@ -1,53 +1,46 @@
 ---
+# Stage one or more explicitly named files for the next gitops push.
+# At least one file is required (enforced by the CLI parser). Each path
+# is relative to the instance root.
+#
+# config/wikis.yaml is rendered from wikis.yaml.template, so staging it
+# directly would drop a literal edit (e.g. a wiki display name) on the
+# next render and never reach other hosts. When it is among the files,
+# route it through the reconcile (capture into the template) instead of
+# a bare 'git add'.
+#
+# Input: files (str: space-separated paths), canasta_root.
+
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
-# config/wikis.yaml is rendered from wikis.yaml.template, so staging the
-# rendered file directly would drop a literal edit (e.g. a wiki display
-# name) on the next render and never reach other hosts. Detect an
-# explicit request for it and route it through the same reconcile the
-# no-path form uses, rather than a bare 'git add'.
-- name: Classify the add request
+- name: Parse the requested files
   ansible.builtin.set_fact:
-    _add_all: "{{ path is not defined or path == '' }}"
-    _add_wikis: >-
-      {{ path is defined and path != ''
-         and (path | regex_replace('^\\./', '')) == 'config/wikis.yaml' }}
+    _add_files: >-
+      {{ (files | default('', true)).split()
+         | map('regex_replace', '^\\./', '') | list }}
 
-# Explicit path other than config/wikis.yaml: stage it literally.
-- name: Stage specific file
+- name: Classify the request
+  ansible.builtin.set_fact:
+    _add_has_wikis: "{{ 'config/wikis.yaml' in _add_files }}"
+    _add_other_files: "{{ _add_files | reject('equalto', 'config/wikis.yaml') | list }}"
+
+# Stage each explicitly named file other than the rendered wikis.yaml.
+- name: Stage requested files
   ansible.builtin.command:
-    cmd: "git add {{ path }}"
+    cmd: "git add -- {{ item }}"
     chdir: "{{ instance_path }}"
-  register: _git_add_path
-  changed_when: _git_add_path.rc == 0
-  when:
-    - not _add_all
-    - not _add_wikis
+  register: _git_add_file
+  changed_when: _git_add_file.rc == 0
+  loop: "{{ _add_other_files }}"
 
-# Capture any literal config/wikis.yaml edits back into the template so
-# they are staged and shared rather than dropped on the next render.
-# Runs for the no-path form and for an explicit config/wikis.yaml.
+# config/wikis.yaml: capture the literal edit into the template rather
+# than staging the rendered file.
 - name: Capture wikis.yaml edits into the gitops template
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/gitops/tasks/_reconcile_wikis_template.yml
-  when: _add_all or _add_wikis
+  when: _add_has_wikis
 
-# Scope with an explicit pathspec: since Git 2.0 `git add -A` ignores
-# the working directory and stages the whole tree, so chdir alone does
-# not limit it to config/.
-- name: Stage all changes under config/
-  ansible.builtin.command:
-    cmd: "git add -A -- config"
-    chdir: "{{ instance_path }}"
-  register: _git_add
-  changed_when: _git_add.rc == 0
-  when: _add_all
-
-# An explicit config/wikis.yaml request: the reconcile above captured the
-# edit into the template; also stage the rendered file, but only when it
-# is tracked (it is gitignored on current instances, where there is
-# nothing to stage and a bare 'git add' would error).
 - name: Check whether config/wikis.yaml is tracked
   ansible.builtin.command:
     cmd: "git ls-files --error-unmatch config/wikis.yaml"
@@ -55,8 +48,11 @@
   register: _wikis_tracked
   failed_when: false
   changed_when: false
-  when: _add_wikis
+  when: _add_has_wikis
 
+# Stage the rendered wikis.yaml only when it is tracked (it is gitignored
+# on current instances, where there is nothing to stage and a bare
+# 'git add' would error).
 - name: Stage the tracked rendered wikis.yaml
   ansible.builtin.command:
     cmd: "git add -- config/wikis.yaml"
@@ -64,13 +60,11 @@
   register: _git_add_wikis
   changed_when: _git_add_wikis.rc == 0
   when:
-    - _add_wikis
+    - _add_has_wikis
     - (_wikis_tracked.rc | default(1)) == 0
 
-# wikis.yaml.template lives at the instance root, outside config/, so
-# the pathspec above does not reach it. Stage it whenever it exists (a
-# no-op when unchanged) so a template edit captured by an earlier
-# 'config regenerate' is not left behind on push.
+# wikis.yaml.template lives at the instance root; stage it whenever it
+# exists (a no-op when unchanged).
 - name: Stage wikis.yaml.template
   ansible.builtin.command:
     cmd: "git add -- wikis.yaml.template"
@@ -78,7 +72,7 @@
   register: _git_add_tmpl
   changed_when: _git_add_tmpl.rc == 0
   when:
-    - _add_all or _add_wikis
+    - _add_has_wikis
     - _reconcile_wikis_tmpl.stat.exists | default(false)
 
 - name: Report captured wikis.yaml edits
@@ -87,6 +81,6 @@
       Captured config/wikis.yaml edits into wikis.yaml.template
       (e.g. wiki display names). Staged for push.
   when:
-    - _add_all or _add_wikis
+    - _add_has_wikis
     - _reconcile_wikis_write is defined
     - _reconcile_wikis_write.changed | default(false)

--- a/roles/gitops/tasks/add.yml
+++ b/roles/gitops/tasks/add.yml
@@ -2,22 +2,36 @@
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
+# config/wikis.yaml is rendered from wikis.yaml.template, so staging the
+# rendered file directly would drop a literal edit (e.g. a wiki display
+# name) on the next render and never reach other hosts. Detect an
+# explicit request for it and route it through the same reconcile the
+# no-path form uses, rather than a bare 'git add'.
+- name: Classify the add request
+  ansible.builtin.set_fact:
+    _add_all: "{{ path is not defined or path == '' }}"
+    _add_wikis: >-
+      {{ path is defined and path != ''
+         and (path | regex_replace('^\\./', '')) == 'config/wikis.yaml' }}
+
+# Explicit path other than config/wikis.yaml: stage it literally.
 - name: Stage specific file
   ansible.builtin.command:
     cmd: "git add {{ path }}"
     chdir: "{{ instance_path }}"
   register: _git_add_path
   changed_when: _git_add_path.rc == 0
-  when: path is defined and path != ''
+  when:
+    - not _add_all
+    - not _add_wikis
 
-# config/wikis.yaml is not tracked (it is rendered from
-# wikis.yaml.template). Capture any literal edits (e.g. a wiki's
-# display name) back into the template so they are staged and shared
-# rather than dropped on the next render.
+# Capture any literal config/wikis.yaml edits back into the template so
+# they are staged and shared rather than dropped on the next render.
+# Runs for the no-path form and for an explicit config/wikis.yaml.
 - name: Capture wikis.yaml edits into the gitops template
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/gitops/tasks/_reconcile_wikis_template.yml
-  when: path is not defined or path == ''
+  when: _add_all or _add_wikis
 
 # Scope with an explicit pathspec: since Git 2.0 `git add -A` ignores
 # the working directory and stages the whole tree, so chdir alone does
@@ -28,7 +42,30 @@
     chdir: "{{ instance_path }}"
   register: _git_add
   changed_when: _git_add.rc == 0
-  when: path is not defined or path == ''
+  when: _add_all
+
+# An explicit config/wikis.yaml request: the reconcile above captured the
+# edit into the template; also stage the rendered file, but only when it
+# is tracked (it is gitignored on current instances, where there is
+# nothing to stage and a bare 'git add' would error).
+- name: Check whether config/wikis.yaml is tracked
+  ansible.builtin.command:
+    cmd: "git ls-files --error-unmatch config/wikis.yaml"
+    chdir: "{{ instance_path }}"
+  register: _wikis_tracked
+  failed_when: false
+  changed_when: false
+  when: _add_wikis
+
+- name: Stage the tracked rendered wikis.yaml
+  ansible.builtin.command:
+    cmd: "git add -- config/wikis.yaml"
+    chdir: "{{ instance_path }}"
+  register: _git_add_wikis
+  changed_when: _git_add_wikis.rc == 0
+  when:
+    - _add_wikis
+    - (_wikis_tracked.rc | default(1)) == 0
 
 # wikis.yaml.template lives at the instance root, outside config/, so
 # the pathspec above does not reach it. Stage it whenever it exists (a
@@ -41,7 +78,7 @@
   register: _git_add_tmpl
   changed_when: _git_add_tmpl.rc == 0
   when:
-    - path is not defined or path == ''
+    - _add_all or _add_wikis
     - _reconcile_wikis_tmpl.stat.exists | default(false)
 
 - name: Report captured wikis.yaml edits
@@ -50,6 +87,6 @@
       Captured config/wikis.yaml edits into wikis.yaml.template
       (e.g. wiki display names). Staged for push.
   when:
-    - path is not defined or path == ''
+    - _add_all or _add_wikis
     - _reconcile_wikis_write is defined
     - _reconcile_wikis_write.changed | default(false)

--- a/roles/gitops/tasks/push_compose.yml
+++ b/roles/gitops/tasks/push_compose.yml
@@ -145,9 +145,9 @@
     - _gh_check.rc | default(0) != 0
 
 # --- Commit and push ---
-# Note: no 'git add -A' here. Users stage changes explicitly via
-# 'canasta gitops add' (which runs git add -A). Push only commits
-# what's already staged and pushes any unpushed commits.
+# Note: no staging here. Users stage changes explicitly via
+# 'canasta gitops add <files>'. Push only commits what's already staged
+# and pushes any unpushed commits.
 
 - name: Check for staged changes
   ansible.builtin.command:

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -2797,6 +2797,59 @@ def test_config_refresh_template(inst):
     )
 
 
+def test_gitops_add_wikis_yaml(inst):
+    """`gitops add config/wikis.yaml` (explicit path) must route through the
+    wikis.yaml->template reconcile, not stage the rendered file. On old code
+    the bare `git add` of the gitignored file errors; with the fix the edit
+    is captured into wikis.yaml.template."""
+    if shutil.which("git-crypt") is None:
+        raise SkipTest("git-crypt not installed")
+    import yaml
+
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir, "-e", inst.env_file,
+    )
+
+    print("Creating bare git repository...")
+    bare_repo = os.path.join(inst.work_dir, "gitops-remote.git")
+    subprocess.run(
+        ["git", "init", "--bare", bare_repo], capture_output=True, check=True,
+    )
+    key_file = os.path.join(inst.work_dir, "gitops-test.key")
+
+    print("Initializing gitops...")
+    inst.run_ok(
+        "gitops", "init", "-i", inst.id, "-n", "testhost",
+        "--repo", bare_repo, "--key", key_file,
+    )
+
+    wikis_yaml = os.path.join(inst.instance_path(), "config", "wikis.yaml")
+    template = os.path.join(inst.instance_path(), "wikis.yaml.template")
+    assert os.path.isfile(template), (
+        "gitops init should create wikis.yaml.template"
+    )
+
+    print("Editing the wiki display name directly in config/wikis.yaml...")
+    with open(wikis_yaml) as f:
+        data = yaml.safe_load(f)
+    data["wikis"][0]["name"] = "DWIM Display Name"
+    with open(wikis_yaml, "w") as f:
+        yaml.safe_dump(data, f)
+
+    print("Staging by explicit path: canasta gitops add config/wikis.yaml...")
+    inst.run_ok("gitops", "add", "-i", inst.id, "config/wikis.yaml")
+
+    print("The edit must have been captured into wikis.yaml.template...")
+    with open(template) as f:
+        tmpl = f.read()
+    assert "DWIM Display Name" in tmpl, (
+        "explicit-path gitops add did not reconcile into the template:\n%s"
+        % tmpl
+    )
+
+
 # --- Test runner ---
 
 ALL_TESTS = {
@@ -2813,6 +2866,7 @@ ALL_TESTS = {
     "backup-custom-dockerfile": test_backup_custom_dockerfile,
     "backup-missing-dockerfile": test_backup_missing_dockerfile,
     "gitops": test_gitops,
+    "gitops-add-wikis-yaml": test_gitops_add_wikis_yaml,
     "gitops-join": test_gitops_join,
     "gitops-pull-diff": test_gitops_pull_diff,
     "extension-skin": test_extension_skin,

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -2849,6 +2849,27 @@ def test_gitops_add_wikis_yaml(inst):
         % tmpl
     )
 
+    print("gitops add with no file argument must be rejected...")
+    _, rc = inst.run("gitops", "add", "-i", inst.id)
+    assert rc != 0, "no-arg 'gitops add' should error (at least one file)"
+
+    print("gitops add accepts multiple files...")
+    # Use non-gitignored paths (config/default.vcl etc. are gitignored).
+    gdir = os.path.join(inst.instance_path(), "config", "settings", "global")
+    rel_a = "config/settings/global/zz-test-a.php"
+    rel_b = "config/settings/global/zz-test-b.php"
+    for name in ("zz-test-a.php", "zz-test-b.php"):
+        with open(os.path.join(gdir, name), "w") as f:
+            f.write("<?php // test\n")
+    inst.run_ok("gitops", "add", "-i", inst.id, rel_a, rel_b)
+    staged = subprocess.run(
+        ["git", "-C", inst.instance_path(), "diff", "--cached", "--name-only"],
+        capture_output=True, text=True,
+    ).stdout
+    assert rel_a in staged and rel_b in staged, (
+        "both named files should be staged; got:\n%s" % staged
+    )
+
 
 # --- Test runner ---
 

--- a/tests/unit/test_gitops_add_scope.py
+++ b/tests/unit/test_gitops_add_scope.py
@@ -1,14 +1,10 @@
-"""Regression guard for 'canasta gitops add' (no path).
+"""Regression guard for 'canasta gitops add' staging scope.
 
-The no-path form is meant to stage only changes under config/. It used
-to run `git add -A` after chdir-ing into config/, but since Git 2.0
-`git add -A` with no pathspec stages the WHOLE working tree regardless
-of the current directory — so it also swept in extensions/, untracked
-host files (hosts/hosts.yaml), public_assets/, etc.
-
-The fix scopes the add with an explicit `config` pathspec. This test
-asserts the no-path staging command carries that pathspec, so a revert
-to the bare whole-tree form is caught.
+'gitops add' now requires explicit file arguments and stages only those
+paths. It must never fall back to a whole-tree `git add -A` (which, since
+Git 2.0, ignores chdir and stages extensions/, host files, public_assets/,
+etc. regardless of pathspec). This test asserts add.yml carries no
+`git add -A` form, so a reintroduced wildcard stage is caught.
 """
 
 import os
@@ -40,23 +36,13 @@ def _cmd(task):
 
 
 class TestGitopsAddScope:
-    def test_no_path_add_is_scoped_to_config(self):
-        """The no-path staging command must name `config` as a pathspec,
-        not rely on chdir + bare `git add -A` (which is whole-tree)."""
-        tasks = _load_tasks()
-        # Only the whole-tree-capable `git add -A` form is at risk of the
-        # chdir-ignored bug. Match it by command rather than by its `when`
-        # expression (implementation detail). Explicit single-file stages
-        # (e.g. `git add -- wikis.yaml.template`) are already scoped.
-        no_path = [t for t in tasks if "git add -A" in _cmd(t)]
-        assert no_path, "add.yml lost its no-path staging task"
-        for t in no_path:
-            cmd = _cmd(t)
-            # A bare `git add -A` (the buggy form) has no pathspec, so
-            # `config` would only appear in chdir — assert it's in the cmd.
-            tokens = cmd.split()
-            assert "config" in tokens, (
-                "no-path 'gitops add' must stage with a `config` pathspec "
-                "(e.g. `git add -A -- config`), not bare `git add -A`; got: %r"
-                % cmd
-            )
+    def test_no_whole_tree_add(self):
+        """add.yml must never use a whole-tree `git add -A`. Staging is
+        always to explicit, named paths."""
+        offenders = [
+            _cmd(t) for t in _load_tasks() if "git add -A" in _cmd(t)
+        ]
+        assert not offenders, (
+            "gitops add must stage explicit paths, not whole-tree "
+            "`git add -A` (chdir-ignored since Git 2.0); found: %r" % offenders
+        )

--- a/tests/unit/test_gitops_add_scope.py
+++ b/tests/unit/test_gitops_add_scope.py
@@ -45,13 +45,10 @@ class TestGitopsAddScope:
         not rely on chdir + bare `git add -A` (which is whole-tree)."""
         tasks = _load_tasks()
         # Only the whole-tree-capable `git add -A` form is at risk of the
-        # chdir-ignored bug. Explicit single-file stages (e.g.
-        # `git add -- wikis.yaml.template`) are intentionally scoped.
-        no_path = [
-            t for t in tasks
-            if "path is not defined" in str(t.get("when", ""))
-            and ("git add -A" in _cmd(t))
-        ]
+        # chdir-ignored bug. Match it by command rather than by its `when`
+        # expression (implementation detail). Explicit single-file stages
+        # (e.g. `git add -- wikis.yaml.template`) are already scoped.
+        no_path = [t for t in tasks if "git add -A" in _cmd(t)]
         assert no_path, "add.yml lost its no-path staging task"
         for t in no_path:
             cmd = _cmd(t)

--- a/tests/unit/test_gitops_wikis_template_reconcile.py
+++ b/tests/unit/test_gitops_wikis_template_reconcile.py
@@ -80,22 +80,22 @@ class TestWiring:
 
     def test_add_reconciles_before_staging_and_stages_template(self):
         raw = _flat_text(ADD_YML)
-        names_in_order = [t.get("name", "") for t in raw if isinstance(t, dict)]
         cmds = " ".join(str(t) for t in raw)
         # reconcile include present
         assert any(RECONCILE_INCLUDE in _include_path(t) for t in _walk(raw))
         # template explicitly staged (it lives outside config/)
         assert "git add -- wikis.yaml.template" in cmds
-        # reconcile must come before the config staging
+        # reconcile must run before the template is staged (it writes the
+        # template the stage then captures)
         recon_idx = next(
             i for i, t in enumerate(raw)
             if isinstance(t, dict) and RECONCILE_INCLUDE in _include_path(t)
         )
         stage_idx = next(
             i for i, t in enumerate(raw)
-            if isinstance(t, dict) and "git add -A -- config" in str(t)
+            if isinstance(t, dict) and "git add -- wikis.yaml.template" in str(t)
         )
-        assert recon_idx < stage_idx, "reconcile must run before staging config/"
+        assert recon_idx < stage_idx, "reconcile must run before staging template"
 
     def test_template_staged_whenever_it_exists_not_only_on_capture(self):
         """A template edit captured by an earlier 'config regenerate' is


### PR DESCRIPTION
## Summary

`canasta gitops add` with no arguments wildcard-staged the entire `config/` tree (`git add -A -- config`) — surprising for an "add" verb. Require at least one explicit file, and accept multiple files.

Closes #866.

> Stacked on #867 (the wikis.yaml DWIM routing). Removing the no-arg form means the `wikis.yaml`→template reconcile has to live on the per-file path, which #867 provides. **Merge #867 first**, then this retargets cleanly to `main`.

## Changes

- **command def**: `path` (single, optional) → `files` (positional, `multi`, `required`). The parser now emits `nargs="+"` for a required positional multi, so no-arg `gitops add` is rejected with a usage error.
- **add.yml**: stage each named file explicitly; `config/wikis.yaml` among them still routes through the template reconcile. No whole-tree `git add -A` remains.
- **status advisory** (#855) now points at `gitops add config/wikis.yaml`.
- repurposed the add-scope unit guard to assert no whole-tree `git add -A` exists; updated the reconcile-ordering test for the new staging task; comment cleanup in `push_compose.yml`.

## Behavior

```
canasta gitops add                          # error: at least one FILE required
canasta gitops add config/wikis.yaml        # reconcile into template
canasta gitops add a.php b.php config/...    # stage each named file
```

## Testing

- Parser: no-arg rejected (`error: the following arguments are required: FILES`); multi usage `FILES [FILES ...]`.
- Localhost harness through the real `add.yml`: `gitops add config/default.vcl config/README config/wikis.yaml` stages the two named files and routes wikis.yaml into the template; no whole-tree add.
- Extended integration test: no-arg rejected + multiple files staged.
- `make lint`/`make validate`/`make test-unit` (1352) pass.
