### PR TITLE
docs(sidecars): fix k8s_build_sidecars comment on Compose build behavior

### DIFF
--- a/roles/orchestrator/tasks/k8s_build_sidecars.yml
+++ b/roles/orchestrator/tasks/k8s_build_sidecars.yml
@@ -3,8 +3,11 @@
 # registry, so the k8s pod can pull them. The chart references a build:
 # sidecar at 10.43.0.2:5000/canasta-<id>-<name>:local; this pushes to the
 # same repo path via the registry's loopback hostPort (localhost:5000).
-# Runs at start, before the Helm rollout. Compose builds build: sidecars
-# natively (docker compose up --build), so this is k8s-only.
+# Runs at start, before the Helm rollout. This is k8s-only: on Compose the
+# engine builds a build: sidecar's image locally (implicitly on `docker
+# compose up` when the image is missing, and via `docker compose build`
+# during `canasta upgrade`), whereas the kubelet can only pull — so the
+# image must be built and pushed to the in-cluster registry.
 #
 # Input: instance_path, instance_id
 


### PR DESCRIPTION
## Summary

The header comment in `roles/orchestrator/tasks/k8s_build_sidecars.yml` claimed Compose "builds build: sidecars natively (docker compose up --build)". That is inaccurate:

- The Compose start path (`roles/orchestrator/tasks/start.yml:44`) runs `docker compose ... up -d` with **no** `--build`, so a `build:` sidecar image is built only when it is missing and is never rebuilt on a context change during start/restart.
- The only Compose rebuild path is `docker compose build` during `canasta upgrade` (`roles/orchestrator/tasks/upgrade_rebuild_buildable.yml:115`, gated on a detected image bump).
- `docker compose up --build` appears nowhere in the repo.

This corrects the comment to describe the real behavior. Comment-only change; no behavior impact.

Whether Compose *should* rebuild sidecars on start/restart is a separate behavior change and is intentionally **not** addressed here.

## Testing

`make test-unit` — 1496 passed.

Addresses the sidecar-comment item in #965.