### PR TITLE
fix(upgrade): make MySQL 8-to-MariaDB migration work (port from Go CLI)

### DIFF
--- a/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
+++ b/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
@@ -1,47 +1,58 @@
 ---
-# Migration: Detect MySQL 8.0 data and migrate to MariaDB.
+# Migration: Detect MySQL 8.0 data and migrate it to MariaDB.
+# Ported from the retired Go CLI (cmd/upgrade/mysql_to_mariadb.go).
 # Compose-only; the orchestrator guard is owned by the caller
 # (roles/orchestrator/tasks/upgrade_db_migration.yml), so no
 # instance_orchestrator switch is needed here.
 # Input: instance_path
+#
+# Approach: detection is a read-only file check against the data volume, so
+# it works whether the DB is running, stopped, or crash-looping (e.g. a
+# MariaDB container already failing to boot on MySQL 8 data). The dump runs
+# against a throwaway mysql:8.0 container we start ourselves, so it does not
+# depend on the instance's compose still pinning MySQL 8 — and it can recover
+# an instance whose compose was already swapped to MariaDB. Only user
+# databases are dumped; MySQL 8's system schema (mysql/sys/*_schema) is left
+# behind, since MariaDB rebuilds its own grant tables on a fresh datadir.
 
-- name: Check for MySQL 8.0 data
+- name: MySQL 8.0 to MariaDB migration
   block:
-    # Detection (and the migration itself) requires a live db container to
-    # exec into. A stopped instance has no db service, so skip rather than
-    # abort the upgrade. ignore_errors on the include_tasks below would not
-    # help: it does not propagate to the shell task inside exec.yml, so the
-    # running-state is guarded explicitly here instead.
-    - name: Default MySQL 8 detection flag
+    # Compose v2 derives the project name by lowercasing the instance
+    # directory name and stripping characters outside [a-z0-9_-], then
+    # prefixes the volume. Match that exactly or the volume is not found.
+    - name: Resolve the MySQL data volume name
       ansible.builtin.set_fact:
-        _is_mysql8: false
+        _mig_volume: >-
+          {{ (instance_path | basename | lower
+              | regex_replace('[^a-z0-9_-]', '')) }}_mysql-data-volume
 
-    - name: Check whether the db service is running
+    # mysql.ibd is MySQL 8.0's system-schema InnoDB tablespace; MariaDB never
+    # creates it (it keeps the mysql schema in Aria tables under mysql/). Its
+    # presence is the definitive MySQL 8 marker. A throwaway container reads
+    # the volume without needing the DB service up.
+    - name: Detect MySQL 8.0 data on the volume
       ansible.builtin.command:
-        cmd: "docker compose ps -q db"
-        chdir: "{{ instance_path }}"
-      register: _db_ps
+        cmd: >-
+          docker run --rm -v {{ _mig_volume }}:/data
+          alpine test -f /data/mysql.ibd
+      register: _mig_detect
       changed_when: false
-      ignore_errors: true  # OK if db container not running
+      failed_when: false
 
-    - name: Detect MySQL 8.0 data (db running only)
-      when:
-        - _db_ps.rc == 0
-        - _db_ps.stdout | default('') | trim | length > 0
-      block:
-        - name: Check if MySQL data volume has read-only flag (MySQL 8.0 indicator)
-          ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
-          vars:
-            exec_service: db
-            exec_command: "test -f /var/lib/mysql/.rocksdb && echo mysql8 || echo mariadb"
-
-        - name: Set MySQL 8 detection flag
-          ansible.builtin.set_fact:
-            _is_mysql8: "{{ exec_result.stdout | default('') | trim == 'mysql8' }}"
+    - name: Set MySQL 8 detection flag
+      ansible.builtin.set_fact:
+        _is_mysql8: "{{ _mig_detect.rc == 0 }}"
 
     - name: Migrate MySQL 8.0 to MariaDB
       when: _is_mysql8 | bool
+      vars:
+        _mig_temp_container: "canasta-mysql-migrate-{{ instance_path | basename }}"
+        _mig_dump_host: "{{ instance_path }}/mysql8_dump.sql"
       block:
+        - name: Report migration required
+          ansible.builtin.debug:
+            msg: "Detected MySQL 8.0 data — migrating to MariaDB..."
+
         - name: Read DB password
           canasta_env:
             path: "{{ instance_path }}/.env"
@@ -50,82 +61,148 @@
           register: _mig_dbpass
           no_log: true
 
-        - name: Get wiki list for dump
-          canasta_wikis_yaml:
-            instance_path: "{{ instance_path }}"
-            state: read
-          register: _mig_wikis
-
-        - name: Dump all databases before migration
-          ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
-          vars:
-            exec_service: db
-            exec_no_log: true
-            exec_long: true
-            exec_command: >-
-              mysqldump -u root
-              -p{{ _mig_dbpass.value | quote }}
-              --all-databases --single-transaction
-              > /tmp/mysql8_dump.sql
-          no_log: true
-
-        - name: Copy dump from container
-          ansible.builtin.command:
-            cmd: "docker compose cp db:/tmp/mysql8_dump.sql {{ instance_path }}/mysql8_dump.sql"
-            chdir: "{{ instance_path }}"
-          changed_when: true
-
-        - name: Stop containers for volume clear
+        # Stop the instance so the data volume is released before a second
+        # mysqld (the throwaway dump container) opens the same datadir.
+        - name: Stop containers before dump
           ansible.builtin.include_role:
             name: orchestrator
             tasks_from: stop.yml
 
-        - name: Clear MySQL data volume
-          ansible.builtin.command:
-            cmd: "docker volume rm {{ instance_path | basename }}_mysql-data-volume"
-            chdir: "{{ instance_path }}"
-          changed_when: true
-          ignore_errors: true  # OK if volume already removed
+        # Everything from here preserves the host-side dump on failure so a
+        # partial migration can be finished by hand rather than losing data.
+        - name: Dump, clear, and reimport
+          block:
+            - name: Remove any stale dump container
+              ansible.builtin.command:
+                cmd: "docker rm -f {{ _mig_temp_container }}"
+              changed_when: false
+              failed_when: false
 
-        - name: Start new MariaDB containers
-          ansible.builtin.include_role:
-            name: orchestrator
-            tasks_from: start.yml
+            - name: Start a temporary MySQL 8.0 container for the dump
+              ansible.builtin.command:
+                cmd: >-
+                  docker run -d --name {{ _mig_temp_container }}
+                  -v {{ _mig_volume }}:/var/lib/mysql
+                  -e MYSQL_ROOT_PASSWORD={{ _mig_dbpass.value | quote }}
+                  mysql:8.0
+              changed_when: true
+              no_log: true
 
-        - name: Wait for database
-          ansible.builtin.include_role:
-            name: mediawiki
-            tasks_from: wait_for_db.yml
+            - name: Wait for the temporary MySQL 8.0 server
+              ansible.builtin.command:
+                cmd: >-
+                  docker exec -e MYSQL_PWD={{ _mig_dbpass.value | quote }}
+                  {{ _mig_temp_container }}
+                  mysqladmin ping -h localhost --user=root --wait=60
+              changed_when: false
+              no_log: true
 
-        - name: Copy dump back into container
-          ansible.builtin.command:
-            cmd: "docker compose cp {{ instance_path }}/mysql8_dump.sql db:/tmp/mysql8_dump.sql"
-            chdir: "{{ instance_path }}"
-          changed_when: true
+            # List user databases (excluding the system schemas) and dump them
+            # in one shell so an empty list is handled cleanly. SHOW DATABASES
+            # + grep avoids SQL string literals, which the command module's
+            # shlex parsing (no shell) would mangle. --routines / --triggers /
+            # --events carry stored programs across.
+            - name: Dump user databases from MySQL 8.0
+              ansible.builtin.command:
+                cmd: >-
+                  docker exec -e MYSQL_PWD={{ _mig_dbpass.value | quote }}
+                  {{ _mig_temp_container }} bash -c
+                  '{{ _mig_dump_script }}'
+              vars:
+                _mig_dump_script: >-
+                  set -eo pipefail;
+                  DBS=$(mysql --user=root --skip-column-names --batch
+                  -e "SHOW DATABASES"
+                  | grep -vxE "mysql|sys|information_schema|performance_schema"
+                  | tr "\n" " ");
+                  if [ -z "$DBS" ]; then : > /tmp/dump.sql; exit 0; fi;
+                  mysqldump --user=root --databases $DBS
+                  --single-transaction --routines --triggers --events
+                  > /tmp/dump.sql
+              changed_when: true
+              no_log: true
 
-        - name: Import dump into MariaDB
-          ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
-          vars:
-            exec_service: db
-            exec_no_log: true
-            exec_long: true
-            exec_command: >-
-              mariadb -u root
-              -p{{ _mig_dbpass.value | quote }}
-              < /tmp/mysql8_dump.sql
-          no_log: true
+            - name: Copy the dump out of the temporary container
+              ansible.builtin.command:
+                cmd: "docker cp {{ _mig_temp_container }}:/tmp/dump.sql {{ _mig_dump_host }}"
+              changed_when: true
 
-        - name: Clean up dump files
-          ansible.builtin.file:
-            path: "{{ instance_path }}/mysql8_dump.sql"
-            state: absent
+            - name: Remove the temporary MySQL 8.0 container
+              ansible.builtin.command:
+                cmd: "docker rm -f {{ _mig_temp_container }}"
+              changed_when: true
 
-        - name: Clean up container dump
-          ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
-          vars:
-            exec_service: db
-            exec_command: "rm -f /tmp/mysql8_dump.sql"
+            # Empty the datadir so MariaDB initializes a fresh one on start.
+            - name: Clear the MySQL data volume
+              ansible.builtin.command:
+                cmd: >-
+                  docker run --rm -v {{ _mig_volume }}:/data
+                  alpine sh -c 'rm -rf /data/* /data/..?* /data/.[!.]*'
+              changed_when: true
 
-        - name: Report migration complete
-          ansible.builtin.debug:
-            msg: "MySQL 8.0 data migrated to MariaDB successfully."
+            # The managed-compose refresh that pins the MariaDB image runs
+            # later in the upgrade, so force it now — otherwise the restart
+            # below would bring MySQL 8 back up on the cleared volume.
+            - name: Refresh compose to the managed MariaDB image
+              ansible.builtin.include_role:
+                name: orchestrator
+                tasks_from: write_stack_files.yml
+              vars:
+                stack_files_force: true
+
+            - name: Start MariaDB containers
+              ansible.builtin.include_role:
+                name: orchestrator
+                tasks_from: start.yml
+
+            - name: Wait for MariaDB
+              ansible.builtin.include_role:
+                name: mediawiki
+                tasks_from: wait_for_db.yml
+
+            - name: Copy the dump into the MariaDB container
+              ansible.builtin.command:
+                cmd: "docker compose cp {{ _mig_dump_host }} db:/tmp/dump.sql"
+                chdir: "{{ instance_path }}"
+              changed_when: true
+
+            - name: Import the dump into MariaDB
+              ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+              vars:
+                exec_service: db
+                exec_no_log: true
+                exec_long: true
+                exec_command: >-
+                  mariadb --no-defaults -u root
+                  -p{{ _mig_dbpass.value | quote }}
+                  < /tmp/dump.sql
+              no_log: true
+
+            - name: Clean up the dump inside the container
+              ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+              vars:
+                exec_service: db
+                exec_command: "rm -f /tmp/dump.sql"
+
+            - name: Clean up the host-side dump
+              ansible.builtin.file:
+                path: "{{ _mig_dump_host }}"
+                state: absent
+
+            - name: Report migration complete
+              ansible.builtin.debug:
+                msg: "MySQL 8.0 data migrated to MariaDB successfully."
+
+          rescue:
+            - name: Remove the temporary container after a failed migration
+              ansible.builtin.command:
+                cmd: "docker rm -f {{ _mig_temp_container }}"
+              changed_when: false
+              failed_when: false
+
+            - name: Report preserved dump for manual recovery
+              ansible.builtin.fail:
+                msg: >-
+                  MySQL 8.0 to MariaDB migration failed. The database dump, if
+                  it was written, is preserved at {{ _mig_dump_host }} for
+                  manual import.

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -316,6 +316,130 @@ def test_upgrade(inst):
     wait_for_wiki(inst.http_port)
 
 
+def test_upgrade_mysql_to_mariadb(inst):
+    """A legacy MySQL 8.0 datadir is migrated to MariaDB on upgrade, preserving
+    user data.
+
+    Regression: detection keyed off /var/lib/mysql/.rocksdb, a marker absent
+    from every real MySQL 8 datadir, so the migration was silently skipped and
+    MariaDB later crashed booting on the un-migrated MySQL 8 data. This seeds a
+    genuine MySQL 8.0 datadir (with a sentinel row) into the instance's data
+    volume, runs upgrade, and asserts the row is present in MariaDB afterward.
+    Because MariaDB physically cannot boot on a MySQL 8 datadir, a successful
+    query also proves detection fired and the migration ran.
+    """
+    volume = "%s_mysql-data-volume" % re.sub(
+        r"[^a-z0-9_-]", "", inst.id.lower()
+    )
+
+    def wipe_volume():
+        subprocess.run(
+            ["docker", "run", "--rm", "-v", "%s:/data" % volume, "alpine",
+             "sh", "-c", "rm -rf /data/* /data/.[!.]* /data/..?* 2>/dev/null || true"],
+            check=True, capture_output=True,
+        )
+
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir,
+        "-e", inst.env_file,
+    )
+    # No need to wait for the wiki — the datadir is replaced wholesale below.
+    time.sleep(10)
+
+    password = read_env(inst.env_path()).get("MYSQL_PASSWORD", "mediawiki")
+
+    print("Stopping instance and wiping the MariaDB datadir...")
+    inst.run_ok("stop", "-i", inst.id)
+    wipe_volume()
+
+    print("Seeding a genuine MySQL 8.0 datadir with a sentinel row...")
+    seed = "canasta-mysql8-seed-%s" % inst.id
+    subprocess.run(["docker", "rm", "-f", seed], capture_output=True)
+    subprocess.run(
+        ["docker", "run", "-d", "--name", seed,
+         "-v", "%s:/var/lib/mysql" % volume,
+         "-e", "MYSQL_ROOT_PASSWORD=%s" % password,
+         "-e", "MYSQL_ROOT_HOST=%",
+         "mysql:8.0"],
+        check=True, capture_output=True,
+    )
+    try:
+        print("  Waiting for the seed MySQL 8.0 server...")
+        deadline = time.time() + 120
+        while time.time() < deadline:
+            ping = subprocess.run(
+                ["docker", "exec", "-e", "MYSQL_PWD=%s" % password, seed,
+                 "mysqladmin", "ping", "-h", "localhost", "--user=root"],
+                capture_output=True, text=True,
+            )
+            if ping.returncode == 0 and "alive" in ping.stdout:
+                break
+            time.sleep(3)
+        else:
+            raise AssertionError("seed MySQL 8.0 server never became ready")
+
+        seed_sql = (
+            "CREATE DATABASE IF NOT EXISTS main; "
+            "CREATE TABLE main.canary (id INT PRIMARY KEY, note VARCHAR(64)); "
+            "INSERT INTO main.canary VALUES (1, 'survived-migration');"
+        )
+        result = subprocess.run(
+            ["docker", "exec", "-e", "MYSQL_PWD=%s" % password, seed,
+             "mysql", "--user=root", "-e", seed_sql],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, (
+            "seeding the sentinel failed:\n%s\n%s"
+            % (result.stdout, result.stderr)
+        )
+
+        # Confirm the seed really produced a MySQL 8 datadir (the exact thing
+        # the buggy probe failed to recognize).
+        ibd = subprocess.run(
+            ["docker", "exec", seed, "test", "-f", "/var/lib/mysql/mysql.ibd"],
+            capture_output=True,
+        )
+        assert ibd.returncode == 0, "seed did not produce a MySQL 8 datadir"
+    finally:
+        subprocess.run(["docker", "rm", "-f", seed], capture_output=True)
+
+    print("Running upgrade (must detect MySQL 8 and migrate to MariaDB)...")
+    inst.run_ok("upgrade")
+
+    print("Verifying the sentinel row survived into MariaDB...")
+    query = subprocess.run(
+        ["docker", "compose", "exec", "-T", "db", "sh", "-c",
+         "MYSQL_PWD=%s mariadb -u root --skip-column-names -N "
+         "-e 'SELECT note FROM main.canary WHERE id=1'" % password],
+        cwd=inst.instance_path(), capture_output=True, text=True,
+    )
+    assert query.returncode == 0, (
+        "querying MariaDB after migration failed — did MariaDB boot, or is it "
+        "crash-looping on un-migrated MySQL 8 data?\n%s\n%s"
+        % (query.stdout, query.stderr)
+    )
+    assert "survived-migration" in query.stdout, (
+        "sentinel row missing from MariaDB after migration:\n%s" % query.stdout
+    )
+
+    print("Verifying the datadir is now MariaDB format...")
+    fmt = subprocess.run(
+        ["docker", "run", "--rm", "-v", "%s:/data" % volume, "alpine",
+         "sh", "-c", "ls -a /data"],
+        capture_output=True, text=True,
+    )
+    assert "aria_log_control" in fmt.stdout, (
+        "expected a MariaDB datadir (aria_log_control) after migration:\n%s"
+        % fmt.stdout
+    )
+    assert "mysql.ibd" not in fmt.stdout, (
+        "MySQL 8 system tablespace still present after migration:\n%s"
+        % fmt.stdout
+    )
+
+
 def test_upgrade_backfill_hosts_yaml(inst):
     """Initialize gitops, simulate Go-CLI layout (no hosts.yaml),
     run upgrade, verify the backfill_hosts_yaml migration recreates
@@ -3221,6 +3345,7 @@ ALL_TESTS = {
     "lifecycle": test_lifecycle,
     "import": test_import_export,
     "upgrade": test_upgrade,
+    "upgrade-mysql-to-mariadb": test_upgrade_mysql_to_mariadb,
     "upgrade-refreshes-gitignore": test_upgrade_refreshes_gitignore,
     "upgrade-backfills-wikis-template": test_upgrade_backfills_wikis_template,
     "upgrade-backfill-hosts-yaml": test_upgrade_backfill_hosts_yaml,

--- a/tests/unit/test_mysql_to_mariadb_migration.py
+++ b/tests/unit/test_mysql_to_mariadb_migration.py
@@ -1,0 +1,191 @@
+"""Guards for the MySQL 8.0 -> MariaDB upgrade migration.
+
+This migration was ported from the retired Go CLI
+(cmd/upgrade/mysql_to_mariadb.go). The first Ansible port regressed it in
+three independent ways, each of which left an instance's DB unbootable or
+its data mangled; these tests lock the Go-faithful behavior back in.
+
+1. Detection keyed off /var/lib/mysql/.rocksdb, a MyRocks marker Canasta
+   never creates and that is absent from every stock MySQL 8 datadir, so the
+   probe always returned "not MySQL 8" and the migration was skipped. The
+   definitive MySQL 8 marker is mysql.ibd, its system-schema InnoDB
+   tablespace, which MariaDB never writes.
+
+2. The dump ran against whatever container the instance compose happened to
+   start, and the restart used that same (still MySQL 8) compose. The Go
+   design instead dumps from a throwaway mysql:8.0 container it starts
+   itself, so it is independent of the instance compose and can even recover
+   an instance already swapped to MariaDB. The instance compose must be
+   force-refreshed to the MariaDB image between clearing the volume and the
+   restart.
+
+3. The dump used mysqldump --all-databases, dragging MySQL 8's system schema
+   (mysql/sys/*_schema, whose grant-table layout differs from MariaDB's) into
+   the import. Only user databases must be dumped; MariaDB rebuilds its own
+   system tables on the fresh datadir.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+MIGRATION = os.path.join(
+    REPO_ROOT, "roles", "upgrade", "tasks", "migrations", "mysql_to_mariadb.yml"
+)
+
+
+def _load():
+    with open(MIGRATION) as f:
+        return yaml.safe_load(f)
+
+
+def _iter_tasks(tasks):
+    """Yield every task, descending into block/rescue/always wrappers."""
+    for t in tasks:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for key in ("block", "rescue", "always"):
+            if key in t and isinstance(t[key], list):
+                yield from _iter_tasks(t[key])
+
+
+def _all_tasks():
+    return list(_iter_tasks(_load()))
+
+
+def _command_strings():
+    """Every ansible.builtin.command cmd in the file, as a list of strings."""
+    cmds = []
+    for t in _all_tasks():
+        cmd = t.get("ansible.builtin.command")
+        if isinstance(cmd, dict):
+            cmd = cmd.get("cmd", "")
+        if isinstance(cmd, str) and cmd:
+            cmds.append(cmd)
+    return cmds
+
+
+def _shell_text():
+    """Command cmds plus per-task vars string values (the dump shell script
+    lives in a vars block, referenced from the cmd)."""
+    text = list(_command_strings())
+    for t in _all_tasks():
+        for v in (t.get("vars") or {}).values():
+            if isinstance(v, str):
+                text.append(v)
+    return text
+
+
+def _ordered_names():
+    return [t.get("name", "") for t in _all_tasks()]
+
+
+def _index_of(substr):
+    for i, n in enumerate(_ordered_names()):
+        if substr in n:
+            return i
+    raise AssertionError("no task name contains %r" % substr)
+
+
+class TestDetectionMarker:
+    def test_detects_by_ibd_not_rocksdb(self):
+        cmds = " \n".join(_command_strings())
+        assert "mysql.ibd" in cmds, (
+            "detection must key off mysql.ibd (MySQL 8's system tablespace)"
+        )
+        assert ".rocksdb" not in cmds, (
+            ".rocksdb is a MyRocks marker absent from stock MySQL 8 datadirs; "
+            "keying off it makes the migration a silent no-op"
+        )
+
+    def test_detection_is_volume_read_only_not_service_exec(self):
+        # A throwaway container reading the volume works whether the DB is up,
+        # stopped, or crash-looping — unlike an exec into the running service.
+        detect = next(
+            (c for c in _command_strings()
+             if "mysql.ibd" in c and "test -f" in c),
+            None,
+        )
+        assert detect is not None, "detection must be a `test -f` on the volume"
+        assert "docker run" in detect and "-v" in detect, (
+            "detection must read the data volume from a throwaway container so "
+            "it works even when the DB container is not running"
+        )
+
+
+class TestDumpFromDedicatedContainer:
+    def test_dump_uses_temporary_mysql8_container(self):
+        cmds = " \n".join(_command_strings())
+        assert "mysql:8.0" in cmds, (
+            "the dump must run against a temporary mysql:8.0 container the "
+            "migration starts itself, not the instance's own db service"
+        )
+
+    def test_temp_container_is_always_removed(self):
+        # It must be torn down on both the happy path and the failure path.
+        removals = [c for c in _command_strings() if "docker rm -f" in c]
+        assert len(removals) >= 2, (
+            "the temporary container must be removed on success and cleaned up "
+            "again in the rescue path"
+        )
+
+    def test_dump_excludes_system_schemas(self):
+        dump = next(
+            (c for c in _shell_text() if "mysqldump" in c), None
+        )
+        assert dump is not None, "a mysqldump command must exist"
+        assert "--all-databases" not in dump, (
+            "--all-databases drags MySQL 8's system schema into MariaDB and "
+            "breaks the grant tables; dump only user databases"
+        )
+        for sysdb in ("mysql", "information_schema", "performance_schema", "sys"):
+            assert sysdb in dump, (
+                "the user-database query must exclude the %s system schema" % sysdb
+            )
+
+    def test_dump_carries_routines_triggers_events(self):
+        dump = next(
+            (c for c in _shell_text() if "mysqldump" in c), None
+        )
+        for flag in ("--routines", "--triggers", "--events"):
+            assert flag in dump, (
+                "mysqldump must pass %s to carry stored programs across" % flag
+            )
+
+
+class TestOrderingAndRecovery:
+    def test_stop_before_dump(self):
+        # A second mysqld must not open the datadir while the instance's own
+        # db container still holds it.
+        assert _index_of("Stop containers before dump") < _index_of(
+            "temporary MySQL 8.0 container"
+        ), "the instance must be stopped before the dump container starts"
+
+    def test_compose_refreshed_between_clear_and_start(self):
+        clear = _index_of("Clear the MySQL data volume")
+        refresh = _index_of("Refresh compose to the managed MariaDB image")
+        start = _index_of("Start MariaDB containers")
+        assert clear < refresh < start, (
+            "compose must be refreshed to the MariaDB image after the volume "
+            "is cleared and before the DB is restarted, or MySQL 8 comes back"
+        )
+
+    def test_import_is_after_start(self):
+        assert _index_of("Start MariaDB containers") < _index_of(
+            "Import the dump into MariaDB"
+        )
+
+    def test_failure_preserves_dump_for_manual_recovery(self):
+        fail = next(
+            (t for t in _all_tasks() if "ansible.builtin.fail" in t), None
+        )
+        assert fail is not None, (
+            "a rescue must fail loudly rather than swallowing a partial migration"
+        )
+        msg = str(fail["ansible.builtin.fail"].get("msg", ""))
+        assert "preserved" in msg and "manual" in msg, (
+            "the failure must tell the operator the dump is preserved for "
+            "manual import"
+        )


### PR DESCRIPTION
Fixes #959.

## Problem

The MySQL 8.0-to-MariaDB upgrade migration left the database unbootable after `canasta upgrade`:

```
[Note] [Entrypoint]: MariaDB upgrade information missing, assuming required
[ERROR] [Entrypoint]: Unable to start server.
```

Root cause: the Ansible port of this migration regressed the retired Go CLI's working implementation (`Canasta-Go`'s `cmd/upgrade/mysql_to_mariadb.go`) in **three** independent ways:

1. **Detection** keyed off `/var/lib/mysql/.rocksdb` — a MyRocks marker absent from every stock MySQL 8 datadir — so the migration was *always* silently skipped. The upgrade then force-refreshed the compose to `mariadb:11.4` and restarted, and MariaDB crashed booting on the un-migrated MySQL 8 datadir.
2. **Dump mechanism**: it dumped from whatever container the instance compose started and restarted via that same (still MySQL 8) compose, so even with the marker fixed it couldn't produce a working MariaDB and couldn't recover an instance already swapped to MariaDB.
3. **Dump scope**: `mysqldump --all-databases` dragged MySQL 8's system schema (`mysql`/`sys`/`*_schema`, whose grant-table layout differs) into MariaDB, breaking the import.

(The detection bug dates to the migration's original commit, but stayed dormant until #615 made the compose refresh authoritative on upgrade — see the [backstory](https://github.com/CanastaWiki/Canasta-CLI/pull/960#issuecomment-4858853555).)

## Fix — port the Go behavior faithfully

- Detect via a read-only `mysql.ibd` check against the data volume from a throwaway container, so it works whether the DB is up, stopped, or crash-looping (and can recover an instance already swapped to MariaDB).
- Dump from a temporary `mysql:8.0` container the migration starts itself, independent of the instance compose.
- Dump only user databases (exclude `mysql`/`sys`/`*_schema`); MariaDB rebuilds its own system tables on the fresh datadir. Carry stored programs with `--routines`/`--triggers`/`--events`.
- Force-refresh the compose to the MariaDB image between clearing the volume and the restart. Preserve the host-side dump on failure for manual recovery.

## Tests

Neither the Go CLI nor the Ansible CLI had any test for this migration — that's why it shipped broken.

- **Unit** (`tests/unit/test_mysql_to_mariadb_migration.py`): structural guards for the `mysql.ibd` marker, the dedicated `mysql:8.0` dump container, user-DB-only dump, stop→dump and clear→refresh→start ordering, and dump-preserved-on-failure.
- **Integration** (`upgrade-mysql-to-mariadb`): seeds a genuine MySQL 8.0 datadir with a sentinel row, runs `canasta upgrade`, and asserts the row survives in MariaDB — the end-to-end coverage that was missing. It fails on the old code (migration skipped → MariaDB crash-loops → the query errors).

Full unit suite passes (1496). The integration test requires Docker + a `mysql:8.0` pull and is push-to-main-gated, so it hasn't run in CI yet; a live e2e against real MySQL 8 data is still recommended before relying on it in a release.