### PR TITLE
fix(exec): fall back to sh when a container has no bash

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -864,7 +864,12 @@ def handle_interactive_exec(args):
     if not service:
         service = "web"
     if not command:
-        command = ["/bin/bash"]
+        # Interactive shell: prefer bash, but fall back to sh so a slim sidecar
+        # image (alpine, *-slim) without bash still opens a usable shell. A
+        # command (the else branch above) is exec'd directly and needs no shell.
+        command = ["/bin/sh", "-c",
+                   "if command -v bash >/dev/null 2>&1; then exec bash; "
+                   "else exec sh; fi"]
 
     if orchestrator in ("kubernetes", "k8s"):
         # Find the pod for this service

--- a/roles/orchestrator/tasks/exec.yml
+++ b/roles/orchestrator/tasks/exec.yml
@@ -19,12 +19,23 @@
 # Output:
 #   exec_result (registered result with .stdout, .rc, etc.)
 
+# Run under bash when the image has it (Canasta's own containers do, and some
+# callers rely on bash-isms), else fall back to sh. App sidecars are arbitrary
+# images — many slim ones (alpine, *-slim) ship only sh — so a hard /bin/bash
+# would fail there. Detecting per-exec keeps `maintenance exec --service
+# <sidecar>` working regardless of the sidecar's base image. The command is
+# passed as $0 to the inner shell.
+- name: Define the in-container shell (bash if present, else sh)
+  ansible.builtin.set_fact:
+    _exec_shell: >-
+      /bin/sh -c 'if command -v bash >/dev/null 2>&1; then exec bash -c "$0"; else exec sh -c "$0"; fi'
+
 - name: Build exec command (Compose)
   ansible.builtin.set_fact:
     _exec_full_cmd: >-
       docker compose exec -T
       {{ exec_service | default('web') }}
-      /bin/bash -c {{ exec_command | quote }}
+      {{ _exec_shell }} {{ exec_command | quote }}
     _exec_chdir: "{{ instance_path }}"
   when: instance_orchestrator | default('compose') == 'compose'
   no_log: "{{ exec_no_log | default(false) }}"
@@ -48,7 +59,7 @@
         _exec_full_cmd: >-
           kubectl exec {{ '-i ' if (exec_stdin | default('')) | length > 0 else '' }}{{ _k8s_pod_name }}
           -n {{ _k8s_namespace }} --
-          /bin/bash -c {{ exec_command | quote }}
+          {{ _exec_shell }} {{ exec_command | quote }}
         _exec_chdir: null
       no_log: "{{ exec_no_log | default(false) }}"
 

--- a/tests/unit/test_exec_path_parity.py
+++ b/tests/unit/test_exec_path_parity.py
@@ -163,3 +163,44 @@ class TestStdinFlagParity:
         assert "-T" in captured["argv"]
         # Ansible compose build is always non-interactive (-T).
         assert "docker compose exec -T" in EXEC_YML
+
+
+def _python_exec_argv(monkeypatch, service, exec_args, orchestrator="compose"):
+    """Capture the docker/kubectl argv the Python direct path execs."""
+    captured = {}
+    monkeypatch.setattr(canasta, "resolve_instance", lambda _id: {
+        "id": "x", "orchestrator": orchestrator,
+        "host": "localhost", "path": "/tmp/i"})
+    monkeypatch.setattr(canasta, "_redirect_stdin_from_file", lambda p: None)
+    monkeypatch.setattr(canasta.os, "chdir", lambda p: None)
+    monkeypatch.setattr(canasta.subprocess, "run", lambda *a, **k:
+                        types.SimpleNamespace(returncode=0, stdout="pod-1"))
+    monkeypatch.setattr(canasta.os, "execvp",
+                        lambda f, argv: captured.__setitem__("argv", list(argv)))
+    canasta.handle_interactive_exec(Namespace(
+        id="x", service=service, exec_args=exec_args, stdin_file=None))
+    return captured["argv"]
+
+
+class TestShellFallbackParity:
+    """Neither exec path may hard-require bash: an exec into a slim sidecar
+    image (no bash) must still work. The interactive (no-command) shell falls
+    back bash->sh; a command is exec'd directly and needs no shell at all."""
+
+    def test_ansible_path_falls_back_to_sh(self):
+        # No bare '/bin/bash -c'; the wrapper tries bash then sh.
+        assert "/bin/bash -c" not in EXEC_YML
+        assert "command -v bash" in EXEC_YML
+        assert "exec sh -c" in EXEC_YML
+
+    def test_python_interactive_falls_back_to_sh(self, monkeypatch):
+        argv = " ".join(_python_exec_argv(monkeypatch, "slimcar", exec_args=[]))
+        assert "command -v bash" in argv and "exec sh" in argv
+        assert "/bin/bash" not in argv  # no hard bash dependency
+
+    def test_python_command_execs_tokens_directly(self, monkeypatch):
+        # A command needs no shell wrapper, so it runs on a bash-less sidecar.
+        argv = _python_exec_argv(monkeypatch, "slimcar",
+                                 exec_args=["redis-cli", "ping"])
+        assert argv[-2:] == ["redis-cli", "ping"]
+        assert "bash" not in " ".join(argv)


### PR DESCRIPTION
Closes #895.

## What

`maintenance exec` hard-required `bash`, so execing into a sidecar built on a slim image (alpine, `*-slim`) that ships only `sh` failed. This makes both shell-using exec paths fall back bash→sh.

## Changes

- **`canasta.py`** — the Python direct path's interactive default (no command) becomes `/bin/sh -c 'if command -v bash …; then exec bash; else exec sh; fi'` instead of `["/bin/bash"]`. (A *command* is exec'd directly as tokens, no shell wrapper, so it already worked on bash-less images.)
- **`roles/orchestrator/tasks/exec.yml`** — a shared `_exec_shell` fact wraps the command as `… exec bash -c "$0" … else exec sh -c "$0" …`, used by both the Compose and k8s builders, replacing the hard `/bin/bash -c`.

## Why it's safe

Containers that have bash (web, db, all of Canasta's own) exec bash via the wrapper — byte-identical behavior. Only bash-less images, which previously failed, now degrade to sh.

## Testing

- New parity tests pin that neither path hard-requires bash and that a command is still exec'd directly (`tests/unit/test_exec_path_parity.py`).
- Full unit suite: 1395 passed; `make lint` + `make validate` clean.

## Context

Enables `canasta maintenance exec --service <sidecar>` against arbitrary app-sidecar images (Wicker apps). The Wicker side — routing its sidecar `shell` action through `canasta maintenance exec` instead of raw `docker exec` (which is Compose-only) — is a separate change in the Wicker repo.
