### PR TITLE
fix(wiki): unwrap hard-wrapped descriptions on generated CLI: pages

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -206,8 +206,8 @@ command_groups:
       Kubernetes instance. Enable or disable CrowdSec itself with
       `canasta config set CANASTA_ENABLE_CROWDSEC=true|false` (the
       same pattern as the other optional features). The subcommands
-      below handle the tasks that take more than flipping a setting on
-      or off:
+      below allow further configuration and monitoring once CrowdSec
+      is enabled:
 
       * `bouncer-enroll` registers the Caddy bouncer with the CrowdSec
         engine, captures the generated API key, stores it as

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -205,8 +205,9 @@ command_groups:
       Manage the optional CrowdSec security feature on a Compose or
       Kubernetes instance. Enable or disable CrowdSec itself with
       `canasta config set CANASTA_ENABLE_CROWDSEC=true|false` (the
-      same pattern as the other optional features); this group covers
-      the steps that don't reduce to a single config value:
+      same pattern as the other optional features). The subcommands
+      below handle the tasks that take more than flipping a setting on
+      or off:
 
       * `bouncer-enroll` registers the Caddy bouncer with the CrowdSec
         engine, captures the generated API key, stores it as

--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -187,6 +187,50 @@ def _backticks_to_code(text):
     return _BACKTICK_RE.sub(r"<code>\1</code>", text)
 
 
+# Logical-line markers: a line that, after stripping leading whitespace,
+# begins one of these starts a new logical line rather than continuing the
+# previous one. Covers MediaWiki list/heading/table syntax plus the dash
+# and numbered-list styles authors use in long_description prose.
+_MARKER_RE = re.compile(r"^([*#:;=!|]|\{\||\|\}|-\s|\d+\.\s)")
+
+
+def _reflow_prose(text):
+    """Unwrap hard-wrapped prose so each paragraph or list item is a
+    single wikitext line.
+
+    long_description fields in command_definitions.yml are authored as
+    YAML literal blocks (|), so their hand-wrapped continuation lines are
+    indented for source readability. MediaWiki renders any line that
+    begins with a space as a preformatted (monospace) block, so those
+    indented continuations come out as broken gray boxes. Collapsing each
+    logical line onto one physical line removes the leading spaces and
+    keeps multi-line list items intact (MediaWiki needs a list item's text
+    on a single line). Blank lines (paragraph breaks) and lines that start
+    a new list item / heading / table row are preserved.
+    """
+    if not text:
+        return text
+    out = []
+    cur = None
+    for raw in text.split("\n"):
+        line = raw.strip()
+        if line == "":
+            if cur is not None:
+                out.append(cur)
+                cur = None
+            out.append("")
+            continue
+        if cur is None or _MARKER_RE.match(line):
+            if cur is not None:
+                out.append(cur)
+            cur = line
+        else:
+            cur += " " + line
+    if cur is not None:
+        out.append(cur)
+    return "\n".join(out)
+
+
 def _render_config_keys_table():
     """Render the 'Settings safe to change' table for the canasta
     config landing page.
@@ -327,7 +371,7 @@ def gen_wikitext(cmd, global_flags=None, cmd_index=None):
     if long_desc:
         lines.append("=== Synopsis ===")
         lines.append("")
-        lines.append(_backticks_to_code(long_desc.strip()))
+        lines.append(_backticks_to_code(_reflow_prose(long_desc.strip())))
         lines.append("")
 
     # Usage line — match the live wiki's compact form ('canasta create
@@ -477,6 +521,11 @@ def gen_group_wikitext(group_name, group_def, cmd_index, global_flags=None):
 
     long_desc = group_def.get("long_description", "").strip()
     if long_desc:
+        # Reflow before substituting the table so the generated <pre>
+        # block's intentional indentation survives (reflow strips leading
+        # whitespace; the placeholder sits on its own line and is left
+        # untouched).
+        long_desc = _reflow_prose(long_desc)
         # {{CONFIG_KEYS_TABLE}} expands to a generated reference table
         # built from roles/config/defaults/main.yml — same source of
         # truth `canasta config set`'s validator uses, so the docs and

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -753,3 +753,62 @@ class TestEveryCommandLinkedFromIndex:
             assert ("canasta " + cmd) in menu
         for cmd in ("crowdsec", "argocd"):  # groups -> menu
             assert ("canasta " + cmd) in menu
+
+
+class TestReflowProse:
+    """long_description fields are authored as YAML literal blocks with
+    hand-wrapped, indented continuation lines. MediaWiki renders any line
+    that begins with a space as a preformatted block, so those
+    continuations must be unwrapped onto a single logical line before
+    publishing."""
+
+    def _no_indented_lines(self, page):
+        """Assert no line outside a <pre>/<syntaxhighlight> block begins
+        with whitespace (the cause of stray MediaWiki preformatted boxes).
+        """
+        inpre = False
+        for line in page.split("\n"):
+            low = line.strip().lower()
+            if low.startswith(("<pre", "<syntaxhighlight")):
+                inpre = True
+            if not inpre and (line.startswith(" ") or line.startswith("\t")):
+                return line
+            if low.startswith(("</pre", "</syntaxhighlight")):
+                inpre = False
+        return None
+
+    def test_no_generated_page_has_stray_indentation(self):
+        data = wp.load_definitions()
+        for title, content in wp.generate_all_pages(data):
+            bad = self._no_indented_lines(content)
+            assert bad is None, "%s has space-prefixed line: %r" % (title, bad)
+
+    def test_bullet_continuation_collapsed_to_one_line(self):
+        text = (
+            "Intro paragraph that\nwraps across lines.\n\n"
+            "* first item that\n  wraps onto a second line\n"
+            "* second item\n"
+        )
+        out = wp._reflow_prose(text)
+        assert "Intro paragraph that wraps across lines." in out
+        assert "* first item that wraps onto a second line" in out
+        assert "* second item" in out
+        # No line begins with a space after reflow.
+        assert not any(ln.startswith(" ") for ln in out.split("\n"))
+
+    def test_blank_lines_and_list_items_preserved(self):
+        text = "para one\n\n- a\n  cont\n- b"
+        out = wp._reflow_prose(text)
+        assert out == "para one\n\n- a cont\n- b"
+
+    def test_numbered_items_stay_separate(self):
+        text = "1. first\n   wrapped\n2. second"
+        out = wp._reflow_prose(text)
+        assert out == "1. first wrapped\n2. second"
+
+    def test_config_keys_table_indentation_preserved(self):
+        """Reflow runs before the {{CONFIG_KEYS_TABLE}} substitution, so
+        the generated <pre> block keeps its intentional indentation."""
+        pages = dict(wp.generate_all_pages(wp.load_definitions()))
+        config = pages[wp.PAGE_PREFIX + "canasta config"]
+        assert "\n    HTTP_PORT" in config


### PR DESCRIPTION
Closes #897.

## Problem

Several auto-generated `CLI:` reference pages rendered parts of their command descriptions as broken gray monospace (preformatted) boxes — e.g. https://canasta.wiki/wiki/CLI:Canasta_crowdsec.

The `long_description` fields in `meta/command_definitions.yml` are authored as YAML literal blocks (`|`) with hand-wrapped, indented continuation lines. That indentation is preserved in the string, so `scripts/wiki_publish.py` emitted wikitext lines beginning with a space — and MediaWiki renders any space-prefixed line as a preformatted block.

Affected pages: `CLI:Canasta crowdsec`, `CLI:Canasta version`, `CLI:Canasta gitops fix-submodules`, `CLI:Canasta argocd`, `CLI:Canasta start`.

## Fix

- Add `_reflow_prose()` in `scripts/wiki_publish.py` that collapses each paragraph/list item onto a single wikitext line before rendering. This removes the leading spaces and keeps multi-line list items intact (MediaWiki needs a list item's text on one line). Blank lines (paragraph breaks) and list/heading/table markers — `*`, `-`, and numbered (`1.`) styles — are preserved.
- Applied to both leaf-command and group-page synopses, running **before** the `{{CONFIG_KEYS_TABLE}}` substitution so the generated `<pre>` table keeps its intentional indentation.
- Reword the crowdsec synopsis to drop jargon ("steps that don't reduce to a single config value").

Being a rendering-layer fix, it also prevents this class of breakage for any future `long_description`.

## Tests

- New `TestReflowProse` class, including a guard asserting **no** generated page has a space-prefixed line outside a `<pre>`/`<syntaxhighlight>` block.
- Full unit suite: 1397 passed.

Note: this changes only what the publisher generates. The live wiki updates when `wiki_publish.py` runs against the API (publish job), not as part of this merge.