### PR TITLE
fix(crowdsec): auto-enroll must ignore ambient --force (infinite loop)

### DIFF
--- a/roles/crowdsec/tasks/bouncer_enroll.yml
+++ b/roles/crowdsec/tasks/bouncer_enroll.yml
@@ -62,9 +62,17 @@
 # Enroll when forced, when no bouncer is registered yet, or when one is
 # registered but we have no stored key (cscli can't reveal an existing
 # key, so the only way to recover is to revoke and re-issue).
+#
+# The `force` branch is gated on NOT the auto path: `force` is a global
+# extra-var shared with `config set --force` (which only means "allow an
+# unrecognized key"). Without this guard, running `config set --force` on a
+# CrowdSec instance makes every auto-enroll inside the triggered restart see
+# force=true and re-issue the bouncer, restart, and re-enroll forever. An
+# explicit `canasta crowdsec bouncer-enroll --force` (auto path off) still
+# forces a fresh key.
 - name: Enroll the bouncer
   when: >-
-    (force | default(false) | bool)
+    ((force | default(false) | bool) and not (bouncer_enroll_auto | default(false) | bool))
     or (not (_crowdsec_existing | bool))
     or (not (_crowdsec_have_key | bool))
   block:

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -1555,3 +1555,42 @@ class TestCrowdsecK8sTrustedProxy:
         assert "combine" not in out
 
 
+BOUNCER_ENROLL = os.path.join(
+    REPO_ROOT, "roles", "crowdsec", "tasks", "bouncer_enroll.yml"
+)
+
+
+class TestBouncerEnrollForceGuard:
+    """The auto-enroll path must ignore an ambient `force` so that
+    `config set --force` (which only means "allow an unrecognized key") can't
+    re-issue the bouncer on every restart and loop forever. `force` is a
+    global extra-var shared between the two commands."""
+
+    def _enroll_task(self):
+        with open(BOUNCER_ENROLL) as f:
+            tasks = yaml.safe_load(f)
+        task = next(
+            (t for t in tasks if t.get("name") == "Enroll the bouncer"), None
+        )
+        assert task is not None, "bouncer_enroll.yml must have the enroll task"
+        return task
+
+    def test_force_branch_is_gated_on_not_auto(self):
+        when = " ".join(str(self._enroll_task().get("when", "")).split())
+        # The force branch must be conjoined with `not bouncer_enroll_auto`.
+        assert "force" in when and "bouncer_enroll_auto" in when, (
+            "the enroll `when` must guard `force` with `bouncer_enroll_auto`"
+        )
+        assert "and not (bouncer_enroll_auto" in when, (
+            "force must be ANDed with `not bouncer_enroll_auto` so the auto "
+            "path ignores an ambient --force (the config-set/enroll loop)"
+        )
+
+    def test_no_key_and_no_bouncer_still_enroll(self):
+        # The non-force re-enroll conditions must remain so a genuinely
+        # un-enrolled instance (no bouncer / no stored key) still enrolls.
+        when = " ".join(str(self._enroll_task().get("when", "")).split())
+        assert "_crowdsec_existing" in when
+        assert "_crowdsec_have_key" in when
+
+


### PR DESCRIPTION
Fixes #918.

## Problem

`canasta config set --force <key>=<value>` on a CrowdSec-enabled instance loops forever:

```
Starting containers...
CrowdSec is enabled — registering with the Central API and enrolling the Caddy bouncer...
Registered bouncer 'canasta-caddy'. Storing its key and restarting to activate it...
Starting containers...
(forever)
```

`force` is a global extra-var with two unrelated meanings: `config set --force` ("allow an unrecognized key") and `bouncer_enroll`'s `force` ("revoke and re-issue the bouncer"). The CrowdSec auto-enroll runs *inside* the restart that `config set` triggers, and extra-vars outrank `include_role` vars — so the ambient `force=true` re-issues the bouncer on every pass: register → store key → restart → register → … This is distinct from the loops already fixed by #653 and #908 (both present in 4.4.1).

## Fix

The auto-enroll path already passes `bouncer_enroll_auto: true`. Gate the `force` branch of the enroll so the auto path ignores an ambient `--force`:

```yaml
when: >-
  ((force | default(false) | bool) and not (bouncer_enroll_auto | default(false) | bool))
  or (not (_crowdsec_existing | bool))
  or (not (_crowdsec_have_key | bool))
```

An explicit `canasta crowdsec bouncer-enroll --force` (auto path off) still forces a fresh key, and a genuinely un-enrolled instance (no bouncer registered, or no stored key) still enrolls. Mirrors the `bouncer_enroll_auto` guard already used on the "already enrolled" message in the same file.

## Tests

- `TestBouncerEnrollForceGuard`: the enroll `when` ANDs `force` with `not bouncer_enroll_auto`, and the non-force re-enroll conditions (`_crowdsec_existing` / `_crowdsec_have_key`) are preserved.
- Full unit suite passes; YAML lint clean.

## Workaround for affected instances

Don't use `canasta config set --force` on a CrowdSec instance until this ships; edit `.env` directly + `docker compose up -d` for an unrecognized key.
