### PR TITLE
fix(gitops): make elasticsearch/varnish/observability flags durable on gitops

### DIFF
--- a/roles/gitops/vars/main.yml
+++ b/roles/gitops/vars/main.yml
@@ -12,13 +12,18 @@ gitops_placeholder_keys:
   - HTTPS_PORT
   - HTTP_PORT
   - CADDY_AUTO_HTTPS
-  # Optional edge-security features. These are per-host toggles and
-  # credentials, so a gitops render/pull must preserve them rather than
-  # reset them to the off state captured at init time. CANASTA_CADDY_IMAGE
-  # and COMPOSE_PROFILES are intentionally absent: both are re-derived from
-  # these flags by sync_compose_profiles on every start, so storing them
-  # would only freeze a value the start sequence already reconciles.
+  # Per-host feature toggles that drive COMPOSE_PROFILES, plus the CrowdSec
+  # bouncer key and trusted-proxy setting. A gitops render/pull must preserve
+  # these rather than reset them to the off state captured at init time —
+  # otherwise sync_compose_profiles derives the profile off and silently
+  # disables the feature on the next restart. CANASTA_CADDY_IMAGE and
+  # COMPOSE_PROFILES are intentionally absent: both are re-derived from these
+  # flags on every start, so storing them would only freeze a value the start
+  # sequence already reconciles.
   - CANASTA_ENABLE_CROWDSEC
+  - CANASTA_ENABLE_ELASTICSEARCH
+  - CANASTA_ENABLE_OBSERVABILITY
+  - CANASTA_ENABLE_VARNISH
   - CROWDSEC_BOUNCER_API_KEY
   - CADDY_TRUSTED_PROXIES
 

--- a/tests/unit/test_gitops_feature_flag_durability.py
+++ b/tests/unit/test_gitops_feature_flag_durability.py
@@ -1,0 +1,32 @@
+"""A feature-enable flag must be a gitops placeholder key, or a `config set`
+of it updates only the live .env: the next gitops pull re-renders .env from
+env.template's init-time literal, and sync_compose_profiles then derives the
+profile off — silently disabling the feature."""
+
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+GITOPS_VARS = os.path.join(REPO_ROOT, "roles", "gitops", "vars", "main.yml")
+
+
+def _placeholder_keys():
+    with open(GITOPS_VARS) as f:
+        return yaml.safe_load(f)["gitops_placeholder_keys"]
+
+
+def test_profile_feature_flags_are_placeholder_keys():
+    keys = _placeholder_keys()
+    for flag in (
+        "CANASTA_ENABLE_CROWDSEC",
+        "CANASTA_ENABLE_ELASTICSEARCH",
+        "CANASTA_ENABLE_OBSERVABILITY",
+        "CANASTA_ENABLE_VARNISH",
+    ):
+        assert flag in keys, (
+            "%s must be a gitops placeholder key so 'config set' of it persists "
+            "to the gitops source; otherwise a pull renders it back to the "
+            "init-time literal and the profile derives off" % flag
+        )


### PR DESCRIPTION
Fixes #932.

## Problem

On a gitops instance, `canasta config set CANASTA_ENABLE_ELASTICSEARCH=true` (or `_VARNISH` / `_OBSERVABILITY`) updates the live `.env` but not the durable gitops source. `config set` persists a key to `env.template` (as a placeholder) + `vars.yaml` only when it is in `gitops_placeholder_keys` or matches the secret prefix. `CANASTA_ENABLE_CROWDSEC` is listed; the other three profile-driving flags are not. So the next `gitops pull` re-renders `.env` from the init-time literal (`=false`), and `sync_compose_profiles` — which trusts the flag — derives the profile off, silently disabling the feature. Same class as #921 (a literal in `env.template` that `config set` doesn't propagate).

## Fix

Add `CANASTA_ENABLE_ELASTICSEARCH`, `CANASTA_ENABLE_OBSERVABILITY`, and `CANASTA_ENABLE_VARNISH` to `gitops_placeholder_keys`. `config set` then converts the `env.template` literal to a managed placeholder and records the value in `vars.yaml`, exactly as it already does for `CANASTA_ENABLE_CROWDSEC`, so the toggle survives the render.

Existing gitops instances are unchanged until `config set` next touches the flag (which then converts it); fresh gitops inits get the placeholder from the start.

## Tests

`test_gitops_feature_flag_durability.py` — all four profile-driving `CANASTA_ENABLE_*` flags are placeholder keys. Full unit suite passes; `make validate` + YAML lint clean.
