### PR TITLE
fix(gitops): capture a newly added wiki's files (settings, logos, template)

### DIFF
--- a/playbooks/add.yml
+++ b/playbooks/add.yml
@@ -226,6 +226,17 @@
     name: instance_lifecycle
     tasks_from: restart.yml
 
+# Stage the new wiki's gitops-tracked files (per-wiki settings,
+# public_assets, and the farm template). 'gitops init' captures wikis
+# present at init time; a wiki added later was never brought into
+# tracking, so its logos/settings could be lost on a repo-based recovery.
+# No-op on non-gitops instances.
+- name: Capture the new wiki for gitops
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/gitops/tasks/stage_new_wiki.yml
+  vars:
+    new_wiki_id: "{{ wiki }}"
+
 - name: Report wiki added
   ansible.builtin.debug:
     msg: "Wiki '{{ wiki }}' added to instance '{{ instance_id }}'."

--- a/roles/gitops/tasks/stage_new_wiki.yml
+++ b/roles/gitops/tasks/stage_new_wiki.yml
@@ -1,0 +1,66 @@
+---
+# Stage a newly added wiki's gitops-tracked files so a wiki added after
+# 'gitops init' is captured on the next push and recoverable from the
+# repo. 'gitops init' stages everything present at init time, but a wiki
+# added later was never brought into tracking — its per-wiki settings and
+# public_assets (logos) silently stayed out of gitops.
+#
+# Captures the new wiki into the farm template (wikis.yaml.template) and
+# stages its tracked paths (config/settings/wikis/<id>, public_assets/<id>)
+# when present. Best-effort and non-fatal: a staging hiccup must not fail
+# the wiki-add that already succeeded. Gitops-only — no-ops when the
+# gitops marker is absent.
+#
+# Input: instance_path, canasta_root, new_wiki_id.
+
+- name: Check for gitops instance
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/.gitops-host"
+  register: _snw_gitops
+
+- name: Capture the new wiki for gitops
+  when: _snw_gitops.stat.exists
+  block:
+    # The new wiki is already in config/wikis.yaml (rendered); capture it
+    # into the tracked template so it survives render and reaches other
+    # hosts. A no-op when the instance has no template.
+    - name: Capture wikis.yaml into the template
+      ansible.builtin.include_tasks: >-
+        {{ canasta_root }}/roles/gitops/tasks/_reconcile_wikis_template.yml
+
+    - name: Stage wikis.yaml.template
+      ansible.builtin.command:
+        cmd: "git add -- wikis.yaml.template"
+        chdir: "{{ instance_path }}"
+      register: _snw_tmpl
+      changed_when: _snw_tmpl.rc == 0
+      failed_when: false
+      when: _reconcile_wikis_tmpl.stat.exists | default(false)
+
+    - name: Stat the new wiki's tracked paths
+      ansible.builtin.stat:
+        path: "{{ instance_path }}/{{ item }}"
+      loop:
+        - "config/settings/wikis/{{ new_wiki_id }}"
+        - "public_assets/{{ new_wiki_id }}"
+      loop_control:
+        label: "{{ item }}"
+      register: _snw_paths
+
+    - name: Stage the new wiki's tracked paths
+      ansible.builtin.command:
+        cmd: "git add -- {{ item.item }}"
+        chdir: "{{ instance_path }}"
+      loop: "{{ _snw_paths.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+      register: _snw_add
+      changed_when: _snw_add.rc == 0
+      failed_when: false
+      when: item.stat.exists | default(false)
+
+    - name: Report new wiki staged for gitops
+      ansible.builtin.debug:
+        msg: >-
+          Staged new wiki '{{ new_wiki_id }}' for gitops. Review with
+          'canasta gitops status' and publish with 'canasta gitops push'.

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -2926,6 +2926,69 @@ def test_upgrade_refreshes_gitignore(inst):
     )
 
 
+def test_gitops_add_wiki_tracked(inst):
+    """A wiki added after gitops init must have its tracked files captured
+    into gitops by 'canasta add' (settings, public_assets logos, and the
+    farm template) — they used to silently stay untracked."""
+    if shutil.which("git-crypt") is None:
+        raise SkipTest("git-crypt not installed")
+
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir, "-e", inst.env_file,
+    )
+
+    print("Creating bare git repository...")
+    bare_repo = os.path.join(inst.work_dir, "gitops-remote.git")
+    subprocess.run(
+        ["git", "init", "--bare", bare_repo], capture_output=True, check=True,
+    )
+    key_file = os.path.join(inst.work_dir, "gitops-test.key")
+
+    print("Initializing gitops...")
+    inst.run_ok(
+        "gitops", "init", "-i", inst.id, "-n", "testhost",
+        "--repo", bare_repo, "--key", key_file,
+    )
+
+    # Place a logo for the new wiki before adding it, so the add's staging
+    # step has something to capture (public_assets is otherwise populated
+    # by the container at runtime).
+    logo_dir = os.path.join(inst.instance_path(), "public_assets", "docs")
+    os.makedirs(logo_dir, exist_ok=True)
+    with open(os.path.join(logo_dir, "Logo.png"), "w") as f:
+        f.write("PNGDATA")
+
+    settings_src = os.path.join(inst.work_dir, "docs-settings.php")
+    with open(settings_src, "w") as f:
+        f.write("<?php\n$wgDocsWiki = true;\n")
+
+    print("Adding a second wiki (docs)...")
+    inst.run_ok(
+        "add", "-i", inst.id, "-w", "docs",
+        "-u", "localhost:%s/docs" % inst.http_port,
+        "-l", settings_src,
+    )
+
+    staged = subprocess.run(
+        ["git", "-C", inst.instance_path(), "diff", "--cached", "--name-only"],
+        capture_output=True, text=True,
+    ).stdout
+    assert "public_assets/docs/Logo.png" in staged, (
+        "canasta add must stage the new wiki's public_assets logo:\n%s"
+        % staged
+    )
+    assert "config/settings/wikis/docs/Settings.php" in staged, (
+        "canasta add must stage the new wiki's settings:\n%s" % staged
+    )
+    template = os.path.join(inst.instance_path(), "wikis.yaml.template")
+    with open(template) as f:
+        assert "id: docs" in f.read(), (
+            "the new wiki must be captured into wikis.yaml.template"
+        )
+
+
 # --- Test runner ---
 
 ALL_TESTS = {
@@ -2944,6 +3007,7 @@ ALL_TESTS = {
     "backup-missing-dockerfile": test_backup_missing_dockerfile,
     "gitops": test_gitops,
     "gitops-add-wikis-yaml": test_gitops_add_wikis_yaml,
+    "gitops-add-wiki-tracked": test_gitops_add_wiki_tracked,
     "gitops-join": test_gitops_join,
     "gitops-pull-diff": test_gitops_pull_diff,
     "extension-skin": test_extension_skin,


### PR DESCRIPTION
Closes #874.

## Problem

`canasta add <wiki>` stages nothing for gitops (`playbooks/add.yml` has no gitops step). `gitops init` captures everything present at init time via `git add -A`, but a wiki added **later** was never brought into tracking. And the old no-arg `gitops add` was `git add -A -- config` (scoped to `config/`), so it could sweep in the new wiki's `config/settings/wikis/<id>/` but never its `public_assets/<id>/` (logos), which live outside `config/`.

Result: a wiki added after `gitops init` has its **logos untracked** — so they're absent from the gitops repo and lost on a repo-based disaster recovery. (A `.gitkeep` doesn't help: git tracks files, not directories, and never auto-includes new files.)

## Fix

`canasta add` is now gitops-aware (`roles/gitops/tasks/stage_new_wiki.yml`, called from `add.yml`, gitops-gated and non-fatal): after the wiki is created it
- reconciles `config/wikis.yaml` into `wikis.yaml.template` and stages the template (so the new wiki is in the farm definition),
- stages `config/settings/wikis/<id>/` and `public_assets/<id>/` when present.

No-op on non-gitops instances. The user pushes when ready (`canasta gitops push`).

Note: content created *after* the add (e.g. a logo uploaded later) still needs an explicit `canasta gitops add public_assets/<id>` — git has no passive auto-capture. This closes the gap where the wiki was never registered in gitops at all.

## Testing

Validated through the real task (localhost harness): a post-init wiki's `public_assets/<id>/Logo.png`, `config/settings/wikis/<id>/`, and the reconciled template all get staged; non-gitops is a no-op. Adds integration test `gitops-add-wiki-tracked` (places a logo, adds a wiki on a gitops instance, asserts the logo + settings are staged and the wiki is in the template).
