### PR TITLE
fix(profiles): derive internal-db from USE_EXTERNAL_DB so it self-heals

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -385,7 +385,12 @@ def _sync_compose_profiles(inst):
 
     entries = _parse_env_entries(content)
     env = {k: v for k, v, c in entries if not c and k}
+    # internal-db is reconciled like a managed profile (stripped from current,
+    # then re-derived below) but keyed on the INVERSE of USE_EXTERNAL_DB, and
+    # it is absent from _MANAGED_PROFILE_SERVICES so its container is never
+    # auto-removed by the teardown.
     managed_names = {p for p, _flag, _default in _MANAGED_PROFILES}
+    managed_names.add("internal-db")
 
     current_raw = env.get("COMPOSE_PROFILES", "")
     current = [p.strip() for p in current_raw.split(",") if p.strip()]
@@ -394,6 +399,13 @@ def _sync_compose_profiles(inst):
     for profile, flag, default in _MANAGED_PROFILES:
         if env.get(flag, default).strip().lower() == "true":
             desired.append(profile)
+    # The bundled database runs by default and is skipped only when an external
+    # DB is configured (mirrors roles/create/tasks/_env_update.yml). Deriving it
+    # every sync — rather than only preserving it when already present — means an
+    # instance whose COMPOSE_PROFILES lost internal-db (created before
+    # external-DB support, or a gitops .env render that dropped it) self-heals.
+    if env.get("USE_EXTERNAL_DB", "false").strip().lower() != "true":
+        desired.append("internal-db")
 
     profiles_changed = sorted(desired) != sorted(current)
 
@@ -440,8 +452,12 @@ def _sync_compose_profiles(inst):
         removed = [
             p for p in current if p in managed_names and p not in desired
         ]
+        # internal-db is in managed_names but not in _MANAGED_PROFILE_SERVICES:
+        # switching to an external DB drops it from the profile set, but the
+        # database container is intentionally never torn down here.
         stale_services = [
-            svc for p in removed for svc in _MANAGED_PROFILE_SERVICES[p]
+            svc for p in removed if p in _MANAGED_PROFILE_SERVICES
+            for svc in _MANAGED_PROFILE_SERVICES[p]
         ]
         if stale_services:
             profile_flags = []

--- a/roles/orchestrator/tasks/sync_compose_profiles.yml
+++ b/roles/orchestrator/tasks/sync_compose_profiles.yml
@@ -14,15 +14,23 @@
       {{ (_env_profiles.variables.COMPOSE_PROFILES | default(''))
          | split(',') | map('trim') | reject('equalto', '') | list }}
 
+# internal-db is reconciled like the feature profiles (stripped, then
+# re-derived) but keyed on the INVERSE of USE_EXTERNAL_DB: the bundled database
+# runs by default and is skipped only when an external DB is configured (mirrors
+# roles/create/tasks/_env_update.yml). Deriving it every sync self-heals an
+# instance whose COMPOSE_PROFILES lost internal-db (created before external-DB
+# support, or a gitops .env render that dropped it). It is excluded from the
+# teardown below (_profile_services), so the database container is never removed.
 - name: Compute desired profiles
   ansible.builtin.set_fact:
     _desired_profiles: >-
       {{
-        (_current_profiles | reject('in', ['observable', 'elasticsearch', 'varnish', 'crowdsec']) | list) +
+        (_current_profiles | reject('in', ['observable', 'elasticsearch', 'varnish', 'crowdsec', 'internal-db']) | list) +
         ((_env_profiles.variables.CANASTA_ENABLE_OBSERVABILITY | default('false') | lower == 'true') | ternary(['observable'], [])) +
         ((_env_profiles.variables.CANASTA_ENABLE_ELASTICSEARCH | default('false') | lower == 'true') | ternary(['elasticsearch'], [])) +
         ((_env_profiles.variables.CANASTA_ENABLE_VARNISH | default('true') | lower == 'true') | ternary(['varnish'], [])) +
-        ((_env_profiles.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true') | ternary(['crowdsec'], []))
+        ((_env_profiles.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true') | ternary(['crowdsec'], [])) +
+        ((_env_profiles.variables.USE_EXTERNAL_DB | default('false') | lower != 'true') | ternary(['internal-db'], []))
       }}
 
 - name: Update COMPOSE_PROFILES in .env

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1533,10 +1533,11 @@ class TestSyncComposeProfiles:
         )
         direct_commands._sync_compose_profiles(self._inst(tmp_path))
         content = (tmp_path / ".env").read_text()
-        # Every managed profile is dropped because all flags are false
+        # Every feature profile is dropped because all flags are false, but
+        # internal-db stays (default-on; no external DB configured).
         for line in content.split("\n"):
             if line.startswith("COMPOSE_PROFILES="):
-                assert line == "COMPOSE_PROFILES="
+                assert line == "COMPOSE_PROFILES=internal-db"
                 break
 
     def test_preserves_unmanaged_profiles(self, tmp_path):
@@ -1559,13 +1560,54 @@ class TestSyncComposeProfiles:
     def test_no_write_when_already_in_sync(self, tmp_path):
         env_path = tmp_path / ".env"
         env_path.write_text(
-            "CANASTA_ENABLE_VARNISH=true\nCOMPOSE_PROFILES=varnish\n"
+            "CANASTA_ENABLE_VARNISH=true\n"
+            "COMPOSE_PROFILES=varnish,internal-db\n"
         )
         original_mtime = env_path.stat().st_mtime_ns
         direct_commands._sync_compose_profiles(self._inst(tmp_path))
         # If _sync wrote the file, mtime would update. The guard in
         # _sync (sorted(desired) == sorted(current)) must prevent that.
         assert env_path.stat().st_mtime_ns == original_mtime
+
+    def test_adds_internal_db_by_default(self, tmp_path):
+        # No USE_EXTERNAL_DB set: the bundled database runs by default, so
+        # internal-db must be derived even when COMPOSE_PROFILES omits it.
+        (tmp_path / ".env").write_text("COMPOSE_PROFILES=\n")
+        direct_commands._sync_compose_profiles(self._inst(tmp_path))
+        content = (tmp_path / ".env").read_text()
+        assert "internal-db" in content
+
+    def test_self_heals_missing_internal_db(self, tmp_path):
+        # An old/drifted instance whose COMPOSE_PROFILES lost internal-db
+        # gets it restored on the next sync (no external DB configured).
+        (tmp_path / ".env").write_text(
+            "CANASTA_ENABLE_VARNISH=true\nCOMPOSE_PROFILES=varnish\n"
+        )
+        direct_commands._sync_compose_profiles(self._inst(tmp_path))
+        content = (tmp_path / ".env").read_text()
+        for line in content.split("\n"):
+            if line.startswith("COMPOSE_PROFILES="):
+                assert "internal-db" in line
+                assert "varnish" in line
+                break
+
+    def test_external_db_drops_internal_db_without_teardown(self, tmp_path):
+        # USE_EXTERNAL_DB=true: internal-db leaves the profile set, but the
+        # database container must NEVER be auto-torn-down (it is absent from
+        # _MANAGED_PROFILE_SERVICES, so no compose rm is issued for it).
+        (tmp_path / ".env").write_text(
+            "USE_EXTERNAL_DB=true\n"
+            "CANASTA_ENABLE_VARNISH=true\n"
+            "COMPOSE_PROFILES=internal-db,varnish\n"
+        )
+        direct_commands._sync_compose_profiles(self._inst(tmp_path))
+        content = (tmp_path / ".env").read_text()
+        for line in content.split("\n"):
+            if line.startswith("COMPOSE_PROFILES="):
+                assert "internal-db" not in line
+                break
+        # No teardown call was issued for the dropped internal-db profile.
+        assert self.compose_calls == []
 
     def test_deactivated_profile_tears_down_its_container(self, tmp_path):
         # elasticsearch was active; the flag is now false. The profile is
@@ -1688,10 +1730,11 @@ class TestSyncComposeProfiles:
         )
         direct_commands._sync_compose_profiles(self._inst(tmp_path))
         content = (tmp_path / ".env").read_text()
-        # Profile dropped and the managed image cleared back to default.
+        # crowdsec dropped (internal-db stays, default-on) and the managed
+        # image cleared back to default.
         for line in content.split("\n"):
             if line.startswith("COMPOSE_PROFILES="):
-                assert line == "COMPOSE_PROFILES="
+                assert line == "COMPOSE_PROFILES=internal-db"
             if line.startswith("CANASTA_CADDY_IMAGE="):
                 assert line == "CANASTA_CADDY_IMAGE="
 


### PR DESCRIPTION
Fixes #911.

## Problem

`internal-db` was only honored if it already happened to be in `COMPOSE_PROFILES`. `sync_compose_profiles` preserved it when present but never restored it when missing. Instances created before external-DB support — or whose gitops `.env` render dropped it — therefore ran the bundled database **unmanaged**: invisible to `docker compose up`/`down` and excluded from restarts. A `stop`/`start` cycle would not bring it back.

(Found while diagnosing a production outage; the same drift class also left Elasticsearch unmanaged.)

## Fix

Reconcile `internal-db` on every sync, keyed on the **inverse** of `USE_EXTERNAL_DB`: the bundled database runs by default and is skipped only when an external DB is configured — mirroring what `roles/create/tasks/_env_update.yml` already does at create time. This self-heals old/drifted instances on the next sync.

`internal-db` stays absent from `_MANAGED_PROFILE_SERVICES`, so it is reconciled **on** but the database container is **never auto-removed** ("ensure on" without "force off"). Switching to an external DB drops it from the profile set without tearing down the container.

Applied to both implementations:
- `direct_commands/_helpers.py` (`_sync_compose_profiles`, the Python fast-path) — plus a guard so the teardown never `KeyError`s on the now-managed-but-serviceless `internal-db`.
- `roles/orchestrator/tasks/sync_compose_profiles.yml` (the Ansible twin).

## Tests

- Updated 3 existing tests that assumed `internal-db` was never auto-added.
- Added: default-on, self-heal-when-missing, and external-DB-drops-without-teardown.
- Full unit suite (1408) passes; YAML lint clean.

## Note

This is the foundation for the follow-ups on the same drift class: #912 (run sync after `gitops pull` renders `.env`) and #910 (symmetric sync before `stop` + dynamic Varnish backend).
