### PR TITLE
feat(reconcile): add 'canasta reconcile' to fix config/runtime drift

### DIFF
--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -238,8 +238,8 @@ def _consistency_warnings(env, current_profiles, running_services, uses_cirrus):
         if stale:
             detail.append("should drop %s" % ", ".join(stale))
         warns.append(
-            "COMPOSE_PROFILES out of sync with the feature flags (%s) — "
-            "run 'canasta restart' to reconcile" % "; ".join(detail))
+            "COMPOSE_PROFILES out of sync with the feature flags (%s)"
+            % "; ".join(detail))
 
     for svc in running_services:
         prof = _SERVICE_PROFILE.get(svc)
@@ -312,6 +312,7 @@ def _instance_consistency_lines(inst):
     lines = ["", "Instance consistency (%s):" % inst.get("id", "?")]
     if warns:
         lines += ["  WARN: %s" % w for w in warns]
+        lines.append("  Run 'canasta reconcile' to fix.")
     else:
         lines.append(
             "  OK (profiles, running services, and search backend agree)")

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -501,6 +501,30 @@ commands:
         type: string
         description: "Canasta instance ID"
 
+  - name: reconcile
+    description: "Bring an instance's config and running containers back into agreement"
+    long_description: |
+      Reconcile an instance to a consistent state without a disruptive
+      restart. Re-derives COMPOSE_PROFILES from the feature flags and
+      database mode, regenerates rendered config (e.g. the Caddyfile),
+      and converges the running containers with 'docker compose up -d' —
+      starting anything missing and recreating only what changed, with no
+      stop. Idempotent and safe to run anytime.
+
+      This is the fix companion to 'canasta doctor': when doctor reports
+      config/runtime drift (profiles out of sync with the flags, a
+      container running unmanaged, search configured without its backend),
+      'canasta reconcile' applies the reconcilers to fix it.
+    examples:
+      - "canasta reconcile"
+      - "canasta reconcile --id mysite"
+    playbook: reconcile.yml
+    parameters:
+      - name: id
+        short: i
+        type: string
+        description: "Canasta instance ID"
+
   - name: rebuild
     description: "Rebuild custom images for a Canasta instance"
     long_description: |

--- a/playbooks/reconcile.yml
+++ b/playbooks/reconcile.yml
@@ -1,0 +1,8 @@
+---
+# canasta reconcile - Bring an instance's config and runtime into agreement
+# without a disruptive restart (regenerate config + sync profiles + up -d).
+
+- name: Reconcile instance
+  ansible.builtin.include_role:
+    name: instance_lifecycle
+    tasks_from: reconcile.yml

--- a/roles/instance_lifecycle/tasks/reconcile.yml
+++ b/roles/instance_lifecycle/tasks/reconcile.yml
@@ -1,0 +1,33 @@
+---
+# Reconcile a Canasta instance: bring its config and running containers into
+# agreement WITHOUT a disruptive stop. Re-derives COMPOSE_PROFILES from the
+# feature flags + DB mode, regenerates rendered config (Caddyfile), and
+# converges the runtime via `up -d` — recreating only what changed. Idempotent;
+# the fix companion to `canasta doctor`'s drift detection.
+# Input: id (optional)
+
+- name: Resolve instance (skip if caller already resolved it)
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
+  when: instance_path is not defined
+
+# Regenerate rendered config (e.g. the Caddyfile from the current wikis.yaml)
+# so the converge below picks up drift between sources and rendered state.
+- name: Regenerate config
+  ansible.builtin.include_role:
+    name: orchestrator
+    tasks_from: update_config.yml
+
+# start.yml runs sync_compose_profiles (reconciles COMPOSE_PROFILES from the
+# flags + DB mode, and tears down containers of deactivated profiles) and then
+# `docker compose up -d`, which starts anything missing and recreates only
+# changed services. No `down`, so this is non-disruptive.
+- name: Converge containers (sync profiles + up -d)
+  ansible.builtin.include_role:
+    name: orchestrator
+    tasks_from: start.yml
+
+- name: Report reconciled
+  ansible.builtin.debug:
+    msg: >-
+      Instance '{{ instance_id }}' reconciled — config and running containers
+      are in sync.

--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -113,7 +113,7 @@ CMD_GROUPS = [
         "create", "delete", "list", "status", "upgrade", "version", "config",
     ]),
     ("Wiki management", ["add", "remove", "import", "export"]),
-    ("Container lifecycle", ["start", "stop", "restart", "rebuild", "scale"]),
+    ("Container lifecycle", ["start", "stop", "restart", "reconcile", "rebuild", "scale"]),
     ("Extensions & skins", ["extension", "skin"]),
     ("App sidecars", ["sidecar"]),
     ("Maintenance", ["maintenance", "sitemap"]),

--- a/tests/unit/test_doctor_consistency.py
+++ b/tests/unit/test_doctor_consistency.py
@@ -129,6 +129,7 @@ class TestInstanceConsistencyLines:
         assert "WARN" in body
         assert "internal-db" in body      # drift
         assert "CirrusSearch" in body     # search backend
+        assert "canasta reconcile" in body  # points at the fix command
 
     def test_compose_instance_clean_reports_ok(self, monkeypatch):
         inst = {"id": "site", "orchestrator": "compose", "path": "/srv/site",

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -1,0 +1,64 @@
+"""Structural guards for `canasta reconcile` — the non-disruptive converge
+that brings an instance's config and runtime back into agreement (the fix
+companion to `canasta doctor`).
+
+It must regenerate config and converge via `start` (sync profiles + up -d) but
+must NOT `stop` — that's what keeps it non-disruptive (no `down`).
+"""
+
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+RECONCILE = os.path.join(
+    REPO_ROOT, "roles", "instance_lifecycle", "tasks", "reconcile.yml"
+)
+PLAYBOOK = os.path.join(REPO_ROOT, "playbooks", "reconcile.yml")
+COMMAND_DEFS = os.path.join(REPO_ROOT, "meta", "command_definitions.yml")
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _tasks_from(task):
+    inc = task.get("ansible.builtin.include_role") or task.get("include_role")
+    return inc.get("tasks_from", "") if isinstance(inc, dict) else ""
+
+
+def _commands():
+    data = _load(COMMAND_DEFS)
+    return data["commands"] if isinstance(data, dict) else data
+
+
+class TestReconcileTask:
+    def test_converges_via_start_and_regenerates_config(self):
+        froms = [_tasks_from(t) for t in _load(RECONCILE)]
+        assert "update_config.yml" in froms, (
+            "reconcile must regenerate rendered config (update_config.yml)"
+        )
+        assert "start.yml" in froms, (
+            "reconcile must converge via start.yml (sync profiles + up -d)"
+        )
+
+    def test_is_non_disruptive_no_stop(self):
+        froms = [_tasks_from(t) for t in _load(RECONCILE)]
+        assert "stop.yml" not in froms, (
+            "reconcile must NOT stop — it's the non-disruptive converge; a "
+            "full down/up is `canasta restart`"
+        )
+
+
+class TestReconcileWiring:
+    def test_playbook_includes_the_reconcile_role_task(self):
+        froms = [_tasks_from(t) for t in _load(PLAYBOOK)]
+        assert "reconcile.yml" in froms
+
+    def test_command_is_defined_with_its_playbook(self):
+        rec = next(
+            (c for c in _commands() if c.get("name") == "reconcile"), None)
+        assert rec is not None, "reconcile must be in command_definitions.yml"
+        assert rec.get("playbook") == "reconcile.yml"


### PR DESCRIPTION
Fixes #923.

## What

Adds `canasta reconcile` — an idempotent, opt-in command that brings an instance's config and running containers back into agreement **without a disruptive restart**. It's the fix companion to `canasta doctor`'s drift detection (#920): doctor reports drift, `reconcile` fixes it.

This is the "self-healing without an invasive change" piece from the recent incident: a stuck operator runs one command and recovers, instead of hand-diagnosing internals.

## Behavior

`reconcile` = `restart` minus the `stop`. A new `roles/instance_lifecycle/tasks/reconcile.yml` includes:
1. `update_config` — regenerate rendered config (Caddyfile from the current `wikis.yaml`).
2. `start` — which already runs `sync_compose_profiles` (re-derive `COMPOSE_PROFILES` from the flags + DB mode, tearing down deactivated profiles) and then `docker compose up -d` (start missing, recreate only changed).

No `down`, so it's non-disruptive. It does **not** re-render from the gitops source (that's `gitops pull`); a full down/up stays `canasta restart`.

`doctor`'s consistency warnings now point operators at `canasta reconcile`.

## Tests

- `tests/unit/test_reconcile.py` — reconcile converges via `start` + `update_config`, never `stop`; the playbook wires the role task; the command is defined with its playbook.
- `test_doctor_consistency.py` updated to assert doctor points at `canasta reconcile`.
- Full unit suite passes; `make validate` (83 commands) + generated docs + YAML lint all clean.
