### PR TITLE
fix(gitops): run argocd status kubectl over ssh for remote instances

### DIFF
--- a/direct_commands/gitops.py
+++ b/direct_commands/gitops.py
@@ -201,26 +201,39 @@ def _parse_gitops_status(stdout, instance_id):
     return "\n".join(lines)
 
 
-def _gitops_argocd_status(instance_id):
+def _gitops_argocd_status(instance_id, host="localhost"):
     """Query Argo CD Application for this instance; return parsed status.
 
     Returns a tuple (sync_status, health, last_sync, revision). Falls
     back to 'Not registered' / 'N/A' sentinels when Argo CD isn't
     installed or no Application exists — matches the Ansible path's
     behavior for K8s instances without Argo CD.
+
+    For remote hosts, SSH and run kubectl on the host — its kubeconfig
+    points at the cluster it's part of. Running kubectl on the laptop
+    would query whatever the laptop's kubeconfig points at, reporting
+    'Not registered' for instances that are actually Synced.
     """
-    try:
-        result = subprocess.run(
-            ["kubectl", "get", "application", "canasta-%s" % instance_id,
-             "-n", "argocd", "-o", "json"],
-            capture_output=True, text=True, timeout=10,
+    if _helpers._is_localhost(host):
+        try:
+            result = subprocess.run(
+                ["kubectl", "get", "application", "canasta-%s" % instance_id,
+                 "-n", "argocd", "-o", "json"],
+                capture_output=True, text=True, timeout=10,
+            )
+            rc, stdout = result.returncode, result.stdout
+        except (subprocess.TimeoutExpired, OSError):
+            return ("Not registered", "N/A", "never", "unknown")
+    else:
+        rc, stdout = _helpers._ssh_run(
+            host,
+            "kubectl get application canasta-%s -n argocd -o json"
+            % instance_id,
         )
-    except (subprocess.TimeoutExpired, OSError):
-        return ("Not registered", "N/A", "never", "unknown")
-    if result.returncode != 0:
+    if rc != 0:
         return ("Not registered", "N/A", "never", "unknown")
     try:
-        app = json.loads(result.stdout)
+        app = json.loads(stdout)
     except ValueError:
         return ("Unknown", "Unknown", "never", "unknown")
     status = app.get("status") or {}
@@ -298,7 +311,7 @@ def cmd_gitops_status(args):
             return 1
 
     if orchestrator in ("kubernetes", "k8s"):
-        argocd = _gitops_argocd_status(inst_id)
+        argocd = _gitops_argocd_status(inst_id, host)
         print(_parse_gitops_status_k8s(stdout, inst_id, argocd))
     else:
         print(_parse_gitops_status(stdout, inst_id))

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2269,6 +2269,49 @@ class TestGitopsArgocdStatus:
         result = direct_commands._gitops_argocd_status("mysite")
         assert result == ("Unknown", "Unknown", "never", "unknown")
 
+    def test_remote_host_queries_over_ssh(self, monkeypatch):
+        app = {
+            "status": {
+                "sync": {"status": "Synced", "revision": "abcdef1234567890"},
+                "health": {"status": "Healthy"},
+                "operationState": {"finishedAt": "2026-04-23T10:00:00Z"},
+            }
+        }
+        calls = {}
+
+        def fake_ssh(host, cmd):
+            calls["host"] = host
+            calls["cmd"] = cmd
+            return (0, json.dumps(app))
+
+        def fail_run(*a, **kw):
+            raise AssertionError("kubectl must not run locally for remote host")
+
+        monkeypatch.setattr(direct_commands._helpers, "_ssh_run", fake_ssh)
+        monkeypatch.setattr(subprocess, "run", fail_run)
+        sync, health, last, rev = direct_commands._gitops_argocd_status(
+            "mysite", "admin@remote",
+        )
+        assert sync == "Synced"
+        assert health == "Healthy"
+        assert calls["host"] == "admin@remote"
+        assert "kubectl get application canasta-mysite" in calls["cmd"]
+
+    def test_localhost_queries_locally(self, monkeypatch):
+        app = {"status": {"sync": {"status": "Synced", "revision": "abc"},
+                          "health": {"status": "Healthy"}}}
+
+        def fake_run(*a, **kw):
+            return type("R", (), {"returncode": 0, "stdout": json.dumps(app)})()
+
+        def fail_ssh(*a, **kw):
+            raise AssertionError("localhost must not use ssh")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(direct_commands._helpers, "_ssh_run", fail_ssh)
+        sync, _, _, _ = direct_commands._gitops_argocd_status("mysite", "localhost")
+        assert sync == "Synced"
+
 
 class TestParseGitopsStatusK8s:
     def _make_output(self, hostname="myhost", commit="abc1234", revcount="0\t0"):
@@ -2349,15 +2392,17 @@ class TestCmdGitopsStatusK8s:
                 "host": "admin@k8s-control",
             }),
         )
-        monkeypatch.setattr(direct_commands._helpers, "_ssh_run",
-            lambda host, cmd: (0, ssh_output),
-        )
-        monkeypatch.setattr(
-            subprocess, "run",
-            lambda *a, **kw: type("R", (), {
-                "returncode": 0, "stdout": json.dumps(app),
-            })(),
-        )
+        # Remote host: both the git status and the Argo CD kubectl run
+        # over SSH against the host's kubeconfig, not the laptop's.
+        def fake_ssh(host, cmd):
+            if "kubectl get application" in cmd:
+                return (0, json.dumps(app))
+            return (0, ssh_output)
+        monkeypatch.setattr(direct_commands._helpers, "_ssh_run", fake_ssh)
+
+        def fail_run(*a, **kw):
+            raise AssertionError("kubectl must not run locally for remote host")
+        monkeypatch.setattr(subprocess, "run", fail_run)
         args = type("Args", (), {"id": "mysite"})()
         rc = direct_commands.cmd_gitops_status(args)
         assert rc == 0


### PR DESCRIPTION
Addresses part of #965 — remote `gitops status`. Other #965 items are in separate PRs.

`_gitops_argocd_status` always ran `kubectl get application` on the local machine. For a remote K8s gitops instance the git-status half went over SSH, but the Argo CD query hit the laptop's kubeconfig, so remote instances were falsely reported "Not registered / N/A / never" — the same bug class already fixed for `_check_running_k8s`.

Fix: the function takes a `host` param and branches like `info.py::_kubectl_section` — localhost uses `subprocess.run`, remote runs kubectl via `_ssh_run` on the host (whose kubeconfig points at its own cluster).

New unit tests assert remote routes over SSH and localhost stays local; an existing test that had encoded the buggy behavior was corrected. Full unit suite passes.
