### PR TITLE
fix(config): apply gitops handling to config unset (mirror config set)

### DIFF
--- a/roles/config/tasks/_remove_gitops_var.yml
+++ b/roles/config/tasks/_remove_gitops_var.yml
@@ -1,0 +1,74 @@
+---
+# Remove a single unset key from the gitops durable source. A key with a
+# gitops placeholder is dropped from vars.yaml and its placeholder line from
+# env.template; a literal key is dropped from env.template. Mirrors
+# _update_gitops_var.yml on the set side.
+# Input: _config_key (str), _config_placeholder_map (dict),
+#        _config_host_raw, instance_path
+
+- name: Look up placeholder name
+  ansible.builtin.set_fact:
+    _rgv_placeholder: "{{ _config_placeholder_map[_config_key] | default('') }}"
+
+- name: Remove from vars.yaml and env.template when key has a placeholder
+  when: _rgv_placeholder != ''
+  block:
+    - name: Determine vars file path
+      ansible.builtin.set_fact:
+        _rgv_vars_file: >-
+          {{ instance_path }}/hosts/{{ _config_host_raw.content | b64decode | trim }}/vars.yaml
+
+    # vars.yaml holds passwords/keys, so suppress its contents when the key
+    # being removed is a secret. The write below is always no_log.
+    - name: Read current vars
+      ansible.builtin.slurp:
+        src: "{{ _rgv_vars_file }}"
+      register: _rgv_vars_raw
+      no_log: "{{ _config_key is search(canasta_secret_key_pattern) }}"
+
+    - name: Drop placeholder from vars
+      ansible.builtin.set_fact:
+        _rgv_updated_vars: >-
+          {{ (_rgv_vars_raw.content | b64decode | from_yaml | default({}, true))
+             | dict2items | rejectattr('key', 'equalto', _rgv_placeholder)
+             | items2dict }}
+      no_log: "{{ _config_key is search(canasta_secret_key_pattern) }}"
+
+    - name: Write updated vars.yaml
+      ansible.builtin.copy:
+        content: "{{ _rgv_updated_vars | to_nice_yaml(indent=2) }}"
+        dest: "{{ _rgv_vars_file }}"
+        mode: "0644"
+      no_log: true
+
+    - name: Remove placeholder line from env.template
+      ansible.builtin.lineinfile:
+        path: "{{ instance_path }}/env.template"
+        regexp: "^{{ _config_key }}="
+        state: absent
+
+    - name: Stage updated vars.yaml and env.template
+      ansible.builtin.command:
+        cmd: "git add {{ _rgv_vars_file }} env.template"
+        chdir: "{{ instance_path }}"
+      changed_when: true
+
+# A key with no placeholder lives as a literal in env.template (or is absent).
+# Remove that literal so the next gitops pull / config regenerate re-renders
+# .env without it, instead of resurrecting the value.
+- name: Remove env.template literal when key has no placeholder
+  when: _rgv_placeholder == ''
+  block:
+    - name: Remove the literal from env.template
+      ansible.builtin.lineinfile:
+        path: "{{ instance_path }}/env.template"
+        regexp: "^{{ _config_key }}="
+        state: absent
+      register: _rgv_literal_removed
+
+    - name: Stage updated env.template
+      ansible.builtin.command:
+        cmd: "git add env.template"
+        chdir: "{{ instance_path }}"
+      changed_when: true
+      when: _rgv_literal_removed is changed

--- a/roles/config/tasks/_remove_gitops_vars.yml
+++ b/roles/config/tasks/_remove_gitops_vars.yml
@@ -1,0 +1,45 @@
+---
+# Remove config-unset keys from a gitops instance's durable source so they
+# survive the next gitops pull (which re-renders .env from env.template). A
+# placeholder key is dropped from both vars.yaml and its env.template
+# placeholder line; a literal key is dropped from env.template. Mirrors
+# _update_gitops_vars.yml on the set side. Compose-only guard lives in the
+# caller, roles/orchestrator/tasks/config_remove_gitops_vars.yml.
+# Input: instance_path, keys, _config_gitops_stat
+
+- name: Load gitops placeholder definitions
+  ansible.builtin.include_vars:
+    file: "{{ canasta_root }}/roles/gitops/vars/main.yml"
+
+- name: Read .gitops-host
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/.gitops-host"
+  register: _config_host_raw
+
+- name: Build key-to-placeholder map from env.template
+  ansible.builtin.shell:
+    cmd: |
+      python3 -c "
+      import json, re
+      with open('{{ instance_path }}/env.template') as f:
+          lines = f.readlines()
+      m = {}
+      for line in lines:
+          match = re.match(r'^([A-Z][^=]*)=\{\{([^}]+)\}\}', line.strip())
+          if match:
+              m[match.group(1)] = match.group(2)
+      print(json.dumps(m))
+      "
+  register: _config_map_raw
+  changed_when: false
+
+- name: Parse placeholder map
+  ansible.builtin.set_fact:
+    _config_placeholder_map: "{{ _config_map_raw.stdout | from_json }}"
+
+- name: Remove each unset key from vars.yaml / env.template
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/config/tasks/_remove_gitops_var.yml
+  loop: "{{ keys.split() }}"
+  loop_control:
+    loop_var: _config_key

--- a/roles/config/tasks/unset.yml
+++ b/roles/config/tasks/unset.yml
@@ -11,6 +11,21 @@
   loop_control:
     loop_var: _config_key
 
+# If the instance is gitops-managed, remove the key from the durable source
+# so the next gitops pull doesn't resurrect it (it re-renders .env from
+# template).
+- name: Check for gitops instance
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/.gitops-host"
+  register: _config_gitops_stat
+
+# The orchestrator owns the compose-vs-K8s decision (K8s gitops uses a
+# different layout, values.template.yaml, not vars.yaml); dispatch.
+- name: Remove gitops vars for unset keys
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/config_remove_gitops_vars.yml
+  when: _config_gitops_stat.stat.exists | default(false)
+
 - name: Regenerate Caddyfile after config change
   ansible.builtin.include_role:
     name: orchestrator

--- a/roles/orchestrator/tasks/config_remove_gitops_vars.yml
+++ b/roles/orchestrator/tasks/config_remove_gitops_vars.yml
@@ -1,0 +1,27 @@
+---
+# Propagate config-unset removals into gitops vars for this orchestrator.
+# Compose: remove the key from vars.yaml and env.template (the compose-gitops
+# source of truth) so the next gitops pull doesn't resurrect it. Kubernetes:
+# config unset writes the local values.yaml, but the committed gitops source
+# (values.template.yaml -> hosts/<name>/rendered-values.yaml) that Argo CD
+# deploys is left untouched, so warn the operator to push. A silent
+# write-through isn't possible here: making the removal durable requires
+# committing and pushing to the repo Argo CD watches, which is exactly what
+# 'canasta gitops push' does.
+# Input: instance_path, instance_orchestrator, keys, _config_gitops_stat
+
+- name: Remove gitops vars for unset keys (Compose)
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/config/tasks/_remove_gitops_vars.yml
+  when: instance_orchestrator | default('compose') == 'compose'
+
+- name: Warn that a K8s gitops config change needs a push to be durable
+  ansible.builtin.debug:
+    msg: >-
+      This is a gitops-managed Kubernetes instance. 'canasta config unset'
+      updated the local values.yaml, but the committed gitops source
+      (values.template.yaml / rendered-values.yaml) that Argo CD deploys is
+      unchanged. Run 'canasta gitops push' to commit and deploy the change —
+      otherwise Argo CD may revert it on the next sync, and it won't reach
+      other hosts.
+  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']

--- a/tests/unit/test_config_unset_gitops.py
+++ b/tests/unit/test_config_unset_gitops.py
@@ -1,0 +1,141 @@
+"""On a gitops instance, `config unset` must remove the key from the durable
+source, not just .env: a placeholder key from vars.yaml and its env.template
+placeholder line, a literal key from env.template. Otherwise the next pull /
+config regenerate re-renders .env and resurrects the key. On K8s gitops the
+committed source (values.template.yaml -> rendered-values.yaml) can't be
+written through, so unset must warn the operator to push. Mirrors the set-side
+gitops tests (test_config_gitops_writethrough / test_config_gitops_k8s_warn).
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+UNSET = os.path.join(REPO_ROOT, "roles", "config", "tasks", "unset.yml")
+REMOVE_VAR = os.path.join(
+    REPO_ROOT, "roles", "config", "tasks", "_remove_gitops_var.yml"
+)
+DISPATCH = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "config_remove_gitops_vars.yml"
+)
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _find(tasks, name_substring):
+    return next(
+        (t for t in tasks if name_substring in t.get("name", "")), None)
+
+
+def _when(task):
+    w = task.get("when", [])
+    return " ".join(w if isinstance(w, list) else [str(w)])
+
+
+def _lineinfile(task):
+    return (task.get("ansible.builtin.lineinfile")
+            or task.get("lineinfile")) if isinstance(task, dict) else None
+
+
+def _debug_msg(task):
+    d = task.get("ansible.builtin.debug") or task.get("debug") or {}
+    return d.get("msg", "") if isinstance(d, dict) else ""
+
+
+# --- unset.yml wires the gitops check + dispatch (mirrors _set_config.yml) ---
+
+def test_unset_checks_for_gitops_instance():
+    tasks = _load(UNSET)
+    stat = _find(tasks, "Check for gitops instance")
+    assert stat is not None, "unset must stat .gitops-host like set does"
+    st = stat.get("ansible.builtin.stat") or stat.get("stat") or {}
+    assert st.get("path", "").endswith(".gitops-host")
+
+
+def test_unset_dispatches_to_orchestrator_role():
+    tasks = _load(UNSET)
+    dispatch = _find(tasks, "Remove gitops vars for unset keys")
+    assert dispatch is not None, "unset must dispatch gitops removal"
+    inc = str(dispatch.get("ansible.builtin.include_tasks", ""))
+    assert inc.endswith("config_remove_gitops_vars.yml"), (
+        "must dispatch to the orchestrator role, not branch on "
+        "instance_orchestrator in the action code")
+    assert "_config_gitops_stat.stat.exists" in _when(dispatch)
+
+
+# --- Compose removal: placeholder -> vars.yaml + env.template line ----------
+
+def test_placeholder_key_dropped_from_vars_yaml():
+    tasks = _load(REMOVE_VAR)
+    block = _find(tasks, "vars.yaml and env.template when key has a placeholder")
+    assert block is not None
+    assert "_rgv_placeholder != ''" in _when(block)
+    # It must actually drop the placeholder from the vars dict.
+    drop = next(
+        (t for t in block.get("block", [])
+         if "Drop placeholder from vars" in t.get("name", "")), None)
+    assert drop is not None, "must remove the placeholder from vars.yaml"
+
+
+def test_placeholder_key_line_removed_from_env_template():
+    tasks = _load(REMOVE_VAR)
+    block = _find(tasks, "vars.yaml and env.template when key has a placeholder")
+    li = next(
+        (t for t in block.get("block", [])
+         if (_lineinfile(t) or {}).get("path", "").endswith("env.template")),
+        None,
+    )
+    assert li is not None, "must remove the placeholder line from env.template"
+    assert _lineinfile(li).get("state") == "absent"
+
+
+# --- Compose removal: literal key -> env.template ---------------------------
+
+def test_non_placeholder_key_removed_from_env_template():
+    tasks = _load(REMOVE_VAR)
+    block = _find(tasks, "env.template literal when key has no placeholder")
+    assert block is not None, (
+        "config unset must remove a non-placeholder key's literal from "
+        "env.template, or the next render resurrects it")
+    assert "_rgv_placeholder == ''" in _when(block)
+    li = next(
+        (t for t in block.get("block", [])
+         if (_lineinfile(t) or {}).get("path", "").endswith("env.template")),
+        None,
+    )
+    assert li is not None, "must lineinfile the literal absent in env.template"
+    assert _lineinfile(li).get("state") == "absent"
+    assert "_config_key" in str(_lineinfile(li).get("regexp", ""))
+
+
+# --- K8s dispatch warns to push (not a silent no-op) ------------------------
+
+def test_compose_branch_removes_vars():
+    tasks = _load(DISPATCH)
+    compose = [t for t in tasks
+               if str(t.get("ansible.builtin.include_tasks", ""))
+               .endswith("_remove_gitops_vars.yml")]
+    assert compose, "Compose must remove vars from the gitops source"
+    assert "== 'compose'" in _when(compose[0])
+
+
+def test_k8s_branch_warns_to_push():
+    tasks = _load(DISPATCH)
+    k8s = [t for t in tasks
+           if "kubernetes" in _when(t) and "k8s" in _when(t)]
+    assert k8s, "must have a K8s-gated task"
+    msg = _debug_msg(k8s[0])
+    assert "gitops push" in msg, "K8s warning must tell the user to push"
+    assert "unchanged" in msg or "not" in msg.lower()
+
+
+def test_k8s_branch_is_not_a_silent_noop():
+    tasks = _load(DISPATCH)
+    k8s = [t for t in tasks if "kubernetes" in _when(t)]
+    assert any(_debug_msg(t) for t in k8s), (
+        "K8s config unset on a gitops instance must surface a warning, "
+        "not silently skip")


### PR DESCRIPTION
Addresses part of #965 — the `config unset` gitops gap. Other #965 items are handled in separate PRs.

`config set` became gitops-aware in #934/#954, but `config unset` still removed keys from `.env` only. On a Compose gitops instance the unset key was resurrected from the tracked source (`env.template`/`vars.yaml`) by the next `gitops pull`; on K8s gitops it was a silent no-op.

Fix mirrors the set path: `unset.yml` now stats `.gitops-host` and dispatches to the orchestrator role (no `instance_orchestrator ==` branching in the action code). New `config_remove_gitops_vars.yml` dispatches — Compose removes the key from the tracked source, K8s emits the same "run `canasta gitops push`" warning. Placeholder keys are dropped from `vars.yaml` and their `env.template` line removed; literal keys have their `env.template` line removed. The set-path domain re-derivation block is intentionally not mirrored (it only applies to set).

New unit tests in `test_config_unset_gitops.py`; full unit suite and lint pass.
