### PR TITLE
fix(upgrade): persist K8s image bump to gitops vars.yaml image_tag

### DIFF
--- a/roles/orchestrator/tasks/upgrade_image_tag.yml
+++ b/roles/orchestrator/tasks/upgrade_image_tag.yml
@@ -43,6 +43,32 @@
         dest: "{{ instance_path }}/values.yaml"
         mode: "0644"
 
+    # On a gitops K8s instance, render_kubernetes.yml regenerates the deployed
+    # values from values.template.yaml overlaid with hosts/<host>/vars.yaml's
+    # image_tag — so the values.yaml write above is reverted on the next pull
+    # unless image_tag is updated too. Update it to the bumped tag (stripped of
+    # the repo prefix, matching how init/join record it). No-op off gitops.
+    - name: Check if instance is gitops-managed
+      ansible.builtin.stat:
+        path: "{{ instance_path }}/.gitops-host"
+      register: _upgrade_k8s_gitops_stat
+
+    - name: Read gitops host name
+      ansible.builtin.slurp:
+        src: "{{ instance_path }}/.gitops-host"
+      register: _upgrade_k8s_host
+      when: _upgrade_k8s_gitops_stat.stat.exists | default(false)
+
+    - name: Persist image_tag to gitops vars.yaml (durable across pulls)
+      ansible.builtin.lineinfile:
+        path: >-
+          {{ instance_path }}/hosts/{{ _upgrade_k8s_host.content
+             | b64decode | trim }}/vars.yaml
+        regexp: "^image_tag:"
+        line: "image_tag: {{ canasta_default_image | regex_replace('^[^:]+:', '') }}"
+        state: present
+      when: _upgrade_k8s_gitops_stat.stat.exists | default(false)
+
 # --- Update Compose CANASTA_IMAGE tag ---
 # Bump the tag if it's the default ghcr.io image,
 # leave it alone if user set a custom/local-build image.

--- a/tests/unit/test_upgrade_refresh_compose.py
+++ b/tests/unit/test_upgrade_refresh_compose.py
@@ -148,3 +148,32 @@ class TestImageTagGitopsDurable:
             and t.get("canasta_env", {}).get("key") == "CANASTA_IMAGE"
         ]
         assert env_writes, "the .env CANASTA_IMAGE write must remain"
+
+    @staticmethod
+    def _lineinfile(task):
+        return (task.get("ansible.builtin.lineinfile")
+                or task.get("lineinfile")) if isinstance(task, dict) else None
+
+    def test_k8s_bump_updates_gitops_image_tag(self):
+        # K8s analog: on a gitops instance the upgrade must update
+        # hosts/<host>/vars.yaml's image_tag, or render_kubernetes regenerates
+        # the deployed values from the stale tag and reverts the bump.
+        block = next(
+            t for t in _load(IMAGE_TAG)
+            if isinstance(t, dict)
+            and t.get("name") == "Update Kubernetes image tag in values.yaml"
+        )
+        upd = next(
+            (t for t in block.get("block", [])
+             if self._lineinfile(t)
+             and "image_tag" in str(self._lineinfile(t).get("regexp", ""))
+             and "vars.yaml" in str(self._lineinfile(t).get("path", ""))),
+            None,
+        )
+        assert upd is not None, (
+            "K8s upgrade must update image_tag in hosts/<host>/vars.yaml so the "
+            "bump survives a gitops pull"
+        )
+        assert "stat.exists" in str(upd.get("when", "")), (
+            "the vars.yaml update must be gated on .gitops-host existing"
+        )


### PR DESCRIPTION
Fixes #926. The Kubernetes analog of #921.

## Problem

On a gitops-managed K8s instance, `canasta upgrade` updates `values.yaml`'s `image.tag` but not the durable source. `render_kubernetes.yml` regenerates the deployed values from `values.template.yaml` overlaid with `hosts/<host>/vars.yaml`'s `image_tag` — so the `values.yaml` write is reverted on the next `gitops pull`. `config_update_gitops_vars` (the Compose path) is a deliberate no-op on K8s, so nothing propagated the bump.

## Fix

In the K8s branch of `upgrade_image_tag.yml`, on a gitops instance, also update `image_tag` in `hosts/<host>/vars.yaml` to the bumped tag — stripped of the repo prefix, matching how `init`/`join` record it. It stays inside the K8s block, which is already guarded by `buildFrom == ''`, so `--build-from` instances are untouched.

## Tests

`test_k8s_bump_updates_gitops_image_tag` — the K8s block updates `image_tag` in `hosts/<host>/vars.yaml`, gated on `.gitops-host` existing. Full unit suite passes; `make validate` + YAML lint clean.

## Note

Found by code inspection; full validation needs a live K8s + Argo CD gitops instance (the maintainer validates K8s live before releases). The structural fix + test mirrors how other K8s paths are guarded in this repo.
