### PR TITLE
fix(gitops): reconcile COMPOSE_PROFILES on pull (compose)

### DIFF
--- a/roles/gitops/tasks/pull_compose.yml
+++ b/roles/gitops/tasks/pull_compose.yml
@@ -158,6 +158,17 @@
         dest: "{{ instance_path }}/config/wikis.yaml"
         mode: "0644"
 
+# --- Step 7b: Reconcile COMPOSE_PROFILES with the rendered flags ---
+# .env is rendered verbatim from env.template + vars, so a stale
+# COMPOSE_PROFILES literal (or a render that dropped internal-db / a feature
+# profile) would otherwise survive the pull and leave services unmanaged —
+# running but invisible to up/down. Run the same sync used before start so the
+# profile set matches the feature flags and the DB mode. This runs before the
+# change-detection below, so a profile change correctly flags a restart.
+- name: Reconcile COMPOSE_PROFILES after render
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/sync_compose_profiles.yml
+
 # --- Step 8: Write admin password files ---
 - name: Write admin password files from vars
   ansible.builtin.copy:

--- a/tests/unit/test_gitops_pull_sync_profiles.py
+++ b/tests/unit/test_gitops_pull_sync_profiles.py
@@ -1,0 +1,60 @@
+"""Structural guard for COMPOSE_PROFILES reconciliation on `gitops pull`.
+
+A Compose `gitops pull` renders `.env` verbatim from env.template + host
+vars, so without reconciliation a stale COMPOSE_PROFILES literal — or a
+render that dropped internal-db / a feature profile — survives the pull and
+leaves services running-but-unmanaged. The pull must run the same
+sync_compose_profiles used before start, and it must run BEFORE change
+detection so a profile change correctly flags a restart.
+
+This path mutates a real .env / containers, so it is skipped by the CI
+integration suite; this structural assertion is the CI-runnable guard.
+"""
+
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+PULL_COMPOSE = os.path.join(
+    REPO_ROOT, "roles", "gitops", "tasks", "pull_compose.yml"
+)
+
+
+def _tasks(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _includes(task):
+    inc = task.get("ansible.builtin.include_tasks") or task.get("include_tasks")
+    if isinstance(inc, dict):
+        return inc.get("file", "")
+    return inc or ""
+
+
+def test_pull_compose_reconciles_profiles_after_render():
+    tasks = _tasks(PULL_COMPOSE)
+    sync_idx = next(
+        (i for i, t in enumerate(tasks)
+         if "sync_compose_profiles.yml" in _includes(t)),
+        None,
+    )
+    assert sync_idx is not None, (
+        "pull_compose.yml must reconcile COMPOSE_PROFILES "
+        "(include sync_compose_profiles.yml) after rendering .env"
+    )
+
+    # Must run before change detection so a reconciled profile change is
+    # picked up by the new-.env comparison and flags a restart.
+    change_idx = next(
+        (i for i, t in enumerate(tasks)
+         if t.get("name") == "Read new .env for comparison"),
+        None,
+    )
+    assert change_idx is not None, "expected the new-.env comparison step"
+    assert sync_idx < change_idx, (
+        "profile reconciliation must run before change detection so a "
+        "profile change is seen by the .env comparison"
+    )


### PR DESCRIPTION
Fixes #912.

## Problem

`canasta gitops pull` (Compose) renders `.env` verbatim from `env.template` + host `vars.yaml` and **never reconciles `COMPOSE_PROFILES`**. So a stale `COMPOSE_PROFILES` literal committed in the template — or a render that dropped `internal-db`/a feature profile — survives the pull. The services then run but are **unmanaged**: invisible to `docker compose up`/`down` and skipped by restarts. This is how profile drift was reintroduced on every pull (observed in production: Elasticsearch and the bundled DB running while `COMPOSE_PROFILES` listed neither).

## Fix

Run `sync_compose_profiles` immediately after the render, **before** change detection, so the profile set is reconciled from the feature flags and the DB mode. Placing it before the new-`.env` comparison means a profile change correctly flags `_pull_needs_restart`.

The rendered `.env` is gitignored in the gitops layout, so this reconciliation does not create uncommitted changes that would block the next pull.

Pairs with #911 (internal-db derivation): together, a pull always lands a correct, fully-managed profile set.

## Tests

- New `tests/unit/test_gitops_pull_sync_profiles.py` asserts the sync include is present and ordered before change detection (mirrors the existing structural-guard pattern for the backup-schedule rematerialize path).
- Full unit suite passes; YAML lint and `make validate` clean.
