### PR TITLE
fix(docs): honor long/positional param definitions in wiki_publish flag tables

### DIFF
--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -187,6 +187,13 @@ def _orchestrator_label(value):
     return _ORCHESTRATOR_LABELS.get(value, value)
 
 
+def _flag_name(p):
+    """Displayed long flag name for a param. The CLI honors the `long:`
+    override when building argparse options (e.g. host add's `host_name`
+    param is the flag `--name`), so the docs must too."""
+    return p.get("long", p["name"]).replace("_", "-")
+
+
 # Match single-backtick inline code spans — the same convention used in
 # markdown and in the `docs/commands/*.md` renderings of long_description.
 # MediaWiki doesn't interpret backticks, so translate them to <code> on the
@@ -319,8 +326,8 @@ def _global_flags_section(global_flags):
         "!! style=\"text-align:center\" | Required "
         "!! style=\"text-align:center\" | Orchestrator"
     )
-    for p in sorted(global_flags, key=lambda x: x["name"]):
-        flag = "<code>--" + p["name"].replace("_", "-") + "</code>"
+    for p in sorted(global_flags, key=_flag_name):
+        flag = "<code>--%s</code>" % _flag_name(p)
         short = ""
         if p.get("short"):
             short = "<code>-%s</code>" % p["short"]
@@ -391,12 +398,24 @@ def gen_wikitext(cmd, global_flags=None, cmd_index=None):
     # Usage line — match the live wiki's compact form ('canasta create
     # [flags]') instead of an inline listing of every option. The
     # detailed flag table below is the authoritative reference.
-    # Skip entirely when the command has no parameters: the line would
-    # read just 'canasta host list' and duplicate the bare-command
-    # example below.
-    if cmd.get("parameters"):
+    # Positional parameters are appended as uppercase metavars, the way
+    # the CLI's own help renders them. Skip entirely when the command
+    # has no parameters: the line would read just 'canasta host list'
+    # and duplicate the bare-command example below.
+    params = cmd.get("parameters", [])
+    positionals = [p for p in params if p.get("positional")]
+    flag_params = [p for p in params if not p.get("positional")]
+    if params:
+        usage = "%s [flags]" % display
+        for p in positionals:
+            token = p["name"].upper()
+            if p.get("multi") or p["name"] in ("exec_args", "script_args"):
+                token += "..."
+            if not p.get("required"):
+                token = "[%s]" % token
+            usage += " " + token
         lines.append("<syntaxhighlight lang=\"bash\">")
-        lines.append("%s [flags]" % display)
+        lines.append(usage)
         lines.append("</syntaxhighlight>")
         lines.append("")
 
@@ -431,11 +450,43 @@ def gen_wikitext(cmd, global_flags=None, cmd_index=None):
         lines.append("</syntaxhighlight>")
         lines.append("")
 
+    # Arguments table — positional parameters, in definition order (the
+    # order the CLI expects them on the command line). These are not
+    # flags; rendering them with a -- prefix produces commands that fail
+    # as written.
+    if positionals:
+        lines.append("=== Arguments ===")
+        lines.append("")
+        lines.append('{| class="wikitable"')
+        lines.append(
+            "! Argument !! Description "
+            "!! style=\"text-align:center\" | Default "
+            "!! style=\"text-align:center\" | Required "
+            "!! style=\"text-align:center\" | Orchestrator"
+        )
+        for p in positionals:
+            arg = "<code>%s</code>" % p["name"].upper()
+            desc = _backticks_to_code(p.get("description", ""))
+            default = ""
+            if p.get("default") not in (None, "", False, 0):
+                default = "<code>%s</code>" % p["default"]
+            required = "✓" if p.get("required") else ""
+            orch = _orchestrator_label(p.get("orchestrator_only"))
+            lines.append("|-")
+            lines.append(
+                "| %s || %s "
+                '|| style="text-align:center" | %s '
+                '|| style="text-align:center" | %s '
+                '|| style="text-align:center" | %s'
+                % (arg, desc, default, required, orch)
+            )
+        lines.append("|}")
+        lines.append("")
+
     # Flags table — alphabetized by flag name so readers can scan
     # quickly. Definition order in command_definitions.yml is convenient
     # for authors but unhelpful when there are 30+ flags.
-    params = cmd.get("parameters", [])
-    if params:
+    if flag_params:
         lines.append("=== Flags ===")
         lines.append("")
         lines.append('{| class="wikitable"')
@@ -449,8 +500,8 @@ def gen_wikitext(cmd, global_flags=None, cmd_index=None):
         # asterisk in the Default column pointing to a footnote about
         # cwd resolution.
         show_cwd_note = False
-        for p in sorted(params, key=lambda x: x["name"]):
-            flag = "<code>--" + p["name"].replace("_", "-") + "</code>"
+        for p in sorted(flag_params, key=_flag_name):
+            flag = "<code>--%s</code>" % _flag_name(p)
             short = ""
             if p.get("short"):
                 short = "<code>-%s</code>" % p["short"]

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -518,6 +518,93 @@ class TestUsageLineSkipsWhenNoParams:
         assert page.count('<syntaxhighlight lang="bash"') == 2
 
 
+class TestFlagAndArgumentRendering:
+    """Flag tables must show the flag the CLI actually accepts: the
+    `long:` override wins over the param name, and positional params
+    are arguments, not flags. The live-wiki bug was `--host-name` on
+    CLI:canasta host add and a fake `--settings` flag on CLI:canasta
+    config set."""
+
+    def test_long_override_renders_long_name(self):
+        page = wp.gen_wikitext({
+            "name": "host_add",
+            "description": "Add a host",
+            "parameters": [{"name": "host_name", "short": "n",
+                            "long": "name", "type": "string",
+                            "required": True,
+                            "description": "Host name"}],
+        })
+        assert "<code>--name</code>" in page
+        assert "--host-name" not in page
+
+    def test_positional_renders_as_argument_not_flag(self):
+        page = wp.gen_wikitext({
+            "name": "config_set",
+            "description": "Set config",
+            "parameters": [{"name": "settings", "type": "string",
+                            "positional": True, "multi": True,
+                            "description": "KEY=VALUE pairs to set"}],
+        })
+        assert "--settings" not in page
+        assert "=== Arguments ===" in page
+        assert "<code>SETTINGS</code>" in page
+        # No flags besides the positional -> no Flags section.
+        assert "=== Flags ===" not in page
+
+    def test_plain_param_unchanged(self):
+        page = wp.gen_wikitext({
+            "name": "start",
+            "description": "Start",
+            "parameters": [{"name": "id", "short": "i",
+                            "type": "string",
+                            "description": "Canasta instance ID"}],
+        })
+        assert "<code>--id</code>" in page
+        assert "=== Flags ===" in page
+        assert "=== Arguments ===" not in page
+
+    def test_usage_line_shows_positional_metavar(self):
+        page = wp.gen_wikitext({
+            "name": "config_set",
+            "description": "Set config",
+            "parameters": [{"name": "settings", "type": "string",
+                            "positional": True, "multi": True,
+                            "description": "KEY=VALUE pairs to set"}],
+        })
+        assert "canasta config set [flags] [SETTINGS...]" in page
+
+    def test_flags_sorted_by_displayed_name(self):
+        page = wp.gen_wikitext({
+            "name": "host_add",
+            "description": "Add a host",
+            "parameters": [
+                {"name": "host_name", "long": "name", "type": "string",
+                 "description": "Host name"},
+                {"name": "address", "type": "string",
+                 "description": "Address"},
+            ],
+        })
+        # `host_name` displays as --name, so it sorts after --address.
+        assert page.index("<code>--address</code>") < page.index(
+            "<code>--name</code>"
+        )
+
+    def test_real_pages_render_cli_accurate_flags(self):
+        """End-to-end against command_definitions.yml: the previously
+        wrong pages now match the CLI."""
+        data = wp.load_definitions()
+        pages = dict(wp.generate_all_pages(data))
+        host_add = pages[wp.PAGE_PREFIX + "canasta host add"]
+        assert "<code>--name</code>" in host_add
+        assert "--host-name" not in host_add
+        config_set = pages[wp.PAGE_PREFIX + "canasta config set"]
+        assert "--settings" not in config_set
+        assert "<code>SETTINGS</code>" in config_set
+        maint_exec = pages[wp.PAGE_PREFIX + "canasta maintenance exec"]
+        assert "--exec-args" not in maint_exec
+        assert "<code>EXEC_ARGS</code>" in maint_exec
+
+
 class TestBacktickToCode:
     """MediaWiki doesn't interpret single-backtick inline code (unlike
     markdown). The publisher translates backticks to <code> tags so


### PR DESCRIPTION
Addresses the `wiki_publish.py` item in #967. The live-wiki edits in #967 are separate and remain open.

`scripts/wiki_publish.py` built flag names from the raw param name, ignoring two things the CLI itself honors when constructing argparse from `command_definitions.yml`:

- the `long:` override — so `host add` documented `--host-name` while its own examples (and the real CLI) use `--name`; same on `gitops init`/`join`, `host remove`, and `sidecar remove` (`--sidecar-name`);
- `positional: true` — positional params (`SETTINGS`, `exec_args`, …) were rendered as bogus flags like `--settings`, producing example-breaking docs.

Fix: a `_flag_name` helper uses `param.get("long", name)`; positional params are emitted in a separate Arguments section and as usage-line metavars (`canasta config set [flags] [SETTINGS...]`), mirroring how `canasta.py` and `generate_docs.py` already treat them (including the `exec_args`/`script_args` REMAINDER handling). Dry-run confirms `host add` now shows `--name`/`-n` and `config set` shows a `SETTINGS` argument; zero `--host-name`/`--sidecar-name` remain.

This is the repo-side fix; the corrected pages publish on the next `wiki_publish.py` run after merge. Unit tests added for long-name and positional rendering.
