### PR TITLE
feat(upgrade): backfill wikis.yaml.template for legacy gitops instances

### DIFF
--- a/roles/gitops/tasks/backfill_wikis_template.yml
+++ b/roles/gitops/tasks/backfill_wikis_template.yml
@@ -1,0 +1,46 @@
+---
+# Create wikis.yaml.template for a gitops instance that lacks it. 'gitops
+# init' generates the template (reconcile_create), but a repo created by
+# the Go-CLI predates that feature and nothing backfilled it — leaving the
+# whole config/wikis.yaml <-> wikis.yaml.template reconcile machinery inert
+# (display-name capture, the gitops status advisory). This creates it from
+# the live config/wikis.yaml when missing.
+#
+# Create-only: never re-renders an existing template (which could drop a
+# hand-customized one). Gitops-only — no-ops when the marker is absent.
+# Does not stage it; the next 'canasta gitops add config/wikis.yaml' /
+# 'gitops push' captures it (it is intentionally left for the user to
+# review, like the .gitignore refresh).
+#
+# Input: instance_path, canasta_root.
+
+- name: Stat gitops marker and wikis.yaml.template
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/{{ item }}"
+  loop:
+    - .gitops-host
+    - wikis.yaml.template
+  loop_control:
+    label: "{{ item }}"
+  register: _bwt_stats
+
+- name: Backfill wikis.yaml.template
+  when:
+    - _bwt_stats.results[0].stat.exists | default(false)
+    - not (_bwt_stats.results[1].stat.exists | default(false))
+  block:
+    - name: Create wikis.yaml.template from live wikis.yaml
+      ansible.builtin.include_tasks: >-
+        {{ canasta_root }}/roles/gitops/tasks/_reconcile_wikis_template.yml
+      vars:
+        reconcile_create: true
+
+    - name: Report wikis.yaml.template created
+      ansible.builtin.debug:
+        msg: >-
+          Created wikis.yaml.template (was missing on this gitops instance).
+          Capture it with 'canasta gitops add config/wikis.yaml' and
+          'canasta gitops push'.
+      when:
+        - _reconcile_wikis_write is defined
+        - _reconcile_wikis_write.changed | default(false)

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -115,6 +115,14 @@
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/gitops/tasks/refresh_gitignore.yml
 
+# Create wikis.yaml.template for a gitops instance that lacks it (e.g. a
+# Go-CLI-era repo predating the template). Without it the wikis.yaml
+# reconcile/advisory machinery is inert. No-ops on non-gitops instances
+# and when the template already exists.
+- name: Backfill gitops wikis.yaml.template if missing
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/gitops/tasks/backfill_wikis_template.yml
+
 # --- Bump configured image tag (orchestrator-specific) ---
 # K8s updates values.yaml image.tag; Compose updates CANASTA_IMAGE in .env.
 - name: Update configured image tag

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -2921,6 +2921,51 @@ def test_upgrade_refreshes_gitignore(inst):
     )
 
 
+def test_upgrade_backfills_wikis_template(inst):
+    """canasta upgrade creates wikis.yaml.template on a gitops instance
+    that lacks it (a Go-CLI-era repo predating the template)."""
+    if shutil.which("git-crypt") is None:
+        raise SkipTest("git-crypt not installed")
+
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir, "-e", inst.env_file,
+    )
+
+    print("Creating bare git repository...")
+    bare_repo = os.path.join(inst.work_dir, "gitops-remote.git")
+    subprocess.run(
+        ["git", "init", "--bare", bare_repo], capture_output=True, check=True,
+    )
+    key_file = os.path.join(inst.work_dir, "gitops-test.key")
+
+    print("Initializing gitops...")
+    inst.run_ok(
+        "gitops", "init", "-i", inst.id, "-n", "testhost",
+        "--repo", bare_repo, "--key", key_file,
+    )
+
+    template = os.path.join(inst.instance_path(), "wikis.yaml.template")
+    assert os.path.isfile(template), "gitops init should create the template"
+
+    print("Removing the template to simulate a legacy gitops repo...")
+    os.remove(template)
+
+    print("Upgrading...")
+    inst.run_ok("upgrade")
+
+    assert os.path.isfile(template), (
+        "upgrade should backfill the missing wikis.yaml.template"
+    )
+    with open(template) as f:
+        content = f.read()
+    assert "id: main" in content, (
+        "backfilled template should contain the instance's wiki(s):\n%s"
+        % content
+    )
+
+
 # --- Test runner ---
 
 ALL_TESTS = {
@@ -2932,6 +2977,7 @@ ALL_TESTS = {
     "import": test_import_export,
     "upgrade": test_upgrade,
     "upgrade-refreshes-gitignore": test_upgrade_refreshes_gitignore,
+    "upgrade-backfills-wikis-template": test_upgrade_backfills_wikis_template,
     "upgrade-backfill-hosts-yaml": test_upgrade_backfill_hosts_yaml,
     "backup": test_backup,
     "backup-advanced": test_backup_advanced,


### PR DESCRIPTION
## Problem

`wikis.yaml.template` (instance root, tracked) is the source of truth that `config/wikis.yaml` renders from, and the whole reconcile machinery depends on it: capturing display-name edits, the `gitops status` "Uncaptured config/wikis.yaml edits" advisory (#855), and `gitops add config/wikis.yaml` routing (#867).

`gitops init` creates it (`init_compose.yml`, reconcile with `reconcile_create: true`), but a gitops repo created by the **Go CLI** predates that feature, and **no upgrade migration backfills it** (nothing in `roles/upgrade/` creates it). On such instances the template is simply absent forever, so all of that reconcile machinery is inert — `config/wikis.yaml` is just tracked directly, and the advisory never fires.

Sibling of #865/#868 (refreshing `.gitignore` on upgrade): the same class of legacy-gitops gap.

## Fix

On `canasta upgrade`, for a gitops instance missing `wikis.yaml.template`, create it from the live `config/wikis.yaml` (`reconcile_create: true`). Create-only — never re-renders an existing template (which could drop a hand-customized one). No-ops on non-gitops instances and when the template already exists. Does not stage it; the next `gitops add config/wikis.yaml` / `gitops push` captures it (left for the user to review, like the `.gitignore` refresh).

Leaves a legacy tracked `config/wikis.yaml` as-is; fully untracking it (`git rm --cached`) stays a deliberate manual step.
