### PR TITLE
fix(upgrade): restart when running image != configured (already-on-disk tag)

### DIFF
--- a/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
+++ b/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
@@ -47,15 +47,17 @@
               | map(attribute='key')
               | list) if (_upgrade_compose_config.rc | default(1)) == 0 else [] }}
 
-# Running-vs-configured check. Catches the case where pull skipped
-# the buildable web service (--ignore-buildable) but the configured
-# CANASTA_IMAGE is newer than what's running. Only meaningful when
-# at least one service has a build directive — otherwise the regular
-# pull-based detection is authoritative.
+# Running-vs-configured check. The pull-based signal (_images_updated) only
+# fires when `docker compose pull` DOWNLOADS a new image — it misses the case
+# where the configured image is already on disk (pulled by an earlier attempt,
+# or a buildable web service that pull skipped) while the running container is
+# still on an older image. Without this, `canasta upgrade` bumps the tag,
+# reports success, and leaves the old container running. Compare the configured
+# image to the running one and flag a restart on a mismatch, for every Compose
+# instance — not just those with a build directive.
 - name: Check running container image vs configured (Compose)
   when:
     - instance_orchestrator | default('compose') == 'compose'
-    - (_buildable_services | default([]) | length) > 0
     - not (_images_updated | bool)
   block:
     - name: Get running web container image ID

--- a/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
+++ b/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
@@ -47,14 +47,12 @@
               | map(attribute='key')
               | list) if (_upgrade_compose_config.rc | default(1)) == 0 else [] }}
 
-# Running-vs-configured check. The pull-based signal (_images_updated) only
-# fires when `docker compose pull` DOWNLOADS a new image — it misses the case
-# where the configured image is already on disk (pulled by an earlier attempt,
-# or a buildable web service that pull skipped) while the running container is
-# still on an older image. Without this, `canasta upgrade` bumps the tag,
-# reports success, and leaves the old container running. Compare the configured
-# image to the running one and flag a restart on a mismatch, for every Compose
-# instance — not just those with a build directive.
+# Flag a restart when the configured image differs from the running one.
+# The pull-based signal (_images_updated) is set only when `docker compose
+# pull` downloads a new image, so it misses a configured tag that is already
+# on disk (pre-pulled, or a buildable web service pull skips) while the
+# container still runs an older one. Runs for every Compose instance, and only
+# when pull hasn't already flagged an update.
 - name: Check running container image vs configured (Compose)
   when:
     - instance_orchestrator | default('compose') == 'compose'

--- a/tests/unit/test_upgrade_rebuild.py
+++ b/tests/unit/test_upgrade_rebuild.py
@@ -97,9 +97,9 @@ class TestRebuildFiresOnAnyImageChange:
         )
 
     def test_running_vs_configured_check_still_gated_on_not_updated(self):
-        """The running-vs-configured fallback only needs to fire when
-        pull didn't already detect an update. Its gate is unchanged
-        from the original logic and must stay."""
+        """The running-vs-configured check only needs to fire when pull didn't
+        already detect an update — that gate must stay. (It no longer requires
+        a buildable service; see TestRunningVsConfiguredAllInstances / #928.)"""
         tasks = _load_tasks()
         check = _find_task(tasks, "Check running container image vs configured")
         when = check.get("when", [])
@@ -107,7 +107,36 @@ class TestRebuildFiresOnAnyImageChange:
             when = [when]
         joined = " ".join(when)
         assert "not (_images_updated | bool)" in joined or "not _images_updated" in joined
-        assert "_buildable_services" in joined, (
-            "Fallback check is only meaningful when there's a "
-            "buildable service to potentially rebuild"
+
+
+class TestRunningVsConfiguredAllInstances:
+    """#928: the running-vs-configured image check must run for EVERY Compose
+    instance, not only --build-from ones. Otherwise an upgrade to an image
+    already on disk bumps the tag but never restarts (running != configured),
+    and reports success while leaving the old container up."""
+
+    def test_check_not_gated_on_buildable_services(self):
+        check = _find_task(
+            _load_tasks(), "Check running container image vs configured")
+        assert check is not None, "the running-vs-configured check must exist"
+        when = str(check.get("when", ""))
+        assert "_buildable_services" not in when, (
+            "the running-vs-configured check must not require buildable "
+            "services; it applies to every Compose instance (#928)"
         )
+        assert "compose" in when and "_images_updated" in when, (
+            "it must stay Compose-scoped and skip when pull already flagged "
+            "an update"
+        )
+
+    def test_check_flags_restart_on_image_mismatch(self):
+        check = _find_task(
+            _load_tasks(), "Check running container image vs configured")
+        flag = next(
+            (t for t in check.get("block", [])
+             if "Flag restart" in t.get("name", "")),
+            None,
+        )
+        assert flag is not None, "the check must flag a restart on mismatch"
+        assert flag.get("ansible.builtin.set_fact", {}).get(
+            "_images_updated") is True

--- a/tests/unit/test_upgrade_rebuild.py
+++ b/tests/unit/test_upgrade_rebuild.py
@@ -96,10 +96,9 @@ class TestRebuildFiresOnAnyImageChange:
             "the `web` service (#562, gap 2)"
         )
 
-    def test_running_vs_configured_check_still_gated_on_not_updated(self):
-        """The running-vs-configured check only needs to fire when pull didn't
-        already detect an update — that gate must stay. (It no longer requires
-        a buildable service; see TestRunningVsConfiguredAllInstances / #928.)"""
+    def test_running_vs_configured_check_gated_on_not_updated(self):
+        """The running-vs-configured check fires only when pull didn't already
+        detect an update — that gate must stay."""
         tasks = _load_tasks()
         check = _find_task(tasks, "Check running container image vs configured")
         when = check.get("when", [])
@@ -110,10 +109,9 @@ class TestRebuildFiresOnAnyImageChange:
 
 
 class TestRunningVsConfiguredAllInstances:
-    """#928: the running-vs-configured image check must run for EVERY Compose
-    instance, not only --build-from ones. Otherwise an upgrade to an image
-    already on disk bumps the tag but never restarts (running != configured),
-    and reports success while leaving the old container up."""
+    """The running-vs-configured image check runs for every Compose instance,
+    so an upgrade to an image already on disk still restarts (running !=
+    configured) instead of reporting success while leaving the old container."""
 
     def test_check_not_gated_on_buildable_services(self):
         check = _find_task(
@@ -122,7 +120,7 @@ class TestRunningVsConfiguredAllInstances:
         when = str(check.get("when", ""))
         assert "_buildable_services" not in when, (
             "the running-vs-configured check must not require buildable "
-            "services; it applies to every Compose instance (#928)"
+            "services; it applies to every Compose instance"
         )
         assert "compose" in when and "_images_updated" in when, (
             "it must stay Compose-scoped and skip when pull already flagged "


### PR DESCRIPTION
Fixes #928.

## Problem

`canasta upgrade` decides whether to restart from `_images_updated`, which is only true when `docker compose pull` **downloads** a new image. If the target image is already on disk (e.g. pulled by an earlier attempt), pull reports "up to date", `_images_updated` stays false, and the upgrade bumps `CANASTA_IMAGE` but **skips the restart** — printing "Upgraded" while the container keeps running the old version (running ≠ configured).

## Fix

A running-vs-configured image check that sets `_images_updated: true` on a mismatch **already exists** in `upgrade_rebuild_buildable.yml` — but it was gated on `(_buildable_services | length) > 0`, so it only ran for `--build-from` instances. Standard image instances skipped it. Drop that gate so the check runs for **every** Compose instance (still skipped when pull already flagged an update). A bump to an already-pulled tag now recreates the container.

## Tests

`TestRunningVsConfiguredAllInstances` — the check is no longer gated on buildable services, stays Compose-scoped + `not _images_updated`, and still flags a restart on mismatch. Updated the prior test that asserted the buildable gate. Full unit suite passes; YAML lint clean.
