### PR TITLE
fix(upgrade): persist image-tag bump to gitops source (durable across pulls)

### DIFF
--- a/roles/orchestrator/tasks/upgrade_image_tag.yml
+++ b/roles/orchestrator/tasks/upgrade_image_tag.yml
@@ -62,3 +62,20 @@
         state: set
         key: CANASTA_IMAGE
         value: "{{ canasta_default_image }}"
+
+    # On a gitops instance the .env above is re-rendered from env.template on
+    # the next pull, which would revert the tag. Persist it to the gitops
+    # source (env.template placeholder + vars.yaml) via the same path config
+    # set uses, so the upgrade survives the next pull. No-op off gitops.
+    - name: Check if instance is gitops-managed
+      ansible.builtin.stat:
+        path: "{{ instance_path }}/.gitops-host"
+      register: _upgrade_image_gitops_stat
+
+    - name: Persist CANASTA_IMAGE to gitops source (durable across pulls)
+      ansible.builtin.include_tasks: >-
+        {{ canasta_root }}/roles/orchestrator/tasks/config_update_gitops_vars.yml
+      vars:
+        _config_settings: "CANASTA_IMAGE={{ canasta_default_image }}"
+        _config_gitops_stat: "{{ _upgrade_image_gitops_stat }}"
+      when: _upgrade_image_gitops_stat.stat.exists | default(false)

--- a/tests/unit/test_upgrade_refresh_compose.py
+++ b/tests/unit/test_upgrade_refresh_compose.py
@@ -102,3 +102,49 @@ class TestUpgradeRefreshesAndRecreatesOnComposeChange:
             "'Already up to date' must key off _restart_needed so a compose "
             "change isn't reported as a no-op"
         )
+
+
+IMAGE_TAG = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "upgrade_image_tag.yml"
+)
+
+
+def _includes(task):
+    inc = task.get("ansible.builtin.include_tasks") or task.get("include_tasks")
+    if isinstance(inc, dict):
+        return inc.get("file", "")
+    return inc or ""
+
+
+class TestImageTagGitopsDurable:
+    """The compose image bump must persist to the gitops source, or the next
+    gitops pull re-renders .env from env.template and reverts the upgrade."""
+
+    def test_bump_propagates_to_gitops_vars(self):
+        tasks = _load(IMAGE_TAG)
+        prop = next(
+            (t for t in _iter_tasks(tasks)
+             if "config_update_gitops_vars.yml" in _includes(t)),
+            None,
+        )
+        assert prop is not None, (
+            "upgrade_image_tag.yml must propagate CANASTA_IMAGE to the gitops "
+            "source (config_update_gitops_vars.yml) so the bump survives a pull"
+        )
+        # It passes CANASTA_IMAGE as the setting and is gated on the instance
+        # actually being gitops-managed.
+        assert "CANASTA_IMAGE" in str(prop.get("vars", {}).get("_config_settings", ""))
+        assert "stat.exists" in str(prop.get("when", "")), (
+            "gitops propagation must be gated on .gitops-host existing"
+        )
+
+    def test_bump_still_writes_env(self):
+        # The .env write must remain — gitops persistence is in addition to it,
+        # and non-gitops instances rely on the .env write alone.
+        tasks = _load(IMAGE_TAG)
+        env_writes = [
+            t for t in _iter_tasks(tasks)
+            if isinstance(t, dict) and "canasta_env" in t
+            and t.get("canasta_env", {}).get("key") == "CANASTA_IMAGE"
+        ]
+        assert env_writes, "the .env CANASTA_IMAGE write must remain"


### PR DESCRIPTION
Fixes #921.

## Problem

On a gitops-managed Compose instance, `canasta upgrade` wrote `CANASTA_IMAGE` to `.env` only. `.env` is re-rendered from `env.template` on the next `gitops pull`, so the upgrade was silently reverted — the instance flipped to the new tag, then a render put it back. Observed in production: stuck on `canasta:3.5.1` with `env.template` literally pinning that tag, after an upgrade that appeared to run. Same gitops-durability family as #911 / #912.

## Fix

After bumping `.env`, on a gitops instance, propagate `CANASTA_IMAGE` through the same `config_update_gitops_vars` path `config set` already uses — it converts the `env.template` literal to a managed placeholder and records the value in `vars.yaml`, so the next render keeps the new tag. Gated on `.gitops-host` existing (no-op off gitops); the `.env` write is preserved for non-gitops instances.

## Tests

`TestImageTagGitopsDurable` — the bump propagates to `config_update_gitops_vars` with `CANASTA_IMAGE`, gated on the instance being gitops-managed, and the `.env` write remains. Full unit suite passes; YAML lint + `make validate` clean.
