### PR TITLE
fix(sidecars): fully tear down sidecars on restart and delete; add e2e tests

### DIFF
--- a/direct_commands/lifecycle.py
+++ b/direct_commands/lifecycle.py
@@ -38,7 +38,11 @@ def cmd_stop(args):
         return _helpers.FALLBACK
     if _helpers._instance_has_sidecars(inst):
         return _helpers.FALLBACK  # Ansible includes the sidecar -f layer.
-    return _helpers._run_compose(inst_id, inst, ["down"])
+    # --remove-orphans sweeps a sidecar container left over from a sidecar
+    # that was just removed: sidecars.yaml is now empty (so we take this
+    # non-sidecar path), but its docker-compose.sidecars.yml entry and
+    # running container still linger and a plain `down` would not touch them.
+    return _helpers._run_compose(inst_id, inst, ["down", "--remove-orphans"])
 
 
 @register("restart")
@@ -49,7 +53,10 @@ def cmd_restart(args):
         return _helpers.FALLBACK
     if _helpers._instance_has_sidecars(inst):
         return _helpers.FALLBACK  # Ansible renders + layers the sidecars.
-    rc = _helpers._run_compose(inst_id, inst, ["down"])
+    # --remove-orphans sweeps a sidecar container left over from a sidecar
+    # that was just removed (sidecars.yaml is empty so we take this path, but
+    # its docker-compose.sidecars.yml entry and container still linger).
+    rc = _helpers._run_compose(inst_id, inst, ["down", "--remove-orphans"])
     if rc != 0:
         return rc
     _helpers._sync_compose_profiles(inst)

--- a/roles/orchestrator/tasks/destroy.yml
+++ b/roles/orchestrator/tasks/destroy.yml
@@ -5,12 +5,32 @@
 - name: Destroy (Docker Compose)
   when: instance_orchestrator | default('compose') == 'compose'
   block:
+    - name: Check for docker-compose.sidecars.yml
+      ansible.builtin.stat:
+        path: "{{ instance_path }}/docker-compose.sidecars.yml"
+      register: _destroy_sidecars
+
+    - name: Check for docker-compose.override.yml
+      ansible.builtin.stat:
+        path: "{{ instance_path }}/docker-compose.override.yml"
+      register: _destroy_override
+
+    # Pass the sidecars layer explicitly: `down -v` only removes volumes
+    # declared in the compose files it loads, and an app sidecar's named
+    # volume lives in docker-compose.sidecars.yml, which Compose does not
+    # auto-load. Without it the volume survives delete and later blocks
+    # recreate with a stale-volume error. --remove-orphans still sweeps any
+    # stray containers.
+    - name: Build compose file arguments for destroy
+      ansible.builtin.set_fact:
+        _destroy_compose_files: >-
+          {{ ['-f', 'docker-compose.yml'] +
+             (_destroy_sidecars.stat.exists | ternary(['-f', 'docker-compose.sidecars.yml'], [])) +
+             (_destroy_override.stat.exists | ternary(['-f', 'docker-compose.override.yml'], [])) }}
+
     - name: Destroy containers and volumes
-      # --remove-orphans sweeps containers not in the default compose files,
-      # notably app sidecars (created via the docker-compose.sidecars.yml -f
-      # layer), so a full teardown leaves nothing behind.
       ansible.builtin.command:
-        cmd: "docker compose down -v --remove-orphans"
+        cmd: "docker compose {{ _destroy_compose_files | join(' ') }} down -v --remove-orphans"
         chdir: "{{ instance_path }}"
       changed_when: true
       ignore_errors: true  # OK if containers already removed

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -3034,6 +3034,183 @@ def test_gitops_add_wiki_tracked(inst):
         )
 
 
+def _sidecar_running(inst, service):
+    """True if the named sidecar has a running container.
+
+    Sidecars render into docker-compose.sidecars.yml, which plain
+    `docker compose` does not auto-load, so query the Docker daemon by the
+    Compose labels instead (project = the instance directory basename).
+    """
+    project = os.path.basename(inst.instance_path())
+    result = subprocess.run(
+        ["docker", "ps", "-q", "--filter", "status=running",
+         "--filter", "label=com.docker.compose.project=%s" % project,
+         "--filter", "label=com.docker.compose.service=%s" % service],
+        capture_output=True, text=True,
+    )
+    return result.stdout.strip() != ""
+
+
+def _sidecar_volume_exists(inst, volume):
+    """True if the Compose volume <project>_<volume> exists."""
+    project = os.path.basename(inst.instance_path())
+    result = subprocess.run(
+        ["docker", "volume", "ls", "-q",
+         "--filter", "name=%s_%s" % (project, volume)],
+        capture_output=True, text=True,
+    )
+    return result.stdout.strip() != ""
+
+
+def test_sidecar_lifecycle(inst):
+    """add (from file) -> list -> restart -> the sidecar runs and is
+    reachable from web by service name -> remove -> restart -> it is gone.
+
+    Regression guard for sidecar bugs that previously surfaced only in
+    manual e2e: the orphan container left behind after removal, and the
+    stop/restart wedge from k8s-notation resources.
+    """
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir,
+        "-e", inst.env_file,
+    )
+    wait_for_wiki(inst.http_port)
+
+    # A trivial HTTP service the web container can reach by name.
+    sidecar_file = os.path.join(inst.work_dir, "echo-sidecar.yaml")
+    with open(sidecar_file, "w") as f:
+        f.write("name: echo\nimage: traefik/whoami\nports: [80]\n")
+
+    print("Adding the sidecar from a file...")
+    inst.run_ok("sidecar", "add", "-i", inst.id, "--file", sidecar_file)
+
+    declared = os.path.join(inst.instance_path(), "config", "sidecars.yaml")
+    assert os.path.isfile(declared), "sidecars.yaml should be written"
+    with open(declared) as f:
+        assert "echo" in f.read(), "the sidecar should be declared"
+
+    print("Listing sidecars...")
+    # 'sidecar list' reports via an Ansible debug task, so run verbose.
+    out = inst.run_ok("sidecar", "list", "-i", inst.id)
+    assert "echo" in out and "traefik/whoami" in out, (
+        "sidecar list should show the sidecar and its image:\n%s" % out
+    )
+
+    print("Restarting to deploy the sidecar...")
+    inst.run_ok("restart", "-i", inst.id)
+    wait_for_wiki(inst.http_port)
+    assert _sidecar_running(inst, "echo"), (
+        "the echo sidecar container should be running after restart"
+    )
+
+    print("Checking web can reach the sidecar by service name...")
+    reach = subprocess.run(
+        ["docker", "compose", "exec", "-T", "web",
+         "bash", "-c", "exec 3<>/dev/tcp/echo/80"],
+        capture_output=True, text=True, cwd=inst.instance_path(),
+    )
+    assert reach.returncode == 0, (
+        "web should reach the sidecar by service name 'echo':\n%s"
+        % (reach.stderr or reach.stdout)
+    )
+
+    print("Removing the sidecar...")
+    inst.run_ok("sidecar", "remove", "-i", inst.id, "--name", "echo")
+    if os.path.isfile(declared):
+        with open(declared) as f:
+            assert "echo" not in f.read(), (
+                "the sidecar should be removed from sidecars.yaml"
+            )
+
+    print("Restarting after removal...")
+    inst.run_ok("restart", "-i", inst.id)
+    wait_for_wiki(inst.http_port)
+    assert not _sidecar_running(inst, "echo"), (
+        "the echo sidecar container should be gone after removal + restart "
+        "(regression guard for the orphan-container bug)"
+    )
+
+
+def test_sidecar_migrate(inst):
+    """sidecar migrate MOVES a sidecar service: it must both write the
+    declaration to config/sidecars.yaml AND remove the service from
+    docker-compose.override.yml (a left-behind override entry would shadow
+    the migrated sidecar). --dry-run must change nothing.
+    """
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir,
+        "-e", inst.env_file,
+    )
+    wait_for_wiki(inst.http_port)
+
+    override = os.path.join(
+        inst.instance_path(), "docker-compose.override.yml",
+    )
+    with open(override, "w") as f:
+        f.write(
+            "services:\n"
+            "  echo:\n"
+            "    image: traefik/whoami\n"
+            "    volumes:\n"
+            "      - echodata:/data\n"
+            "volumes:\n"
+            "  echodata:\n"
+        )
+
+    declared = os.path.join(inst.instance_path(), "config", "sidecars.yaml")
+
+    print("Dry-run migrate must not change anything...")
+    out = inst.run_ok("sidecar", "migrate", "-i", inst.id, "--dry-run")
+    assert "echo" in out, (
+        "the dry-run plan should mention the echo service:\n%s" % out
+    )
+    assert not os.path.isfile(declared), "dry-run must not write sidecars.yaml"
+    with open(override) as f:
+        assert "echo" in f.read(), "dry-run must leave the override untouched"
+
+    print("Migrating for real...")
+    inst.run_ok("sidecar", "migrate", "-i", inst.id)
+
+    assert os.path.isfile(declared), "migrate should write sidecars.yaml"
+    with open(declared) as f:
+        decl = f.read()
+    assert "echo" in decl, "the migrated sidecar should appear in sidecars.yaml"
+    assert "persistent" in decl, (
+        "a named-volume sidecar should migrate to a persistent volume"
+    )
+
+    ov = ""
+    if os.path.isfile(override):
+        with open(override) as f:
+            ov = f.read()
+    assert "echo" not in ov, (
+        "the migrated service must be REMOVED from the override (a left-behind "
+        "entry would shadow the migrated sidecar):\n%s" % ov
+    )
+
+    print("Restarting to deploy the migrated sidecar...")
+    inst.run_ok("restart", "-i", inst.id)
+    wait_for_wiki(inst.http_port)
+    assert _sidecar_running(inst, "echo"), (
+        "the migrated sidecar should run after restart"
+    )
+    assert _sidecar_volume_exists(inst, "echo-echodata"), (
+        "the migrated sidecar's persistent volume should be created"
+    )
+
+    # delete must tear down the sidecar's named volume too — otherwise it
+    # lingers and blocks a later recreate with a stale-volume error.
+    print("Deleting and checking the sidecar volume is removed...")
+    inst.run_ok("delete", "-i", inst.id, "--yes")
+    assert not _sidecar_volume_exists(inst, "echo-echodata"), (
+        "delete must remove the migrated sidecar's named volume"
+    )
+
+
 # --- Test runner ---
 
 ALL_TESTS = {
@@ -3074,6 +3251,8 @@ ALL_TESTS = {
     "gitops-status-fetch": test_gitops_status_fetch,
     "gitops-fix-submodules": test_gitops_fix_submodules_orphan,
     "crowdsec": test_crowdsec,
+    "sidecar-lifecycle": test_sidecar_lifecycle,
+    "sidecar-migrate": test_sidecar_migrate,
 }
 
 

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1356,6 +1356,8 @@ class TestLifecycleCommands:
         rc = direct_commands.cmd_stop(args)
         assert rc == 0
         assert "down" in captured_cmds[0]
+        # Sweep a sidecar container orphaned by `sidecar remove`.
+        assert "--remove-orphans" in captured_cmds[0]
 
     def test_restart_runs_down_then_up(self, monkeypatch):
         captured_cmds = []
@@ -1380,6 +1382,8 @@ class TestLifecycleCommands:
         assert rc == 0
         assert len(captured_cmds) == 2
         assert "down" in captured_cmds[0]
+        # Sweep a sidecar container orphaned by `sidecar remove`.
+        assert "--remove-orphans" in captured_cmds[0]
         assert "up" in captured_cmds[1]
 
     def test_restart_stops_on_down_failure(self, monkeypatch):

--- a/tests/unit/test_sidecar_render_wiring.py
+++ b/tests/unit/test_sidecar_render_wiring.py
@@ -45,11 +45,14 @@ def test_stop_includes_sidecar_layer_for_teardown():
     assert "docker-compose.sidecars.yml" in body
 
 
-def test_destroy_removes_sidecar_orphans():
-    # delete uses a bare `down` (no sidecar -f layer), so it must pass
-    # --remove-orphans or the sidecar container survives deletion.
+def test_destroy_removes_sidecar_orphans_and_volumes():
+    # delete must remove BOTH the sidecar container (--remove-orphans) and
+    # its named volume. The volume is declared only in
+    # docker-compose.sidecars.yml, so `down -v` must load that layer or the
+    # volume survives and later blocks recreate with a stale-volume error.
     body = _text(DESTROY)
     assert "down -v --remove-orphans" in body
+    assert "docker-compose.sidecars.yml" in body
 
 
 def test_scale_up_is_generalized_to_all():


### PR DESCRIPTION
## Summary

Adds end-to-end integration coverage for the `canasta sidecar` command family (new in 4.3.0, previously only module/unit-tested), and fixes two teardown bugs the new tests uncovered (#882).

### Fixes (#882)

- **Orphan container on restart/stop.** `cmd_stop`/`cmd_restart` (`direct_commands/lifecycle.py`) take a Python fast path when the instance has no sidecars. After removing the last sidecar, `sidecars.yaml` is empty, so this path ran a plain `docker compose down` and left the removed sidecar's container running as an orphan. Now passes `--remove-orphans` on the `down`.
- **Stale volume on delete.** `roles/orchestrator/tasks/destroy.yml` ran `docker compose down -v --remove-orphans` with no `-f` flags, so it never loaded `docker-compose.sidecars.yml` and left the sidecar's named volume behind (which then blocks recreate with a stale-volume error). Now builds the `-f` list including the sidecars/override layers so `down -v` removes the volume.

### Tests

- `test_sidecar_lifecycle` (Compose): create → `sidecar add --file` (a `traefik/whoami` HTTP service) → `sidecar list` shows it → `restart` → the sidecar runs **and** the web container reaches it by service name → `sidecar remove` → `restart` → the container is **gone** (guards the orphan fix).
- `test_sidecar_migrate` (Compose): seeds a `docker-compose.override.yml` with a named-volume sidecar, verifies `--dry-run` changes nothing, then that `migrate` writes `config/sidecars.yaml` (named volume → persistent) **and** removes the service from the override; restarts and confirms the migrated sidecar runs; then `delete` and confirms the named volume is removed (guards the volume fix).
- Unit guards: `cmd_stop`/`cmd_restart` pass `--remove-orphans`; `destroy.yml` loads the sidecars layer for `down -v`.

## Testing

Both integration tests run green locally against Docker:

```
python tests/integration/run_tests.py sidecar-lifecycle sidecar-migrate
# Results: 2 passed, 0 failed, 0 skipped
```

`make test-unit` (1355 passed), `make validate`, `ruff check --select F401`, and `yamllint --strict` all clean.

## Scope

Closes #882. Addresses the sidecar portion of #881. The remaining #881 items — `gitops sync` rematerialize and `storage list` / `storage setup efs` coverage (lower severity; `storage setup efs` needs AWS, and `gitops sync` overlaps the gitops-lifecycle work tracked in #758) — are left for a follow-up.
