### PR TITLE
feat(sidecars): source k8s sidecar secrets from a per-instance Secret (envSecret)

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1008,6 +1008,13 @@ commands:
         type: bool
         default: false
         description: "Allow setting unrecognized keys"
+      - name: secret
+        type: bool
+        default: false
+        description: >-
+          Write to the gitignored config/secrets.env instead of .env (opaque
+          app secrets; on K8s these feed a per-instance Secret consumed by
+          sidecars via secretKeyRef). Bypasses .env validation and side effects.
 
   - name: config_regenerate
     description: "Regenerate rendered config files (e.g. Caddyfile) from current sources"

--- a/roles/common/module_utils/canasta_sidecar_render.py
+++ b/roles/common/module_utils/canasta_sidecar_render.py
@@ -218,9 +218,17 @@ def render_k8s_values(sidecars, env, file_reader):
             item["image"] = sidecar["image"]
         if sidecar.get("command"):
             item["command"] = resolve_env_value(sidecar["command"], env)
+        # envSecret keys are sourced from the per-instance app Secret (rendered
+        # as secretKeyRef by the chart), so they are NOT resolved to cleartext
+        # here. Everything else stays a resolved literal, exactly as before.
+        secret_keys = set(sidecar.get("envSecret") or [])
         if sidecar.get("env"):
-            item["env"] = {k: resolve_env_value(v, env)
-                           for k, v in sidecar["env"].items()}
+            plain = {k: resolve_env_value(v, env)
+                     for k, v in sidecar["env"].items() if k not in secret_keys}
+            if plain:
+                item["env"] = plain
+        if secret_keys:
+            item["envSecret"] = sorted(secret_keys)
         if sidecar.get("ports"):
             item["ports"] = [int(p) for p in sidecar["ports"]]
         if sidecar.get("volumes"):

--- a/roles/config/tasks/_set_config.yml
+++ b/roles/config/tasks/_set_config.yml
@@ -1,0 +1,58 @@
+---
+# Set .env config values (validation + side effects). Split out of set.yml so
+# `--secret` can take a separate, side-effect-free path (_set_secret.yml).
+# Input: _config_settings, instance_path, force.
+
+- name: Validate, apply side effects, and set each key
+  ansible.builtin.include_tasks: _set_single.yml
+  loop: "{{ _config_settings.split() }}"
+  loop_control:
+    loop_var: _setting
+    label: "{{ _setting.split('=', 1)[0] }}"
+
+# Surface pre-existing .env hygiene problems while the user is here. Quoted
+# values and CRLF endings are stripped on read (so `config get` looks fine)
+# but reach containers via docker --env-file literally — a common cause of
+# restic "wrong password" and similar. canasta_env's `set` writes clean
+# lines, so this only flags lines the user hasn't fixed.
+- name: Check .env for quoted or CRLF values
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: lint
+  register: _set_env_lint
+
+- name: Build .env hygiene warning
+  ansible.builtin.set_fact:
+    _set_env_warn: >-
+      {{ ([] if _set_env_lint.quoted_keys | length == 0
+           else ['quoted values (' + (_set_env_lint.quoted_keys | join(', ')) + ')'])
+         + ([] if not _set_env_lint.has_crlf else ['CRLF line endings']) }}
+
+- name: Warn about quoted or CRLF .env values
+  ansible.builtin.debug:
+    msg: >-
+      Warning: {{ instance_path }}/.env has {{ _set_env_warn | join(' and ') }}.
+      Containers (docker --env-file) receive these literally, unlike
+      'canasta config get' which strips them — a common cause of restic
+      'wrong password' or backend auth failures. Remove surrounding quotes
+      and use LF line endings.
+  when: _set_env_warn | length > 0
+
+# If the instance is gitops-managed, update vars.yaml so the change
+# survives the next gitops pull (which re-renders .env from template).
+- name: Check for gitops instance
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/.gitops-host"
+  register: _config_gitops_stat
+
+# The orchestrator owns the compose-vs-K8s decision (K8s gitops uses a
+# different layout, values.template.yaml, not vars.yaml); dispatch.
+- name: Update gitops vars for changed keys
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/config_update_gitops_vars.yml
+  when: _config_gitops_stat.stat.exists | default(false)
+
+- name: Regenerate Caddyfile after config change
+  ansible.builtin.include_role:
+    name: orchestrator
+    tasks_from: update_config.yml

--- a/roles/config/tasks/_set_secret.yml
+++ b/roles/config/tasks/_set_secret.yml
@@ -1,0 +1,19 @@
+---
+# canasta config set --secret — write opaque secret values to the gitignored
+# config/secrets.env, bypassing .env validation and side effects (these are
+# arbitrary app keys, not recognized .env config). On K8s they feed the
+# per-instance app Secret (k8s_sync_config.yml), consumed by sidecars via
+# secretKeyRef; on Compose secrets.env is an extra gitignored env source.
+# Input: _config_settings, instance_path.
+
+- name: Write each secret to config/secrets.env
+  canasta_env:
+    path: "{{ instance_path }}/config/secrets.env"
+    state: set
+    key: "{{ _setting.split('=', 1)[0] }}"
+    value: "{{ _setting.split('=', 1)[1] }}"
+  loop: "{{ _config_settings.split() }}"
+  loop_control:
+    loop_var: _setting
+    label: "{{ _setting.split('=', 1)[0] }}"
+  no_log: true

--- a/roles/config/tasks/set.yml
+++ b/roles/config/tasks/set.yml
@@ -16,59 +16,15 @@
   ansible.builtin.set_fact:
     _config_settings: "{{ config_settings_override | default(settings) }}"
 
-- name: Validate, apply side effects, and set each key
-  ansible.builtin.include_tasks: _set_single.yml
-  loop: "{{ _config_settings.split() }}"
-  loop_control:
-    loop_var: _setting
-    label: "{{ _setting.split('=', 1)[0] }}"
+# Dispatch: --secret writes opaque values to the gitignored config/secrets.env
+# (no .env validation/side effects); otherwise the normal .env config path.
+- name: Set opaque secret values (config/secrets.env)
+  ansible.builtin.include_tasks: _set_secret.yml
+  when: secret | default(false) | bool
 
-# Surface pre-existing .env hygiene problems while the user is here. Quoted
-# values and CRLF endings are stripped on read (so `config get` looks fine)
-# but reach containers via docker --env-file literally — a common cause of
-# restic "wrong password" and similar. canasta_env's `set` writes clean
-# lines, so this only flags lines the user hasn't fixed.
-- name: Check .env for quoted or CRLF values
-  canasta_env:
-    path: "{{ instance_path }}/.env"
-    state: lint
-  register: _set_env_lint
-
-- name: Build .env hygiene warning
-  ansible.builtin.set_fact:
-    _set_env_warn: >-
-      {{ ([] if _set_env_lint.quoted_keys | length == 0
-           else ['quoted values (' + (_set_env_lint.quoted_keys | join(', ')) + ')'])
-         + ([] if not _set_env_lint.has_crlf else ['CRLF line endings']) }}
-
-- name: Warn about quoted or CRLF .env values
-  ansible.builtin.debug:
-    msg: >-
-      Warning: {{ instance_path }}/.env has {{ _set_env_warn | join(' and ') }}.
-      Containers (docker --env-file) receive these literally, unlike
-      'canasta config get' which strips them — a common cause of restic
-      'wrong password' or backend auth failures. Remove surrounding quotes
-      and use LF line endings.
-  when: _set_env_warn | length > 0
-
-# If the instance is gitops-managed, update vars.yaml so the change
-# survives the next gitops pull (which re-renders .env from template).
-- name: Check for gitops instance
-  ansible.builtin.stat:
-    path: "{{ instance_path }}/.gitops-host"
-  register: _config_gitops_stat
-
-# The orchestrator owns the compose-vs-K8s decision (K8s gitops uses a
-# different layout, values.template.yaml, not vars.yaml); dispatch.
-- name: Update gitops vars for changed keys
-  ansible.builtin.include_tasks: >-
-    {{ canasta_root }}/roles/orchestrator/tasks/config_update_gitops_vars.yml
-  when: _config_gitops_stat.stat.exists | default(false)
-
-- name: Regenerate Caddyfile after config change
-  ansible.builtin.include_role:
-    name: orchestrator
-    tasks_from: update_config.yml
+- name: Set .env config values
+  ansible.builtin.include_tasks: _set_config.yml
+  when: not (secret | default(false) | bool)
 
 - name: Restart instance to apply changes
   when: not (no_restart | default(false) | bool)

--- a/roles/gitops/files/gitignore.default
+++ b/roles/gitops/files/gitignore.default
@@ -1,5 +1,6 @@
 # Generated at deploy time — do not track
 .env
+config/secrets.env
 config/wikis.yaml
 admin-password_*
 

--- a/roles/orchestrator/files/helm/canasta/templates/_helpers.tpl
+++ b/roles/orchestrator/files/helm/canasta/templates/_helpers.tpl
@@ -57,6 +57,14 @@ MW secret name.
 {{- end }}
 
 {{/*
+App secret name — holds sidecar secrets (sidecars[].envSecret), upserted by
+Ansible from config/secrets.env. Referenced via secretKeyRef.
+*/}}
+{{- define "canasta.appSecretName" -}}
+{{- .Values.secrets.appSecretName | default (printf "%s-app-secrets" .Values.instance.id) }}
+{{- end }}
+
+{{/*
 Backend service for ingress — always routes to caddy.
 Caddy handles wiki farm routing, then forwards to varnish or web.
 */}}

--- a/roles/orchestrator/files/helm/canasta/templates/sidecars.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/sidecars.yaml
@@ -46,11 +46,18 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- with $sc.env }}
+          {{- if or $sc.env $sc.envSecret }}
           env:
-            {{- range $k, $v := . }}
+            {{- range $k, $v := $sc.env }}
             - name: {{ $k }}
               value: {{ $v | quote }}
+            {{- end }}
+            {{- range $sc.envSecret }}
+            - name: {{ . }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "canasta.appSecretName" $ }}
+                  key: {{ . }}
             {{- end }}
           {{- end }}
           {{- with $sc.ports }}

--- a/roles/orchestrator/tasks/k8s_sync_config.yml
+++ b/roles/orchestrator/tasks/k8s_sync_config.yml
@@ -289,6 +289,43 @@
   when: _crowdsec_key_data | length > 0
   no_log: true
 
+# --- App secrets Secret ---
+# Sidecar env keys listed in sidecars[].envSecret are sourced from this Secret
+# via secretKeyRef (templates/sidecars.yaml). Values live in the gitignored
+# config/secrets.env (written by `canasta config set --secret`), never in
+# values.yaml or the gitops repo. Created here — in the sync/restart path, like
+# the crowdsec key above — so a secret set after create reaches the pod on the
+# next start. Absent until a secret is set: the block is skipped, so existing
+# instances get no Secret (purely additive).
+- name: Check for config/secrets.env
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/config/secrets.env"
+  register: _app_secrets_stat
+
+- name: Read app secrets
+  canasta_env:
+    path: "{{ instance_path }}/config/secrets.env"
+    state: read_all
+  register: _app_secrets_dict
+  when: _app_secrets_stat.stat.exists
+  no_log: true
+
+- name: Apply app secrets Secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ instance_id }}-app-secrets"
+        namespace: "{{ _k8s_namespace }}"
+      type: Opaque
+      stringData: "{{ _app_secrets_dict.variables | default({}) }}"
+  when:
+    - _app_secrets_stat.stat.exists
+    - (_app_secrets_dict.variables | default({})) | length > 0
+  no_log: true
+
 # --- Write configData into values.yaml ---
 # The Helm chart templates render ConfigMaps from configData values.
 # This allows both Ansible-driven and Argo CD-driven workflows to use

--- a/tests/unit/test_canasta_sidecar_render.py
+++ b/tests/unit/test_canasta_sidecar_render.py
@@ -142,6 +142,40 @@ class TestK8sValues:
         assert render.render_k8s_values([], {}, lambda s: "") == []
 
 
+# A sidecar sourcing one env key from the app Secret, one plain.
+SECRETSC = {"name": "gen", "image": "x:1",
+            "env": {"OP_TOKEN": "${OP_SERVICE_ACCOUNT_TOKEN}",
+                    "PLAIN": "${PLAIN_VAL}"},
+            "envSecret": ["OP_TOKEN"]}
+
+
+class TestK8sEnvSecret:
+    def test_secret_key_not_resolved_and_listed(self):
+        env = {"OP_SERVICE_ACCOUNT_TOKEN": "tok", "PLAIN_VAL": "pv"}
+        item = render.render_k8s_values([SECRETSC], env, lambda s: "")[0]
+        # The secret key is withheld from the cleartext env map...
+        assert "OP_TOKEN" not in item.get("env", {})
+        # ...the plain key is still resolved as before...
+        assert item["env"]["PLAIN"] == "pv"
+        # ...and the secret key is carried as envSecret for secretKeyRef.
+        assert item["envSecret"] == ["OP_TOKEN"]
+
+    def test_all_keys_secret_drops_cleartext_env(self):
+        sc = {"name": "g", "image": "x:1",
+              "env": {"OP_TOKEN": "${T}"}, "envSecret": ["OP_TOKEN"]}
+        item = render.render_k8s_values([sc], {"T": "v"}, lambda s: "")[0]
+        assert "env" not in item
+        assert item["envSecret"] == ["OP_TOKEN"]
+
+    def test_no_envsecret_is_byte_identical(self):
+        # Backward compat: a sidecar without envSecret renders exactly as before
+        # (no envSecret key, env fully resolved).
+        env = {"REDIS_MAX_MEMORY": "256mb", "CITATION_SHARED_SECRET": "s3cr3t"}
+        item = render.render_k8s_values([CITATION], env, lambda s: "FILE")[0]
+        assert "envSecret" not in item
+        assert item["env"] == {"SHARED_SECRET": "s3cr3t"}
+
+
 class TestEnvBridge:
     def test_collect_refs_from_env_and_command(self):
         refs = render.collect_env_refs([CACHE, CITATION])

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -1411,3 +1411,49 @@ class TestGitopsArgoRepoSecretShared:
             "known-host (it reads known-hosts at startup; without this the "
             "first sync fails 'knownhosts: key is unknown')"
         )
+
+
+class TestK8sAppSecrets:
+    """Sidecar secrets are sourced from a per-instance Secret via secretKeyRef;
+    values live in the gitignored config/secrets.env, never in values.yaml."""
+
+    SIDECARS_TPL = os.path.join(HELM_CHART, "templates", "sidecars.yaml")
+    HELPERS = os.path.join(HELM_CHART, "templates", "_helpers.tpl")
+    SYNC = os.path.join(ORCHESTRATOR_TASKS, "k8s_sync_config.yml")
+    GITIGNORE = os.path.join(
+        REPO_ROOT, "roles", "gitops", "files", "gitignore.default")
+    SET = os.path.join(REPO_ROOT, "roles", "config", "tasks", "set.yml")
+    SET_SECRET = os.path.join(
+        REPO_ROOT, "roles", "config", "tasks", "_set_secret.yml")
+
+    @staticmethod
+    def _read(path):
+        with open(path) as f:
+            return f.read()
+
+    def test_chart_renders_envsecret_as_secretkeyref(self):
+        c = self._read(self.SIDECARS_TPL)
+        assert "$sc.envSecret" in c, "chart must iterate sidecar envSecret keys"
+        assert "secretKeyRef" in c, "envSecret keys must use secretKeyRef"
+        assert 'include "canasta.appSecretName"' in c
+
+    def test_appsecretname_helper_defined(self):
+        assert 'define "canasta.appSecretName"' in self._read(self.HELPERS)
+
+    def test_sync_upserts_app_secret_guarded(self):
+        c = self._read(self.SYNC)
+        assert "-app-secrets" in c, "must upsert a per-instance app Secret"
+        # Guarded on secrets.env existence -> no Secret for existing instances.
+        assert "secrets.env" in c
+        assert "_app_secrets_stat.stat.exists" in c
+
+    def test_secrets_env_is_gitignored(self):
+        assert "config/secrets.env" in self._read(self.GITIGNORE)
+
+    def test_config_set_dispatches_secret_path(self):
+        c = self._read(self.SET)
+        assert "_set_secret.yml" in c
+        assert "secret | default(false) | bool" in c
+        sec = self._read(self.SET_SECRET)
+        assert "config/secrets.env" in sec
+        assert "no_log: true" in sec  # never echo a secret value


### PR DESCRIPTION
Closes #891. Phase 1 of the k8s secret store (#774 follow-up to #890).

## What

Routes **sidecar** secrets through a per-instance k8s Secret so their values never land in the gitops repo. `envPrivate` (#890) kept a sidecar-only secret out of the web bridge, but on k8s the value was still resolved to cleartext in `values-sidecars.yaml`. This closes that, reusing Canasta's existing DB/MW-secret machinery.

## Flow

`canasta config set --secret KEY=VALUE` → gitignored `config/secrets.env` → Ansible upserts `{id}-app-secrets` on sync → the chart renders a sidecar's `envSecret` keys as `valueFrom: secretKeyRef`.

## Changes

- **`config/secrets.env`** — gitignored sibling of `.env` for opaque app secrets (added to `gitignore.default`).
- **`config set --secret`** — writes `secrets.env` (`no_log`), bypassing `.env` validation/side effects. `set.yml` dispatches to new `_set_secret.yml` / `_set_config.yml`.
- **`k8s_sync_config.yml`** — upserts `{id}-app-secrets` from `secrets.env` on the sync path, guarded on file existence, mirroring the crowdsec/backup-env Secret pattern.
- **`sidecars[].envSecret`** — keys sourced from the app Secret. `render_k8s_values` withholds them from the cleartext env map; the chart (`templates/sidecars.yaml`) renders them as `secretKeyRef` against a new `canasta.appSecretName` helper.

## Backward compatibility (purely additive)

- An existing sidecar with no `envSecret` renders **byte-identical** — verified with `helm template` diff (old chart vs new) and a unit test.
- The Secret upsert is a **no-op** without `secrets.env` (no new resource for existing instances).
- `--secret` is opt-in; plain `config set` is unchanged.
- Compose is untouched (`.env` is already the gitignored store there).
- The only touch to existing instances is the `gitignore.default` line (harmless; file does not exist).

## Out of scope (Phase 2)

Web/jobrunner-targeted secrets via `secretKeyRef` (deployment changes), and the Wicker routing updates to write via `config set --secret` and populate `envSecret`.

## Testing

- `helm template` backward-compat diff (identical) + `envSecret` → `secretKeyRef` render check
- Full unit suite: 1387 passed (new render + structural tests)
- `make lint` + `make validate`: clean
