### PR TITLE
fix(config): warn that K8s gitops config-set needs a push to be durable

### DIFF
--- a/roles/orchestrator/tasks/config_update_gitops_vars.yml
+++ b/roles/orchestrator/tasks/config_update_gitops_vars.yml
@@ -1,8 +1,12 @@
 ---
 # Propagate config-set changes into gitops vars for this orchestrator.
 # Compose: update vars.yaml (the compose-gitops source of truth) so the
-# change survives the next gitops pull. Kubernetes: no-op — K8s gitops
-# uses a different layout (values.template.yaml), not vars.yaml.
+# change survives the next gitops pull. Kubernetes: config set writes the
+# local values.yaml, but the committed gitops source (values.template.yaml →
+# hosts/<name>/rendered-values.yaml) that Argo CD deploys is left untouched,
+# so warn the operator to push. A silent write-through isn't possible here:
+# making the change durable requires committing and pushing to the repo Argo
+# CD watches, which is exactly what 'canasta gitops push' does.
 # Input: instance_path, instance_orchestrator, _config_settings,
 #        _config_gitops_stat
 
@@ -10,3 +14,14 @@
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/config/tasks/_update_gitops_vars.yml
   when: instance_orchestrator | default('compose') == 'compose'
+
+- name: Warn that a K8s gitops config change needs a push to be durable
+  ansible.builtin.debug:
+    msg: >-
+      This is a gitops-managed Kubernetes instance. 'canasta config set'
+      updated the local values.yaml, but the committed gitops source
+      (values.template.yaml / rendered-values.yaml) that Argo CD deploys is
+      unchanged. Run 'canasta gitops push' to commit and deploy the change —
+      otherwise Argo CD may revert it on the next sync, and it won't reach
+      other hosts.
+  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']

--- a/tests/unit/test_config_gitops_k8s_warn.py
+++ b/tests/unit/test_config_gitops_k8s_warn.py
@@ -1,0 +1,59 @@
+"""On a gitops-managed Kubernetes instance, `config set` writes the local
+values.yaml but not the committed gitops source (values.template.yaml ->
+rendered-values.yaml) that Argo CD deploys. Since a silent write-through
+would require committing and pushing (i.e. `gitops push`), config set must
+instead warn the operator to push. Guards config_update_gitops_vars.yml's
+per-orchestrator dispatch.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+DISPATCH = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "config_update_gitops_vars.yml"
+)
+
+
+def _tasks():
+    with open(DISPATCH) as f:
+        return yaml.safe_load(f)
+
+
+def _when(task):
+    w = task.get("when", [])
+    return " ".join(w if isinstance(w, list) else [str(w)])
+
+
+def _debug_msg(task):
+    d = task.get("ansible.builtin.debug") or task.get("debug") or {}
+    return d.get("msg", "") if isinstance(d, dict) else ""
+
+
+def test_compose_branch_updates_vars():
+    compose = [t for t in _tasks()
+               if str(t.get("ansible.builtin.include_tasks", ""))
+               .endswith("_update_gitops_vars.yml")]
+    assert compose, "Compose must still update vars.yaml"
+    assert "== 'compose'" in _when(compose[0])
+
+
+def test_k8s_branch_warns_to_push():
+    k8s = [t for t in _tasks()
+           if "kubernetes" in _when(t) and "k8s" in _when(t)]
+    assert k8s, "must have a K8s-gated task"
+    warn = k8s[0]
+    msg = _debug_msg(warn)
+    assert "gitops push" in msg, "K8s warning must tell the user to push"
+    # It must not claim to have persisted the change itself.
+    assert "unchanged" in msg or "not" in msg.lower()
+
+
+def test_k8s_branch_is_not_a_silent_noop():
+    # Regression: the K8s path used to be an unmentioned no-op, silently
+    # dropping the change from the gitops source.
+    k8s = [t for t in _tasks() if "kubernetes" in _when(t)]
+    assert any(_debug_msg(t) for t in k8s), (
+        "K8s config set on a gitops instance must surface a warning, "
+        "not silently skip")


### PR DESCRIPTION
Addresses finding 4.2 in #941 (the K8s-only remainder; the Compose counterpart was fixed in #935).

On a gitops-managed Kubernetes instance, `canasta config set` writes the
local `values.yaml` (and `.env`) and restarts, but the committed gitops
source — `values.template.yaml` → `hosts/<name>/rendered-values.yaml`, which
Argo CD deploys — is left untouched. So the change is local-only: Argo CD can
revert it on the next sync, and it never reaches other hosts. Previously the
K8s branch of `config_update_gitops_vars.yml` was a silent no-op.

Unlike Compose (which write-throughs to `vars.yaml` / `env.template`), there
is no silent K8s equivalent: making the change durable requires committing and
pushing to the repo Argo CD watches — exactly what `canasta gitops push` does.
Auto-pushing from `config set` would be a surprising, heavy behavior change,
so instead emit a warning pointing the operator at `gitops push`.

Tests: structural guards on the per-orchestrator dispatch — Compose still
updates `vars.yaml`, the K8s path warns and references `gitops push`, and the
K8s path is no longer a silent skip. Full unit suite + lint green.
