### PR TITLE
Use American English spelling in code comments

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -1587,10 +1587,10 @@ def main():
                 % (description, target)
             )
         except (EOFError, KeyboardInterrupt):
-            print("\nOperation cancelled.")
+            print("\nOperation canceled.")
             sys.exit(1)
         if answer.strip().lower() != "y":
-            print("Operation cancelled.")
+            print("Operation canceled.")
             sys.exit(0)
         # Tell the playbook to skip its own confirmation check
         args.yes = True

--- a/roles/orchestrator/files/traefik-externaltrafficpolicy.yaml
+++ b/roles/orchestrator/files/traefik-externaltrafficpolicy.yaml
@@ -3,7 +3,7 @@
 # The k3s-bundled Traefik LoadBalancer service defaults to
 # externalTrafficPolicy: Cluster, which SNATs the source IP to the node CNI
 # gateway before the request reaches Traefik/Caddy. That breaks every
-# real-client-IP behaviour on K8s: CrowdSec sees only private IPs and
+# real-client-IP behavior on K8s: CrowdSec sees only private IPs and
 # whitelists all traffic (protecting nothing), and access logs are useless.
 #
 # externalTrafficPolicy: Local preserves the client IP, but a node only serves

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -1152,7 +1152,7 @@ class TestSelfUpdateCli:
     ):
         # On a development build ahead of the latest release tag: the
         # release tag is contained in HEAD, so 'canasta upgrade' must NOT
-        # check it out (no travelling backward in time).
+        # check it out (no traveling backward in time).
         self._patch_repo(monkeypatch, tmp_path)
         execv_calls = []
         monkeypatch.setattr(


### PR DESCRIPTION
Standardizes British spellings that had crept into the codebase on American English. No functional change.

- `roles/orchestrator/files/traefik-externaltrafficpolicy.yaml`: behaviour → behavior (comment)
- `tests/unit/test_canasta_cli.py`: travelling → traveling (comment)
- `canasta.py`: "Operation cancelled." → "Operation canceled." (user-facing confirmation output)

`RELEASE_NOTES.md` is already clean. `make test-unit` passes (1486 tests).

Closes #955