### PR TITLE
fix(gitops): match git status for untracked files (use --porcelain, not ls-files)

### DIFF
--- a/direct_commands/gitops.py
+++ b/direct_commands/gitops.py
@@ -55,9 +55,11 @@ def _gitops_status_script(path, ssh_key=None):
         "echo '%(d)s'; "
         "cat wikis.yaml.template 2>/dev/null; "
         "echo '%(d)s'; "
-        # Untracked, non-ignored files. --directory collapses a wholly
-        # untracked dir to one entry, matching `git status`.
-        "git ls-files --others --exclude-standard --directory 2>/dev/null"
+        # Untracked files, parsed from porcelain '?? ' lines below. Uses
+        # `git status` (not `git ls-files --directory`, which over-reports
+        # dirs whose contents are all ignored and mishandles submodules) so
+        # it matches what `git status` shows exactly.
+        "git status --porcelain 2>/dev/null"
     ) % {"p": qp, "d": d, "ssh": _git_ssh_env_prefix(ssh_key)}
 
 
@@ -131,8 +133,13 @@ def _parse_gitops_status(stdout, instance_id):
     tmpl_wikis_raw = parts[8] if len(parts) > 8 else ""
     wikis_drift = _wikis_uncaptured_edit(live_wikis_raw, tmpl_wikis_raw)
 
-    untracked_raw = parts[9].strip() if len(parts) > 9 else ""
-    untracked = untracked_raw.split("\n") if untracked_raw else []
+    # parts[9] is `git status --porcelain`; untracked entries are the
+    # '?? <path>' lines (staged/modified come from git diff above).
+    status_raw = parts[9].strip() if len(parts) > 9 else ""
+    untracked = [
+        ln[3:] for ln in status_raw.split("\n")
+        if ln.startswith("?? ")
+    ]
 
     try:
         revcount_parts = revcount_raw.split("\t")

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1952,7 +1952,7 @@ class TestParseGitopsStatus:
 
     def test_with_untracked_files(self):
         out = self._make_output(
-            untracked="hosts/hosts.yaml\npublic_assets/notes/",
+            untracked="?? hosts/hosts.yaml\n?? public_assets/notes/",
         )
         result = direct_commands._parse_gitops_status(out, "mysite")
         assert "Untracked files (2):" in result
@@ -1967,6 +1967,17 @@ class TestParseGitopsStatus:
         result = direct_commands._parse_gitops_status(out, "mysite")
         assert "No changes." in result
         assert "Untracked files" not in result
+
+    def test_only_porcelain_untracked_lines_shown(self):
+        # git status --porcelain mixes staged/modified with untracked;
+        # only '?? ' lines are untracked (the rest come from git diff).
+        out = self._make_output(
+            untracked=" M config/default.vcl\n?? hosts/hosts.yaml",
+        )
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "Untracked files (1):" in result
+        assert "hosts/hosts.yaml" in result
+        assert "config/default.vcl" not in result
 
     def test_ahead_of_remote(self):
         out = self._make_output(revcount="3\t0")


### PR DESCRIPTION
Closes #878.

## Problem

The untracked-files reporting added in #877 over-reports relative to `git status`. It uses `git ls-files --others --exclude-standard --directory`, which:

- lists directories whose contents are **entirely gitignored** — e.g. `config/settings/wikis/<id>/` holding only the ignored per-wiki `README`, surfacing `config/settings/wikis/smw/`;
- mishandles **submodule** directories (`extensions/`, `skins/`), which `git status` does not report.

Observed: `canasta gitops status` listed 6 untracked entries while `git status` showed 3.

## Fix

Parse untracked entries from `git status --porcelain` (`?? ` lines) instead of `git ls-files`, so the section matches `git status` exactly — same exclude handling, submodule awareness, and directory collapsing. Follow-up to #877 (#876).

## Testing

Reproduced the over-report (a dir holding only a gitignored file) and confirmed `git status --porcelain` matches `git status` while `git ls-files --directory` did not. Parser unit tests updated (porcelain `?? ` filtering; staged/modified lines excluded). `make test-unit` (1355) + lint green; verified end-to-end against a real git repo.
