### PR TITLE
fix(sidecar): preserve bind-mount paths in migrate; resolve env refs in list commands for k8s render

### DIFF
--- a/roles/common/module_utils/canasta_override_migrate.py
+++ b/roles/common/module_utils/canasta_override_migrate.py
@@ -87,7 +87,15 @@ def _volumes(svc, reasons, assumptions, name):
         source, mount = parts[0], parts[1]
         mode = parts[2] if len(parts) > 2 else "rw"
         if source.startswith((".", "/", "~")):  # bind mount -> files
-            files.append({"source": source.lstrip("./"), "mountPath": mount,
+            # files[].source is instance-relative; anything else can't be
+            # modeled, so the service stays in the override.
+            rel = source[2:] if source.startswith("./") else source
+            if (source.startswith(("/", "~")) or not rel
+                    or rel in (".", "..") or rel.startswith("../")):
+                reasons.append(
+                    "bind mount '%s' outside the instance directory" % source)
+                continue
+            files.append({"source": rel, "mountPath": mount,
                           "readOnly": "ro" in mode})
         else:  # named volume -> persistent (size assumed)
             out.append({"name": source, "mountPath": mount,

--- a/roles/common/module_utils/canasta_sidecar_render.py
+++ b/roles/common/module_utils/canasta_sidecar_render.py
@@ -217,7 +217,12 @@ def render_k8s_values(sidecars, env, file_reader):
         else:
             item["image"] = sidecar["image"]
         if sidecar.get("command"):
-            item["command"] = resolve_env_value(sidecar["command"], env)
+            command = sidecar["command"]
+            if isinstance(command, list):
+                # Resolve each element — k8s never interpolates ${VAR}.
+                item["command"] = [resolve_env_value(c, env) for c in command]
+            else:
+                item["command"] = resolve_env_value(command, env)
         # envSecret keys are sourced from the per-instance app Secret (rendered
         # as secretKeyRef by the chart), so they are NOT resolved to cleartext
         # here. Everything else stays a resolved literal, exactly as before.

--- a/tests/unit/test_canasta_override_migrate.py
+++ b/tests/unit/test_canasta_override_migrate.py
@@ -44,6 +44,37 @@ class TestTranslateService:
                                 "mountPath": "/srv/app.yaml", "readOnly": True}]
         assert "volumes" not in sc
 
+    def test_dotfile_bind_mount_keeps_leading_dot(self):
+        sc, reasons, _ = m.translate_service("x", {
+            "image": "i", "volumes": ["./.env:/srv/.env:ro"]})
+        assert reasons == []
+        assert sc["files"] == [{"source": ".env", "mountPath": "/srv/.env",
+                                "readOnly": True}]
+
+    def test_absolute_bind_mount_skips(self):
+        sc, reasons, _ = m.translate_service("x", {
+            "image": "i", "volumes": ["/etc/ssl/certs/a.pem:/srv/a.pem:ro"]})
+        assert sc is None
+        assert any("outside the instance directory" in r for r in reasons)
+
+    def test_parent_bind_mount_skips(self):
+        sc, reasons, _ = m.translate_service("x", {
+            "image": "i", "volumes": ["../shared/data:/data"]})
+        assert sc is None
+        assert any("outside the instance directory" in r for r in reasons)
+
+    def test_home_bind_mount_skips(self):
+        sc, reasons, _ = m.translate_service("x", {
+            "image": "i", "volumes": ["~/certs:/certs"]})
+        assert sc is None
+        assert any("outside the instance directory" in r for r in reasons)
+
+    def test_bare_dot_bind_mount_skips(self):
+        sc, reasons, _ = m.translate_service("x", {
+            "image": "i", "volumes": [".:/srv/app"]})
+        assert sc is None
+        assert any("outside the instance directory" in r for r in reasons)
+
     def test_named_volume_becomes_persistent_with_assumption(self):
         sc, _, notes = m.translate_service("cache", {
             "image": "i", "volumes": ["data:/data"]})

--- a/tests/unit/test_canasta_sidecar_render.py
+++ b/tests/unit/test_canasta_sidecar_render.py
@@ -48,6 +48,13 @@ class TestComposeRender:
         assert "${REDIS_MAX_MEMORY:-100mb}" in svc["command"]
         assert svc["restart"] == "unless-stopped"
 
+    def test_list_command_passes_through(self):
+        sc = {"name": "x", "image": "i",
+              "command": ["serve", "--mem", "${MEM:-100mb}"]}
+        svc, _ = render.render_compose_service(sc)
+        # Unresolved on Compose — it interpolates from .env itself.
+        assert svc["command"] == ["serve", "--mem", "${MEM:-100mb}"]
+
     def test_ports_become_expose(self):
         svc, _ = render.render_compose_service(CACHE)
         assert svc["expose"] == ["6379"]
@@ -132,6 +139,14 @@ class TestK8sValues:
         citation = next(s for s in out if s["name"] == "citation")
         assert "256mb" in cache["command"]
         assert citation["env"]["SHARED_SECRET"] == "s3cr3t"
+
+    def test_list_command_resolved_per_element(self):
+        sc = {"name": "x", "image": "i",
+              "command": ["serve", "--mem", "${MEM:-100mb}",
+                          "--token", "${TOK}"]}
+        item = render.render_k8s_values([sc], {"TOK": "t0k"}, lambda s: "")[0]
+        assert item["command"] == ["serve", "--mem", "100mb",
+                                   "--token", "t0k"]
 
     def test_file_content_inlined(self):
         out = render.render_k8s_values([CITATION], {}, lambda s: "FILE-BODY")


### PR DESCRIPTION
Addresses part of #965 — the two sidecar-module bugs. The other items in #965 remain open for follow-up PRs.

**`sidecar migrate` mangled bind-mount paths.** `canasta_override_migrate.py` used `source.lstrip("./")`, a charset strip, so `/etc/ssl/certs/a.pem` became `etc/ssl/certs/a.pem`, `../shared/data` became `shared/data`, and `./.env` became `env`. Since `files[].source` is instance-relative, on Compose the next start bind-mounted a nonexistent path and on K8s the render crashed with FileNotFoundError. Fix: strip a literal `./` prefix once; route absolute, `~`, and parent-escaping sources to the skip path with a reason so the service stays in the override (matching the module's all-or-nothing contract).

**K8s render left `${VAR}` unresolved in list-form commands.** `render_k8s_values` applied `resolve_env_value` once to the whole `command`, so a list command reached the chart with literal `${VAR}` tokens Kubernetes never interpolates — while Compose interpolates both forms. Fix: map `resolve_env_value` over list elements. No other field has the same list/scalar dual form.

New unit tests cover dotfile preservation, each skip case, and per-element env resolution.
