### PR TITLE
fix(upgrade): derive migration wiki dirs from wikis.yaml, not a config/ scan

### DIFF
--- a/roles/upgrade/files/probe_migration_state.py
+++ b/roles/upgrade/files/probe_migration_state.py
@@ -19,6 +19,7 @@ Output JSON shape:
 """
 import json
 import os
+import re
 import sys
 
 
@@ -30,10 +31,6 @@ ENV_KEYS_OF_INTEREST = (
     "COMPOSE_PROFILES",
     "USE_EXTERNAL_DB",
 )
-
-# Subdirs of config/ that are NOT per-wiki state and must not be
-# moved by the directory-structure migration.
-CONFIG_NON_WIKI = ("settings", "logstash", "backup", "persistent")
 
 
 def parse_env(path):
@@ -114,6 +111,60 @@ def list_files_matching(dir_path, suffix):
     )
 
 
+def wiki_ids_from_yaml(path):
+    """Wiki ids declared under the top-level `wikis:` key of wikis.yaml.
+
+    Parsed without PyYAML (not guaranteed on the target host): scan the
+    `wikis:` block for list-item `id:` values. wikis.yaml is machine-
+    written with `id` as the first key of each entry; both `- id: x`
+    and flush `- id: x` indent styles are handled. A missing or
+    unreadable file yields [].
+    """
+    try:
+        with open(path) as f:
+            lines = f.readlines()
+    except OSError:
+        return []
+    ids = []
+    in_wikis = False
+    wikis_indent = 0
+    for raw in lines:
+        line = raw.rstrip("\n")
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if not in_wikis:
+            if stripped == "wikis:" or stripped.startswith("wikis:"):
+                in_wikis = True
+                wikis_indent = indent
+            continue
+        # A new key at or below the `wikis:` indent ends the block.
+        if indent <= wikis_indent and not stripped.startswith("-"):
+            break
+        m = re.match(r"-?\s*id:\s*(.+)$", stripped)
+        if m:
+            val = m.group(1).strip().strip('"').strip("'")
+            if val:
+                ids.append(val)
+    return ids
+
+
+def old_wiki_dirs(base):
+    """Per-wiki config dirs still in the pre-migration location
+    config/<id>/. The wiki set is the farm declared in
+    config/wikis.yaml, NOT a scan of config/* — so non-wiki dirs
+    (crowdsec, logstash, backup, …) can never be selected for the
+    directory-structure migration.
+    """
+    config = os.path.join(base, "config")
+    ids = wiki_ids_from_yaml(os.path.join(config, "wikis.yaml"))
+    return sorted(
+        wid for wid in ids
+        if os.path.isdir(os.path.join(config, wid))
+    )
+
+
 def main():
     if len(sys.argv) != 2:
         print(json.dumps(
@@ -146,9 +197,7 @@ def main():
             "legacy_git": os.path.isdir(legacy_git),
             "hosts_yaml": os.path.isfile(hosts_yaml),
         },
-        "old_wiki_dirs": list_subdirs(
-            os.path.join(base, "config"), exclude=CONFIG_NON_WIKI,
-        ),
+        "old_wiki_dirs": old_wiki_dirs(base),
         "stray_php": list_files_matching(
             os.path.join(base, "config", "settings"), ".php",
         ),

--- a/tests/unit/test_probe_migration_state.py
+++ b/tests/unit/test_probe_migration_state.py
@@ -201,22 +201,75 @@ class TestMyCnf:
 
 
 class TestOldWikiDirs:
-    def test_only_system_dirs_yields_empty(self, probe, instance_dir):
-        for sys_dir in ("settings", "logstash", "backup", "persistent"):
-            (instance_dir / "config" / sys_dir).mkdir(exist_ok=True)
+    """old_wiki_dirs is derived from the wikis declared in
+    config/wikis.yaml, not a scan of config/* — so a per-wiki dir is
+    selected only when its id is a declared wiki AND it still sits in
+    the pre-migration config/<id>/ location. Non-wiki config dirs
+    (crowdsec, logstash, …) can never be selected."""
+
+    def _write_wikis(self, instance_dir, ids):
+        body = "wikis:\n" + "".join(
+            "  - id: %s\n    url: %s.example\n" % (wid, wid) for wid in ids
+        )
+        (instance_dir / "config" / "wikis.yaml").write_text(body)
+
+    def test_no_wikis_yaml_yields_empty(self, probe, instance_dir):
+        for d in ("logstash", "backup", "persistent", "wiki1"):
+            (instance_dir / "config" / d).mkdir(exist_ok=True)
         result = _run(probe, instance_dir)
         assert result["old_wiki_dirs"] == []
 
-    def test_per_wiki_dirs_listed(self, probe, instance_dir):
-        for d in ("settings", "wiki1", "wiki2"):
-            (instance_dir / "config" / d).mkdir(exist_ok=True)
+    def test_declared_wiki_in_old_location_is_selected(self, probe, instance_dir):
+        self._write_wikis(instance_dir, ["wiki1", "wiki2"])
+        (instance_dir / "config" / "wiki1").mkdir()
+        (instance_dir / "config" / "wiki2").mkdir()
         result = _run(probe, instance_dir)
         assert result["old_wiki_dirs"] == ["wiki1", "wiki2"]
 
-    def test_files_under_config_are_ignored(self, probe, instance_dir):
-        (instance_dir / "config" / "wikis.yaml").write_text("wikis: []\n")
+    def test_declared_wiki_already_migrated_is_not_selected(self, probe, instance_dir):
+        """Once config/<id>/ has moved to config/settings/wikis/<id>/,
+        there is nothing left to migrate — the probe reports empty."""
+        self._write_wikis(instance_dir, ["main"])
+        (instance_dir / "config" / "settings" / "wikis").mkdir(parents=True)
+        (instance_dir / "config" / "settings" / "wikis" / "main").mkdir()
         result = _run(probe, instance_dir)
         assert result["old_wiki_dirs"] == []
+
+    def test_undeclared_config_dir_is_not_selected(self, probe, instance_dir):
+        """A stray config/<name>/ that is not a declared wiki is left
+        alone, even in the old location."""
+        self._write_wikis(instance_dir, ["main"])
+        (instance_dir / "config" / "main").mkdir()
+        (instance_dir / "config" / "orphan").mkdir()
+        result = _run(probe, instance_dir)
+        assert result["old_wiki_dirs"] == ["main"]
+
+    def test_crowdsec_dir_is_never_selected(self, probe, instance_dir):
+        """Regression: config/crowdsec/ must not be treated as a wiki
+        and moved into config/settings/wikis/crowdsec/ (issue #938)."""
+        self._write_wikis(instance_dir, ["main"])
+        (instance_dir / "config" / "main").mkdir()
+        (instance_dir / "config" / "crowdsec").mkdir()
+        (instance_dir / "config" / "crowdsec" / "acquis.yaml").write_text("x\n")
+        result = _run(probe, instance_dir)
+        assert result["old_wiki_dirs"] == ["main"]
+        assert "crowdsec" not in result["old_wiki_dirs"]
+
+    def test_empty_wikis_list_yields_empty(self, probe, instance_dir):
+        (instance_dir / "config" / "wikis.yaml").write_text("wikis: []\n")
+        (instance_dir / "config" / "crowdsec").mkdir()
+        result = _run(probe, instance_dir)
+        assert result["old_wiki_dirs"] == []
+
+    def test_flush_indent_style_is_parsed(self, probe, instance_dir):
+        """wikis.yaml written with flush (0-indent) block sequence."""
+        (instance_dir / "config" / "wikis.yaml").write_text(
+            "wikis:\n- id: main\n  url: localhost\n- id: two\n  url: two.example\n"
+        )
+        (instance_dir / "config" / "main").mkdir()
+        (instance_dir / "config" / "two").mkdir()
+        result = _run(probe, instance_dir)
+        assert result["old_wiki_dirs"] == ["main", "two"]
 
 
 class TestStrayPhp:


### PR DESCRIPTION
Fixes #938.

## Problem

The `canasta upgrade` directory-structure migration moves non-wiki subdirectories of `config/` into the per-wiki settings namespace. On a CrowdSec-enabled Compose instance it moves `config/crowdsec/` → `config/settings/wikis/crowdsec/`, colliding with the namespace reserved for a wiki whose id is `crowdsec` and stranding the acquisition/whitelist files away from their bind-mount source (so CrowdSec detection silently breaks).

Because a restart recreates `config/crowdsec/`, the migration re-fires on **every** upgrade; running upgrade twice produces a nested `config/settings/wikis/crowdsec/crowdsec/` (an `mv` into an already-existing target).

## Root cause

`roles/upgrade/files/probe_migration_state.py` discovered old-layout wiki dirs by listing every subdir of `config/` minus a hardcoded denylist:

```python
CONFIG_NON_WIKI = ("settings", "logstash", "backup", "persistent")
"old_wiki_dirs": list_subdirs(config/, exclude=CONFIG_NON_WIKI)
```

The denylist was frozen when the migration landed (#492/#493), **before** `config/crowdsec/` existed (added in #603), and was never updated. Any non-wiki `config/` subdir added since hits the same trap.

Wiki identity is defined by `config/wikis.yaml`, not by which dirs exist under `config/`. Per-wiki settings only ever live in `config/settings/global/` and `config/settings/wikis/<wikiid>/`.

## Fix

Compute `old_wiki_dirs` from the wiki ids declared in `config/wikis.yaml`, keeping only those whose `config/<id>/` dir still sits in the pre-migration location. `CONFIG_NON_WIKI` is removed — non-wiki dirs are structurally unreachable. The probe runs on the target host with stdlib only, so wiki ids are extracted from `wikis.yaml` without PyYAML (both indent styles handled; `id` is always the first key of each entry as written by `canasta_wikis_yaml`).

This also fixes the "migration never completes" symptom: a fully-migrated CrowdSec instance now correctly reports zero old dirs instead of always seeing `config/crowdsec`.

## Tests

`TestOldWikiDirs` rewritten around the wikis.yaml source, including:
- a named #938 regression: `config/crowdsec/` is never selected;
- a declared wiki still in `config/<id>/` **is** selected;
- an already-migrated wiki (only under `config/settings/wikis/<id>/`) is **not**;
- an undeclared `config/<name>/` dir is left alone;
- both `wikis.yaml` indent styles parse.

`make test-unit` (1444 passed), `make lint`, `make validate` all pass.