### PR TITLE
feat(secrets): source web/jobrunner secrets from the app Secret (appSecretEnv)

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1015,6 +1015,13 @@ commands:
           Write to the gitignored config/secrets.env instead of .env (opaque
           app secrets; on K8s these feed a per-instance Secret consumed by
           sidecars via secretKeyRef). Bypasses .env validation and side effects.
+      - name: web
+        type: bool
+        default: false
+        description: >-
+          With --secret, also expose the key(s) to the web and jobrunner pods
+          via secretKeyRef (for a secret the MediaWiki process itself needs).
+          Recorded in config/secrets-web (key names only).
 
   - name: config_regenerate
     description: "Regenerate rendered config files (e.g. Caddyfile) from current sources"

--- a/roles/config/tasks/_set_secret.yml
+++ b/roles/config/tasks/_set_secret.yml
@@ -4,7 +4,9 @@
 # arbitrary app keys, not recognized .env config). On K8s they feed the
 # per-instance app Secret (k8s_sync_config.yml), consumed by sidecars via
 # secretKeyRef; on Compose secrets.env is an extra gitignored env source.
-# Input: _config_settings, instance_path.
+# With --web, the key is also recorded in config/secrets-web so K8s exposes it
+# to the web + jobrunner pods via secretKeyRef (.Values.appSecretEnv).
+# Input: _config_settings, instance_path, web.
 
 - name: Write each secret to config/secrets.env
   canasta_env:
@@ -17,3 +19,16 @@
     loop_var: _setting
     label: "{{ _setting.split('=', 1)[0] }}"
   no_log: true
+
+# Key names only (not secret); idempotent. Drives .Values.appSecretEnv.
+- name: Record web-exposed secret keys
+  ansible.builtin.lineinfile:
+    path: "{{ instance_path }}/config/secrets-web"
+    line: "{{ _setting.split('=', 1)[0] }}"
+    create: true
+    mode: "0644"
+  loop: "{{ _config_settings.split() }}"
+  loop_control:
+    loop_var: _setting
+    label: "{{ _setting.split('=', 1)[0] }}"
+  when: web | default(false) | bool

--- a/roles/config/tasks/set.yml
+++ b/roles/config/tasks/set.yml
@@ -16,6 +16,13 @@
   ansible.builtin.set_fact:
     _config_settings: "{{ config_settings_override | default(settings) }}"
 
+- name: Require --secret with --web
+  ansible.builtin.fail:
+    msg: "--web only applies to secret values; pass it together with --secret."
+  when:
+    - web | default(false) | bool
+    - not (secret | default(false) | bool)
+
 # Dispatch: --secret writes opaque values to the gitignored config/secrets.env
 # (no .env validation/side effects); otherwise the normal .env config path.
 - name: Set opaque secret values (config/secrets.env)

--- a/roles/gitops/files/gitignore.default
+++ b/roles/gitops/files/gitignore.default
@@ -1,6 +1,7 @@
 # Generated at deploy time — do not track
 .env
 config/secrets.env
+config/secrets-web
 config/wikis.yaml
 admin-password_*
 

--- a/roles/orchestrator/files/helm/canasta/templates/deployment-jobrunner.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/deployment-jobrunner.yaml
@@ -86,6 +86,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "canasta.mwSecretName" . }}
                   key: MW_SECRET_KEY
+            {{- range .Values.appSecretEnv }}
+            - name: {{ . }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "canasta.appSecretName" $ }}
+                  key: {{ . }}
+            {{- end }}
           volumeMounts:
             - name: config
               mountPath: /mediawiki/config

--- a/roles/orchestrator/files/helm/canasta/templates/deployment-web.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/deployment-web.yaml
@@ -107,6 +107,13 @@ spec:
                   key: MW_SECRET_KEY
             - name: CANASTA_ENABLE_VARNISH
               value: "{{ .Values.varnish.enabled }}"
+            {{- range .Values.appSecretEnv }}
+            - name: {{ . }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "canasta.appSecretName" $ }}
+                  key: {{ . }}
+            {{- end }}
           volumeMounts:
             - name: config
               mountPath: /mediawiki/config

--- a/roles/orchestrator/files/helm/canasta/values.yaml
+++ b/roles/orchestrator/files/helm/canasta/values.yaml
@@ -154,6 +154,13 @@ persistence:
 secrets:
   dbSecretName: ""      # set by Ansible: <instance_id>-db-credentials
   mwSecretName: ""      # set by Ansible: <instance_id>-mw-secrets
+  appSecretName: ""     # set by Ansible: <instance_id>-app-secrets
+
+# App secret keys exposed to the web + jobrunner pods via secretKeyRef from
+# the app Secret. Populated from config/secrets-web (keys set with
+# `config set --secret --web`) by k8s_sync_config.yml; empty by default so
+# existing instances render no extra env.
+appSecretEnv: []
 
 # Config data — populated by Ansible or committed via gitops.
 # Helm renders these into ConfigMaps for each component.

--- a/roles/orchestrator/tasks/k8s_sync_config.yml
+++ b/roles/orchestrator/tasks/k8s_sync_config.yml
@@ -326,6 +326,28 @@
     - (_app_secrets_dict.variables | default({})) | length > 0
   no_log: true
 
+# Web/jobrunner secrets: config/secrets-web lists the app-secret keys (names
+# only) that should reach the web + jobrunner pods, set with
+# `config set --secret --web`. They render as secretKeyRef env on those pods
+# (deployment-web.yaml / deployment-jobrunner.yaml) via .Values.appSecretEnv.
+- name: Check for config/secrets-web
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/config/secrets-web"
+  register: _app_secrets_web_stat
+
+- name: Read web-exposed secret keys
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/config/secrets-web"
+  register: _app_secrets_web_raw
+  when: _app_secrets_web_stat.stat.exists
+
+- name: Build appSecretEnv list
+  ansible.builtin.set_fact:
+    _app_secret_env: >-
+      {{ ((_app_secrets_web_raw.content | b64decode).split('\n')
+          | map('trim') | select() | reject('match', '^#') | list | unique)
+         if _app_secrets_web_stat.stat.exists else [] }}
+
 # --- Write configData into values.yaml ---
 # The Helm chart templates render ConfigMaps from configData values.
 # This allows both Ansible-driven and Argo CD-driven workflows to use
@@ -345,6 +367,7 @@
             'caddy': _caddy_config_data,
             'varnish': _varnish_config_data,
             'crowdsec': _crowdsec_config_data,
-          }} | to_nice_yaml(indent=2) }}
+          },
+          'appSecretEnv': _app_secret_env | default([])} | to_nice_yaml(indent=2) }}
     dest: "{{ instance_path }}/values-configdata.yaml"
     mode: "0644"

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -1457,3 +1457,50 @@ class TestK8sAppSecrets:
         sec = self._read(self.SET_SECRET)
         assert "config/secrets.env" in sec
         assert "no_log: true" in sec  # never echo a secret value
+
+
+class TestK8sWebAppSecrets:
+    """Web/jobrunner secrets (config set --secret --web) are exposed to those
+    pods via secretKeyRef from the app Secret, driven by .Values.appSecretEnv."""
+
+    WEB = os.path.join(HELM_CHART, "templates", "deployment-web.yaml")
+    JOB = os.path.join(HELM_CHART, "templates", "deployment-jobrunner.yaml")
+    VALUES = os.path.join(HELM_CHART, "values.yaml")
+    SYNC = os.path.join(ORCHESTRATOR_TASKS, "k8s_sync_config.yml")
+    GITIGNORE = os.path.join(
+        REPO_ROOT, "roles", "gitops", "files", "gitignore.default")
+    SET = os.path.join(REPO_ROOT, "roles", "config", "tasks", "set.yml")
+    SET_SECRET = os.path.join(
+        REPO_ROOT, "roles", "config", "tasks", "_set_secret.yml")
+
+    @staticmethod
+    def _read(path):
+        with open(path) as f:
+            return f.read()
+
+    def test_web_and_jobrunner_expose_appsecretenv(self):
+        for path in (self.WEB, self.JOB):
+            c = self._read(path)
+            assert "range .Values.appSecretEnv" in c, (
+                "%s must expose appSecretEnv keys" % os.path.basename(path))
+            assert 'include "canasta.appSecretName"' in c
+            assert "secretKeyRef" in c
+
+    def test_appsecretenv_default_in_values(self):
+        assert "appSecretEnv: []" in self._read(self.VALUES)
+
+    def test_sync_reads_secrets_web_into_appsecretenv(self):
+        c = self._read(self.SYNC)
+        assert "config/secrets-web" in c
+        assert "appSecretEnv" in c
+        assert "_app_secret_env" in c
+
+    def test_secrets_web_is_gitignored(self):
+        assert "config/secrets-web" in self._read(self.GITIGNORE)
+
+    def test_web_flag_records_keys_and_requires_secret(self):
+        sec = self._read(self.SET_SECRET)
+        assert "config/secrets-web" in sec
+        assert "web | default(false) | bool" in sec
+        # --web without --secret must fail fast.
+        assert "Require --secret with --web" in self._read(self.SET)


### PR DESCRIPTION
Closes #893. Phase 2 of the k8s secret store (follow-up to #892).

## What

Sources **web/jobrunner**-targeted secrets from the per-instance `{id}-app-secrets` Secret via `secretKeyRef`, closing the last cleartext-in-gitops exposure for app secrets on k8s. Phase 1 (#892) did this for sidecar secrets; this reuses the same Secret for the web tier.

## Flow

`canasta config set --secret --web KEY=VALUE` → records `KEY` in gitignored `config/secrets-web` (+ writes the value to `secrets.env`, as Phase 1) → `k8s_sync_config.yml` reads it into `.Values.appSecretEnv` → web + jobrunner deployments render a `secretKeyRef` env entry per key.

## Changes

- **`config set --secret --web`** — `--web` records key names in `config/secrets-web` (idempotent); `--web` without `--secret` fails fast. Added to `gitignore.default`.
- **`k8s_sync_config.yml`** — reads `config/secrets-web` into `.Values.appSecretEnv` (empty when absent).
- **`deployment-web.yaml` / `deployment-jobrunner.yaml`** — range over `appSecretEnv`, emitting `valueFrom: secretKeyRef` per key against `canasta.appSecretName`. `appSecretEnv: []` default in `values.yaml`.

Because the web pod env is a curated allowlist, `secretKeyRef` reaches `getenv()` directly — no cleartext bridge fragment needed.

## Backward compatibility (purely additive)

- With no `config/secrets-web` (`appSecretEnv` defaults to `[]`), the web and jobrunner deployments render **byte-identical** — verified with `helm template` diff (old vs new) for both.
- `--web` is opt-in; only the `gitignore.default` line touches existing instances.

## Out of scope

Wicker routing (drive `--web` for `web`-targeted secrets on k8s and skip the cleartext bridge there) — next, in the Wicker repo.

## Testing

- `helm template` backward-compat diff (identical, web + jobrunner) + `appSecretEnv` → `secretKeyRef` render check
- Full unit suite: 1392 passed (new structural tests)
- `make lint` + `make validate`: clean
