### PR TITLE
ci: cap ansible-core below 2.21 (2.21.1 breaks unit-test collection)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible-core>=2.15
+ansible-core>=2.15,<2.21
 bcrypt>=4.0
 certifi>=2024.0
 kubernetes>=28.1.0


### PR DESCRIPTION
Fixes #951.

ansible-core 2.21.1 (just released) fails on import under PyYAML 6.0.3
with a base.yml `ConstructorError: could not determine a constructor for
the tag None`, aborting unit-test collection for every ansible-importing
test. The requirement was unbounded (`>=2.15`), so CI resolved 2.21.1
nondeterministically — some PR runs got a working 2.20.x and passed,
others got 2.21.1 and failed at collection.

Cap at `<2.21`; 2.20.5 is known-good locally.

After this merges, `main` should be merged into the open PRs so their CI
reruns against the pinned version.
