### PR TITLE
docs(modules): document all argument_spec params; add parity test

### DIFF
--- a/roles/common/library/canasta_registry.py
+++ b/roles/common/library/canasta_registry.py
@@ -75,6 +75,11 @@ options:
   config_dir:
     description: Override the config directory (instead of auto-detection).
     type: str
+  docker_host:
+    description: >-
+      Docker daemon endpoint (DOCKER_HOST) for the instance's containers,
+      stored as dockerHost in the registry.
+    type: str
 """
 
 import json

--- a/roles/common/library/canasta_render_sidecars.py
+++ b/roles/common/library/canasta_render_sidecars.py
@@ -19,8 +19,8 @@ DOCUMENTATION = r"""
 module: canasta_render_sidecars
 short_description: Render config/sidecars.yaml to runtime artifacts
 description:
-  - Compose -> docker-compose.sidecars.yml (removed when no sidecars).
-  - Kubernetes -> values-sidecars.yaml (sidecars: [] when none).
+  - "Compose -> docker-compose.sidecars.yml (removed when no sidecars)."
+  - "Kubernetes -> values-sidecars.yaml (sidecars: [] when none)."
 options:
   instance_path:
     description: Path to the Canasta instance directory.

--- a/roles/common/library/canasta_wikis_yaml.py
+++ b/roles/common/library/canasta_wikis_yaml.py
@@ -45,6 +45,15 @@ options:
   site_name:
     description: Display name of the wiki.
     type: str
+  port:
+    description: With state=update_port, the new port for the wiki URL(s).
+    type: str
+  default_port:
+    description: >-
+      The scheme's default port ("443" for HTTPS, "80" for HTTP); the port is
+      omitted from the URL when it equals this.
+    type: str
+    default: "443"
 """
 
 import os

--- a/tests/unit/test_module_doc_parity.py
+++ b/tests/unit/test_module_doc_parity.py
@@ -1,0 +1,42 @@
+"""Guard that every custom Ansible module's argument_spec params appear in its
+DOCUMENTATION options block, so `ansible-doc` and readers never miss a param.
+
+Parses source text (not the loaded module) to avoid importing Ansible: the
+argument_spec entries are `name=dict(type=...)` lines and DOCUMENTATION is a
+YAML literal.
+"""
+
+import glob
+import os
+import re
+
+import pytest
+import yaml
+
+_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+_MODULES = sorted(glob.glob(os.path.join(_ROOT, "roles", "*", "library", "*.py")))
+
+
+def _spec_params(src):
+    return set(re.findall(r"(\w+)=dict\(type", src))
+
+
+def _documented_options(src):
+    m = re.search(r'DOCUMENTATION = r?"""(.*?)"""', src, re.S)
+    if not m:
+        return None
+    return set((yaml.safe_load(m.group(1)) or {}).get("options", {}) or {})
+
+
+@pytest.mark.parametrize("path", _MODULES, ids=lambda p: os.path.basename(p))
+def test_every_spec_param_is_documented(path):
+    src = open(path).read()
+    spec = _spec_params(src)
+    if not spec:
+        pytest.skip("no argument_spec params")
+    documented = _documented_options(src)
+    assert documented is not None, "module has argument_spec but no DOCUMENTATION"
+    undocumented = spec - documented
+    assert not undocumented, (
+        "argument_spec params missing from DOCUMENTATION options: %s"
+        % sorted(undocumented))


### PR DESCRIPTION
Addresses finding 6.1 in #941.

`canasta_registry`'s `docker_host` and `canasta_wikis_yaml`'s `port` /
`default_port` were in each module's `argument_spec` but missing from the
`DOCUMENTATION` options block, so `ansible-doc` and readers couldn't see
them. Document all three.

Add a test asserting every `argument_spec` param is present in the
`DOCUMENTATION` options for all custom library modules. The test also
surfaced a pre-existing bug: `canasta_render_sidecars`'s `DOCUMENTATION`
failed to parse as YAML (an unquoted `sidecars: []` inside a description
was read as a nested mapping); the description strings are now quoted so
the block parses and `ansible-doc` can render it.
