### PR TITLE
fix(config): persist every config-set key to the gitops source (env.template literal)

### DIFF
--- a/roles/config/tasks/_update_gitops_var.yml
+++ b/roles/config/tasks/_update_gitops_var.yml
@@ -48,3 +48,23 @@
         cmd: "git add {{ _ugv_vars_file }}"
         chdir: "{{ instance_path }}"
       changed_when: true
+
+# A key with no gitops placeholder lives as a literal in env.template (or is
+# absent). Update that literal so the change reaches the durable source; a
+# gitops pull / config regenerate re-renders .env from env.template, so a
+# literal left stale reverts the value on the next render.
+- name: Update env.template literal when key has no placeholder
+  when: _ugv_placeholder == ''
+  block:
+    - name: Set the literal in env.template
+      ansible.builtin.lineinfile:
+        path: "{{ instance_path }}/env.template"
+        regexp: "^{{ _ugv_key }}="
+        line: "{{ _ugv_key }}={{ _ugv_value }}"
+        state: present
+
+    - name: Stage updated env.template
+      ansible.builtin.command:
+        cmd: "git add env.template"
+        chdir: "{{ instance_path }}"
+      changed_when: true

--- a/tests/unit/test_config_gitops_writethrough.py
+++ b/tests/unit/test_config_gitops_writethrough.py
@@ -1,0 +1,52 @@
+"""On a gitops instance, `config set` must persist EVERY key to the durable
+source: placeholder/secret keys to vars.yaml, everything else to the
+env.template literal. A non-placeholder key left as a .env-only write is
+reverted the next time a pull / config regenerate re-renders .env."""
+
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+UPDATE_VAR = os.path.join(
+    REPO_ROOT, "roles", "config", "tasks", "_update_gitops_var.yml"
+)
+
+
+def _tasks():
+    with open(UPDATE_VAR) as f:
+        return yaml.safe_load(f)
+
+
+def _find(name_substring):
+    return next(
+        (t for t in _tasks() if name_substring in t.get("name", "")), None)
+
+
+def _lineinfile(task):
+    return (task.get("ansible.builtin.lineinfile")
+            or task.get("lineinfile")) if isinstance(task, dict) else None
+
+
+def test_placeholder_key_still_writes_vars_yaml():
+    block = _find("vars.yaml if key has a gitops placeholder")
+    assert block is not None
+    assert "_ugv_placeholder != ''" in str(block.get("when", ""))
+
+
+def test_non_placeholder_key_updates_env_template_literal():
+    block = _find("env.template literal when key has no placeholder")
+    assert block is not None, (
+        "config set must persist a non-placeholder key to env.template, or it "
+        "is a .env-only write that the next render reverts"
+    )
+    assert "_ugv_placeholder == ''" in str(block.get("when", ""))
+    li = next(
+        (t for t in block.get("block", [])
+         if (_lineinfile(t) or {}).get("path", "").endswith("env.template")),
+        None,
+    )
+    assert li is not None, "must lineinfile the key's literal in env.template"
+    assert "_ugv_key" in str(_lineinfile(li).get("regexp", ""))
+    assert "_ugv_value" in str(_lineinfile(li).get("line", ""))


### PR DESCRIPTION
Fixes #934. The general fix for the gitops config-drift class — retires the per-key whack-a-mole (#921/#925, #932/#933).

## Problem

On a gitops instance, `config set KEY=VALUE` writes the live `.env` but persists to the durable source only when KEY is a placeholder/secret key. `_update_gitops_var.yml` updated `vars.yaml` for placeholder keys and did **nothing** otherwise — so a key that lives as a literal in `env.template` was a `.env`-only write, and the next `gitops pull` / `config regenerate` re-rendered `.env` from the stale template and reverted it.

## Fix

Add the missing branch: when a key has no placeholder, update its **literal** in `env.template` and stage it — mirroring the `vars.yaml` path for placeholder keys. Now every `config set` key reaches the source (placeholder/secret → `vars.yaml`, everything else → the `env.template` literal), so `.env` cannot diverge from the source via `config set`. This upholds the invariant `.env == render(env.template + vars.yaml)` that `gitops pull` and `config regenerate` rely on.

## Tests

`test_config_gitops_writethrough.py` — the placeholder branch still writes `vars.yaml`, and a non-placeholder key updates its `env.template` literal (regexp/line keyed on the key). Full unit suite passes; `make validate` + YAML lint clean.
