### PR TITLE
fix(scripts): resolve three-token subcommands in coverage audit

### DIFF
--- a/scripts/audit_command_coverage.py
+++ b/scripts/audit_command_coverage.py
@@ -62,7 +62,52 @@ def _string_const(node):
     return None
 
 
-def extract_test_invocations(test_file, subcommand_groups):
+def _leading_name_tokens(args):
+    """Return the leading run of string-literal positional tokens.
+
+    Stops at the first non-string argument or the first flag/option
+    (a string token beginning with "-"), so option values are never
+    folded into the command name.
+    """
+    tokens = []
+    for arg in args:
+        value = _string_const(arg)
+        if value is None or value.startswith("-"):
+            break
+        tokens.append(value)
+    return tokens
+
+
+def resolve_command(args, subcommand_groups, known_commands=None):
+    """Resolve a run* call's positional args to a canonical command key.
+
+    Tries the longest subcommand path first: a three-token
+    "group sub sub" resolves to "group_sub_sub", a two-token
+    "group sub" to "group_sub", otherwise the first token alone. The
+    CLI/tests use hyphenated names (bouncer-enroll) while
+    command_definitions.yml uses underscores, so hyphens are normalized.
+    When known_commands is supplied, the longest candidate that names a
+    real command wins; otherwise the greedy two-token form is used.
+    """
+    tokens = _leading_name_tokens(args)
+    if not tokens:
+        return None
+    first = tokens[0]
+    if first not in subcommand_groups or len(tokens) < 2:
+        return first
+
+    def key(n):
+        return "_".join(tokens[:n]).replace("-", "_")
+
+    if known_commands is not None:
+        for n in range(len(tokens), 1, -1):
+            candidate = key(n)
+            if candidate in known_commands:
+                return candidate
+    return key(2)
+
+
+def extract_test_invocations(test_file, subcommand_groups, known_commands=None):
     """Walk the test file and yield (test_func_name, command_name) tuples.
 
     command_name is the canonical underscore-joined form
@@ -103,27 +148,9 @@ def extract_test_invocations(test_file, subcommand_groups):
                      or func.value.id.startswith("inst_"))):
             continue
 
-        # First positional arg is the command name (or group name).
-        if not node.args:
+        command = resolve_command(node.args, subcommand_groups, known_commands)
+        if command is None:
             continue
-        first = _string_const(node.args[0])
-        if first is None:
-            continue
-
-        # If the first arg is a subcommand group, the second positional
-        # arg is the actual subcommand name.
-        if first in subcommand_groups and len(node.args) >= 2:
-            second = _string_const(node.args[1])
-            if second is not None:
-                # command_definitions.yml names subcommands with
-                # underscores (crowdsec_bouncer_enroll), but the CLI and
-                # tests use the hyphenated user-facing form
-                # (crowdsec bouncer-enroll). Normalize so they match.
-                command = ("%s_%s" % (first, second)).replace("-", "_")
-            else:
-                command = first
-        else:
-            command = first
 
         yield func_for_line(node.lineno), command
 
@@ -146,7 +173,7 @@ def main():
     coverage = defaultdict(set)  # command -> {test_func_name, ...}
     unknown = set()              # invoked commands not in definitions
 
-    for test_name, command in extract_test_invocations(TEST_FILE, groups):
+    for test_name, command in extract_test_invocations(TEST_FILE, groups, all_commands):
         if command in all_commands:
             coverage[command].add(test_name or "?")
         else:

--- a/tests/unit/test_audit_command_coverage.py
+++ b/tests/unit/test_audit_command_coverage.py
@@ -16,6 +16,11 @@ import audit_command_coverage as audit  # noqa: E402
 GROUPS = {"backup", "config", "extension", "skin", "gitops", "host",
           "maintenance", "sitemap", "devmode", "storage", "crowdsec"}
 
+# A small stand-in for the command_definitions.yml name set, used to
+# exercise longest-path (three-token) resolution.
+KNOWN = {"create", "backup_create", "backup_schedule_set",
+         "backup_schedule_list", "backup_schedule_remove"}
+
 
 def write_test_file(content):
     """Write content to a temp .py file and return its path."""
@@ -172,6 +177,52 @@ class TestExtractInvocations:
             assert results == [("test_x", "backup")]
         finally:
             os.unlink(path)
+
+    def test_three_token_subcommand(self):
+        # A three-token leaf command resolves to group_sub_sub when the
+        # known-command set is supplied.
+        path = write_test_file(
+            'def test_x(inst):\n'
+            '    inst.run_ok("backup", "schedule", "set", "-i", "x", "0 3 * * *")\n'
+        )
+        try:
+            results = list(
+                audit.extract_test_invocations(path, GROUPS, KNOWN),
+            )
+            assert results == [("test_x", "backup_schedule_set")]
+        finally:
+            os.unlink(path)
+
+
+def _args(*values):
+    """Build an ast positional-arg list from literal string values."""
+    import ast
+    return [ast.Constant(value=v) for v in values]
+
+
+class TestResolveCommand:
+    def test_three_token_resolves_to_group_sub_sub(self):
+        args = _args("backup", "schedule", "set", "-i", "x")
+        assert audit.resolve_command(args, GROUPS, KNOWN) == \
+            "backup_schedule_set"
+
+    def test_two_token_resolves_to_group_sub(self):
+        args = _args("backup", "create", "-i", "x")
+        assert audit.resolve_command(args, GROUPS, KNOWN) == "backup_create"
+
+    def test_one_token_command(self):
+        assert audit.resolve_command(_args("create", "-i", "x"),
+                                     GROUPS, KNOWN) == "create"
+
+    def test_trailing_flag_not_folded_into_name(self):
+        # The option value after a flag must never join the command name.
+        args = _args("backup", "create", "-i", "schedule")
+        assert audit.resolve_command(args, GROUPS, KNOWN) == "backup_create"
+
+    def test_leading_tokens_stop_at_first_flag(self):
+        args = _args("backup", "create", "--force", "set")
+        tokens = audit._leading_name_tokens(args)
+        assert tokens == ["backup", "create"]
 
 
 class TestLoadCommands:


### PR DESCRIPTION
Addresses part of #966 — the coverage-audit attribution bug.

`scripts/audit_command_coverage.py` only tried a two-token `group_sub` key, so a three-token invocation like `inst.run_ok("backup", "schedule", "set", ...)` collapsed to `backup_schedule` (matching no command) — falsely reporting `backup_schedule_set/list/remove` uncovered and printing 62/83 when the real number is 65/83.

Fix: token resolution is extracted into importable helpers; when a two-token match fails and a third positional string token exists it tries `group_sub_sub`, picking the longest real command. Flags (tokens starting with `-`) are never folded into the name. Running the audit now reports 65/83 with no unknown-invocation warning.

New unit tests in `test_audit_command_coverage.py`; full unit suite passes.
