### PR TITLE
fix(sidecar): skip services with unparseable ports instead of crashing migrate

### DIFF
--- a/roles/common/module_utils/canasta_override_migrate.py
+++ b/roles/common/module_utils/canasta_override_migrate.py
@@ -50,14 +50,22 @@ def _env_to_map(environment):
     return out
 
 
-def _ports_to_list(svc):
+def _ports_to_list(svc, reasons):
     out = []
     for entry in svc.get("expose", []) or []:
-        out.append(int(str(entry)))
+        try:
+            out.append(int(str(entry)))
+        except ValueError:
+            reasons.append("unparseable expose port '%s'" % entry)
     for entry in svc.get("ports", []) or []:
         # HOST:CONTAINER[/proto] or CONTAINER — take the container port.
         container = str(entry).split("/")[0].split(":")[-1]
-        port = int(container)
+        try:
+            port = int(container)
+        except ValueError:
+            # e.g. a port range (8000-8005) or a variable in the container slot.
+            reasons.append("unparseable port '%s'" % entry)
+            continue
         if port not in out:
             out.append(port)
     return out
@@ -152,7 +160,7 @@ def translate_service(name, svc):
         sidecar["command"] = svc["command"]
     if svc.get("environment"):
         sidecar["env"] = _env_to_map(svc["environment"])
-    ports = _ports_to_list(svc)
+    ports = _ports_to_list(svc, reasons)
     if ports:
         sidecar["ports"] = ports
     volumes, files = _volumes(svc, reasons, assumptions, name)

--- a/tests/unit/test_canasta_override_migrate.py
+++ b/tests/unit/test_canasta_override_migrate.py
@@ -97,6 +97,18 @@ class TestTranslateService:
         assert sc is None
         assert any("deploy.replicas" in r for r in reasons)
 
+    def test_port_range_skips_instead_of_crashing(self):
+        sc, reasons, _ = m.translate_service(
+            "x", {"image": "i", "ports": ["8000-8005"]})
+        assert sc is None
+        assert any("unparseable port" in r for r in reasons)
+
+    def test_unparseable_expose_port_skips(self):
+        sc, reasons, _ = m.translate_service(
+            "x", {"image": "i", "expose": ["${PORT}"]})
+        assert sc is None
+        assert any("unparseable expose port" in r for r in reasons)
+
 
 CORE_AND_SIDECARS = {
     "services": {


### PR DESCRIPTION
Addresses finding 4.1 in #941.

`_ports_to_list` did an unguarded `int()` on each container port, so a
Compose service with a port range (e.g. `8000-8005`) or a variable in the
container slot raised an uncaught `ValueError` that propagated out of
`plan_migration` and aborted the entire `canasta sidecar migrate` with a
traceback — instead of the module's intended behavior of leaving an
unmodellable service in the override and reporting it.

Guard the `expose`/`ports` conversions and append a reason so the service
is routed to `skipped`, matching how other unsupported fields
(long-form volumes, custom dockerfiles, unknown keys) are handled.

Tests: added coverage for a port range and an unparseable `expose` port;
full unit suite green.
