### PR TITLE
fix(env): preserve raw .env lines; detect quote-only changes on set

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -221,6 +221,38 @@ def _set_env_entry(entries, key, value):
     return new_entries
 
 
+def _env_key_of(line):
+    """Key defined by a raw .env line, or None for comments, blanks, and
+    malformed lines. Tolerates a trailing CR. Mirrors canasta_env._key_of()."""
+    stripped = line.rstrip("\r").strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    parts = stripped.split("=", 1)
+    if len(parts) != 2:
+        return None
+    return parts[0].strip()
+
+
+def _set_env_lines(lines, key, value):
+    """Rewrite the first line defining `key` as an unquoted 'key=value',
+    dropping later duplicates and appending if absent. Untouched lines are
+    kept verbatim so their quoting (and any inline '#') survives. Mirrors
+    canasta_env.set_line()."""
+    found = False
+    new_lines = []
+    for line in lines:
+        if _env_key_of(line) == key:
+            if not found:
+                new_lines.append("%s=%s" % (key, value))
+                found = True
+            # Drop duplicate definitions of the same key.
+        else:
+            new_lines.append(line)
+    if not found:
+        new_lines.append("%s=%s" % (key, value))
+    return new_lines
+
+
 def _write_env_content(path, host, content):
     """Write content to .env. Returns True on success.
 
@@ -438,16 +470,18 @@ def _sync_compose_profiles(inst):
     if not profiles_changed and not image_changed:
         return  # No change needed
 
-    new_entries = entries
+    # Rewrite only the keys that changed, keeping every other line verbatim so
+    # quoting (and any inline '#' inside quotes) on unrelated keys survives.
+    new_lines = content.split("\n")
     if profiles_changed:
-        new_entries = _set_env_entry(
-            new_entries, "COMPOSE_PROFILES", ",".join(desired),
+        new_lines = _set_env_lines(
+            new_lines, "COMPOSE_PROFILES", ",".join(desired),
         )
     if image_changed:
-        new_entries = _set_env_entry(
-            new_entries, "CANASTA_CADDY_IMAGE", desired_caddy_image,
+        new_lines = _set_env_lines(
+            new_lines, "CANASTA_CADDY_IMAGE", desired_caddy_image,
         )
-    _write_env_content(path, host, _entries_to_content(new_entries))
+    _write_env_content(path, host, "\n".join(new_lines))
 
     # A feature flag flipped off drops its profile from COMPOSE_PROFILES, but
     # docker compose up/down only act on active profiles — a container still

--- a/roles/common/library/canasta_env.py
+++ b/roles/common/library/canasta_env.py
@@ -46,7 +46,10 @@ from ansible.module_utils.basic import AnsibleModule
 def parse_env_file(content):
     """Parse a .env file into an ordered list of (key, value, is_comment) tuples.
 
-    Preserves ordering, comments, and blank lines for faithful round-tripping.
+    `value` has surrounding quotes stripped, for reads. Preserves ordering,
+    comments, and blank lines. To rewrite the file while keeping untouched
+    lines (and their quoting) verbatim, use parse_env_lines / set_line /
+    unset_lines / lines_to_content instead.
     """
     entries = []
     for line in content.split("\n"):
@@ -58,7 +61,7 @@ def parse_env_file(content):
         if len(parts) == 2:
             key = parts[0].strip()
             value = parts[1].strip()
-            # Strip surrounding quotes (double or single)
+            # Strip surrounding quotes (double or single) for the read value.
             if len(value) >= 2:
                 if (value.startswith('"') and value.endswith('"')) or \
                    (value.startswith("'") and value.endswith("'")):
@@ -68,6 +71,60 @@ def parse_env_file(content):
             # Malformed line, preserve as-is
             entries.append((None, line, True))
     return entries
+
+
+def _key_of(line):
+    """Return the key defined by a raw .env line, or None for comments,
+    blanks, and malformed lines. Tolerates a trailing CR (CRLF files)."""
+    stripped = line.rstrip("\r").strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    parts = stripped.split("=", 1)
+    if len(parts) != 2:
+        return None
+    return parts[0].strip()
+
+
+def raw_value_of(line):
+    """Return the un-stripped value text of a raw 'key=value' line (quotes
+    intact), or None if the line does not define a key."""
+    if _key_of(line) is None:
+        return None
+    return line.rstrip("\r").strip().split("=", 1)[1].strip()
+
+
+def parse_env_lines(content):
+    """Split content into raw lines, preserving them verbatim for rewriting."""
+    return content.split("\n")
+
+
+def lines_to_content(lines):
+    return "\n".join(lines)
+
+
+def set_line(lines, key, value):
+    """Rewrite the first line defining `key` as an unquoted 'key=value',
+    dropping later duplicates and appending if absent. Untouched lines are
+    kept verbatim so their quoting (and any inline '#') survives.
+    """
+    found = False
+    new_lines = []
+    for line in lines:
+        if _key_of(line) == key:
+            if not found:
+                new_lines.append("%s=%s" % (key, value))
+                found = True
+            # Drop duplicate definitions of the same key.
+        else:
+            new_lines.append(line)
+    if not found:
+        new_lines.append("%s=%s" % (key, value))
+    return new_lines
+
+
+def unset_lines(lines, key):
+    """Remove every line defining `key`, keeping other lines verbatim."""
+    return [line for line in lines if _key_of(line) != key]
 
 
 def lint_env_file(content):
@@ -206,12 +263,20 @@ def run_module():
         if value is None:
             module.fail_json(msg="value is required when state=set")
             return
-        old_value = env_dict.get(key)
-        if old_value != value:
+        lines = parse_env_lines(content)
+        # Compare against the raw (un-stripped) value so a quote-only change
+        # (KEY="secret" -> KEY=secret) is detected and repaired, and so an
+        # already-clean identical value stays idempotent.
+        old_raw = None
+        for line in lines:
+            if _key_of(line) == key:
+                old_raw = raw_value_of(line)
+                break
+        if old_raw != value:
             changed = True
-            entries = set_variable(entries, key, value)
+            new_lines = set_line(lines, key, value)
             if not module.check_mode:
-                new_content = entries_to_content(entries)
+                new_content = lines_to_content(new_lines)
                 with open(path, "w") as f:
                     f.write(new_content)
         result["changed"] = changed
@@ -222,13 +287,14 @@ def run_module():
         if not keys:
             module.fail_json(msg="key or keys is required when state=unset")
             return
+        lines = parse_env_lines(content)
         for k in keys:
             if k in env_dict:
                 changed = True
-                entries = unset_variable(entries, k)
+                lines = unset_lines(lines, k)
                 del env_dict[k]
         if changed and not module.check_mode:
-            new_content = entries_to_content(entries)
+            new_content = lines_to_content(lines)
             with open(path, "w") as f:
                 f.write(new_content)
         result["changed"] = changed

--- a/tests/unit/test_canasta_env.py
+++ b/tests/unit/test_canasta_env.py
@@ -238,3 +238,93 @@ class TestRunModuleLint:
         assert "QUOTED_VALUE" in result["quoted_keys"]
         assert "MW_SITE_NAME" in result["quoted_keys"]
         assert result["has_crlf"] is False
+
+
+class TestRawLineHelpers:
+    def test_raw_value_keeps_quotes(self):
+        assert canasta_env.raw_value_of('K="secret"') == '"secret"'
+        assert canasta_env.raw_value_of("K='s'") == "'s'"
+        assert canasta_env.raw_value_of("K=bare") == "bare"
+
+    def test_raw_value_none_for_non_entry(self):
+        assert canasta_env.raw_value_of("# comment") is None
+        assert canasta_env.raw_value_of("") is None
+        assert canasta_env.raw_value_of("noequals") is None
+
+    def test_set_line_normalizes_quoted_target(self):
+        lines = ['A="secret"', "B=keep"]
+        out = canasta_env.set_line(lines, "A", "secret")
+        assert out == ["A=secret", "B=keep"]
+
+    def test_set_line_leaves_other_lines_verbatim(self):
+        lines = ['A="a #b"', "B=old"]
+        out = canasta_env.set_line(lines, "B", "new")
+        # A untouched byte-for-byte, including the inline '#' inside quotes.
+        assert out == ['A="a #b"', "B=new"]
+
+    def test_set_line_dedupes_and_appends(self):
+        assert canasta_env.set_line(["K=1", "K=2", "X=y"], "K", "3") == [
+            "K=3", "X=y",
+        ]
+        assert canasta_env.set_line(["A=1"], "B", "2") == ["A=1", "B=2"]
+
+    def test_unset_lines_keeps_others_verbatim(self):
+        lines = ['A="a #b"', "B=1", "# c", "B=2"]
+        assert canasta_env.unset_lines(lines, "B") == ['A="a #b"', "# c"]
+
+
+class TestSetQuoteHandling:
+    def _write(self, tmp_path, content):
+        p = tmp_path / ".env"
+        p.write_text(content)
+        return str(p)
+
+    def test_quote_only_change_reports_changed_and_repairs(self, tmp_path):
+        # Value equal after stripping the existing quotes must still be
+        # detected as a change so the quotes get repaired.
+        path = self._write(tmp_path, 'RESTIC_PASSWORD="secret"\nOTHER=x\n')
+        result, failed, _ = run_module_with_params(canasta_env, {
+            "path": path, "state": "set",
+            "key": "RESTIC_PASSWORD", "value": "secret", "keys": None,
+        })
+        assert not failed
+        assert result["changed"]
+        assert open(path).read() == "RESTIC_PASSWORD=secret\nOTHER=x\n"
+
+    def test_already_clean_value_is_idempotent(self, tmp_path):
+        path = self._write(tmp_path, "K=v\n")
+        result, _f, _ = run_module_with_params(canasta_env, {
+            "path": path, "state": "set", "key": "K", "value": "v",
+            "keys": None,
+        })
+        assert not result["changed"]
+        assert open(path).read() == "K=v\n"
+
+    def test_setting_key_leaves_other_quoted_value_intact(self, tmp_path):
+        # Setting B must not touch A, whose quoted value contains ' #'
+        # (which compose's env parser would truncate if unquoted).
+        original = 'A="abc #def"\nB=old\n# keep\n'
+        path = self._write(tmp_path, original)
+        result, _f, _ = run_module_with_params(canasta_env, {
+            "path": path, "state": "set", "key": "B", "value": "new",
+            "keys": None,
+        })
+        assert result["changed"]
+        assert open(path).read() == 'A="abc #def"\nB=new\n# keep\n'
+
+    def test_new_key_append_keeps_existing_quotes(self, tmp_path):
+        path = self._write(tmp_path, 'A="q #x"\n')
+        run_module_with_params(canasta_env, {
+            "path": path, "state": "set", "key": "NEW", "value": "1",
+            "keys": None,
+        })
+        assert open(path).read() == 'A="q #x"\n\nNEW=1'
+
+    def test_unset_keeps_other_quoted_values_intact(self, tmp_path):
+        path = self._write(tmp_path, 'A="q #x"\nB=drop\n')
+        result, _f, _ = run_module_with_params(canasta_env, {
+            "path": path, "state": "unset", "key": "B", "value": None,
+            "keys": None,
+        })
+        assert result["changed"]
+        assert open(path).read() == 'A="q #x"\n'

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1521,6 +1521,40 @@ class TestEnvFileWriter:
             assert f.read() == "K=v\n"
 
 
+class TestEnvRawLineHelpers:
+    """_set_env_lines rewrites only the target key, keeping other lines
+    verbatim (quoting and inline '#' preserved)."""
+
+    def test_normalizes_quoted_target(self):
+        out = direct_commands._helpers._set_env_lines(
+            ['A="secret"', "B=keep"], "A", "secret",
+        )
+        assert out == ["A=secret", "B=keep"]
+
+    def test_leaves_other_lines_verbatim(self):
+        # A's quoted value contains ' #'; compose would truncate it if the
+        # quotes were dropped, so it must survive a set of an unrelated key.
+        out = direct_commands._helpers._set_env_lines(
+            ['A="abc #def"', "B=old", "# c"], "B", "new",
+        )
+        assert out == ['A="abc #def"', "B=new", "# c"]
+
+    def test_dedupes_and_appends(self):
+        assert direct_commands._helpers._set_env_lines(
+            ["K=1", "K=2", "X=y"], "K", "3",
+        ) == ["K=3", "X=y"]
+        assert direct_commands._helpers._set_env_lines(
+            ["A=1"], "B", "2",
+        ) == ["A=1", "B=2"]
+
+    def test_key_of(self):
+        ko = direct_commands._helpers._env_key_of
+        assert ko('K="v"') == "K"
+        assert ko("# c") is None
+        assert ko("") is None
+        assert ko("noeq") is None
+
+
 class TestSyncComposeProfiles:
     def _inst(self, tmp_path):
         return {"path": str(tmp_path), "host": "localhost"}
@@ -1640,6 +1674,25 @@ class TestSyncComposeProfiles:
                 break
         # No teardown call was issued for the dropped internal-db profile.
         assert self.compose_calls == []
+
+    def test_preserves_unrelated_quoted_values(self, tmp_path):
+        # Syncing COMPOSE_PROFILES must not re-serialize (and thus strip
+        # quotes from) unrelated keys. A quoted value containing ' #' would
+        # be truncated by compose's env parser if the quotes were dropped.
+        (tmp_path / ".env").write_text(
+            'RESTIC_PASSWORD="abc #def"\n'
+            "CANASTA_ENABLE_ELASTICSEARCH=true\n"
+            "COMPOSE_PROFILES=\n"
+            "# trailing comment\n"
+        )
+        direct_commands._sync_compose_profiles(self._inst(tmp_path))
+        content = (tmp_path / ".env").read_text()
+        assert 'RESTIC_PASSWORD="abc #def"' in content
+        assert "# trailing comment" in content
+        for line in content.split("\n"):
+            if line.startswith("COMPOSE_PROFILES="):
+                assert "elasticsearch" in line
+                break
 
     def test_deactivated_profile_tears_down_its_container(self, tmp_path):
         # elasticsearch was active; the flag is now false. The profile is


### PR DESCRIPTION
Addresses part of #965 — `.env` quote handling. Other #965 items are in separate PRs.

The `.env` codec stripped quotes on read and, on any write, re-serialized every entry from its stripped value. So (a) a quote-only `config set` reported `changed=false` and left the quotes (the CLI's own remediation was a no-op), and (b) setting an unrelated key stripped quotes file-wide — `KEY="abc #def"` became `KEY=abc #def`, which compose truncates at ` #`.

Fix (module + `_helpers.py` mirror): a raw-line codec rewrites only the targeted key and keeps every other line byte-for-byte; the targeted key is compared/written from the raw value, so a quote-only change is detected and repaired. The entry-based read API and `lint` normalization are untouched.

New unit tests cover quote-only repair, byte-for-byte preservation of untouched lines (including ` #` inside quotes), and idempotency. Full unit suite passes; no pre-existing test modified.
