### PR TITLE
fix(wiki): retry rate-limited edits in the publish job

### DIFF
--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -41,6 +41,20 @@ PAGE_PREFIX = "CLI:"
 EDIT_DELAY = 2  # seconds between edits
 HTTP_TIMEOUT = 30  # seconds; a hung wiki API must not stall the publish
 
+# Transient API errors worth retrying rather than failing the publish:
+# 'ratelimited' is the wiki throttling the bot when a single run changes
+# many pages; 'maxlag' is the DB-replication backpressure guard. Without
+# backoff a single throttle leaves the rest of the namespace stale.
+RETRYABLE_ERROR_CODES = {"ratelimited", "maxlag"}
+MAX_EDIT_RETRIES = 5
+RETRY_BACKOFF_BASE = 15  # seconds; doubled each retry, capped at the max
+RETRY_BACKOFF_MAX = 120
+
+
+def _retry_delay(attempt):
+    """Backoff (seconds) before retry number `attempt` (0-based)."""
+    return min(RETRY_BACKOFF_BASE * (2 ** attempt), RETRY_BACKOFF_MAX)
+
 
 class PermissionDeniedError(RuntimeError):
     """The bot account lacks the right for an API action (e.g. delete
@@ -752,23 +766,35 @@ class MediaWikiClient:
 
     def edit_page(self, title, content, summary):
         token = self._get_token("csrf")
-        result = self._post({
-            "action": "edit",
-            "title": title,
-            "text": content,
-            "summary": summary,
-            "token": token,
-            "format": "json",
-        })
-        if "error" in result:
-            raise RuntimeError(
-                "API error: %s: %s"
-                % (result["error"]["code"], result["error"]["info"])
-            )
-        if result.get("edit", {}).get("result") != "Success":
-            raise RuntimeError(
-                "Edit failed: %s" % result.get("edit", {}).get("result")
-            )
+        for attempt in range(MAX_EDIT_RETRIES + 1):
+            result = self._post({
+                "action": "edit",
+                "title": title,
+                "text": content,
+                "summary": summary,
+                "token": token,
+                "format": "json",
+            })
+            error = result.get("error")
+            if error:
+                code = error.get("code")
+                if code in RETRYABLE_ERROR_CODES and attempt < MAX_EDIT_RETRIES:
+                    delay = _retry_delay(attempt)
+                    print(
+                        "Rate limited on %s; retrying in %ds (%d/%d)"
+                        % (title, delay, attempt + 1, MAX_EDIT_RETRIES),
+                        file=sys.stderr,
+                    )
+                    time.sleep(delay)
+                    continue
+                raise RuntimeError(
+                    "API error: %s: %s" % (code, error.get("info"))
+                )
+            if result.get("edit", {}).get("result") != "Success":
+                raise RuntimeError(
+                    "Edit failed: %s" % result.get("edit", {}).get("result")
+                )
+            return
 
     def resolve_namespace_id(self, name):
         """Return the namespace id whose canonical or localized name

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -9,6 +9,8 @@ page at the wrong title.
 import os
 import sys
 
+import pytest
+
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts"))
@@ -753,6 +755,72 @@ class TestEveryCommandLinkedFromIndex:
             assert ("canasta " + cmd) in menu
         for cmd in ("crowdsec", "argocd"):  # groups -> menu
             assert ("canasta " + cmd) in menu
+
+
+class TestEditRetry:
+    """A large publish run can trip the wiki's edit rate limit partway
+    through. edit_page must retry transient errors with backoff so the
+    rest of the namespace doesn't get left stale (the failed run that
+    skipped CLI:Canasta crowdsec)."""
+
+    def _client(self):
+        # Bypass __init__ (which logs in over the network).
+        return object.__new__(wp.MediaWikiClient)
+
+    def test_retries_ratelimited_then_succeeds(self, monkeypatch):
+        c = self._client()
+        c._get_token = lambda kind: "token+\\"
+        calls = {"n": 0}
+
+        def fake_post(params):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                return {"error": {"code": "ratelimited", "info": "slow down"}}
+            return {"edit": {"result": "Success"}}
+
+        c._post = fake_post
+        sleeps = []
+        monkeypatch.setattr(wp.time, "sleep", sleeps.append)
+        c.edit_page("CLI:canasta crowdsec", "text", "summary")
+        assert calls["n"] == 3
+        assert sleeps == [wp._retry_delay(0), wp._retry_delay(1)]
+
+    def test_gives_up_after_max_retries(self, monkeypatch):
+        c = self._client()
+        c._get_token = lambda kind: "token"
+        calls = {"n": 0}
+
+        def fake_post(params):
+            calls["n"] += 1
+            return {"error": {"code": "ratelimited", "info": "nope"}}
+
+        c._post = fake_post
+        monkeypatch.setattr(wp.time, "sleep", lambda s: None)
+        with pytest.raises(RuntimeError, match="ratelimited"):
+            c.edit_page("t", "c", "s")
+        # Initial attempt plus MAX_EDIT_RETRIES retries.
+        assert calls["n"] == wp.MAX_EDIT_RETRIES + 1
+
+    def test_non_retryable_error_raises_immediately(self, monkeypatch):
+        c = self._client()
+        c._get_token = lambda kind: "token"
+        calls = {"n": 0}
+
+        def fake_post(params):
+            calls["n"] += 1
+            return {"error": {"code": "badtoken", "info": "bad token"}}
+
+        c._post = fake_post
+        monkeypatch.setattr(wp.time, "sleep", lambda s: None)
+        with pytest.raises(RuntimeError, match="badtoken"):
+            c.edit_page("t", "c", "s")
+        assert calls["n"] == 1  # no retries
+
+    def test_backoff_grows_and_is_capped(self):
+        assert wp._retry_delay(0) == wp.RETRY_BACKOFF_BASE
+        assert wp._retry_delay(1) == wp.RETRY_BACKOFF_BASE * 2
+        # Far-out attempts saturate at the cap.
+        assert wp._retry_delay(20) == wp.RETRY_BACKOFF_MAX
 
 
 class TestReflowProse:


### PR DESCRIPTION
Closes #899.

## Problem

The `Publish CLI Reference to Wiki` run for the previous merge failed:

```
ERROR uploading MediaWiki:Menu-cli-reference: API error: ratelimited: You've exceeded your rate limit.
Failed to publish 63 of 99 pages
```

It published ~36 pages, then the bot hit the wiki's edit rate limit and the remaining 63 — including `CLI:Canasta crowdsec` and `MediaWiki:Menu-cli-reference` — all errored out, leaving most of the namespace stale.

## Cause

`scripts/wiki_publish.py` waits a fixed 2s between edits but has no retry/backoff when the API returns `ratelimited` (or `maxlag`). The first such error was raised and counted as a permanent failure.

## Fix

`MediaWikiClient.edit_page` now retries the transient error codes (`ratelimited`, `maxlag`) with exponential backoff (15s → 30s → … capped at 120s, up to 5 retries) before giving up, so a single throttle no longer leaves the rest of the namespace stale.

## Tests

New `TestEditRetry`: retries-then-succeeds, gives-up-after-max, non-retryable-raises-immediately, and backoff growth/cap. Full unit suite passes.

## Follow-up

Once merged, the push to main re-triggers the wiki-publish workflow; with backoff it should complete the full set and update the pages the failed run skipped (notably `CLI:Canasta crowdsec`).