### PR TITLE
fix(upgrade): don't re-resolve instance from CWD during CrowdSec auto-enroll

### DIFF
--- a/roles/config/tasks/set.yml
+++ b/roles/config/tasks/set.yml
@@ -2,8 +2,13 @@
 # canasta config set - Change configuration values.
 # Input: id (optional), settings (str: "KEY=VALUE KEY2=VALUE2"), no_restart (bool), force (bool)
 
-- name: Resolve instance
+# Top-level `canasta config set` needs this; the internal caller (crowdsec
+# bouncer_enroll storing the API key during a start/upgrade auto-enroll)
+# already resolved the instance, and re-resolving from CWD would pick the
+# wrong directory when the CLI was invoked outside the instance dir.
+- name: Resolve instance (skip if caller already resolved it)
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
+  when: instance_path is not defined
 
 # Internal callers (crowdsec bouncer_enroll storing the API key) run during
 # a config-set-triggered restart, where `settings` is an Ansible extra-var

--- a/roles/crowdsec/tasks/_preflight.yml
+++ b/roles/crowdsec/tasks/_preflight.yml
@@ -5,8 +5,13 @@
 # Output: instance_id, instance_path, instance_orchestrator (+ the rest of
 # resolve_instance's facts), _cscli_prefix, _cscli_chdir.
 
-- name: Resolve instance
+# Top-level `canasta crowdsec ...` needs this; nested callers (the
+# start/upgrade auto-enroll path) already resolved the instance, and
+# re-resolving from CWD would pick the wrong directory when the CLI was
+# invoked outside the instance dir (e.g. `canasta upgrade` from $HOME).
+- name: Resolve instance (skip if caller already resolved it)
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
+  when: instance_path is not defined
 
 # --- Compose: the crowdsec service must be running ---
 - name: Verify crowdsec service is running (Compose)


### PR DESCRIPTION
## Summary

`canasta upgrade` failed at the CrowdSec auto-enroll step when run from a directory that is not an instance directory (e.g. `$HOME`), even though `upgrade` operates on all registered instances and resolves each one explicitly.

```
CrowdSec is enabled — registering with the Central API and enrolling the Caddy bouncer...
Error: No Canasta instance is registered for this directory (/home/wikiworks).
Specify --id <id>, or cd into an instance directory.
Registered instances: wikifarm
```

Re-running from inside the instance directory succeeded, because the current working directory then matched the registered instance path.

## Root cause

`canasta upgrade` iterates every registered instance and sets `instance_id` / `instance_path` per iteration (`roles/upgrade/_upgrade_single.yml`). The restart it triggers runs the CrowdSec auto-enroll chain (`orchestrator/start.yml` → `crowdsec_autoenroll.yml` → `crowdsec/bouncer_enroll.yml`), which re-resolved the instance from scratch:

- `roles/crowdsec/tasks/_preflight.yml` — the actual failure point
- `roles/config/tasks/set.yml` — fails next (bouncer_enroll persists the API key via `config set`)

Both unconditionally included `roles/common/tasks/resolve_instance.yml`, which (with no `--id`) falls back to matching the current working directory against registered instance paths.

The `instance_lifecycle` tasks (`restart.yml`, `start.yml`, `stop.yml`) already guard this with `when: instance_path is not defined`; these two tasks never adopted the idiom.

## Fix

Add the `when: instance_path is not defined` guard to both tasks so an already-resolved instance is not re-resolved from CWD. Top-level `canasta config set` / `canasta crowdsec ...` are unaffected (`instance_path` is undefined at their entry point).

## Testing

- `make lint`, `make validate`, `make test-unit` (1405 passed)

Fixes #908
