### PR TITLE
feat(doctor): detect any env.template<->.env literal drift (not just CANASTA_IMAGE)

### DIFF
--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -217,7 +217,7 @@ _SERVICE_PROFILE["db"] = "internal-db"
 
 
 def _consistency_warnings(env, current_profiles, running_services, uses_cirrus,
-                          template_image=None):
+                          template_literals=None):
     """Pure: warnings about config/runtime drift for a Compose instance.
 
     - COMPOSE_PROFILES that disagrees with what sync would derive from the
@@ -225,8 +225,8 @@ def _consistency_warnings(env, current_profiles, running_services, uses_cirrus,
     - A container running under a profile that isn't active (unmanaged — a
       stop/start won't restore it).
     - CirrusSearch configured in settings while Elasticsearch is disabled.
-    - env.template's CANASTA_IMAGE stale relative to .env (a gitops pull would
-      re-render .env from env.template and revert the running image).
+    - any env.template literal that differs from .env (the durable gitops
+      source and the live config have diverged; a pull would reset .env to it).
     """
     warns = []
     active = set(current_profiles)
@@ -258,20 +258,28 @@ def _consistency_warnings(env, current_profiles, running_services, uses_cirrus,
             "'elasticsearch' profile is inactive — search depends on an "
             "unmanaged Elasticsearch; set CANASTA_ENABLE_ELASTICSEARCH=true")
 
-    env_image = env.get("CANASTA_IMAGE", "").strip()
-    if template_image and env_image and template_image != env_image:
+    drifted = sorted(
+        k for k, tv in (template_literals or {}).items()
+        if k in env and env[k] != tv)
+    if drifted:
+        detail = "; ".join(
+            "%s (env.template=%s, .env=%s)" % (k, template_literals[k], env[k])
+            for k in drifted)
         warns.append(
-            "env.template pins the image at '%s' but .env is '%s' — the "
-            "durable gitops source is stale; a gitops pull would revert the "
-            "running image" % (template_image, env_image))
+            "env.template disagrees with .env on: %s. A gitops pull or "
+            "'canasta config regenerate' re-renders .env from env.template, so "
+            "these values will change: regenerate if the template is right, or "
+            "update env.template/vars.yaml if the .env value is intended"
+            % detail)
 
     return warns
 
 
 def _gather_runtime(path, host):
-    """(running_services, uses_cirrus, env_template_image) for an instance,
-    localhost or remote. env_template_image is the CANASTA_IMAGE pinned in
-    env.template ('' if not gitops / not present)."""
+    """(running_services, uses_cirrus, env_template_literals) for an instance,
+    localhost or remote. env_template_literals maps each KEY to the literal
+    value pinned in env.template, excluding placeholder (KEY={{...}}) lines and
+    comments; empty when not gitops / no env.template."""
     d = _helpers._SENTINEL
     qpath = _helpers._shell_quote(path)
     script = (
@@ -281,7 +289,8 @@ def _gather_runtime(path, host):
         "grep -rqi cirrussearch %(p)s/config/settings 2>/dev/null "
         "&& echo USES_CIRRUS || echo NO_CIRRUS; "
         "echo '%(d)s'; "
-        "grep '^CANASTA_IMAGE=' %(p)s/env.template 2>/dev/null | head -1"
+        "grep -E '^[A-Za-z_][A-Za-z0-9_]*=' %(p)s/env.template 2>/dev/null "
+        "| grep -v '={{'"
     ) % {"p": qpath, "d": d}
     if _helpers._is_localhost(host):
         try:
@@ -290,21 +299,27 @@ def _gather_runtime(path, host):
                 capture_output=True, text=True, timeout=30,
             ).stdout
         except (subprocess.TimeoutExpired, OSError):
-            return [], False, ""
+            return [], False, {}
     else:
         rc, out = _helpers._ssh_run(host, script)
         if rc != 0 and not out.strip():
-            return [], False, ""
+            return [], False, {}
     parts = out.split(d + "\n")
     head = parts[0].strip() if parts else ""
     running = [s for s in head.split("\n") if s.strip()]
     uses_cirrus = len(parts) > 1 and "USES_CIRRUS" in parts[1]
-    template_image = ""
+    template_literals = {}
     if len(parts) > 2:
-        line = parts[2].strip()
-        if line.startswith("CANASTA_IMAGE="):
-            template_image = line.split("=", 1)[1].strip()
-    return running, uses_cirrus, template_image
+        for line in parts[2].strip().split("\n"):
+            line = line.strip()
+            if "=" not in line or line.startswith("#"):
+                continue
+            key, val = line.split("=", 1)
+            val = val.strip()
+            if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
+                val = val[1:-1]
+            template_literals[key.strip()] = val
+    return running, uses_cirrus, template_literals
 
 
 def _instance_consistency_lines(inst):
@@ -326,9 +341,9 @@ def _instance_consistency_lines(inst):
         p.strip() for p in env.get("COMPOSE_PROFILES", "").split(",")
         if p.strip()
     ]
-    running, uses_cirrus, template_image = _gather_runtime(path, host)
+    running, uses_cirrus, template_literals = _gather_runtime(path, host)
     warns = _consistency_warnings(
-        env, current, running, uses_cirrus, template_image)
+        env, current, running, uses_cirrus, template_literals)
     lines = ["", "Instance consistency (%s):" % inst.get("id", "?")]
     if warns:
         lines += ["  WARN: %s" % w for w in warns]

--- a/tests/unit/test_doctor_consistency.py
+++ b/tests/unit/test_doctor_consistency.py
@@ -67,21 +67,37 @@ class TestConsistencyWarnings:
         assert len(out) == 1
         assert "CirrusSearch" in out[0]
 
-    def test_env_template_image_drift_warns(self):
+    def test_env_template_literal_drift_warns(self):
+        # Multiple literals differ between env.template and .env.
         env = {"CANASTA_IMAGE": "ghcr.io/canastawiki/canasta:3.5.12",
+               "CANASTA_ENABLE_ELASTICSEARCH": "true",
                "COMPOSE_PROFILES": "internal-db,varnish"}
         out = doctor._consistency_warnings(
             env, ["internal-db", "varnish"], ["web"], False,
-            template_image="ghcr.io/canastawiki/canasta:3.5.1")
-        assert len(out) == 1
-        assert "env.template" in out[0] and "stale" in out[0]
+            template_literals={
+                "CANASTA_IMAGE": "ghcr.io/canastawiki/canasta:3.5.1",
+                "CANASTA_ENABLE_ELASTICSEARCH": "false"})
+        drift = [o for o in out if "env.template disagrees with .env" in o]
+        assert len(drift) == 1
+        assert "CANASTA_IMAGE" in drift[0]
+        assert "CANASTA_ENABLE_ELASTICSEARCH" in drift[0]
 
-    def test_env_template_image_match_no_warn(self):
+    def test_env_template_literals_match_no_warn(self):
         env = {"CANASTA_IMAGE": "ghcr.io/canastawiki/canasta:3.5.12",
                "COMPOSE_PROFILES": "internal-db,varnish"}
         out = doctor._consistency_warnings(
             env, ["internal-db", "varnish"], ["web"], False,
-            template_image="ghcr.io/canastawiki/canasta:3.5.12")
+            template_literals={
+                "CANASTA_IMAGE": "ghcr.io/canastawiki/canasta:3.5.12"})
+        assert out == []
+
+    def test_env_template_key_absent_from_env_not_flagged(self):
+        # Only keys present in BOTH are compared, so a template-only key
+        # doesn't produce a false positive.
+        env = {"COMPOSE_PROFILES": "internal-db,varnish"}
+        out = doctor._consistency_warnings(
+            env, ["internal-db", "varnish"], ["web"], False,
+            template_literals={"SOME_OTHER_KEY": "x"})
         assert out == []
 
 
@@ -98,20 +114,23 @@ class TestServiceProfileMap:
 
 
 class TestGatherRuntime:
-    def test_parses_services_cirrus_and_template_image(self, monkeypatch):
+    def test_parses_services_cirrus_and_template_literals(self, monkeypatch):
         d = doctor._helpers._SENTINEL
         out = ("web\nvarnish\ndb\n%s\nUSES_CIRRUS\n%s\n"
-               "CANASTA_IMAGE=ghcr.io/canastawiki/canasta:3.5.1\n" % (d, d))
+               "CANASTA_IMAGE=ghcr.io/canastawiki/canasta:3.5.1\n"
+               'CANASTA_ENABLE_ELASTICSEARCH="false"\n' % (d, d))
 
         class _R:
             stdout = out
 
         monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
         monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _R())
-        running, cirrus, tmpl = doctor._gather_runtime("/srv/x", "localhost")
+        running, cirrus, lits = doctor._gather_runtime("/srv/x", "localhost")
         assert running == ["web", "varnish", "db"]
         assert cirrus is True
-        assert tmpl == "ghcr.io/canastawiki/canasta:3.5.1"
+        assert lits["CANASTA_IMAGE"] == "ghcr.io/canastawiki/canasta:3.5.1"
+        # surrounding quotes are stripped to match .env parsing
+        assert lits["CANASTA_ENABLE_ELASTICSEARCH"] == "false"
 
     def test_no_cirrus_no_template(self, monkeypatch):
         d = doctor._helpers._SENTINEL
@@ -121,10 +140,10 @@ class TestGatherRuntime:
 
         monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
         monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _R())
-        running, cirrus, tmpl = doctor._gather_runtime("/srv/x", "localhost")
+        running, cirrus, lits = doctor._gather_runtime("/srv/x", "localhost")
         assert running == ["web"]
         assert cirrus is False
-        assert tmpl == ""
+        assert lits == {}
 
 
 class TestInstanceConsistencyLines:
@@ -142,7 +161,7 @@ class TestInstanceConsistencyLines:
                                "COMPOSE_PROFILES=varnish\n")
         monkeypatch.setattr(
             doctor, "_gather_runtime",
-            lambda path, host: (["web", "varnish", "db"], True, ""))
+            lambda path, host: (["web", "varnish", "db"], True, {}))
         lines = doctor._instance_consistency_lines(inst)
         assert lines[1] == "Instance consistency (site):"
         body = " ".join(lines)
@@ -160,11 +179,11 @@ class TestInstanceConsistencyLines:
                                "COMPOSE_PROFILES=internal-db,varnish,crowdsec\n")
         monkeypatch.setattr(
             doctor, "_gather_runtime",
-            lambda path, host: (["web", "varnish", "crowdsec", "db"], False, ""))
+            lambda path, host: (["web", "varnish", "crowdsec", "db"], False, {}))
         lines = doctor._instance_consistency_lines(inst)
         assert any("OK (" in line for line in lines)
 
-    def test_env_template_image_drift_warns(self, monkeypatch):
+    def test_env_template_literal_drift_warns(self, monkeypatch):
         # .env has the new tag but env.template still pins the old one.
         inst = {"id": "site", "orchestrator": "compose", "path": "/srv/site",
                 "host": "localhost"}
@@ -175,8 +194,8 @@ class TestInstanceConsistencyLines:
         monkeypatch.setattr(
             doctor, "_gather_runtime",
             lambda path, host: (["web", "varnish", "db"], False,
-                                "ghcr.io/canastawiki/canasta:3.5.1"))
+                                {"CANASTA_IMAGE":
+                                 "ghcr.io/canastawiki/canasta:3.5.1"}))
         body = " ".join(doctor._instance_consistency_lines(inst))
-        assert "env.template" in body and "stale" in body
+        assert "env.template disagrees with .env" in body
         assert "3.5.1" in body and "3.5.12" in body
-        assert "canasta reconcile" in body


### PR DESCRIPTION
Fixes #936. The backstop for the gitops config-drift invariant `.env == render(env.template + vars.yaml)`.

## What

Generalizes the `env.template`↔`.env` consistency check from `CANASTA_IMAGE` alone to **every literal** in `env.template`:

- `_gather_runtime` reads all literal `KEY=value` lines from `env.template`, excluding placeholder (`KEY={{...}}`) lines and comments, stripping surrounding quotes to match `.env` parsing.
- `_consistency_warnings` reports every key whose `env.template` literal differs from `.env`, listing both values.

With config-set write-through (#934) preventing new drift, this is the backstop that catches what still slips: a hand-edited `.env`, an upgrade that skipped the durability write (#929), or legacy drift.

## Detection only

The heal direction is context-dependent — a stale `env.template` should be updated *from* `.env`; a rogue `.env` should be reset *from* the source via `config regenerate` — so the warning describes both options rather than auto-healing in a possibly-wrong direction.

## Tests

`test_doctor_consistency.py` updated for the literals dict: multi-key drift is reported, matching literals are silent, a template-only key (absent from `.env`) isn't a false positive, and the gather parses/strips quotes. Full unit suite passes; lint + `make validate` clean.
