### PR TITLE
fix(upgrade): harden MySQL-to-MariaDB migration guards (external DB, empty DB, stray volume)

### DIFF
--- a/roles/gitops/files/gitignore.default
+++ b/roles/gitops/files/gitignore.default
@@ -21,6 +21,9 @@ public_assets/*/sitemap/
 # Database dumps created by canasta backup
 config/backup/
 
+# MySQL-to-MariaDB migration dump (preserved on failure)
+mysql8_dump.sql
+
 # Backup run log
 backup.log
 

--- a/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
+++ b/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
@@ -15,7 +15,15 @@
 # databases are dumped; MySQL 8's system schema (mysql/sys/*_schema) is left
 # behind, since MariaDB rebuilds its own grant tables on a fresh datadir.
 
+# Only instances running the internal db service can (and should) migrate.
+# An external-DB instance may still have a stale internal data volume; its
+# db service is not in the active compose profiles, so the migration would
+# fail mid-way and take down a healthy site.
 - name: MySQL 8.0 to MariaDB migration
+  when: >-
+    (_mig.env.USE_EXTERNAL_DB | default('false')) | lower != 'true'
+    and (not _mig.env_present.COMPOSE_PROFILES
+         or 'internal-db' in _mig.env.COMPOSE_PROFILES)
   block:
     # Compose v2 derives the project name by lowercasing the instance
     # directory name and stripping characters outside [a-z0-9_-], then
@@ -25,6 +33,16 @@
         _mig_volume: >-
           {{ (instance_path | basename | lower
               | regex_replace('[^a-z0-9_-]', '')) }}_mysql-data-volume
+
+    # A missing volume means nothing to migrate. Check first: `docker run -v`
+    # auto-creates a missing named volume, which would leave a stray empty
+    # volume behind on every instance that never had one.
+    - name: Check whether the MySQL data volume exists
+      ansible.builtin.command:
+        cmd: "docker volume inspect {{ _mig_volume }}"
+      register: _mig_volume_check
+      changed_when: false
+      failed_when: false
 
     # mysql.ibd is MySQL 8.0's system-schema InnoDB tablespace; MariaDB never
     # creates it (it keeps the mysql schema in Aria tables under mysql/). Its
@@ -38,10 +56,13 @@
       register: _mig_detect
       changed_when: false
       failed_when: false
+      when: _mig_volume_check.rc == 0
 
     - name: Set MySQL 8 detection flag
       ansible.builtin.set_fact:
-        _is_mysql8: "{{ _mig_detect.rc == 0 }}"
+        _is_mysql8: >-
+          {{ _mig_volume_check.rc == 0
+             and (_mig_detect.rc | default(1)) == 0 }}
 
     - name: Migrate MySQL 8.0 to MariaDB
       when: _is_mysql8 | bool
@@ -60,6 +81,13 @@
             key: MYSQL_PASSWORD
           register: _mig_dbpass
           no_log: true
+
+        - name: Read DB user
+          canasta_env:
+            path: "{{ instance_path }}/.env"
+            state: read
+            key: MYSQL_USER
+          register: _mig_dbuser
 
         # Stop the instance so the data volume is released before a second
         # mysqld (the throwaway dump container) opens the same datadir.
@@ -100,20 +128,24 @@
             # List user databases (excluding the system schemas) and dump them
             # in one shell so an empty list is handled cleanly. SHOW DATABASES
             # + grep avoids SQL string literals, which the command module's
-            # shlex parsing (no shell) would mangle. --routines / --triggers /
-            # --events carry stored programs across.
+            # shlex parsing (no shell) would mangle. grep's no-match exit is
+            # neutralized inside the pipeline so a system-schemas-only server
+            # reaches the empty-DBS branch instead of tripping pipefail.
+            # --routines / --triggers / --events carry stored programs across.
             - name: Dump user databases from MySQL 8.0
               ansible.builtin.command:
                 cmd: >-
                   docker exec -e MYSQL_PWD={{ _mig_dbpass.value | quote }}
                   {{ _mig_temp_container }} bash -c
-                  '{{ _mig_dump_script }}'
+                  {{ _mig_dump_script | quote }}
               vars:
                 _mig_dump_script: >-
                   set -eo pipefail;
                   DBS=$(mysql --user=root --skip-column-names --batch
                   -e "SHOW DATABASES"
-                  | grep -vxE "mysql|sys|information_schema|performance_schema"
+                  | { grep -vxE
+                  "mysql|sys|information_schema|performance_schema"
+                  || true; }
                   | tr "\n" " ");
                   if [ -z "$DBS" ]; then : > /tmp/dump.sql; exit 0; fi;
                   mysqldump --user=root --databases $DBS
@@ -192,6 +224,17 @@
             - name: Report migration complete
               ansible.builtin.debug:
                 msg: "MySQL 8.0 data migrated to MariaDB successfully."
+
+            # The dump excludes the mysql system schema, so user accounts
+            # and their grants do not survive the migration.
+            - name: Warn that non-root DB users are not migrated
+              ansible.builtin.debug:
+                msg: >-
+                  WARNING: MYSQL_USER is set to
+                  '{{ _mig_dbuser.value }}', but MySQL user accounts and
+                  grants are not carried over by the migration. Recreate
+                  this user and its grants in MariaDB.
+              when: (_mig_dbuser.value | default('')) not in ['', 'root']
 
           rescue:
             - name: Remove the temporary container after a failed migration

--- a/tests/unit/test_mysql_to_mariadb_migration.py
+++ b/tests/unit/test_mysql_to_mariadb_migration.py
@@ -23,6 +23,11 @@ its data mangled; these tests lock the Go-faithful behavior back in.
    (mysql/sys/*_schema, whose grant-table layout differs from MariaDB's) into
    the import. Only user databases must be dumped; MariaDB rebuilds its own
    system tables on the fresh datadir.
+
+Hardening guards covered below: the internal-db gate, the volume-existence
+check before the detection probe, the empty-database-list dump path, the
+quote-filtered dump script, the non-root-user warning, and the gitignored
+failure-path dump.
 """
 
 import os
@@ -32,6 +37,9 @@ import yaml
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 MIGRATION = os.path.join(
     REPO_ROOT, "roles", "upgrade", "tasks", "migrations", "mysql_to_mariadb.yml"
+)
+GITIGNORE = os.path.join(
+    REPO_ROOT, "roles", "gitops", "files", "gitignore.default"
 )
 
 
@@ -188,4 +196,118 @@ class TestOrderingAndRecovery:
         assert "preserved" in msg and "manual" in msg, (
             "the failure must tell the operator the dump is preserved for "
             "manual import"
+        )
+
+
+class TestInternalDbGate:
+    def test_migration_gated_on_internal_db(self):
+        # An external-DB instance may keep a stale internal data volume, but
+        # its db service is not in the active compose profiles — migrating
+        # would fail mid-way and take down a healthy site.
+        top = _load()[0]
+        cond = str(top.get("when", ""))
+        assert "USE_EXTERNAL_DB" in cond, (
+            "the migration must skip external-DB instances"
+        )
+        assert "COMPOSE_PROFILES" in cond and "internal-db" in cond, (
+            "the migration must only run when the internal-db profile is "
+            "active (or COMPOSE_PROFILES is not yet backfilled)"
+        )
+
+
+class TestVolumeExistenceCheck:
+    def test_volume_inspected_before_detection_probe(self):
+        # `docker run -v` auto-creates a missing named volume; probing an
+        # instance that never had one would leave a stray empty volume.
+        assert _index_of("Check whether the MySQL data volume exists") < (
+            _index_of("Detect MySQL 8.0 data")
+        ), "the volume-existence check must precede the detection probe"
+
+    def test_existence_check_uses_volume_inspect(self):
+        assert any(
+            "docker volume inspect" in c for c in _command_strings()
+        ), "existence must be checked with docker volume inspect, not a run"
+
+    def test_detection_skipped_when_volume_missing(self):
+        detect = next(
+            t for t in _all_tasks()
+            if t.get("name", "").startswith("Detect MySQL 8.0")
+        )
+        assert "_mig_volume_check.rc == 0" in str(detect.get("when", "")), (
+            "the docker run probe must be skipped when the volume is missing"
+        )
+
+    def test_detection_flag_requires_existing_volume(self):
+        flag = next(
+            t for t in _all_tasks()
+            if t.get("name") == "Set MySQL 8 detection flag"
+        )
+        expr = str(flag["ansible.builtin.set_fact"]["_is_mysql8"])
+        assert "_mig_volume_check.rc == 0" in expr, (
+            "_is_mysql8 must be false when the volume does not exist"
+        )
+
+
+class TestEmptyDatabaseList:
+    def test_grep_no_match_neutralized_under_pipefail(self):
+        # With only system schemas present, grep -v matches nothing and exits
+        # 1; under pipefail that aborted the script before the empty-DBS
+        # handler could write the empty dump.
+        script = next(c for c in _shell_text() if "SHOW DATABASES" in c)
+        assert "pipefail" in script, (
+            "pipefail must stay on so mysql/mysqldump failures abort the dump"
+        )
+        assert "{ grep" in script and "|| true; }" in script, (
+            "grep's no-match exit must be neutralized inside the pipeline so "
+            "a system-schemas-only server reaches the empty-DBS branch"
+        )
+
+    def test_empty_list_writes_empty_dump(self):
+        script = next(c for c in _shell_text() if "SHOW DATABASES" in c)
+        assert 'if [ -z "$DBS" ]' in script, (
+            "an empty database list must be handled explicitly"
+        )
+
+
+class TestDumpScriptQuoting:
+    def test_dump_script_passed_through_quote_filter(self):
+        dump_cmd = next(c for c in _command_strings() if "bash -c" in c)
+        assert "_mig_dump_script | quote" in dump_cmd, (
+            "the dump script must be escaped with the quote filter, not "
+            "hand-wrapped in single quotes"
+        )
+        assert "'{{ _mig_dump_script }}'" not in dump_cmd
+
+
+class TestNonRootUserWarning:
+    def test_warns_that_non_root_users_are_not_migrated(self):
+        # The dump excludes the mysql system schema, so a non-root
+        # MYSQL_USER's account and grants do not survive the migration.
+        warn = next(
+            (t for t in _all_tasks()
+             if t.get("name") == "Warn that non-root DB users are not migrated"),
+            None,
+        )
+        assert warn is not None, (
+            "the migration must warn when MYSQL_USER is a non-root user"
+        )
+        msg = str(warn["ansible.builtin.debug"].get("msg", ""))
+        assert "grants" in msg and "MariaDB" in msg, (
+            "the warning must tell the operator to recreate the user and its "
+            "grants in MariaDB"
+        )
+        cond = str(warn.get("when", ""))
+        assert "_mig_dbuser" in cond and "root" in cond, (
+            "the warning must fire only for a non-root, non-empty MYSQL_USER"
+        )
+
+
+class TestFailurePathDumpIgnored:
+    def test_gitignore_default_ignores_migration_dump(self):
+        # A dump preserved by the rescue path sits in the instance root; the
+        # gitops `git add -A` must never be able to commit it.
+        with open(GITIGNORE) as f:
+            content = f.read()
+        assert "mysql8_dump.sql" in content, (
+            "gitignore.default must ignore the preserved migration dump"
         )


### PR DESCRIPTION
Fixes #964.

Follow-up hardening on the MySQL 8-to-MariaDB upgrade migration shipped in 4.5.1. Six small guard/robustness fixes; the migration's core design is unchanged.

- **Empty database aborts the upgrade.** `set -eo pipefail` plus `grep -vxE` exited 1 when a datadir had only system schemas, aborting before the empty-list handler. The no-match status is now neutralized inside the pipeline (`| { grep ... || true; }`) while pipefail still protects `mysql`/`mysqldump`. Verified with a stubbed harness.
- **External-DB instances migrated off a stale internal volume.** An instance later switched to an external DB still had its old internal volume, so the migration stopped a healthy site and then failed at `docker compose cp` (the `db` service isn't in the active profiles). A top-of-block guard now skips the migration unless the instance runs the internal db, read from the existing `_mig` probe (`USE_EXTERNAL_DB` / `COMPOSE_PROFILES`).
- **Detection created a stray volume.** `docker run -v <vol>:/data` auto-creates a missing named volume; a `docker volume inspect` gate now runs first so upgrades of instances without the volume leave nothing behind.
- **Failure-path dump could be committed to gitops.** `mysql8_dump.sql` (preserved at the repo root on failure) is now in `gitignore.default`.
- **Non-root DB users dropped silently.** The dump excludes the system schema; a warning now names a non-root `MYSQL_USER` and tells the operator to recreate it and its grants in MariaDB.
- **Manual shell quoting.** The dump `bash -c` now uses the repo-standard `| quote` filter.

Existing Go-parity regression tests are untouched; new unit tests cover each guard.
