### PR TITLE
test: structure coverage for storage list/efs and gitops schedule rematerialize

### DIFF
--- a/tests/unit/test_gitops_backup_schedule_rematerialize.py
+++ b/tests/unit/test_gitops_backup_schedule_rematerialize.py
@@ -1,0 +1,83 @@
+"""Structural guards for the backup-schedule rematerialize path.
+
+A Compose `gitops pull` must re-materialize the host crontab from the
+durable config/backup-schedule.yml the pull brought in, so a schedule
+added/edited/removed in the repo actually takes effect on the instance's
+host. This path writes a real host crontab, so it is skipped by the CI
+integration suite (see run_tests.py) — these structural assertions are the
+CI-runnable guard for the wiring instead.
+
+Also pins that `gitops sync` is a Compose no-op (Argo CD only).
+"""
+
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+PULL_COMPOSE = os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "pull_compose.yml")
+REMATERIALIZE = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "backup_schedule_rematerialize.yml"
+)
+TRIGGER_SYNC = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "gitops_trigger_sync.yml"
+)
+
+
+def _tasks(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _includes(task):
+    inc = task.get("ansible.builtin.include_tasks") or task.get("include_tasks")
+    if isinstance(inc, dict):
+        return inc.get("file", "")
+    return inc or ""
+
+
+def test_pull_compose_rematerializes_when_schedule_file_changed():
+    rematerialize = [
+        t for t in _tasks(PULL_COMPOSE)
+        if "backup_schedule_rematerialize.yml" in _includes(t)
+    ]
+    assert rematerialize, (
+        "pull_compose.yml must re-materialize the backup schedule after a pull"
+    )
+    # Only when the pull actually touched the schedule file.
+    assert "config/backup-schedule.yml" in str(rematerialize[0].get("when", "")), (
+        "the rematerialize must be gated on config/backup-schedule.yml changing"
+    )
+
+
+def test_rematerialize_applies_when_present_and_unapplies_when_absent():
+    tasks = _tasks(REMATERIALIZE)
+    apply = [t for t in tasks if "backup_schedule_apply.yml" in _includes(t)]
+    unapply = [t for t in tasks if "backup_schedule_unapply.yml" in _includes(t)]
+    assert apply, "must apply the schedule when one is persisted"
+    assert unapply, "must remove the crontab entry when no schedule is persisted"
+    # Apply only when the persisted file has a non-empty cron expression.
+    assert "cron_expression" in str(apply[0].get("when", "")), (
+        "apply must be gated on a non-empty cron_expression"
+    )
+    # Unapply only when the file is gone.
+    assert "not _sched_state.stat.exists" in str(unapply[0].get("when", "")), (
+        "unapply must be gated on the schedule file being absent"
+    )
+
+
+def test_gitops_sync_is_a_compose_noop():
+    tasks = _tasks(TRIGGER_SYNC)
+    # On Compose, the only action is a debug message gated on the compose
+    # orchestrator — no reconciler to trigger.
+    debug_compose = [
+        t for t in tasks
+        if "ansible.builtin.debug" in t and "== 'compose'" in str(t.get("when", ""))
+    ]
+    assert debug_compose, "gitops sync must be a no-op (debug only) on Compose"
+    # The Argo CD sync is gated on the kubernetes orchestrator.
+    argocd = [t for t in tasks if "k8s_argocd_sync.yml" in _includes(t)]
+    assert argocd and "kubernetes" in str(argocd[0].get("when", "")), (
+        "gitops sync must dispatch to Argo CD sync only on Kubernetes"
+    )

--- a/tests/unit/test_storage_list.py
+++ b/tests/unit/test_storage_list.py
@@ -1,0 +1,59 @@
+"""Structural test for `canasta storage list`.
+
+Listing StorageClasses needs a live cluster, so it can't run in CI as an
+integration test. These assertions lock in the playbook's contract: read the
+canasta-configured default from the controller registry (delegate_to:
+localhost), list the cluster's StorageClasses, and surface the kubectl
+context so the operator can catch a wrong-cluster listing.
+"""
+
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+LIST_PLAYBOOK = os.path.join(REPO_ROOT, "playbooks", "storage_list.yml")
+
+
+def _tasks():
+    with open(LIST_PLAYBOOK) as f:
+        return yaml.safe_load(f)
+
+
+def _commands():
+    cmds = []
+    for t in _tasks():
+        c = t.get("ansible.builtin.command") or t.get("command")
+        if isinstance(c, dict):
+            cmds.append(c.get("cmd", ""))
+        elif isinstance(c, str):
+            cmds.append(c)
+    return cmds
+
+
+def test_reads_default_storageclass_from_controller_registry():
+    reg = [t for t in _tasks() if "canasta_registry" in t]
+    reads = [
+        t for t in reg
+        if t["canasta_registry"].get("state") == "get_setting"
+        and t["canasta_registry"].get("setting_key") == "defaultStorageClass"
+    ]
+    assert reads, "must read defaultStorageClass from the registry"
+    assert reads[0].get("delegate_to") == "localhost", (
+        "canasta_registry reads must use delegate_to: localhost"
+    )
+
+
+def test_lists_cluster_storageclasses():
+    assert any("kubectl get storageclass" in c for c in _commands()), (
+        "must list the cluster's StorageClasses"
+    )
+
+
+def test_surfaces_kubectl_context():
+    # Surfacing the context is the operator's cue that the listing targets
+    # the intended cluster (not, say, a laptop's Docker Desktop).
+    assert any("kubectl config current-context" in c for c in _commands()), (
+        "must surface the current kubectl context"
+    )

--- a/tests/unit/test_storage_setup_efs.py
+++ b/tests/unit/test_storage_setup_efs.py
@@ -1,0 +1,79 @@
+"""Structural test for `canasta storage setup efs`.
+
+EFS setup needs a live AWS account + Kubernetes cluster, so it can't run in
+CI as an integration test. These assertions lock in the playbook's contract:
+it must validate the cluster up front, install the EFS CSI driver, create a
+StorageClass backed by the EFS provisioner, and persist the chosen default
+StorageClass to the controller registry (with delegate_to: localhost, per
+the registry-lives-on-the-controller rule).
+"""
+
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+EFS_PLAYBOOK = os.path.join(REPO_ROOT, "playbooks", "storage_setup_efs.yml")
+
+
+def _tasks():
+    with open(EFS_PLAYBOOK) as f:
+        return yaml.safe_load(f)
+
+
+def _find(module):
+    return [t for t in _tasks() if module in t]
+
+
+def test_validates_kubernetes_prerequisites_first():
+    tasks = _tasks()
+    role_tasks = [t for t in tasks if "ansible.builtin.include_role" in t]
+    preflight = [
+        t for t in role_tasks
+        if t["ansible.builtin.include_role"].get("tasks_from") == "k8s_preflight.yml"
+    ]
+    assert preflight, "EFS setup must run k8s_preflight before touching the cluster"
+    # Preflight must come before the CSI install / StorageClass creation.
+    assert tasks.index(preflight[0]) < tasks.index(_find("kubernetes.core.helm")[0])
+
+
+def test_installs_efs_csi_driver():
+    repos = _find("kubernetes.core.helm_repository")
+    assert any(
+        "aws-efs-csi-driver" in str(t["kubernetes.core.helm_repository"].get("repo_url", ""))
+        for t in repos
+    ), "must add the aws-efs-csi-driver Helm repo"
+    charts = _find("kubernetes.core.helm")
+    assert any(
+        "aws-efs-csi-driver" in str(t["kubernetes.core.helm"].get("chart_ref", ""))
+        for t in charts
+    ), "must install the aws-efs-csi-driver chart"
+
+
+def test_creates_storageclass_with_efs_provisioner():
+    k8s_tasks = _find("kubernetes.core.k8s")
+    scs = [
+        t for t in k8s_tasks
+        if (t["kubernetes.core.k8s"].get("definition", {}) or {}).get("kind")
+        == "StorageClass"
+    ]
+    assert scs, "must create a StorageClass"
+    sc = scs[0]["kubernetes.core.k8s"]["definition"]
+    assert sc["provisioner"] == "efs.csi.aws.com", (
+        "the StorageClass must use the EFS CSI provisioner"
+    )
+
+
+def test_persists_default_storageclass_to_controller_registry():
+    reg = _find("canasta_registry")
+    saves = [
+        t for t in reg
+        if t["canasta_registry"].get("state") == "set_setting"
+        and t["canasta_registry"].get("setting_key") == "defaultStorageClass"
+    ]
+    assert saves, "must persist defaultStorageClass to the registry"
+    # The registry lives on the controller — the write must be delegated.
+    assert saves[0].get("delegate_to") == "localhost", (
+        "canasta_registry writes must use delegate_to: localhost"
+    )


### PR DESCRIPTION
## Summary

Closes the remaining test gaps from #881 (the sidecar items landed in #885). `storage list`, `storage setup efs`, and the gitops backup-schedule rematerialize path had no referencing tests.

These paths can't run as CI integration tests — `storage setup efs` needs a live AWS account, `storage list` needs a cluster, and the schedule rematerialize writes a real host crontab (the backup-schedule integration tests are already skipped in CI for that reason, see `run_tests.py`). So this adds **structure/contract tests**, which run on every PR (unlike the push-to-main Docker suite):

- **`test_storage_setup_efs.py`** — the playbook validates the cluster (`k8s_preflight`) before touching it, installs the EFS CSI driver, creates a StorageClass with the `efs.csi.aws.com` provisioner, and persists `defaultStorageClass` to the controller registry with `delegate_to: localhost`.
- **`test_storage_list.py`** — reads `defaultStorageClass` from the registry (`delegate_to: localhost`), lists the cluster's StorageClasses, and surfaces the kubectl context (the wrong-cluster cue).
- **`test_gitops_backup_schedule_rematerialize.py`** — a Compose `gitops pull` re-materializes `config/backup-schedule.yml` (apply when a cron expression is persisted, unapply when the file is gone), gated on the pull actually touching that file; and `gitops sync` is a Compose no-op.

### Note on the finding

#881 described the rematerialize as happening on `gitops sync`. In the implementation, `gitops sync` is **Kubernetes-only** (an Argo CD sync; a no-op on Compose) — the schedule rematerialize runs on `gitops pull` (`pull_compose.yml`). The tests cover the actual path and pin the `sync` no-op.

## Testing

`make test-unit` — 1365 passed (10 new). `ruff check --select F401` clean.
