### PR TITLE
fix(upgrade): update env.template literal directly (correct #922 no-op)

### DIFF
--- a/roles/orchestrator/tasks/upgrade_image_tag.yml
+++ b/roles/orchestrator/tasks/upgrade_image_tag.yml
@@ -64,18 +64,20 @@
         value: "{{ canasta_default_image }}"
 
     # On a gitops instance the .env above is re-rendered from env.template on
-    # the next pull, which would revert the tag. Persist it to the gitops
-    # source (env.template placeholder + vars.yaml) via the same path config
-    # set uses, so the upgrade survives the next pull. No-op off gitops.
+    # the next pull, which would revert the tag. CANASTA_IMAGE lives in
+    # env.template as a plain literal (it is not a managed/secret placeholder
+    # key), so update that literal directly — the render copies it verbatim, so
+    # the bump survives the next pull. Without this the upgrade silently
+    # reverts. No-op off gitops.
     - name: Check if instance is gitops-managed
       ansible.builtin.stat:
         path: "{{ instance_path }}/.gitops-host"
       register: _upgrade_image_gitops_stat
 
-    - name: Persist CANASTA_IMAGE to gitops source (durable across pulls)
-      ansible.builtin.include_tasks: >-
-        {{ canasta_root }}/roles/orchestrator/tasks/config_update_gitops_vars.yml
-      vars:
-        _config_settings: "CANASTA_IMAGE={{ canasta_default_image }}"
-        _config_gitops_stat: "{{ _upgrade_image_gitops_stat }}"
+    - name: Persist CANASTA_IMAGE to env.template (durable across pulls)
+      ansible.builtin.lineinfile:
+        path: "{{ instance_path }}/env.template"
+        regexp: "^CANASTA_IMAGE="
+        line: "CANASTA_IMAGE={{ canasta_default_image }}"
+        state: present
       when: _upgrade_image_gitops_stat.stat.exists | default(false)

--- a/tests/unit/test_upgrade_refresh_compose.py
+++ b/tests/unit/test_upgrade_refresh_compose.py
@@ -109,33 +109,55 @@ IMAGE_TAG = os.path.join(
 )
 
 
-def _includes(task):
-    inc = task.get("ansible.builtin.include_tasks") or task.get("include_tasks")
-    if isinstance(inc, dict):
-        return inc.get("file", "")
-    return inc or ""
-
-
 class TestImageTagGitopsDurable:
-    """The compose image bump must persist to the gitops source, or the next
-    gitops pull re-renders .env from env.template and reverts the upgrade."""
+    """The compose image bump must persist to env.template, or the next gitops
+    pull re-renders .env from it and reverts the upgrade. CANASTA_IMAGE is a
+    plain literal in env.template (not a managed/secret placeholder key), so it
+    must be updated directly — the config-set placeholder path skips it."""
 
-    def test_bump_propagates_to_gitops_vars(self):
+    @staticmethod
+    def _lineinfile(task):
+        return (task.get("ansible.builtin.lineinfile")
+                or task.get("lineinfile")) if isinstance(task, dict) else None
+
+    def test_bump_updates_env_template_literal(self):
         tasks = _load(IMAGE_TAG)
-        prop = next(
+        upd = next(
             (t for t in _iter_tasks(tasks)
-             if "config_update_gitops_vars.yml" in _includes(t)),
+             if self._lineinfile(t)
+             and "env.template" in str(self._lineinfile(t).get("path", ""))),
             None,
         )
-        assert prop is not None, (
-            "upgrade_image_tag.yml must propagate CANASTA_IMAGE to the gitops "
-            "source (config_update_gitops_vars.yml) so the bump survives a pull"
+        assert upd is not None, (
+            "upgrade_image_tag.yml must update the CANASTA_IMAGE literal in "
+            "env.template so the bump survives the next gitops pull"
         )
-        # It passes CANASTA_IMAGE as the setting and is gated on the instance
-        # actually being gitops-managed.
-        assert "CANASTA_IMAGE" in str(prop.get("vars", {}).get("_config_settings", ""))
-        assert "stat.exists" in str(prop.get("when", "")), (
-            "gitops propagation must be gated on .gitops-host existing"
+        li = self._lineinfile(upd)
+        assert "CANASTA_IMAGE" in str(li.get("regexp", ""))
+        assert "canasta_default_image" in str(li.get("line", "")), (
+            "the new env.template line must carry the upgrade's target tag"
+        )
+        assert "stat.exists" in str(upd.get("when", "")), (
+            "the env.template update must be gated on .gitops-host existing"
+        )
+
+    def test_env_template_update_inherits_build_from_and_default_image_guards(self):
+        # The env.template write must live INSIDE the guarded block so it never
+        # clobbers a --build-from local build or a custom (non-default) image.
+        block = next(
+            t for t in _load(IMAGE_TAG)
+            if isinstance(t, dict) and t.get("name") == "Update Compose image tag"
+        )
+        when = str(block.get("when", ""))
+        assert "buildFrom" in when, "build-from instances must be excluded"
+        assert "canastawiki/canasta:" in when, (
+            "only the default Canasta image is managed; a custom image is left "
+            "alone"
+        )
+        inside = [t for t in block.get("block", []) if self._lineinfile(t)]
+        assert inside, (
+            "the env.template update must be inside the guarded block so it "
+            "inherits the build-from / default-image guards"
         )
 
     def test_bump_still_writes_env(self):


### PR DESCRIPTION
Refs #921. **Corrects the fix merged in #922, which was a no-op for this case.**

## What was wrong

#922 routed `CANASTA_IMAGE` through `config_update_gitops_vars` → `_ensure_env_template_placeholder`, which only converts keys in the gitops placeholder/secret allowlist (`gitops_placeholder_keys` + the `AWS_/AZURE_/…/SMTP_` prefix pattern). `CANASTA_IMAGE` is neither a listed key nor a secret prefix, so no `env.template` placeholder was created, the literal `CANASTA_IMAGE=ghcr.io/canastawiki/canasta:<tag>` line was left untouched, and the upgrade still reverted on the next `gitops pull`.

## The correction

Update the `env.template` literal **directly** with `lineinfile` — the render copies non-placeholder lines verbatim, so the new tag survives the pull:

```yaml
- name: Persist CANASTA_IMAGE to env.template (durable across pulls)
  ansible.builtin.lineinfile:
    path: "{{ instance_path }}/env.template"
    regexp: "^CANASTA_IMAGE="
    line: "CANASTA_IMAGE={{ canasta_default_image }}"
  when: <.gitops-host exists>
```

It stays **inside** the existing `Update Compose image tag` block, so it inherits the guards: only the default `ghcr.io/canastawiki/canasta:` image on a non-`--build-from` instance is touched — a custom or local-build image is left alone.

## Tests

Rewritten: the env.template literal is updated (gated on gitops), the `.env` write remains, and the update lives inside the build-from / default-image guard block (so a refactor can't move it out from under those guards). Full unit suite passes; `make validate` + YAML lint clean.
