### PR TITLE
fix(lifecycle): layer sidecars values/compose files in scale and rebuild fast paths

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -265,17 +265,28 @@ def _read_env_file(path, host):
     return {k: v for k, v, c in _parse_env_entries(content) if not c and k}
 
 
-def _compose_file_args(path, host, devmode=False):
-    """Build docker compose -f flags based on available files."""
+def _compose_file_args(path, host, devmode=False, include_sidecars=False):
+    """Build docker compose -f flags based on available files.
+
+    include_sidecars layers docker-compose.sidecars.yml (when present)
+    between the base file and the override — the same order the Ansible
+    path uses, so a service-name clash lets the operator's override win.
+    Callers must pass it only when config/sidecars.yaml declares
+    sidecars: the rendered file can linger after `sidecar remove`, and
+    layering it into `up -d` would recreate the removed sidecar.
+    """
+    def _exists(name):
+        full = os.path.join(path, name)
+        if _is_localhost(host):
+            return os.path.isfile(full)
+        rc, _ = _ssh_run(host, "test -f %s" % _shell_quote(full))
+        return rc == 0
+
     files = ["docker-compose.yml"]
-    override = os.path.join(path, "docker-compose.override.yml")
-    if _is_localhost(host):
-        if os.path.isfile(override):
-            files.append("docker-compose.override.yml")
-    else:
-        rc, _ = _ssh_run(host, "test -f %s" % _shell_quote(override))
-        if rc == 0:
-            files.append("docker-compose.override.yml")
+    if include_sidecars and _exists("docker-compose.sidecars.yml"):
+        files.append("docker-compose.sidecars.yml")
+    if _exists("docker-compose.override.yml"):
+        files.append("docker-compose.override.yml")
     if devmode:
         files.append("docker-compose.dev.yml")
     result = []
@@ -284,7 +295,7 @@ def _compose_file_args(path, host, devmode=False):
     return result
 
 
-def _run_compose(inst_id, inst, action_args):
+def _run_compose(inst_id, inst, action_args, include_sidecars=False):
     """Run a docker compose command for an instance. Returns exit code.
 
     Output streams to the terminal and there is NO timeout: the actions
@@ -297,7 +308,7 @@ def _run_compose(inst_id, inst, action_args):
     host = inst.get("host") or "localhost"
     path = inst.get("path", "")
     devmode = inst.get("devMode", False)
-    file_args = _compose_file_args(path, host, devmode)
+    file_args = _compose_file_args(path, host, devmode, include_sidecars)
 
     if _is_localhost(host):
         cmd = ["docker", "compose"] + file_args + action_args
@@ -475,7 +486,7 @@ def _sync_compose_profiles(inst):
             )
 
 
-def _dump_compose_failure(inst):
+def _dump_compose_failure(inst, include_sidecars=False):
     """Print docker compose ps + logs to stderr after a failed 'up'.
 
     Matches the diagnostic block in roles/orchestrator/tasks/start.yml:
@@ -487,7 +498,7 @@ def _dump_compose_failure(inst):
     host = inst.get("host") or "localhost"
     path = inst.get("path", "")
     devmode = inst.get("devMode", False)
-    file_args = _compose_file_args(path, host, devmode)
+    file_args = _compose_file_args(path, host, devmode, include_sidecars)
 
     steps = [
         (["ps", "-a"], "docker compose ps -a"),

--- a/direct_commands/lifecycle.py
+++ b/direct_commands/lifecycle.py
@@ -167,25 +167,34 @@ def cmd_scale(args):
 
     # Apply via helm upgrade. Mirror the args helm_deploy.yml uses so
     # the result matches what `canasta start` / `canasta restart`
-    # would render — including values-configdata.yaml when present.
+    # would render — including values-configdata.yaml and
+    # values-sidecars.yaml when present.
     namespace = "canasta-%s" % inst_id
     chart = os.path.join(path, "_chart")
     configdata = os.path.join(path, "values-configdata.yaml")
+    sidecars = os.path.join(path, "values-sidecars.yaml")
     cmd_parts = [
         "helm upgrade --install canasta-%s %s" % (inst_id, _helpers._shell_quote(chart)),
         "--namespace %s --create-namespace" % namespace,
         "-f %s" % _helpers._shell_quote(values_path),
     ]
-    # Probe for the optional configdata file the same way helm_deploy.yml does.
-    if _helpers._is_localhost(host):
-        has_configdata = os.path.isfile(configdata)
-    else:
+
+    # Probe for the optional values files the same way helm_deploy.yml does.
+    def _file_on_host(p):
+        if _helpers._is_localhost(host):
+            return os.path.isfile(p)
         rc, _ = _helpers._ssh_run(
-            host, "test -f %s" % _helpers._shell_quote(configdata),
+            host, "test -f %s" % _helpers._shell_quote(p),
         )
-        has_configdata = (rc == 0)
-    if has_configdata:
+        return rc == 0
+
+    if _file_on_host(configdata):
         cmd_parts.append("-f %s" % _helpers._shell_quote(configdata))
+    # The sidecars layer is mandatory when present: with --reset-values,
+    # omitting it would revert to the chart default (sidecars: []) and
+    # prune every sidecar Deployment/Service/PVC.
+    if _file_on_host(sidecars):
+        cmd_parts.append("-f %s" % _helpers._shell_quote(sidecars))
     cmd_parts.extend(["--reset-values", "--wait", "--timeout 10m"])
     helm_cmd = " ".join(cmd_parts)
 

--- a/direct_commands/rebuild.py
+++ b/direct_commands/rebuild.py
@@ -8,7 +8,7 @@ from . import _helpers
 from ._helpers import register
 
 
-def _list_buildable_services(inst):
+def _list_buildable_services(inst, include_sidecars=False):
     """Return service names with a build: directive in the merged compose config.
 
     Uses `docker compose config --format json` so docker itself
@@ -18,7 +18,7 @@ def _list_buildable_services(inst):
     host = inst.get("host") or "localhost"
     path = inst.get("path", "")
     devmode = inst.get("devMode", False)
-    file_args = _helpers._compose_file_args(path, host, devmode)
+    file_args = _helpers._compose_file_args(path, host, devmode, include_sidecars)
 
     if _helpers._is_localhost(host):
         try:
@@ -75,7 +75,13 @@ def cmd_rebuild(args):
         )
         return 1
 
-    services = _list_buildable_services(inst)
+    # Layer the rendered docker-compose.sidecars.yml only when
+    # config/sidecars.yaml declares sidecars — the same file set the
+    # Ansible stop/start path uses. Without it, `down`/`up -d` run with
+    # an incomplete file set and tear down the sidecar containers.
+    has_sidecars = _helpers._instance_has_sidecars(inst)
+
+    services = _list_buildable_services(inst, include_sidecars=has_sidecars)
     if not services:
         print(
             "No services have a build: directive — nothing to rebuild. "
@@ -90,7 +96,8 @@ def cmd_rebuild(args):
     build_argv.extend(services)
 
     print("Rebuilding: %s" % ", ".join(services))
-    rc = _helpers._run_compose(inst_id, inst, build_argv)
+    rc = _helpers._run_compose(
+        inst_id, inst, build_argv, include_sidecars=has_sidecars)
     if rc != 0:
         return rc
 
@@ -102,11 +109,13 @@ def cmd_rebuild(args):
         return 0
 
     print("Restarting containers to pick up the rebuilt image...")
-    rc = _helpers._run_compose(inst_id, inst, ["down"])
+    rc = _helpers._run_compose(
+        inst_id, inst, ["down"], include_sidecars=has_sidecars)
     if rc != 0:
         return rc
     _helpers._sync_compose_profiles(inst)
-    rc = _helpers._run_compose(inst_id, inst, ["up", "-d"])
+    rc = _helpers._run_compose(
+        inst_id, inst, ["up", "-d"], include_sidecars=has_sidecars)
     if rc != 0:
-        _helpers._dump_compose_failure(inst)
+        _helpers._dump_compose_failure(inst, include_sidecars=has_sidecars)
     return rc

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1226,6 +1226,34 @@ class TestComposeFileArgs:
         assert "-f" in args
         assert "docker-compose.dev.yml" in args
 
+    def test_sidecars_layered_between_base_and_override(self, tmp_path):
+        # Layer order matches the Ansible path: base, rendered sidecars,
+        # user override (so the operator's override wins a clash).
+        (tmp_path / "docker-compose.sidecars.yml").write_text("")
+        (tmp_path / "docker-compose.override.yml").write_text("")
+        args = direct_commands._compose_file_args(
+            str(tmp_path), "localhost", include_sidecars=True,
+        )
+        assert args == [
+            "-f", "docker-compose.yml",
+            "-f", "docker-compose.sidecars.yml",
+            "-f", "docker-compose.override.yml",
+        ]
+
+    def test_sidecars_skipped_when_file_missing(self, tmp_path):
+        args = direct_commands._compose_file_args(
+            str(tmp_path), "localhost", include_sidecars=True,
+        )
+        assert args == ["-f", "docker-compose.yml"]
+
+    def test_sidecars_excluded_by_default(self, tmp_path):
+        # A rendered file lingering after `sidecar remove` must not be
+        # layered unless the caller opted in: `up -d` with the stale
+        # layer would recreate the removed sidecar.
+        (tmp_path / "docker-compose.sidecars.yml").write_text("")
+        args = direct_commands._compose_file_args(str(tmp_path), "localhost")
+        assert args == ["-f", "docker-compose.yml"]
+
 
 # ---------------------------------------------------------------------------
 # Start / stop / restart tests
@@ -3551,6 +3579,45 @@ class TestScale:
         assert "values.yaml" in cmd_str
         assert "--reset-values" in cmd_str
         assert "--wait" in cmd_str
+        # No optional values files exist, so none may be layered.
+        assert "values-configdata.yaml" not in cmd_str
+        assert "values-sidecars.yaml" not in cmd_str
+
+    def test_layers_sidecars_values_when_present(
+        self, monkeypatch, tmp_path,
+    ):
+        # helm_deploy.yml layers values-sidecars.yaml when present; with
+        # --reset-values, omitting it reverts to the chart default
+        # (sidecars: []) and prunes every sidecar resource.
+        inst_path = tmp_path / "mysite"
+        inst_path.mkdir()
+        (inst_path / "values.yaml").write_text("web:\n  replicaCount: 1\n")
+        (inst_path / "values-configdata.yaml").write_text("configData: {}\n")
+        (inst_path / "values-sidecars.yaml").write_text(
+            "sidecars:\n  - name: cache\n",
+        )
+        monkeypatch.setattr(direct_commands._helpers, "_resolve_instance",
+            lambda args: ("mysite", self._k8s_inst(path=str(inst_path))),
+        )
+        captured = {}
+
+        def fake_call(cmd, *a, **kw):
+            captured["cmd"] = cmd
+            return 0
+
+        monkeypatch.setattr(subprocess, "call", fake_call)
+        rc = direct_commands.cmd_scale(self._args(replicas=5))
+        assert rc == 0
+
+        cmd_str = " ".join(captured["cmd"])
+        assert "values-sidecars.yaml" in cmd_str
+        # Same ordering as helm_deploy.yml: values.yaml, configdata,
+        # sidecars, then --reset-values.
+        assert (
+            cmd_str.index("values-configdata.yaml")
+            < cmd_str.index("values-sidecars.yaml")
+            < cmd_str.index("--reset-values")
+        )
 
     def test_helm_failure_reports_partial_state(
         self, monkeypatch, capsys, tmp_path,

--- a/tests/unit/test_rebuild.py
+++ b/tests/unit/test_rebuild.py
@@ -59,7 +59,7 @@ class TestRebuildNoBuildableServices:
     def test_returns_zero_with_message(self, monkeypatch, capsys):
         _patch_compose_inst(monkeypatch)
         monkeypatch.setattr(direct_commands.rebuild, "_list_buildable_services",
-            lambda inst: [],
+            lambda inst, include_sidecars=False: [],
         )
         rc = direct_commands.cmd_rebuild(_args())
         assert rc == 0
@@ -71,11 +71,11 @@ class TestRebuildBuildAndRestart:
     def test_default_flow_builds_then_restarts(self, monkeypatch):
         _patch_compose_inst(monkeypatch)
         monkeypatch.setattr(direct_commands.rebuild, "_list_buildable_services",
-            lambda inst: ["web"],
+            lambda inst, include_sidecars=False: ["web"],
         )
         calls = []
 
-        def fake_run_compose(inst_id, inst, action_args):
+        def fake_run_compose(inst_id, inst, action_args, include_sidecars=False):
             calls.append(list(action_args))
             return 0
 
@@ -95,11 +95,12 @@ class TestRebuildBuildAndRestart:
     def test_no_cache_flag_passes_through(self, monkeypatch):
         _patch_compose_inst(monkeypatch)
         monkeypatch.setattr(direct_commands.rebuild, "_list_buildable_services",
-            lambda inst: ["web"],
+            lambda inst, include_sidecars=False: ["web"],
         )
         calls = []
         monkeypatch.setattr(direct_commands._helpers, "_run_compose",
-            lambda inst_id, inst, action_args: (calls.append(list(action_args)) or 0),
+            lambda inst_id, inst, action_args, include_sidecars=False:
+                (calls.append(list(action_args)) or 0),
         )
         monkeypatch.setattr(direct_commands._helpers, "_sync_compose_profiles",
             lambda inst: None,
@@ -111,11 +112,12 @@ class TestRebuildBuildAndRestart:
     def test_multiple_buildable_services_all_built(self, monkeypatch):
         _patch_compose_inst(monkeypatch)
         monkeypatch.setattr(direct_commands.rebuild, "_list_buildable_services",
-            lambda inst: ["web", "varnish-custom"],
+            lambda inst, include_sidecars=False: ["web", "varnish-custom"],
         )
         calls = []
         monkeypatch.setattr(direct_commands._helpers, "_run_compose",
-            lambda inst_id, inst, action_args: (calls.append(list(action_args)) or 0),
+            lambda inst_id, inst, action_args, include_sidecars=False:
+                (calls.append(list(action_args)) or 0),
         )
         monkeypatch.setattr(direct_commands._helpers, "_sync_compose_profiles",
             lambda inst: None,
@@ -127,11 +129,12 @@ class TestRebuildBuildAndRestart:
     def test_no_restart_skips_down_up(self, monkeypatch, capsys):
         _patch_compose_inst(monkeypatch)
         monkeypatch.setattr(direct_commands.rebuild, "_list_buildable_services",
-            lambda inst: ["web"],
+            lambda inst, include_sidecars=False: ["web"],
         )
         calls = []
         monkeypatch.setattr(direct_commands._helpers, "_run_compose",
-            lambda inst_id, inst, action_args: (calls.append(list(action_args)) or 0),
+            lambda inst_id, inst, action_args, include_sidecars=False:
+                (calls.append(list(action_args)) or 0),
         )
 
         rc = direct_commands.cmd_rebuild(_args(no_restart=True))
@@ -144,11 +147,11 @@ class TestRebuildBuildAndRestart:
     def test_build_failure_skips_restart_and_returns_code(self, monkeypatch):
         _patch_compose_inst(monkeypatch)
         monkeypatch.setattr(direct_commands.rebuild, "_list_buildable_services",
-            lambda inst: ["web"],
+            lambda inst, include_sidecars=False: ["web"],
         )
         calls = []
 
-        def fake_run_compose(inst_id, inst, action_args):
+        def fake_run_compose(inst_id, inst, action_args, include_sidecars=False):
             calls.append(list(action_args))
             return 2 if action_args[0] == "build" else 0
 
@@ -157,6 +160,71 @@ class TestRebuildBuildAndRestart:
         assert rc == 2
         # Only the build call was attempted, no down/up
         assert calls == [["build", "web"]]
+
+
+class TestRebuildSidecars:
+    """rebuild on a sidecar instance must layer docker-compose.sidecars.yml
+    into every compose call (as the Ansible stop/start path does), or the
+    down/up cycle runs with an incomplete file set and drops the sidecars."""
+
+    def _sidecar_inst(self, tmp_path, sidecars_yaml):
+        site = tmp_path / "test"
+        (site / "config").mkdir(parents=True)
+        (site / "config" / "sidecars.yaml").write_text(sidecars_yaml)
+        return site
+
+    def _run(self, monkeypatch, site):
+        monkeypatch.setattr(direct_commands._helpers, "_resolve_instance",
+            lambda args: ("test", {
+                "path": str(site),
+                "orchestrator": "compose",
+                "host": "localhost",
+                "devMode": False,
+            }),
+        )
+        listed = {}
+
+        def fake_list(inst, include_sidecars=False):
+            listed["include_sidecars"] = include_sidecars
+            return ["web"]
+
+        monkeypatch.setattr(
+            direct_commands.rebuild, "_list_buildable_services", fake_list)
+        calls = []
+
+        def fake_run_compose(inst_id, inst, action_args, include_sidecars=False):
+            calls.append((list(action_args), include_sidecars))
+            return 0
+
+        monkeypatch.setattr(
+            direct_commands._helpers, "_run_compose", fake_run_compose)
+        monkeypatch.setattr(
+            direct_commands._helpers, "_sync_compose_profiles", lambda inst: None)
+        rc = direct_commands.cmd_rebuild(_args())
+        return rc, listed, calls
+
+    def test_sidecar_instance_layers_sidecars_in_all_compose_calls(
+            self, monkeypatch, tmp_path):
+        site = self._sidecar_inst(
+            tmp_path, "sidecars:\n  - name: cache\n    image: redis:7\n")
+        rc, listed, calls = self._run(monkeypatch, site)
+        assert rc == 0
+        assert listed["include_sidecars"] is True
+        assert calls == [
+            (["build", "web"], True),
+            (["down"], True),
+            (["up", "-d"], True),
+        ]
+
+    def test_no_sidecars_keeps_layer_off(self, monkeypatch, tmp_path):
+        # An empty sidecars list must NOT pull in a lingering rendered
+        # file: after `sidecar remove` the layer would recreate the
+        # removed sidecar on `up -d`.
+        site = self._sidecar_inst(tmp_path, "sidecars: []\n")
+        rc, listed, calls = self._run(monkeypatch, site)
+        assert rc == 0
+        assert listed["include_sidecars"] is False
+        assert all(flag is False for _args_, flag in calls)
 
 
 class TestListBuildableServices:


### PR DESCRIPTION
Fixes #963.

Two Python fast-path lifecycle commands diverged from the Ansible path they mirror, both around sidecar handling.

**`canasta scale` deleted K8s sidecars and their PVCs.** `cmd_scale` mirrored `helm_deploy.yml`'s helm args but probed only `values-configdata.yaml`; it omitted `-f values-sidecars.yaml`. Since it runs `helm upgrade --reset-values` and the chart default is `sidecars: []`, scaling an instance with app sidecars pruned every sidecar Deployment, Service, and PVC — destroying persistent data via a command that only claims to change replica count.

**`canasta rebuild` tore down sidecar containers.** `cmd_rebuild` ran `down`/`up -d` without layering `docker-compose.sidecars.yml` (the fast-path `_compose_file_args` never included it), so a Compose instance with sidecars was left with an incomplete file set.

Fix: `_compose_file_args` grows an opt-in `include_sidecars` flag that layers `docker-compose.sidecars.yml` (when present) between the base and override files — the same order the Ansible path uses. `scale` always includes the sidecars values file when present (mandatory under `--reset-values`); `rebuild` includes the compose layer when `_instance_has_sidecars(inst)`. The existing start/stop/restart sidecar fallback guards are unchanged.

Unit tests added for both paths.
