### PR TITLE
feat(doctor): per-instance config<->runtime consistency checks

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -366,6 +366,28 @@ _CADDY_PLUGIN_IMAGE = "ghcr.io/canastawiki/canasta-caddy:2.11.3"
 # runs on stock Caddy. Mirrors rewrite_caddy.yml / sync_compose_profiles.yml.
 _CADDY_PLUGIN_TRUSTED_PROXY_MODES = ("cloudflare", "imperva")
 
+# Profile names sync derives from the env (feature flags + DB mode). internal-db
+# is included (it is derived too) but is intentionally absent from
+# _MANAGED_PROFILE_SERVICES, so the teardown never removes the db container.
+_MANAGED_PROFILE_NAMES = (
+    {p for p, _flag, _default in _MANAGED_PROFILES} | {"internal-db"}
+)
+
+
+def _reconcile_compose_profiles(env, current):
+    """The COMPOSE_PROFILES that sync derives for `env`: unmanaged profiles in
+    `current` preserved, managed feature profiles whose CANASTA_ENABLE_* flag is
+    true, and internal-db unless an external DB is configured. Shared by
+    _sync_compose_profiles and the doctor consistency check so the checker can
+    never disagree with the syncer."""
+    desired = [p for p in current if p not in _MANAGED_PROFILE_NAMES]
+    for profile, flag, default in _MANAGED_PROFILES:
+        if env.get(flag, default).strip().lower() == "true":
+            desired.append(profile)
+    if env.get("USE_EXTERNAL_DB", "false").strip().lower() != "true":
+        desired.append("internal-db")
+    return desired
+
 
 def _sync_compose_profiles(inst):
     """Align COMPOSE_PROFILES (and the CrowdSec Caddy image) in .env with
@@ -385,27 +407,11 @@ def _sync_compose_profiles(inst):
 
     entries = _parse_env_entries(content)
     env = {k: v for k, v, c in entries if not c and k}
-    # internal-db is reconciled like a managed profile (stripped from current,
-    # then re-derived below) but keyed on the INVERSE of USE_EXTERNAL_DB, and
-    # it is absent from _MANAGED_PROFILE_SERVICES so its container is never
-    # auto-removed by the teardown.
-    managed_names = {p for p, _flag, _default in _MANAGED_PROFILES}
-    managed_names.add("internal-db")
+    managed_names = _MANAGED_PROFILE_NAMES  # for the teardown below
 
     current_raw = env.get("COMPOSE_PROFILES", "")
     current = [p.strip() for p in current_raw.split(",") if p.strip()]
-
-    desired = [p for p in current if p not in managed_names]
-    for profile, flag, default in _MANAGED_PROFILES:
-        if env.get(flag, default).strip().lower() == "true":
-            desired.append(profile)
-    # The bundled database runs by default and is skipped only when an external
-    # DB is configured (mirrors roles/create/tasks/_env_update.yml). Deriving it
-    # every sync — rather than only preserving it when already present — means an
-    # instance whose COMPOSE_PROFILES lost internal-db (created before
-    # external-DB support, or a gitops .env render that dropped it) self-heals.
-    if env.get("USE_EXTERNAL_DB", "false").strip().lower() != "true":
-        desired.append("internal-db")
+    desired = _reconcile_compose_profiles(env, current)
 
     profiles_changed = sorted(desired) != sorted(current)
 

--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -204,30 +204,142 @@ def _parse_doctor(stdout, hostname):
     return "\n".join(lines)
 
 
+# service name -> the COMPOSE_PROFILE that must be active for it to be managed.
+# Inverted from _MANAGED_PROFILE_SERVICES, plus db -> internal-db. Services not
+# listed (web, caddy) are profile-less / always-on. Used to flag containers
+# that are running but whose profile isn't in COMPOSE_PROFILES.
+_SERVICE_PROFILE = {
+    svc: prof
+    for prof, svcs in _helpers._MANAGED_PROFILE_SERVICES.items()
+    for svc in svcs
+}
+_SERVICE_PROFILE["db"] = "internal-db"
+
+
+def _consistency_warnings(env, current_profiles, running_services, uses_cirrus):
+    """Pure: warnings about config/runtime drift for a Compose instance.
+
+    - COMPOSE_PROFILES that disagrees with what sync would derive from the
+      flags + DB mode.
+    - A container running under a profile that isn't active (unmanaged — a
+      stop/start won't restore it).
+    - CirrusSearch configured in settings while Elasticsearch is disabled.
+    """
+    warns = []
+    active = set(current_profiles)
+
+    desired = _helpers._reconcile_compose_profiles(env, list(current_profiles))
+    if sorted(desired) != sorted(current_profiles):
+        missing = sorted(p for p in desired if p not in active)
+        stale = sorted(p for p in current_profiles if p not in desired)
+        detail = []
+        if missing:
+            detail.append("should add %s" % ", ".join(missing))
+        if stale:
+            detail.append("should drop %s" % ", ".join(stale))
+        warns.append(
+            "COMPOSE_PROFILES out of sync with the feature flags (%s) — "
+            "run 'canasta restart' to reconcile" % "; ".join(detail))
+
+    for svc in running_services:
+        prof = _SERVICE_PROFILE.get(svc)
+        if prof and prof not in active:
+            warns.append(
+                "'%s' is running but its profile '%s' is not in "
+                "COMPOSE_PROFILES — it is unmanaged, and a stop/start cycle "
+                "won't bring it back" % (svc, prof))
+
+    if uses_cirrus and "elasticsearch" not in active:
+        warns.append(
+            "CirrusSearch is configured (config/settings) but the "
+            "'elasticsearch' profile is inactive — search depends on an "
+            "unmanaged Elasticsearch; set CANASTA_ENABLE_ELASTICSEARCH=true")
+
+    return warns
+
+
+def _gather_runtime(path, host):
+    """(running_services, uses_cirrus) for an instance, localhost or remote."""
+    d = _helpers._SENTINEL
+    qpath = _helpers._shell_quote(path)
+    script = (
+        "cd %(p)s 2>/dev/null && "
+        "docker compose ps --services --status running 2>/dev/null; "
+        "echo '%(d)s'; "
+        "grep -rqi cirrussearch %(p)s/config/settings 2>/dev/null "
+        "&& echo USES_CIRRUS || echo NO_CIRRUS"
+    ) % {"p": qpath, "d": d}
+    if _helpers._is_localhost(host):
+        try:
+            out = subprocess.run(
+                ["bash", "-c", script],
+                capture_output=True, text=True, timeout=30,
+            ).stdout
+        except (subprocess.TimeoutExpired, OSError):
+            return [], False
+    else:
+        rc, out = _helpers._ssh_run(host, script)
+        if rc != 0 and not out.strip():
+            return [], False
+    parts = out.split(d + "\n")
+    head = parts[0].strip() if parts else ""
+    running = [s for s in head.split("\n") if s.strip()]
+    uses_cirrus = len(parts) > 1 and "USES_CIRRUS" in parts[1]
+    return running, uses_cirrus
+
+
+def _instance_consistency_lines(inst):
+    """doctor lines for an instance's config<->runtime consistency, or [] when
+    not applicable (no instance / not Compose / unreadable .env)."""
+    if not inst or inst.get("orchestrator", "compose") in ("kubernetes", "k8s"):
+        return []
+    path = inst.get("path", "")
+    host = inst.get("host") or "localhost"
+    if not path:
+        return []
+    content = _helpers._read_env_content(path, host)
+    if not content:
+        return []
+    env = {
+        k: v for k, v, c in _helpers._parse_env_entries(content) if not c and k
+    }
+    current = [
+        p.strip() for p in env.get("COMPOSE_PROFILES", "").split(",")
+        if p.strip()
+    ]
+    running, uses_cirrus = _gather_runtime(path, host)
+    warns = _consistency_warnings(env, current, running, uses_cirrus)
+    lines = ["", "Instance consistency (%s):" % inst.get("id", "?")]
+    if warns:
+        lines += ["  WARN: %s" % w for w in warns]
+    else:
+        lines.append(
+            "  OK (profiles, running services, and search backend agree)")
+    return lines
+
+
 @register("doctor")
 def cmd_doctor(args):
     host = getattr(args, "host", None)
     inst_id = getattr(args, "id", None)
-    # When the caller doesn't pin a host explicitly, derive it from the
-    # registry: --id wins, then cwd-match, then fall back to localhost.
-    # Matches the "instance-aware default" behavior of `canasta status`,
-    # `version`, and other direct commands so users in an instance
-    # directory get its host checked instead of theirs.
-    if not host:
-        conf_path = os.path.join(_helpers._get_config_dir(), "conf.json")
-        instances = _helpers._read_registry(conf_path)
-        if inst_id:
-            if inst_id not in instances:
-                print(
-                    "Error: Instance '%s' not found in registry" % inst_id,
-                    file=sys.stderr,
-                )
-                return 1
-            host = instances[inst_id].get("host") or "localhost"
-        else:
-            _, inst = _helpers._resolve_instance_by_cwd(args)
-            if inst:
-                host = inst.get("host") or "localhost"
+    # Resolve the instance (--id wins, then cwd-match) so we can both derive
+    # the host to check — matching the "instance-aware default" of `canasta
+    # status` / `version` — and run the per-instance consistency checks below.
+    conf_path = os.path.join(_helpers._get_config_dir(), "conf.json")
+    instances = _helpers._read_registry(conf_path)
+    inst = None
+    if inst_id:
+        if inst_id not in instances:
+            print(
+                "Error: Instance '%s' not found in registry" % inst_id,
+                file=sys.stderr,
+            )
+            return 1
+        inst = instances[inst_id]
+    else:
+        _, inst = _helpers._resolve_instance_by_cwd(args)
+    if not host and inst:
+        host = inst.get("host") or "localhost"
     script = _DOCTOR_SCRIPT % {"delim": _helpers._SENTINEL}
 
     if not host or host == "localhost":
@@ -249,6 +361,9 @@ def cmd_doctor(args):
             return 1
 
     print(_parse_doctor(stdout, hostname))
+
+    for line in _instance_consistency_lines(inst):
+        print(line)
 
     parts = stdout.split(_helpers._SENTINEL + "\n")
     docker = parts[1].strip() if len(parts) > 1 else "MISSING"

--- a/tests/unit/test_doctor_consistency.py
+++ b/tests/unit/test_doctor_consistency.py
@@ -1,0 +1,144 @@
+"""Tests for `canasta doctor`'s per-instance config<->runtime consistency
+checks — the detection half of the drift class from the upgrade incident
+(profiles out of sync with flags, containers running unmanaged, CirrusSearch
+configured while Elasticsearch is disabled)."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from direct_commands import doctor  # noqa: E402
+
+
+def _w(env, profiles, running, cirrus):
+    return doctor._consistency_warnings(env, profiles, running, cirrus)
+
+
+class TestConsistencyWarnings:
+    def test_clean_instance_has_no_warnings(self):
+        env = {
+            "CANASTA_ENABLE_ELASTICSEARCH": "true",
+            "CANASTA_ENABLE_CROWDSEC": "true",
+            "COMPOSE_PROFILES": "internal-db,varnish,crowdsec,elasticsearch",
+        }
+        profiles = ["internal-db", "varnish", "crowdsec", "elasticsearch"]
+        running = ["web", "caddy", "varnish", "crowdsec", "db", "elasticsearch"]
+        assert _w(env, profiles, running, True) == []
+
+    def test_todays_incident_flags_every_drift(self):
+        # ES flag false + COMPOSE_PROFILES missing internal-db/elasticsearch,
+        # but db + elasticsearch are running and CirrusSearch is configured.
+        env = {
+            "CANASTA_ENABLE_ELASTICSEARCH": "false",
+            "CANASTA_ENABLE_CROWDSEC": "true",
+            "COMPOSE_PROFILES": "varnish,crowdsec",
+        }
+        profiles = ["varnish", "crowdsec"]
+        running = ["web", "caddy", "varnish", "crowdsec", "db", "elasticsearch"]
+        out = _w(env, profiles, running, True)
+        joined = " ".join(out)
+        assert "should add internal-db" in joined         # profile drift
+        assert any("'db'" in o for o in out)              # db unmanaged
+        assert any("'elasticsearch'" in o for o in out)   # ES unmanaged
+        assert any("CirrusSearch" in o for o in out)      # search backend
+        assert len(out) == 4
+
+    def test_self_heal_internal_db_drift_only(self):
+        env = {"COMPOSE_PROFILES": "varnish"}
+        out = _w(env, ["varnish"], ["web", "varnish"], False)
+        assert len(out) == 1
+        assert "should add internal-db" in out[0]
+
+    def test_external_db_does_not_warn_about_internal_db(self):
+        env = {
+            "USE_EXTERNAL_DB": "true",
+            "CANASTA_ENABLE_CROWDSEC": "true",
+            "COMPOSE_PROFILES": "varnish,crowdsec",
+        }
+        out = _w(env, ["varnish", "crowdsec"], ["web", "varnish", "crowdsec"], False)
+        assert out == []
+
+    def test_cirrus_without_elasticsearch_warns(self):
+        env = {"COMPOSE_PROFILES": "internal-db,varnish"}
+        # internal-db + varnish are the full derived set here, so no drift;
+        # only the CirrusSearch<->ES mismatch should fire.
+        out = _w(env, ["internal-db", "varnish"], ["web", "varnish", "db"], True)
+        assert len(out) == 1
+        assert "CirrusSearch" in out[0]
+
+
+class TestServiceProfileMap:
+    def test_managed_services_map_to_profiles(self):
+        assert doctor._SERVICE_PROFILE["db"] == "internal-db"
+        assert doctor._SERVICE_PROFILE["elasticsearch"] == "elasticsearch"
+        assert doctor._SERVICE_PROFILE["varnish"] == "varnish"
+        assert doctor._SERVICE_PROFILE["crowdsec"] == "crowdsec"
+
+    def test_always_on_services_are_not_profile_gated(self):
+        assert "web" not in doctor._SERVICE_PROFILE
+        assert "caddy" not in doctor._SERVICE_PROFILE
+
+
+class TestGatherRuntime:
+    def test_parses_services_and_cirrus_flag(self, monkeypatch):
+        d = doctor._helpers._SENTINEL
+        out = "web\nvarnish\ndb\n%s\nUSES_CIRRUS\n" % d
+
+        class _R:
+            stdout = out
+
+        monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
+        monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _R())
+        running, cirrus = doctor._gather_runtime("/srv/x", "localhost")
+        assert running == ["web", "varnish", "db"]
+        assert cirrus is True
+
+    def test_no_cirrus_flag(self, monkeypatch):
+        d = doctor._helpers._SENTINEL
+
+        class _R:
+            stdout = "web\n%s\nNO_CIRRUS\n" % d
+
+        monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
+        monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _R())
+        running, cirrus = doctor._gather_runtime("/srv/x", "localhost")
+        assert running == ["web"]
+        assert cirrus is False
+
+
+class TestInstanceConsistencyLines:
+    def test_skips_when_no_instance_or_k8s(self):
+        assert doctor._instance_consistency_lines(None) == []
+        assert doctor._instance_consistency_lines(
+            {"orchestrator": "kubernetes", "path": "/x"}) == []
+
+    def test_compose_instance_reports_warnings(self, monkeypatch):
+        inst = {"id": "site", "orchestrator": "compose", "path": "/srv/site",
+                "host": "localhost"}
+        monkeypatch.setattr(
+            doctor._helpers, "_read_env_content",
+            lambda path, host: "CANASTA_ENABLE_ELASTICSEARCH=false\n"
+                               "COMPOSE_PROFILES=varnish\n")
+        monkeypatch.setattr(
+            doctor, "_gather_runtime",
+            lambda path, host: (["web", "varnish", "db"], True))
+        lines = doctor._instance_consistency_lines(inst)
+        assert lines[1] == "Instance consistency (site):"
+        body = " ".join(lines)
+        assert "WARN" in body
+        assert "internal-db" in body      # drift
+        assert "CirrusSearch" in body     # search backend
+
+    def test_compose_instance_clean_reports_ok(self, monkeypatch):
+        inst = {"id": "site", "orchestrator": "compose", "path": "/srv/site",
+                "host": "localhost"}
+        monkeypatch.setattr(
+            doctor._helpers, "_read_env_content",
+            lambda path, host: "CANASTA_ENABLE_CROWDSEC=true\n"
+                               "COMPOSE_PROFILES=internal-db,varnish,crowdsec\n")
+        monkeypatch.setattr(
+            doctor, "_gather_runtime",
+            lambda path, host: (["web", "varnish", "crowdsec", "db"], False))
+        lines = doctor._instance_consistency_lines(inst)
+        assert any("OK (" in line for line in lines)


### PR DESCRIPTION
Refs #913 (the doctor-consistency-checks half; the postflight health gate is intentionally deferred — see below).

## What

`canasta doctor` now appends an **Instance consistency** section for a resolved Compose instance, flagging the config↔runtime drift class behind the recent upgrade incident:

- `COMPOSE_PROFILES` out of sync with the `CANASTA_ENABLE_*` flags / DB mode (e.g. *should add internal-db*)
- a container **running but unmanaged** — its profile isn't in `COMPOSE_PROFILES`, so a stop/start cycle won't bring it back
- **CirrusSearch configured** in `config/settings` while the `elasticsearch` profile is **inactive** (search depends on an unmanaged Elasticsearch)

It runs on the instance's host (local or remote); no resolved instance, or a Kubernetes instance, is a clean no-op. The profile-derivation is factored into `_helpers._reconcile_compose_profiles` and shared with `_sync_compose_profiles`, so the checker can never disagree with the syncer.

## Why this half only

#913 originally bundled a postflight health gate too. That piece hooks every `start`/`restart`/`upgrade` and could abort a good deploy on a flaky check, so it's deferred until we see whether the now-merged fixes (#910/#911/#912) let the drift recur at all. This PR delivers the detection with zero converge-path risk.

## Tests

`tests/unit/test_doctor_consistency.py` — pure warning logic (clean, the incident scenario, self-heal drift, external-DB, CirrusSearch mismatch), the service→profile map, runtime-gather parsing, and the k8s/no-instance no-op. Full unit suite passes; `make validate` + YAML lint clean.
