### PR TITLE
fix(wiki): use MediaWiki list markup in long_description fields

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -451,10 +451,10 @@ commands:
       reconciled from the instance's feature flags so optional
       components start or stay down based on their current setting:
 
-      - `CANASTA_ENABLE_VARNISH` (default `true`) — Varnish cache
-      - `CANASTA_ENABLE_OBSERVABILITY` (default `false`) — Prometheus
+      * `CANASTA_ENABLE_VARNISH` (default `true`) — Varnish cache
+      * `CANASTA_ENABLE_OBSERVABILITY` (default `false`) — Prometheus
         and Grafana stack
-      - `CANASTA_ENABLE_ELASTICSEARCH` (default `false`) — Elasticsearch
+      * `CANASTA_ENABLE_ELASTICSEARCH` (default `false`) — Elasticsearch
 
       If the instance has development mode enabled, Xdebug starts
       automatically. Use `canasta devmode enable` or `canasta devmode
@@ -582,14 +582,14 @@ commands:
 
       Additional output depends on context:
 
-      - Inside an instance directory: also reports that instance's
+      * Inside an instance directory: also reports that instance's
         pinned CANASTA_IMAGE tag and running runtime version.
-      - Outside any instance directory: lists every registered
+      * Outside any instance directory: lists every registered
         instance with its pinned CANASTA_IMAGE tag (no runtime query;
         fast).
-      - With --id: reports full image + running version for the
+      * With --id: reports full image + running version for the
         named instance (same as inside that instance's directory).
-      - With --cli-only: prints only the CLI header; skips all
+      * With --cli-only: prints only the CLI header; skips all
         instance reads. Intended for scripts that just want the CLI
         version deterministically.
     examples:
@@ -2330,11 +2330,11 @@ commands:
 
       This handles two cases:
 
-      1. Extensions or skins that were added after gitops init and
-         need to be converted from standalone git repositories to
-         submodules.
-      2. Submodules listed in .gitmodules that were accidentally
-         committed as regular directories instead of gitlinks.
+      # Extensions or skins that were added after gitops init and
+        need to be converted from standalone git repositories to
+        submodules.
+      # Submodules listed in .gitmodules that were accidentally
+        committed as regular directories instead of gitlinks.
 
       After fixing, run `canasta gitops push` to push the changes.
     examples:

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -812,3 +812,33 @@ class TestReflowProse:
         pages = dict(wp.generate_all_pages(wp.load_definitions()))
         config = pages[wp.PAGE_PREFIX + "canasta config"]
         assert "\n    HTTP_PORT" in config
+
+
+class TestListMarkupIsMediaWiki:
+    """long_description list items must use MediaWiki markup (* for
+    unordered, # for ordered). Markdown-style '- ' and '1.' don't start
+    a list in MediaWiki — they render as literal text with a stray dash
+    or number, which is how CLI:Canasta version's list came out wrong."""
+
+    import re as _re
+    _MARKDOWN_LIST = _re.compile(r"^(-\s|\d+\.\s)")
+
+    def _long_descriptions(self):
+        data = wp.load_definitions()
+        for c in data["commands"]:
+            if c.get("long_description"):
+                yield c["name"], c["long_description"]
+        for g in data.get("command_groups", []):
+            if g.get("long_description"):
+                yield "[group] " + g["name"], g["long_description"]
+
+    def test_no_markdown_style_list_markers(self):
+        offenders = []
+        for name, ld in self._long_descriptions():
+            for line in ld.split("\n"):
+                if self._MARKDOWN_LIST.match(line.strip()):
+                    offenders.append("%s: %r" % (name, line.strip()))
+        assert not offenders, (
+            "use '*'/'#' (MediaWiki), not markdown list markers:\n  "
+            + "\n  ".join(offenders)
+        )


### PR DESCRIPTION
Closes #900.

## Problem

On https://canasta.wiki/wiki/CLI:Canasta_version (and `CLI:Canasta start`) the list items render as plain text with a stray leading dash instead of as bullets. `CLI:Canasta gitops fix-submodules` has the same problem with its numbered steps.

## Cause

Those `long_description` fields used markdown-style list markup — `- ` for bullets and `1.`/`2.` for numbered items. MediaWiki only recognizes `*` (unordered) and `#` (ordered); a line beginning with `-` or a number renders as literal text.

## Fix

- `start`, `version`: `- ` → `*`
- `gitops fix-submodules`: `1.`/`2.` → `#`
- Add a test that rejects markdown list markers (`- `, `N.`) in any `long_description`, so this doesn't regress.

The reflow added in #898 collapses each item's wrapped continuation onto one line, so the `*`/`#` items render as proper single-line list entries.

## Tests

`TestListMarkupIsMediaWiki` plus the full unit suite (1401) pass.