### PR TITLE
test: cover multi-instance conflict guards (farm URL/ID + host ports)

### DIFF
--- a/tests/unit/test_canasta_wikis_yaml.py
+++ b/tests/unit/test_canasta_wikis_yaml.py
@@ -471,3 +471,34 @@ class TestRunModuleUpdateDomain:
         assert not failed
         assert not result["changed"]
         assert result["wikis"][0]["url"] == "a.example.com"
+
+
+class TestAddCollision:
+    """Adding a wiki to a farm must reject a colliding id or URL, so two
+    wikis on one instance can't clobber each other."""
+
+    def _add(self, tmp_dir, wiki_id, domain, wiki_path=None):
+        return run_module_with_params(canasta_wikis_yaml, {
+            "instance_path": tmp_dir, "state": "add",
+            "wiki_id": wiki_id, "domain": domain,
+            "wiki_path": wiki_path, "site_name": None, "port": None,
+        })
+
+    def test_duplicate_wiki_id_rejected(self, sample_wikis_yaml):
+        # 'main' already exists in the sample farm.
+        _, failed, msg = self._add(sample_wikis_yaml, "main", "other.com")
+        assert failed
+        assert "Wiki ID 'main' already exists" in msg
+
+    def test_duplicate_url_rejected(self, sample_wikis_yaml):
+        # A different id but the same URL as 'main' (example.com).
+        _, failed, msg = self._add(sample_wikis_yaml, "mirror", "example.com")
+        assert failed
+        assert "Wiki URL 'example.com' already exists" in msg
+
+    def test_distinct_id_and_url_succeeds(self, sample_wikis_yaml):
+        result, failed, _ = self._add(
+            sample_wikis_yaml, "blog", "blog.example.com")
+        assert not failed
+        assert result["changed"]
+        assert any(w["id"] == "blog" for w in result["wikis"])

--- a/tests/unit/test_create_port_preflight.py
+++ b/tests/unit/test_create_port_preflight.py
@@ -1,0 +1,59 @@
+"""Guard that Compose `canasta create` refuses a host whose HTTP/HTTPS ports
+are already in use — the host-level half of multi-instance conflict handling
+(a second instance on the same host must not silently collide with the first).
+
+Structural check over create_preflight.yml: a listener probe for each port
+feeds a hard `fail` gated on that probe finding something.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+PREFLIGHT = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "create_preflight.yml")
+
+
+def _walk(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk(t[nested])
+
+
+def _tasks():
+    with open(PREFLIGHT) as f:
+        return list(_walk(yaml.safe_load(f)))
+
+
+def _fail_tasks():
+    return [t for t in _tasks()
+            if "ansible.builtin.fail" in t or "fail" in t]
+
+
+class TestPortPreflight:
+    def test_fails_when_required_ports_in_use(self):
+        fails = _fail_tasks()
+        for port in ("80", "443"):
+            hits = [t for t in fails
+                    if ("%s is already in use" % port)
+                    in str(t.get("ansible.builtin.fail")
+                           or t.get("fail"))]
+            assert hits, "no hard-fail for port %s already in use" % port
+
+    def test_port_fail_is_gated_on_a_listener_probe(self):
+        # Each port fail must be conditional on its probe register having
+        # found a listener, not fire unconditionally.
+        for t in _fail_tasks():
+            msg = str(t.get("ansible.builtin.fail") or t.get("fail"))
+            if "already in use" not in msg:
+                continue
+            cond = t.get("when", [])
+            cond = " ".join(cond if isinstance(cond, list) else [str(cond)])
+            assert "listener" in cond and "length > 0" in cond, (
+                "port-in-use fail must be gated on a non-empty listener "
+                "probe: %r" % t.get("name"))

--- a/tests/unit/test_gitops_sync_scope.py
+++ b/tests/unit/test_gitops_sync_scope.py
@@ -1,0 +1,72 @@
+"""Guard for 'canasta gitops sync' dispatch and Argo CD sync semantics.
+
+gitops sync had no test. It dispatches per-orchestrator (Compose no-op,
+Kubernetes triggers an Argo CD sync); the K8s path patches the instance's
+Argo CD Application with a hard-refresh annotation and waits for the app to
+report Synced + Healthy. These structural checks lock that in without a
+live cluster.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+TRIGGER_YML = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "gitops_trigger_sync.yml")
+SYNC_YML = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "k8s_argocd_sync.yml")
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _when(task):
+    w = task.get("when", [])
+    return " ".join(w if isinstance(w, list) else [str(w)])
+
+
+class TestSyncDispatch:
+    def test_compose_is_a_gated_noop(self):
+        tasks = _load(TRIGGER_YML)
+        noop = [t for t in tasks
+                if ("ansible.builtin.debug" in t or "debug" in t)
+                and "compose" in _when(t)]
+        assert noop, "Compose must be an explicit gated no-op"
+        assert "== 'compose'" in _when(noop[0])
+
+    def test_k8s_includes_argocd_sync(self):
+        tasks = _load(TRIGGER_YML)
+        inc = [t for t in tasks
+               if str(t.get("ansible.builtin.include_tasks", ""))
+               .endswith("k8s_argocd_sync.yml")]
+        assert inc, "K8s must dispatch to k8s_argocd_sync.yml"
+        cond = _when(inc[0])
+        assert "kubernetes" in cond and "k8s" in cond
+
+
+class TestArgocdSyncSemantics:
+    def test_patches_instance_application_with_hard_refresh(self):
+        tasks = _load(SYNC_YML)
+        patches = [t.get("kubernetes.core.k8s") for t in tasks
+                   if t.get("kubernetes.core.k8s")]
+        assert patches, "must patch the Argo CD Application"
+        patch = patches[0]
+        assert patch.get("state") == "patched"
+        assert patch.get("kind") == "Application"
+        assert "canasta-" in patch.get("name", "")
+        assert "instance_id" in patch.get("name", "")
+        annotations = (patch.get("definition", {})
+                       .get("metadata", {}).get("annotations", {}))
+        assert annotations.get("argocd.argoproj.io/refresh") == "hard"
+
+    def test_waits_for_synced_and_healthy(self):
+        tasks = _load(SYNC_YML)
+        waits = [t for t in tasks if t.get("kubernetes.core.k8s_info")]
+        assert waits, "must poll the Application status"
+        until = waits[0].get("until", [])
+        until_text = " ".join(until if isinstance(until, list) else [until])
+        assert "Synced" in until_text
+        assert "Healthy" in until_text


### PR DESCRIPTION
Addresses the multi-instance conflict-validation test gap in #942.

The two-wikis / two-instances collision paths were untested. Add:

- module-level tests that `canasta_wikis_yaml` `add` rejects a duplicate
  wiki id or a duplicate URL (the farm-level guard against one wiki
  clobbering another); and
- a structural guard that Compose `create_preflight` hard-fails when the
  required HTTP/HTTPS ports are already in use on the host, each fail gated
  on its listener probe (the host-level guard for a second instance).

Full unit suite green.

Note: `create_preflight` probes ports 80/443 hard-coded rather than the
instance's configured `HTTP_PORT`/`HTTPS_PORT`. Whether that blocks the
documented "custom ports for a second instance" workflow is worth a
separate look; this PR only adds coverage for the guard as it stands.
