### PR TITLE
fix(registry): write conf.json atomically

### DIFF
--- a/roles/common/module_utils/canasta_config.py
+++ b/roles/common/module_utils/canasta_config.py
@@ -29,6 +29,7 @@ import json
 import os
 import platform
 import pwd
+import tempfile
 
 
 CONFIG_FILENAME = "conf.json"
@@ -95,12 +96,27 @@ def read_config(config_dir):
 
 
 def write_config(config_dir, data):
-    """Write the registry dict to conf.json, creating config_dir."""
+    """Write the registry dict to conf.json, creating config_dir.
+
+    Written atomically (temp file in the same dir + os.replace) so a crash
+    mid-write can't leave a truncated conf.json — it is the single source of
+    truth for every registered instance."""
     os.makedirs(config_dir, mode=0o755, exist_ok=True)
     path = config_path(config_dir)
-    with open(path, "w") as f:
-        json.dump(data, f, indent=4)
-        f.write("\n")
+    fd, tmp = tempfile.mkstemp(dir=config_dir, prefix=".conf.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=4)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def find_by_path(instances, search_path):

--- a/tests/unit/test_canasta_config.py
+++ b/tests/unit/test_canasta_config.py
@@ -82,6 +82,24 @@ class TestWriteConfig:
             loaded = json.load(f)
         assert loaded["Instances"]["test"]["id"] == "test"
 
+    def test_leaves_no_temp_files_behind(self, tmp_dir):
+        canasta_config.write_config(tmp_dir, {"Instances": {}})
+        assert os.listdir(tmp_dir) == ["conf.json"]
+
+    def test_failed_write_preserves_existing_and_cleans_temp(self, tmp_dir):
+        canasta_config.write_config(tmp_dir, {"Instances": {"a": {"id": "a"}}})
+        # object() is not JSON-serializable -> json.dump raises mid-write.
+        try:
+            canasta_config.write_config(tmp_dir, {"Instances": object()})
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("expected a serialization error")
+        # The good conf.json is intact and no .tmp turd is left.
+        with open(os.path.join(tmp_dir, "conf.json")) as f:
+            assert json.load(f)["Instances"]["a"]["id"] == "a"
+        assert os.listdir(tmp_dir) == ["conf.json"]
+
 
 class TestFindByPath:
     def test_exact_match(self, sample_config):


### PR DESCRIPTION
Addresses finding 4.4 in #941.

`write_config` truncated and rewrote `conf.json` in place, so a crash or
interrupt mid-write could leave a truncated file — and `conf.json` is the
single source of truth for every registered instance.

Write to a temp file in the same directory, `fsync`, then `os.replace()`
onto `conf.json` for an atomic swap. On a serialization failure the temp
file is removed so the existing `conf.json` stays intact.

Tests: added coverage that a successful write leaves no temp files and
that a failed write preserves the previous `conf.json` and cleans up.
