### PR TITLE
feat(reconcile,doctor): detect + heal env.template image drift (#929 safety net)

### DIFF
--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -226,8 +226,7 @@ def _consistency_warnings(env, current_profiles, running_services, uses_cirrus,
       stop/start won't restore it).
     - CirrusSearch configured in settings while Elasticsearch is disabled.
     - env.template's CANASTA_IMAGE stale relative to .env (a gitops pull would
-      revert the running image — e.g. an upgrade that self-updated the CLI in
-      the same invocation, #929).
+      re-render .env from env.template and revert the running image).
     """
     warns = []
     active = set(current_profiles)

--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -216,7 +216,8 @@ _SERVICE_PROFILE = {
 _SERVICE_PROFILE["db"] = "internal-db"
 
 
-def _consistency_warnings(env, current_profiles, running_services, uses_cirrus):
+def _consistency_warnings(env, current_profiles, running_services, uses_cirrus,
+                          template_image=None):
     """Pure: warnings about config/runtime drift for a Compose instance.
 
     - COMPOSE_PROFILES that disagrees with what sync would derive from the
@@ -224,6 +225,9 @@ def _consistency_warnings(env, current_profiles, running_services, uses_cirrus):
     - A container running under a profile that isn't active (unmanaged — a
       stop/start won't restore it).
     - CirrusSearch configured in settings while Elasticsearch is disabled.
+    - env.template's CANASTA_IMAGE stale relative to .env (a gitops pull would
+      revert the running image — e.g. an upgrade that self-updated the CLI in
+      the same invocation, #929).
     """
     warns = []
     active = set(current_profiles)
@@ -255,11 +259,20 @@ def _consistency_warnings(env, current_profiles, running_services, uses_cirrus):
             "'elasticsearch' profile is inactive — search depends on an "
             "unmanaged Elasticsearch; set CANASTA_ENABLE_ELASTICSEARCH=true")
 
+    env_image = env.get("CANASTA_IMAGE", "").strip()
+    if template_image and env_image and template_image != env_image:
+        warns.append(
+            "env.template pins the image at '%s' but .env is '%s' — the "
+            "durable gitops source is stale; a gitops pull would revert the "
+            "running image" % (template_image, env_image))
+
     return warns
 
 
 def _gather_runtime(path, host):
-    """(running_services, uses_cirrus) for an instance, localhost or remote."""
+    """(running_services, uses_cirrus, env_template_image) for an instance,
+    localhost or remote. env_template_image is the CANASTA_IMAGE pinned in
+    env.template ('' if not gitops / not present)."""
     d = _helpers._SENTINEL
     qpath = _helpers._shell_quote(path)
     script = (
@@ -267,7 +280,9 @@ def _gather_runtime(path, host):
         "docker compose ps --services --status running 2>/dev/null; "
         "echo '%(d)s'; "
         "grep -rqi cirrussearch %(p)s/config/settings 2>/dev/null "
-        "&& echo USES_CIRRUS || echo NO_CIRRUS"
+        "&& echo USES_CIRRUS || echo NO_CIRRUS; "
+        "echo '%(d)s'; "
+        "grep '^CANASTA_IMAGE=' %(p)s/env.template 2>/dev/null | head -1"
     ) % {"p": qpath, "d": d}
     if _helpers._is_localhost(host):
         try:
@@ -276,16 +291,21 @@ def _gather_runtime(path, host):
                 capture_output=True, text=True, timeout=30,
             ).stdout
         except (subprocess.TimeoutExpired, OSError):
-            return [], False
+            return [], False, ""
     else:
         rc, out = _helpers._ssh_run(host, script)
         if rc != 0 and not out.strip():
-            return [], False
+            return [], False, ""
     parts = out.split(d + "\n")
     head = parts[0].strip() if parts else ""
     running = [s for s in head.split("\n") if s.strip()]
     uses_cirrus = len(parts) > 1 and "USES_CIRRUS" in parts[1]
-    return running, uses_cirrus
+    template_image = ""
+    if len(parts) > 2:
+        line = parts[2].strip()
+        if line.startswith("CANASTA_IMAGE="):
+            template_image = line.split("=", 1)[1].strip()
+    return running, uses_cirrus, template_image
 
 
 def _instance_consistency_lines(inst):
@@ -307,8 +327,9 @@ def _instance_consistency_lines(inst):
         p.strip() for p in env.get("COMPOSE_PROFILES", "").split(",")
         if p.strip()
     ]
-    running, uses_cirrus = _gather_runtime(path, host)
-    warns = _consistency_warnings(env, current, running, uses_cirrus)
+    running, uses_cirrus, template_image = _gather_runtime(path, host)
+    warns = _consistency_warnings(
+        env, current, running, uses_cirrus, template_image)
     lines = ["", "Instance consistency (%s):" % inst.get("id", "?")]
     if warns:
         lines += ["  WARN: %s" % w for w in warns]

--- a/roles/instance_lifecycle/tasks/reconcile.yml
+++ b/roles/instance_lifecycle/tasks/reconcile.yml
@@ -10,6 +10,38 @@
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
   when: instance_path is not defined
 
+# Reconcile the durable gitops source to the live .env for the image tag. An
+# upgrade that self-updated the CLI in the same invocation can bump .env's
+# CANASTA_IMAGE but skip the env.template write (#929), leaving env.template
+# stale — a gitops pull would then re-render .env back to the old image. Bring
+# env.template's CANASTA_IMAGE up to .env so the running image survives a pull.
+# Compose gitops only; a no-op when they already match.
+- name: Reconcile env.template image tag to .env (gitops Compose)
+  when: instance_orchestrator | default('compose') == 'compose'
+  block:
+    - name: Check if instance is gitops-managed
+      ansible.builtin.stat:
+        path: "{{ instance_path }}/.gitops-host"
+      register: _reconcile_gitops_stat
+
+    - name: Read .env CANASTA_IMAGE
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read
+        key: CANASTA_IMAGE
+      register: _reconcile_env_image
+      when: _reconcile_gitops_stat.stat.exists | default(false)
+
+    - name: Sync env.template CANASTA_IMAGE to .env
+      ansible.builtin.lineinfile:
+        path: "{{ instance_path }}/env.template"
+        regexp: "^CANASTA_IMAGE="
+        line: "CANASTA_IMAGE={{ _reconcile_env_image.value }}"
+        state: present
+      when:
+        - _reconcile_gitops_stat.stat.exists | default(false)
+        - _reconcile_env_image.found | default(false)
+
 # Regenerate rendered config (e.g. the Caddyfile from the current wikis.yaml)
 # so the converge below picks up drift between sources and rendered state.
 - name: Regenerate config

--- a/roles/instance_lifecycle/tasks/reconcile.yml
+++ b/roles/instance_lifecycle/tasks/reconcile.yml
@@ -10,12 +10,10 @@
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
   when: instance_path is not defined
 
-# Reconcile the durable gitops source to the live .env for the image tag. An
-# upgrade that self-updated the CLI in the same invocation can bump .env's
-# CANASTA_IMAGE but skip the env.template write (#929), leaving env.template
-# stale — a gitops pull would then re-render .env back to the old image. Bring
-# env.template's CANASTA_IMAGE up to .env so the running image survives a pull.
-# Compose gitops only; a no-op when they already match.
+# Bring env.template's CANASTA_IMAGE up to the live .env value. A gitops pull
+# re-renders .env from env.template, so a stale env.template would revert the
+# running image to its older tag; syncing it here keeps the running image on
+# the next pull. Compose gitops only; a no-op when they already match.
 - name: Reconcile env.template image tag to .env (gitops Compose)
   when: instance_orchestrator | default('compose') == 'compose'
   block:

--- a/tests/unit/test_doctor_consistency.py
+++ b/tests/unit/test_doctor_consistency.py
@@ -165,7 +165,7 @@ class TestInstanceConsistencyLines:
         assert any("OK (" in line for line in lines)
 
     def test_env_template_image_drift_warns(self, monkeypatch):
-        # .env has the new tag but env.template is stale (the #929 case).
+        # .env has the new tag but env.template still pins the old one.
         inst = {"id": "site", "orchestrator": "compose", "path": "/srv/site",
                 "host": "localhost"}
         monkeypatch.setattr(

--- a/tests/unit/test_doctor_consistency.py
+++ b/tests/unit/test_doctor_consistency.py
@@ -67,6 +67,23 @@ class TestConsistencyWarnings:
         assert len(out) == 1
         assert "CirrusSearch" in out[0]
 
+    def test_env_template_image_drift_warns(self):
+        env = {"CANASTA_IMAGE": "ghcr.io/canastawiki/canasta:3.5.12",
+               "COMPOSE_PROFILES": "internal-db,varnish"}
+        out = doctor._consistency_warnings(
+            env, ["internal-db", "varnish"], ["web"], False,
+            template_image="ghcr.io/canastawiki/canasta:3.5.1")
+        assert len(out) == 1
+        assert "env.template" in out[0] and "stale" in out[0]
+
+    def test_env_template_image_match_no_warn(self):
+        env = {"CANASTA_IMAGE": "ghcr.io/canastawiki/canasta:3.5.12",
+               "COMPOSE_PROFILES": "internal-db,varnish"}
+        out = doctor._consistency_warnings(
+            env, ["internal-db", "varnish"], ["web"], False,
+            template_image="ghcr.io/canastawiki/canasta:3.5.12")
+        assert out == []
+
 
 class TestServiceProfileMap:
     def test_managed_services_map_to_profiles(self):
@@ -81,30 +98,33 @@ class TestServiceProfileMap:
 
 
 class TestGatherRuntime:
-    def test_parses_services_and_cirrus_flag(self, monkeypatch):
+    def test_parses_services_cirrus_and_template_image(self, monkeypatch):
         d = doctor._helpers._SENTINEL
-        out = "web\nvarnish\ndb\n%s\nUSES_CIRRUS\n" % d
+        out = ("web\nvarnish\ndb\n%s\nUSES_CIRRUS\n%s\n"
+               "CANASTA_IMAGE=ghcr.io/canastawiki/canasta:3.5.1\n" % (d, d))
 
         class _R:
             stdout = out
 
         monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
         monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _R())
-        running, cirrus = doctor._gather_runtime("/srv/x", "localhost")
+        running, cirrus, tmpl = doctor._gather_runtime("/srv/x", "localhost")
         assert running == ["web", "varnish", "db"]
         assert cirrus is True
+        assert tmpl == "ghcr.io/canastawiki/canasta:3.5.1"
 
-    def test_no_cirrus_flag(self, monkeypatch):
+    def test_no_cirrus_no_template(self, monkeypatch):
         d = doctor._helpers._SENTINEL
 
         class _R:
-            stdout = "web\n%s\nNO_CIRRUS\n" % d
+            stdout = "web\n%s\nNO_CIRRUS\n%s\n" % (d, d)
 
         monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
         monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _R())
-        running, cirrus = doctor._gather_runtime("/srv/x", "localhost")
+        running, cirrus, tmpl = doctor._gather_runtime("/srv/x", "localhost")
         assert running == ["web"]
         assert cirrus is False
+        assert tmpl == ""
 
 
 class TestInstanceConsistencyLines:
@@ -122,7 +142,7 @@ class TestInstanceConsistencyLines:
                                "COMPOSE_PROFILES=varnish\n")
         monkeypatch.setattr(
             doctor, "_gather_runtime",
-            lambda path, host: (["web", "varnish", "db"], True))
+            lambda path, host: (["web", "varnish", "db"], True, ""))
         lines = doctor._instance_consistency_lines(inst)
         assert lines[1] == "Instance consistency (site):"
         body = " ".join(lines)
@@ -140,6 +160,23 @@ class TestInstanceConsistencyLines:
                                "COMPOSE_PROFILES=internal-db,varnish,crowdsec\n")
         monkeypatch.setattr(
             doctor, "_gather_runtime",
-            lambda path, host: (["web", "varnish", "crowdsec", "db"], False))
+            lambda path, host: (["web", "varnish", "crowdsec", "db"], False, ""))
         lines = doctor._instance_consistency_lines(inst)
         assert any("OK (" in line for line in lines)
+
+    def test_env_template_image_drift_warns(self, monkeypatch):
+        # .env has the new tag but env.template is stale (the #929 case).
+        inst = {"id": "site", "orchestrator": "compose", "path": "/srv/site",
+                "host": "localhost"}
+        monkeypatch.setattr(
+            doctor._helpers, "_read_env_content",
+            lambda path, host: "COMPOSE_PROFILES=internal-db,varnish\n"
+                               "CANASTA_IMAGE=ghcr.io/canastawiki/canasta:3.5.12\n")
+        monkeypatch.setattr(
+            doctor, "_gather_runtime",
+            lambda path, host: (["web", "varnish", "db"], False,
+                                "ghcr.io/canastawiki/canasta:3.5.1"))
+        body = " ".join(doctor._instance_consistency_lines(inst))
+        assert "env.template" in body and "stale" in body
+        assert "3.5.1" in body and "3.5.12" in body
+        assert "canasta reconcile" in body

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -62,3 +62,35 @@ class TestReconcileWiring:
             (c for c in _commands() if c.get("name") == "reconcile"), None)
         assert rec is not None, "reconcile must be in command_definitions.yml"
         assert rec.get("playbook") == "reconcile.yml"
+
+
+RECONCILE_TASKS = os.path.join(
+    REPO_ROOT, "roles", "instance_lifecycle", "tasks", "reconcile.yml"
+)
+
+
+class TestReconcileEnvTemplateImageSync:
+    """#929 safety net: reconcile brings env.template's CANASTA_IMAGE up to
+    .env (gitops Compose) so a durability write skipped during a self-updating
+    upgrade self-heals — a gitops pull can't then revert the running image."""
+
+    def test_reconcile_syncs_env_template_image_to_env(self):
+        block = next(
+            (t for t in _load(RECONCILE_TASKS)
+             if "env.template image" in t.get("name", "")),
+            None,
+        )
+        assert block is not None, (
+            "reconcile must reconcile env.template's image tag to .env"
+        )
+        li = next(
+            (t for t in block.get("block", [])
+             if (t.get("ansible.builtin.lineinfile") or {})
+             .get("path", "").endswith("env.template")),
+            None,
+        )
+        assert li is not None, "must lineinfile env.template's CANASTA_IMAGE"
+        assert "CANASTA_IMAGE" in str(li["ansible.builtin.lineinfile"].get("regexp", ""))
+        assert "stat.exists" in str(li.get("when", "")), (
+            "the env.template sync must be gated on .gitops-host existing"
+        )

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -70,9 +70,9 @@ RECONCILE_TASKS = os.path.join(
 
 
 class TestReconcileEnvTemplateImageSync:
-    """#929 safety net: reconcile brings env.template's CANASTA_IMAGE up to
-    .env (gitops Compose) so a durability write skipped during a self-updating
-    upgrade self-heals — a gitops pull can't then revert the running image."""
+    """reconcile brings env.template's CANASTA_IMAGE up to .env (gitops
+    Compose) so a stale durable source can't revert the running image on the
+    next gitops pull."""
 
     def test_reconcile_syncs_env_template_image_to_env(self):
         block = next(


### PR DESCRIPTION
Refs #929 — a robust self-healing net for the durability-skip, independent of the (still-unpinned) re-exec cause.

## Background

When `canasta upgrade` self-updates the CLI and upgrades in the same invocation, it can bump `.env`'s `CANASTA_IMAGE` but skip the `env.template` durability write (#929), leaving `env.template` stale. A later `gitops pull` then re-renders `.env` back to the old image — silently undoing the upgrade. Pinning the exact re-exec mechanism needs a live repro; this PR makes the drift **detectable and self-healing** either way.

## What

- **doctor**: the instance-consistency section now warns when `env.template`'s `CANASTA_IMAGE` differs from `.env`'s (gitops Compose), and points at `canasta reconcile`. The runtime gather reads the pinned tag from `env.template` alongside the existing running-services / CirrusSearch probes.
- **reconcile**: brings `env.template`'s `CANASTA_IMAGE` up to `.env` (gitops Compose only) so the running image survives the next pull. Idempotent — a no-op when they already match.

This fits the self-healing pattern from the rest of this cycle: `doctor` names the drift, `reconcile` fixes it.

## Tests

- `_consistency_warnings`: warns on template≠.env, silent when equal.
- `_gather_runtime`: parses the `env.template` image alongside services/cirrus.
- `_instance_consistency_lines`: the #929 drift case surfaces (old vs new tag) + points at reconcile.
- `reconcile.yml`: the env.template image sync task exists, is gitops-gated, and lineinfiles `CANASTA_IMAGE`.
- Full unit suite passes; `make validate` (83 commands) + YAML lint clean.
