### PR TITLE
fix(dockerhost): propagate registry dockerHost through devmode and read-only fast paths

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -79,17 +79,29 @@ def _resolve_instance_by_cwd(args):
     Returns (None, None) on no match so callers can emit their own error
     message, unlike canasta.resolve_instance() which exits. Shared by
     `status`, `doctor`, and `version` so they detect instances identically.
+
+    Side effect: like _resolve_instance, exports the resolved instance's
+    registry dockerHost as DOCKER_HOST so subsequent local docker /
+    docker compose subprocesses and SSH-wrapped remote calls target the
+    right (e.g. rootless) socket.
     """
+    def _resolved(iid, inst):
+        if inst:
+            docker_host = inst.get("dockerHost")
+            if docker_host:
+                os.environ["DOCKER_HOST"] = docker_host
+        return (iid, inst)
+
     inst_id = getattr(args, "id", None)
     conf_path = os.path.join(_get_config_dir(), "conf.json")
     instances = _read_registry(conf_path)
     if inst_id:
-        return (inst_id, instances.get(inst_id))
+        return _resolved(inst_id, instances.get(inst_id))
     search = os.path.abspath(os.environ.get("CANASTA_HOST_PWD") or os.getcwd())
     while True:
         for iid, inst in instances.items():
             if os.path.abspath(inst.get("path", "")) == search:
-                return (iid, inst)
+                return _resolved(iid, inst)
         parent = os.path.dirname(search)
         if parent == search:
             break
@@ -837,27 +849,41 @@ def _read_wikis(path, host):
         return []
 
 
-def _check_running(instance_id, path, orchestrator, host):
+def _docker_env(docker_host):
+    """Process env with DOCKER_HOST set to docker_host, or None to inherit.
+
+    Used to target a specific instance's socket per-subprocess rather than
+    mutating os.environ, so concurrent readers of different instances don't
+    clobber each other."""
+    if not docker_host:
+        return None
+    env = dict(os.environ)
+    env["DOCKER_HOST"] = docker_host
+    return env
+
+
+def _check_running(instance_id, path, orchestrator, host, docker_host=None):
     if orchestrator in ("kubernetes", "k8s"):
         return _check_running_k8s(instance_id, host)
-    return _check_running_compose(path, host)
+    return _check_running_compose(path, host, docker_host)
 
 
-def _check_running_compose(path, host):
+def _check_running_compose(path, host, docker_host=None):
     if _is_localhost(host):
         try:
             result = subprocess.run(
                 ["docker", "compose", "ps", "-q", "web"],
                 cwd=path, capture_output=True, text=True, timeout=10,
+                env=_docker_env(docker_host),
             )
             return result.returncode == 0 and result.stdout.strip() != ""
         except (subprocess.TimeoutExpired, OSError):
             return False
     else:
-        rc, stdout = _ssh_run(
-            host,
-            "cd %s && docker compose ps -q web" % _shell_quote(path),
-        )
+        cmd = "cd %s && docker compose ps -q web" % _shell_quote(path)
+        if docker_host:
+            cmd = "DOCKER_HOST=%s %s" % (_shell_quote(docker_host), cmd)
+        rc, stdout = _ssh_run(host, cmd)
         return rc == 0 and stdout.strip() != ""
 
 
@@ -910,20 +936,27 @@ def _gather_instance_info(inst_id, inst):
     host = inst.get("host") or "localhost"
     path = inst.get("path", "")
     orchestrator = inst.get("orchestrator", "compose")
+    # Per-instance socket: many instances are gathered concurrently, so target
+    # this one's rootless socket via a per-command DOCKER_HOST rather than the
+    # process-global env another thread might read.
+    docker_host = inst.get("dockerHost")
     qpath = _shell_quote(path)
 
     if _is_localhost(host):
-        return _gather_local(inst_id, path, orchestrator, host)
+        return _gather_local(inst_id, path, orchestrator, host, docker_host)
 
     if orchestrator in ("kubernetes", "k8s"):
         return _gather_k8s(inst_id, path, host)
 
+    compose_ps = "cd %(p)s && docker compose ps -q web 2>/dev/null || true"
+    if docker_host:
+        compose_ps = "DOCKER_HOST=%s %s" % (_shell_quote(docker_host), compose_ps)
     script = (
         "test -d %(p)s && echo DIR_OK || echo DIR_MISSING; "
         "echo '%(d)s'; "
         "cat %(p)s/config/wikis.yaml 2>/dev/null || echo WIKIS_MISSING; "
         "echo '%(d)s'; "
-        "cd %(p)s && docker compose ps -q web 2>/dev/null || true"
+        + compose_ps
     ) % {"p": qpath, "d": _SENTINEL}
 
     rc, stdout = _ssh_run(host, script)
@@ -953,13 +986,13 @@ def _gather_instance_info(inst_id, inst):
     return _make_detail(inst_id, host, path, orchestrator, status, wikis)
 
 
-def _gather_local(inst_id, path, orchestrator, host):
+def _gather_local(inst_id, path, orchestrator, host, docker_host=None):
     dir_exists = os.path.isdir(path)
     wikis = _read_wikis(path, host) if dir_exists else []
 
     if not dir_exists:
         status = "NOT FOUND"
-    elif _check_running(inst_id, path, orchestrator, host):
+    elif _check_running(inst_id, path, orchestrator, host, docker_host):
         status = "RUNNING"
     else:
         status = "STOPPED"

--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -374,6 +374,11 @@ def cmd_doctor(args):
             )
             return 1
         inst = instances[inst_id]
+        # Match _resolve_instance_by_cwd: target this instance's rootless
+        # socket so the runtime consistency checks below see its containers.
+        docker_host = inst.get("dockerHost")
+        if docker_host:
+            os.environ["DOCKER_HOST"] = docker_host
     else:
         _, inst = _helpers._resolve_instance_by_cwd(args)
     if not host and inst:

--- a/roles/devmode/tasks/disable.yml
+++ b/roles/devmode/tasks/disable.yml
@@ -52,6 +52,7 @@
     host: "{{ _instance_result.instance.host | default(omit) }}"
     managed_cluster: "{{ _instance_result.instance.managedCluster | default(false) }}"
     build_from: "{{ _instance_result.instance.buildFrom | default(omit) }}"
+    docker_host: "{{ _instance_result.instance.dockerHost | default(omit) }}"
     state: present
   delegate_to: localhost
   vars:

--- a/roles/devmode/tasks/enable.yml
+++ b/roles/devmode/tasks/enable.yml
@@ -188,6 +188,7 @@
     host: "{{ _instance_result.instance.host | default(omit) }}"
     managed_cluster: "{{ _instance_result.instance.managedCluster | default(false) }}"
     build_from: "{{ _instance_result.instance.buildFrom | default(omit) }}"
+    docker_host: "{{ _instance_result.instance.dockerHost | default(omit) }}"
     state: present
   delegate_to: localhost
   vars:

--- a/tests/unit/test_devmode_storage.py
+++ b/tests/unit/test_devmode_storage.py
@@ -60,6 +60,35 @@ class TestDevmodeGuards:
                    and "already" not in n.lower())
 
 
+class TestDevmodeRegistryUpdate:
+    """canasta_registry state=present rebuilds the whole record from params, so
+    the registry-update in enable/disable must forward every field it wants
+    kept — including dockerHost (set by create --docker-host or rootless
+    auto-detect), or toggling devmode silently drops it."""
+
+    def _registry_update(self, tasks):
+        for t in tasks:
+            if isinstance(t, dict) and "canasta_registry" in t:
+                params = t["canasta_registry"]
+                if params.get("state") == "present":
+                    return params
+        raise AssertionError("no canasta_registry state=present task found")
+
+    def test_enable_forwards_docker_host(self):
+        params = self._registry_update(
+            _load(os.path.join(DEVMODE_TASKS, "enable.yml")))
+        assert "docker_host" in params
+        assert "dockerHost" in params["docker_host"]
+        assert "default(omit)" in params["docker_host"]
+
+    def test_disable_forwards_docker_host(self):
+        params = self._registry_update(
+            _load(os.path.join(DEVMODE_TASKS, "disable.yml")))
+        assert "docker_host" in params
+        assert "dockerHost" in params["docker_host"]
+        assert "default(omit)" in params["docker_host"]
+
+
 class TestNfsStorageSetup:
     """`canasta storage setup nfs` installs the NFS CSI driver and creates an
     `nfs` StorageClass pointing at the NFS server (#758)."""

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -3681,6 +3681,114 @@ class TestDockerHostPropagation:
             "got %r" % remote_cmd
         )
 
+    def _write_conf(self, tmp_path, inst):
+        conf = tmp_path / "conf.json"
+        conf.write_text(json.dumps({"Instances": {inst["id"]: inst}}, indent=4))
+
+    def test_resolve_by_cwd_sets_docker_host_when_registered(
+        self, tmp_path, monkeypatch,
+    ):
+        # cwd read-only fast paths (status/version/doctor) must also export
+        # the socket, or a rootless instance reports STOPPED while running.
+        monkeypatch.delenv("DOCKER_HOST", raising=False)
+        site = tmp_path / "mysite"
+        site.mkdir()
+        self._write_conf(tmp_path, {
+            "id": "mysite",
+            "path": str(site),
+            "orchestrator": "compose",
+            "dockerHost": "unix:///run/user/1000/podman/podman.sock",
+        })
+        monkeypatch.setenv("CANASTA_CONFIG_DIR", str(tmp_path))
+        monkeypatch.chdir(site)
+        from argparse import Namespace
+        iid, inst = direct_commands._helpers._resolve_instance_by_cwd(
+            Namespace(id=None))
+        assert iid == "mysite"
+        assert (
+            os.environ.get("DOCKER_HOST")
+            == "unix:///run/user/1000/podman/podman.sock"
+        )
+
+    def test_resolve_by_cwd_leaves_docker_host_alone_when_unset(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.delenv("DOCKER_HOST", raising=False)
+        site = tmp_path / "mysite"
+        site.mkdir()
+        self._write_conf(tmp_path, {
+            "id": "mysite",
+            "path": str(site),
+            "orchestrator": "compose",
+        })
+        monkeypatch.setenv("CANASTA_CONFIG_DIR", str(tmp_path))
+        monkeypatch.chdir(site)
+        from argparse import Namespace
+        direct_commands._helpers._resolve_instance_by_cwd(Namespace(id=None))
+        assert "DOCKER_HOST" not in os.environ
+
+    def test_gather_instance_info_uses_per_instance_docker_host(
+        self, tmp_path, monkeypatch,
+    ):
+        # _gather_instance_info iterates many instances concurrently, so it
+        # must pass the socket per-command (subprocess env) rather than
+        # mutating the process-global DOCKER_HOST.
+        monkeypatch.delenv("DOCKER_HOST", raising=False)
+        site = tmp_path / "mysite"
+        (site / "config").mkdir(parents=True)
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["env"] = kw.get("env")
+            class R:
+                returncode = 0
+                stdout = "abc123\n"
+            return R()
+
+        monkeypatch.setattr(direct_commands.subprocess, "run", fake_run)
+        inst = {
+            "id": "mysite",
+            "path": str(site),
+            "orchestrator": "compose",
+            "dockerHost": "unix:///run/user/1000/podman/podman.sock",
+        }
+        detail = direct_commands._gather_instance_info("mysite", inst)
+        assert detail["status"] == "RUNNING"
+        assert captured["env"] is not None, (
+            "compose ps must run with an explicit env carrying DOCKER_HOST"
+        )
+        assert (
+            captured["env"].get("DOCKER_HOST")
+            == "unix:///run/user/1000/podman/podman.sock"
+        )
+        # Must not leak into the process env other threads read.
+        assert "DOCKER_HOST" not in os.environ
+
+    def test_gather_instance_info_no_env_override_without_docker_host(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.delenv("DOCKER_HOST", raising=False)
+        site = tmp_path / "mysite"
+        (site / "config").mkdir(parents=True)
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["env"] = kw.get("env")
+            class R:
+                returncode = 0
+                stdout = "abc123\n"
+            return R()
+
+        monkeypatch.setattr(direct_commands.subprocess, "run", fake_run)
+        inst = {
+            "id": "mysite",
+            "path": str(site),
+            "orchestrator": "compose",
+        }
+        direct_commands._gather_instance_info("mysite", inst)
+        # No dockerHost -> inherit the process env (env=None), don't fabricate.
+        assert captured["env"] is None
+
 
 class TestLintEnvContent:
     """_lint_env_content flags quoted values / CRLF that survive read-time


### PR DESCRIPTION
Addresses part of #965 — `dockerHost` propagation. Other #965 items are in separate PRs. Both fixes share one root cause (the registry's `dockerHost` isn't propagated).

1. `devmode enable`/`disable` rebuilt the registry record via `canasta_registry state=present` without `docker_host`, so the stored `dockerHost` was deleted and later commands hit the default socket. Both tasks now pass `docker_host: "{{ _instance_result.instance.dockerHost | default(omit) }}"`.

2. Read-only fast paths ignored `dockerHost`: `_resolve_instance_by_cwd` now exports `DOCKER_HOST` like `_resolve_instance` (covering status/version/doctor cwd paths), and doctor's `--id` branch does the same. `_gather_instance_info` (concurrent, many instances) passes the socket per-command — local via a per-subprocess `env`, remote via a `DOCKER_HOST=` prefix on the compose command — never mutating `os.environ`.

New unit tests for both; full unit suite and lint pass.
