### PR TITLE
feat(gitops): report untracked files in gitops status

### DIFF
--- a/direct_commands/gitops.py
+++ b/direct_commands/gitops.py
@@ -53,7 +53,11 @@ def _gitops_status_script(path, ssh_key=None):
         "echo '%(d)s'; "
         "cat config/wikis.yaml 2>/dev/null; "
         "echo '%(d)s'; "
-        "cat wikis.yaml.template 2>/dev/null"
+        "cat wikis.yaml.template 2>/dev/null; "
+        "echo '%(d)s'; "
+        # Untracked, non-ignored files. --directory collapses a wholly
+        # untracked dir to one entry, matching `git status`.
+        "git ls-files --others --exclude-standard --directory 2>/dev/null"
     ) % {"p": qp, "d": d, "ssh": _git_ssh_env_prefix(ssh_key)}
 
 
@@ -127,6 +131,9 @@ def _parse_gitops_status(stdout, instance_id):
     tmpl_wikis_raw = parts[8] if len(parts) > 8 else ""
     wikis_drift = _wikis_uncaptured_edit(live_wikis_raw, tmpl_wikis_raw)
 
+    untracked_raw = parts[9].strip() if len(parts) > 9 else ""
+    untracked = untracked_raw.split("\n") if untracked_raw else []
+
     try:
         revcount_parts = revcount_raw.split("\t")
         ahead = int(revcount_parts[0])
@@ -156,6 +163,15 @@ def _parse_gitops_status(stdout, instance_id):
             lines.append("  %s" % f)
         lines.append("")
 
+    if untracked:
+        lines.append("Untracked files (%d):" % len(untracked))
+        for f in untracked:
+            lines.append("  %s" % f)
+        lines.append(
+            "  capture with 'canasta gitops add <file>' (or add to .gitignore)."
+        )
+        lines.append("")
+
     if wikis_drift:
         lines.append("Uncaptured config/wikis.yaml edits (e.g. wiki display name):")
         lines.append(
@@ -164,7 +180,7 @@ def _parse_gitops_status(stdout, instance_id):
         )
         lines.append("")
 
-    if not staged and not unstaged and not wikis_drift:
+    if not staged and not unstaged and not untracked and not wikis_drift:
         lines.append("No changes.")
         lines.append("")
 

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1910,7 +1910,7 @@ class TestParseGitopsStatus:
     def _make_output(self, hostname="myhost", hosts_yaml="MISSING",
                      commit="abc1234", applied="abc1234",
                      staged="", unstaged="", revcount="0\t0",
-                     wikis=None, template=None):
+                     wikis=None, template=None, untracked=None):
         d = direct_commands._SENTINEL
         out = (
             hostname + "\n" + d + "\n"
@@ -1921,10 +1921,11 @@ class TestParseGitopsStatus:
             + unstaged + "\n" + d + "\n"
             + revcount + "\n"
         )
-        if wikis is not None or template is not None:
+        if wikis is not None or template is not None or untracked is not None:
             out += (
                 d + "\n" + (wikis or "") + "\n"
-                + d + "\n" + (template or "")
+                + d + "\n" + (template or "") + "\n"
+                + d + "\n" + (untracked or "")
             )
         return out
 
@@ -1948,6 +1949,24 @@ class TestParseGitopsStatus:
         out = self._make_output(unstaged="docker-compose.override.yml")
         result = direct_commands._parse_gitops_status(out, "mysite")
         assert "Unstaged changes (1 files):" in result
+
+    def test_with_untracked_files(self):
+        out = self._make_output(
+            untracked="hosts/hosts.yaml\npublic_assets/notes/",
+        )
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "Untracked files (2):" in result
+        assert "hosts/hosts.yaml" in result
+        assert "public_assets/notes/" in result
+        assert "canasta gitops add" in result
+        # Untracked files mean there ARE changes — must not claim otherwise.
+        assert "No changes." not in result
+
+    def test_untracked_does_not_break_clean_status(self):
+        out = self._make_output(untracked="")
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "No changes." in result
+        assert "Untracked files" not in result
 
     def test_ahead_of_remote(self):
         out = self._make_output(revcount="3\t0")


### PR DESCRIPTION
## Problem

`canasta gitops status` reports staged (`git diff --cached`) and tracked-but-modified (`git diff`) files, but **never untracked files**. So a repo with untracked content reports "No changes. Up to date with remote." while `git status` shows untracked files:

```
$ git status
Untracked files:
	hosts/hosts.yaml
	public_assets/notes/

$ canasta gitops status
...
No changes.
Up to date with remote.
```

This is actively misleading: untracked-but-not-ignored files in a gitops repo are *uncaptured* — they aren't in the repo and would be lost on a repo-based recovery. Here `hosts/hosts.yaml` is gitops config and `public_assets/notes/` is a wiki's logos; both should be tracked, and status hid them.

## Fix

`canasta gitops status` now gathers `git ls-files --others --exclude-standard --directory` (untracked, non-ignored, with wholly-untracked dirs collapsed to match `git status`) and prints:

```
Untracked files (2):
  hosts/hosts.yaml
  public_assets/notes/
  capture with 'canasta gitops add <file>' (or add to .gitignore).
```

It also no longer claims "No changes." when untracked files exist. On a healthy instance (everything tracked or gitignored) the section is silent, so it's pure signal — it would have surfaced every untracked gap from this cluster instead of hiding them.

Compose status only (the K8s status path is Argo-CD-centric).

## Testing

Unit tests for the parser (untracked shown; untracked alone is not "No changes"; back-compat clean status). Verified end-to-end against a real git repo: output matches `git status` (collapses wholly-untracked dirs, excludes gitignored files). `make test-unit` (1354) + lint + validate green.
