### PR TITLE
Allow overriding the Elasticsearch image on both orchestrators

### DIFF
--- a/roles/config/defaults/main.yml
+++ b/roles/config/defaults/main.yml
@@ -96,6 +96,14 @@ canasta_known_keys:
     group: Docker Image
     description: Override the default Canasta image
 
+  - name: CANASTA_ELASTICSEARCH_IMAGE
+    group: Docker Image
+    description: >-
+      Override the Elasticsearch image (e.g. a build with an extra
+      analysis plugin). Takes effect only while Elasticsearch is enabled
+      (CANASTA_ENABLE_ELASTICSEARCH=true). On Kubernetes the image must be
+      pullable by the cluster (push it to a reachable registry first).
+
   - name: CROWDSEC_BOUNCER_API_KEY
     group: Security (CrowdSec)
     description: >-

--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -358,6 +358,7 @@
 #   CANASTA_ENABLE_ELASTICSEARCH → elasticsearch.enabled: <bool>
 #   CANASTA_STAGING_CERTS  → ingress.certManager.issuer: letsencrypt-{staging,prod}
 #   CANASTA_IMAGE          → image.repository + image.tag
+#   CANASTA_ELASTICSEARCH_IMAGE → elasticsearch.image: <value>
 #
 # External DB keys (USE_EXTERNAL_DB, MYSQL_*) are intentionally NOT
 # propagated here — _validate_key.yml blocks them as immutable after
@@ -370,7 +371,8 @@
     - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
     - _config_key in ['MW_SITE_FQDN', 'CANASTA_ENABLE_VARNISH',
                       'CANASTA_ENABLE_ELASTICSEARCH',
-                      'CANASTA_STAGING_CERTS', 'CANASTA_IMAGE']
+                      'CANASTA_STAGING_CERTS', 'CANASTA_IMAGE',
+                      'CANASTA_ELASTICSEARCH_IMAGE']
   block:
     - name: Read current values.yaml
       ansible.builtin.slurp:
@@ -415,6 +417,14 @@
             repository: "{{ _config_value | regex_replace(':[^:]+$', '') }}"
             tag: "{{ _config_value | regex_replace('^.*:', '') }}"
       when: _config_key == 'CANASTA_IMAGE'
+
+    # Deep-merged into values.yaml, so it composes with elasticsearch.enabled
+    # (CANASTA_ENABLE_ELASTICSEARCH) — setting one preserves the other. The
+    # StatefulSet only deploys while enabled, so this is inert until then.
+    - name: Build values.yaml override for CANASTA_ELASTICSEARCH_IMAGE
+      ansible.builtin.set_fact:
+        _k8s_override: "{{ {'elasticsearch': {'image': _config_value}} }}"
+      when: _config_key == 'CANASTA_ELASTICSEARCH_IMAGE'
 
     - name: Write updated values.yaml
       ansible.builtin.copy:

--- a/roles/orchestrator/files/compose/docker-compose.yml
+++ b/roles/orchestrator/files/compose/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       - mediawiki-logs:/var/log/mediawiki
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+    image: ${CANASTA_ELASTICSEARCH_IMAGE:-docker.elastic.co/elasticsearch/elasticsearch:7.10.2}
     profiles:
       - elasticsearch
     restart: unless-stopped

--- a/tests/unit/test_elasticsearch_image_override.py
+++ b/tests/unit/test_elasticsearch_image_override.py
@@ -1,0 +1,112 @@
+"""Tests for overriding the Elasticsearch image via CANASTA_ELASTICSEARCH_IMAGE.
+
+This mirrors the existing CANASTA_IMAGE mechanism: on Compose the image is
+read from .env (`${CANASTA_ELASTICSEARCH_IMAGE:-<default>}`); on Kubernetes
+`config set` deep-merges `elasticsearch.image` into values.yaml via
+_side_effects.yml.
+
+The key property is composition with the enable/disable profile: setting the
+image must not disturb `elasticsearch.enabled` (CANASTA_ENABLE_ELASTICSEARCH),
+and toggling enablement must not drop a previously-set image. On K8s that is
+guaranteed by `combine(recursive=True)`; these tests model that merge.
+"""
+
+import os
+
+import jinja2
+import yaml
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+
+
+def _read(*parts):
+    with open(os.path.join(REPO_ROOT, *parts)) as f:
+        return f.read()
+
+
+def _render_override(expr, **vars):
+    """Render an Ansible set_fact dict expression the way the playbook does."""
+    env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+    return yaml.safe_load(env.from_string("{{ %s }}" % expr).render(**vars))
+
+
+def _combine_recursive(base, override):
+    """Mirror Ansible's `combine(recursive=True)`: deep-merge, override wins."""
+    result = dict(base)
+    for k, v in override.items():
+        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
+            result[k] = _combine_recursive(result[k], v)
+        else:
+            result[k] = v
+    return result
+
+
+class TestConfigKeyRegistration:
+
+    def test_key_is_known(self):
+        data = yaml.safe_load(_read("roles", "config", "defaults", "main.yml"))
+        keys = {k["name"]: k for k in data["canasta_known_keys"]}
+        assert "CANASTA_ELASTICSEARCH_IMAGE" in keys
+        assert keys["CANASTA_ELASTICSEARCH_IMAGE"]["group"] == "Docker Image"
+
+    def test_key_is_in_k8s_values_propagation_allowlist(self):
+        side_effects = _read("roles", "config", "tasks", "_side_effects.yml")
+        assert "'CANASTA_ELASTICSEARCH_IMAGE'" in side_effects
+        # The override block must target elasticsearch.image specifically.
+        assert "{'elasticsearch': {'image': _config_value}}" in side_effects
+
+
+class TestComposeWiring:
+
+    def test_image_is_env_overridable_with_default_preserved(self):
+        compose = _read("roles", "orchestrator", "files", "compose", "docker-compose.yml")
+        assert "${CANASTA_ELASTICSEARCH_IMAGE:-" in compose
+        # Default kept, so an unset var leaves stock Elasticsearch.
+        assert "elasticsearch:7.10.2" in compose
+
+
+class TestKubernetesPropagation:
+
+    def test_override_targets_elasticsearch_image(self):
+        out = _render_override(
+            "{'elasticsearch': {'image': _config_value}}",
+            _config_value="myreg/es-icu:7.17.9",
+        )
+        assert out == {"elasticsearch": {"image": "myreg/es-icu:7.17.9"}}
+
+    def test_setting_image_preserves_enabled(self):
+        # Profile already on; set a custom image -> both survive.
+        values = {"elasticsearch": {"enabled": True}}
+        override = _render_override(
+            "{'elasticsearch': {'image': _config_value}}",
+            _config_value="myreg/es-icu:7.17.9",
+        )
+        merged = _combine_recursive(values, override)
+        assert merged["elasticsearch"] == {
+            "enabled": True,
+            "image": "myreg/es-icu:7.17.9",
+        }
+
+    def test_toggling_enabled_preserves_image(self):
+        # Custom image already set; flip the profile on -> image survives.
+        values = {"elasticsearch": {"image": "myreg/es-icu:7.17.9"}}
+        override = _render_override(
+            "{'elasticsearch': {'enabled': _config_value | lower == 'true'}}",
+            _config_value="true",
+        )
+        merged = _combine_recursive(values, override)
+        assert merged["elasticsearch"] == {
+            "image": "myreg/es-icu:7.17.9",
+            "enabled": True,
+        }
+
+    def test_disabling_preserves_image_for_later_reenable(self):
+        values = {"elasticsearch": {"enabled": True, "image": "myreg/es-icu:7.17.9"}}
+        override = _render_override(
+            "{'elasticsearch': {'enabled': _config_value | lower == 'true'}}",
+            _config_value="false",
+        )
+        merged = _combine_recursive(values, override)
+        assert merged["elasticsearch"]["enabled"] is False
+        assert merged["elasticsearch"]["image"] == "myreg/es-icu:7.17.9"


### PR DESCRIPTION
## What

Adds a `CANASTA_ELASTICSEARCH_IMAGE` config key so users can run a custom Elasticsearch image (e.g. one with the `analysis-icu` plugin for ICU collation) on **both** orchestrators. Mirrors the existing `CANASTA_IMAGE` mechanism:

- **Compose** — `docker-compose.yml` now reads `${CANASTA_ELASTICSEARCH_IMAGE:-<stock default>}` from `.env`.
- **Kubernetes** — `canasta config set CANASTA_ELASTICSEARCH_IMAGE=<ref>` deep-merges `elasticsearch.image` into the instance `values.yaml`, through the same `_side_effects.yml` propagation `CANASTA_IMAGE` uses. The chart already exposed `elasticsearch.image`; nothing wrote to it before.

## Why

Custom ES images were achievable on Compose via `docker-compose.override.yml`, but there was no equivalent on Kubernetes. Closes #887.

## Composition with the enable/disable profile

`CANASTA_ELASTICSEARCH_IMAGE` and `CANASTA_ENABLE_ELASTICSEARCH` are independent and never clobber each other: on K8s via `combine(recursive=True)` (deep-merge), and on Compose the image var is simply unused while the `elasticsearch` profile is off. The override is inert until Elasticsearch is enabled.

## Scope

- Sets an image **reference**; building/pushing stays the user's responsibility (Compose `--override` builds locally; on K8s push to a registry the cluster can pull from).
- Only Elasticsearch. `db` and `caddy` are deliberately excluded — DB backup/restore assume MariaDB (use an external DB for a custom database), and caddy's image is reconciled for the CrowdSec plugin bridge.

## Tests

`tests/unit/test_elasticsearch_image_override.py` — config-key registration, K8s `values.yaml` propagation, Compose substitution, and the deep-merge composition (set-image-preserves-enabled, toggle-enabled-preserves-image, disable-preserves-image). Full suite green (1372 passed).

## Validation

- **Compose, live**: built a real `analysis-icu` image, confirmed the rendered compose substitution (default → stock, override → custom), the running container used the custom image, the ICU plugin loaded, and an `icu_collation_keyword` mapping worked. Profile gating verified.
- **Kubernetes**: proven via `helm template` against the chart — the override lands in the StatefulSet image and the `enabled` gate composes correctly. (No live cluster run in this change.)

## Docs

canasta.wiki **Help:Extensions and skins → Custom Elasticsearch plugins** updated: restructured by orchestrator, added the Kubernetes path, kept the Compose override walkthrough.