### PR TITLE
ci: remove ansible-core <2.21 cap (misdiagnosis; real fix in conftest)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible-core>=2.15,<2.21
+ansible-core>=2.15
 bcrypt>=4.0
 certifi>=2024.0
 kubernetes>=28.1.0


### PR DESCRIPTION
Removes the `ansible-core<2.21` upper bound added in #952.

That cap was based on a misdiagnosis. The unit-test failure on #948 was
not a version regression — three PRs passed on ansible-core 2.20.7 and
2.21.1 after that run. The real cause was a pytest `--cov` collection-order
bug (ansible's `base.yml` parse breaks when coverage imports `canasta.py`
with the repo root on `sys.path`), fixed by warming ansible in
`tests/unit/conftest.py` (landed with the argocd test PR).

ansible-core 2.21.x works for this project (PR #947's unit tests passed on
2.21.1), so restore the open `>=2.15` requirement.

Refs #951.
