### PR TITLE
fix(doctor): don't over-promise 'reconcile' for drift it can't heal

### DIFF
--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -347,7 +347,9 @@ def _instance_consistency_lines(inst):
     lines = ["", "Instance consistency (%s):" % inst.get("id", "?")]
     if warns:
         lines += ["  WARN: %s" % w for w in warns]
-        lines.append("  Run 'canasta reconcile' to fix.")
+        lines.append(
+            "  Run 'canasta reconcile' to heal profile/runtime and image-tag "
+            "drift; any other warning above names its own fix.")
     else:
         lines.append(
             "  OK (profiles, running services, and search backend agree)")

--- a/tests/unit/test_doctor_consistency.py
+++ b/tests/unit/test_doctor_consistency.py
@@ -199,3 +199,22 @@ class TestInstanceConsistencyLines:
         body = " ".join(doctor._instance_consistency_lines(inst))
         assert "env.template disagrees with .env" in body
         assert "3.5.1" in body and "3.5.12" in body
+
+    def test_reconcile_hint_does_not_overpromise_non_image_drift(
+            self, monkeypatch):
+        # The only drift is a non-image env.template literal, which reconcile
+        # does not heal — the hint must still name reconcile but flag that
+        # other warnings carry their own fix.
+        inst = {"id": "site", "orchestrator": "compose", "path": "/srv/site",
+                "host": "localhost"}
+        monkeypatch.setattr(
+            doctor._helpers, "_read_env_content",
+            lambda path, host: "COMPOSE_PROFILES=internal-db\n"
+                               "HTTP_PORT=8090\n")
+        monkeypatch.setattr(
+            doctor, "_gather_runtime",
+            lambda path, host: (["web", "db"], False, {"HTTP_PORT": "80"}))
+        body = " ".join(doctor._instance_consistency_lines(inst))
+        assert "env.template disagrees with .env" in body
+        assert "canasta reconcile" in body
+        assert "names its own fix" in body


### PR DESCRIPTION
Addresses finding 4.3 in #941.

The instance-consistency block in `canasta doctor` appended a blanket
"Run 'canasta reconcile' to fix" to every warning. But `reconcile` only
heals profile/runtime drift (sync profiles + `up -d`) and the
`CANASTA_IMAGE` env.template literal. Two warning classes it does **not**
heal were still told to run it:

- CirrusSearch configured but the `elasticsearch` profile inactive
  (needs the user to set `CANASTA_ENABLE_ELASTICSEARCH=true`)
- non-image `env.template` <-> `.env` literal drift (needs `config
  regenerate` or a template/vars edit)

Both already carry their own specific remediation text. Reword the closing
hint to state what `reconcile` heals and defer the rest to their own
per-warning guidance.

Tests: added a case asserting the hint names `reconcile` but flags that
other warnings carry their own fix; full unit suite green.
