### PR TITLE
fix(lifecycle): reconcile COMPOSE_PROFILES before down (symmetric sync)

### DIFF
--- a/direct_commands/lifecycle.py
+++ b/direct_commands/lifecycle.py
@@ -38,6 +38,11 @@ def cmd_stop(args):
         return _helpers.FALLBACK
     if _helpers._instance_has_sidecars(inst):
         return _helpers.FALLBACK  # Ansible includes the sidecar -f layer.
+    # Reconcile COMPOSE_PROFILES before `down`: docker compose down only tears
+    # down services in the active profiles, so a drifted profile set leaves a
+    # running container as an unmanaged orphan. Sync first so `down` covers the
+    # full intended set.
+    _helpers._sync_compose_profiles(inst)
     # --remove-orphans sweeps a sidecar container left over from a sidecar
     # that was just removed: sidecars.yaml is now empty (so we take this
     # non-sidecar path), but its docker-compose.sidecars.yml entry and
@@ -53,13 +58,18 @@ def cmd_restart(args):
         return _helpers.FALLBACK
     if _helpers._instance_has_sidecars(inst):
         return _helpers.FALLBACK  # Ansible renders + layers the sidecars.
+    # Reconcile COMPOSE_PROFILES BEFORE `down` so `down` and `up` act on the
+    # same service set. Previously the sync ran only between down and up: with a
+    # drifted profile set (e.g. missing varnish), `down` skipped that service,
+    # then `up -d` recreated web/caddy on new IPs while the survivor kept stale
+    # state — the Varnish stale-backend redirect loop.
+    _helpers._sync_compose_profiles(inst)
     # --remove-orphans sweeps a sidecar container left over from a sidecar
     # that was just removed (sidecars.yaml is empty so we take this path, but
     # its docker-compose.sidecars.yml entry and container still linger).
     rc = _helpers._run_compose(inst_id, inst, ["down", "--remove-orphans"])
     if rc != 0:
         return rc
-    _helpers._sync_compose_profiles(inst)
     rc = _helpers._run_compose(inst_id, inst, ["up", "-d"])
     if rc != 0:
         _helpers._dump_compose_failure(inst)

--- a/roles/orchestrator/tasks/stop.yml
+++ b/roles/orchestrator/tasks/stop.yml
@@ -5,6 +5,15 @@
 - name: Stop (Docker Compose)
   when: instance_orchestrator | default('compose') == 'compose'
   block:
+    # Reconcile COMPOSE_PROFILES before `down`: docker compose down only tears
+    # down services in the active profiles, so a drifted profile set would
+    # leave a running container as an unmanaged orphan. The start path syncs
+    # before `up`; syncing here too keeps `down` and `up` symmetric so a
+    # restart recreates the whole intended set (and never strands a peer like
+    # Varnish on a stale backend IP).
+    - name: Reconcile COMPOSE_PROFILES before stop
+      ansible.builtin.include_tasks: sync_compose_profiles.yml
+
     # Include the sidecar layer (if present) so `down` tears down the
     # sidecar containers; the start path regenerates it. No render here.
     - name: Check for docker-compose.sidecars.yml

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1409,6 +1409,38 @@ class TestLifecycleCommands:
         assert rc == 1
         assert call_count[0] == 1
 
+    def test_restart_syncs_profiles_before_down(self, monkeypatch):
+        # The profile sync must run BEFORE `down` so `down` and `up` act on the
+        # same service set. If it ran between down and up (the old order), a
+        # drifted profile set let `down` skip a service that `up` then didn't
+        # recreate — the Varnish stale-backend redirect loop.
+        events = []
+        monkeypatch.setattr(direct_commands._helpers, "_resolve_instance",
+            lambda args: ("test", {"path": "/srv/test", "orchestrator": "compose"}))
+        monkeypatch.setattr(direct_commands._helpers, "_sync_compose_profiles",
+            lambda inst: events.append("sync"))
+        monkeypatch.setattr(direct_commands._helpers, "_run_compose",
+            lambda inst_id, inst, action: events.append(action[0]) or 0)
+        args = type("Args", (), {"id": "test"})()
+        rc = direct_commands.cmd_restart(args)
+        assert rc == 0
+        assert events == ["sync", "down", "up"]
+
+    def test_stop_syncs_profiles_before_down(self, monkeypatch):
+        # Standalone stop reconciles too, so `down` tears down the full
+        # intended set rather than leaving an out-of-profile orphan running.
+        events = []
+        monkeypatch.setattr(direct_commands._helpers, "_resolve_instance",
+            lambda args: ("test", {"path": "/srv/test", "orchestrator": "compose"}))
+        monkeypatch.setattr(direct_commands._helpers, "_sync_compose_profiles",
+            lambda inst: events.append("sync"))
+        monkeypatch.setattr(direct_commands._helpers, "_run_compose",
+            lambda inst_id, inst, action: events.append(action[0]) or 0)
+        args = type("Args", (), {"id": "test"})()
+        rc = direct_commands.cmd_stop(args)
+        assert rc == 0
+        assert events == ["sync", "down"]
+
     def test_remote_start_uses_ssh(self, monkeypatch):
         # The sync-profiles .env read still goes through _ssh_run...
         def mock_ssh(host, cmd):

--- a/tests/unit/test_stop_syncs_profiles.py
+++ b/tests/unit/test_stop_syncs_profiles.py
@@ -1,0 +1,56 @@
+"""Structural guard: the Compose stop path reconciles COMPOSE_PROFILES before
+`down`.
+
+`docker compose down` only tears down services in the active profiles, so a
+drifted profile set would leave a running container as an unmanaged orphan —
+and, paired with a later recreate, strand Varnish on a stale backend IP. The
+start path already syncs before `up`; stop must sync before `down` so a restart
+recreates the whole intended set symmetrically.
+"""
+
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+STOP = os.path.join(REPO_ROOT, "roles", "orchestrator", "tasks", "stop.yml")
+
+
+def _includes(task):
+    inc = task.get("ansible.builtin.include_tasks") or task.get("include_tasks")
+    if isinstance(inc, dict):
+        return inc.get("file", "")
+    return inc or ""
+
+
+def _compose_block():
+    with open(STOP) as f:
+        tasks = yaml.safe_load(f)
+    compose = next(
+        (t for t in tasks if "compose" in str(t.get("when", ""))
+         and t.get("block")),
+        None,
+    )
+    assert compose is not None, "stop.yml must have a Compose block"
+    return compose["block"]
+
+
+def test_stop_syncs_profiles_before_down():
+    block = _compose_block()
+    sync_idx = next(
+        (i for i, t in enumerate(block)
+         if "sync_compose_profiles.yml" in _includes(t)),
+        None,
+    )
+    assert sync_idx is not None, (
+        "stop.yml must reconcile COMPOSE_PROFILES (include "
+        "sync_compose_profiles.yml) before `down`"
+    )
+    down_idx = next(
+        (i for i, t in enumerate(block)
+         if "down" in str(t.get("ansible.builtin.command", {}).get("cmd", ""))),
+        None,
+    )
+    assert down_idx is not None, "stop.yml must run `docker compose ... down`"
+    assert sync_idx < down_idx, "profile sync must run before `down`"


### PR DESCRIPTION
Fixes #910.

## Problem

The COMPOSE_PROFILES sync ran only before `up` (start) and *between* `down` and `up` (restart) — never before `down`. `docker compose down` only tears down services in the active profiles, and `up -d` does not recreate an already-running container. So with a drifted profile set, `down` skipped a service (e.g. `varnish`), then `up -d` recreated `web`/`caddy` on new IPs while the skipped survivor kept stale state — the Varnish resolve-once backend then pointed at a dead/repurposed IP, producing the `308 https://<site>/` redirect loop that took canasta.wiki down.

## Fix

Reconcile COMPOSE_PROFILES **before** `down` so `down` and `up` always act on the same service set and a restart recreates the whole intended stack together:

- `direct_commands/lifecycle.py`: `cmd_stop` now syncs before `down`; `cmd_restart` syncs once, before `down`, instead of between down and up.
- `roles/orchestrator/tasks/stop.yml`: include `sync_compose_profiles.yml` before the `down`.

Pairs with #911 (internal-db now always derived into the profile set) and #912 (gitops pull reconciles profiles) — together the profile set can no longer drift into this failure.

## Tests

- `test_restart_syncs_profiles_before_down`, `test_stop_syncs_profiles_before_down` (Python ordering).
- `test_stop_syncs_profiles.py` (Ansible structural: sync before `down` in stop.yml).
- Full unit suite passes; YAML lint and `make validate` clean.

## Not included

The deeper Varnish resolve-once hardening (dynamic/DNS backend) needs a custom image with `vmod-dynamic` and is tracked separately in #916.
