### PR TITLE
fix(security): add no_log to secret-key and .env read tasks in upgrade/install

### DIFF
--- a/roles/mediawiki/tasks/install_single_wiki.yml
+++ b/roles/mediawiki/tasks/install_single_wiki.yml
@@ -17,6 +17,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _install_env
+  no_log: true  # .env includes MYSQL_PASSWORD
 
 - name: Set DB server for install
   ansible.builtin.set_fact:

--- a/roles/upgrade/tasks/migrations/extract_secret_key.yml
+++ b/roles/upgrade/tasks/migrations/extract_secret_key.yml
@@ -17,6 +17,7 @@
         chdir: "{{ instance_path }}"
       register: _sk_grep
       changed_when: false
+      no_log: true  # holds the wiki's session-signing secret
 
     - name: Save extracted secret key
       canasta_env:
@@ -25,6 +26,7 @@
         key: MW_SECRET_KEY
         value: "{{ _sk_grep.stdout | trim }}"
       when: _sk_grep.stdout | trim | length > 0
+      no_log: true  # holds the wiki's session-signing secret
 
     - name: Generate new secret key if not found
       when: _sk_grep.stdout | trim | length == 0
@@ -41,3 +43,4 @@
             state: set
             key: MW_SECRET_KEY
             value: "{{ _sk_gen.stdout | trim }}"
+          no_log: true  # holds the wiki's session-signing secret

--- a/tests/unit/test_install_secret_logging.py
+++ b/tests/unit/test_install_secret_logging.py
@@ -21,6 +21,10 @@ REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 INSTALL_WIKI = os.path.join(
     REPO_ROOT, "roles", "mediawiki", "tasks", "install_single_wiki.yml",
 )
+EXTRACT_SECRET_KEY = os.path.join(
+    REPO_ROOT, "roles", "upgrade", "tasks", "migrations",
+    "extract_secret_key.yml",
+)
 
 _PASSWORD_VAR = re.compile(r"_password\b")
 
@@ -81,3 +85,59 @@ class TestInstallSecretsNotLogged:
                     "leaking the secret into Ansible output (#722). "
                     "Command: %s" % command
                 )
+
+    def test_env_read_all_is_no_log(self):
+        """The read_all of .env pulls MYSQL_PASSWORD into a registered
+        variable; the task must be no_log."""
+        with open(INSTALL_WIKI) as f:
+            tasks = yaml.safe_load(f)
+        found = False
+        for task in _walk_tasks(tasks):
+            env = task.get("canasta_env")
+            if isinstance(env, dict) and env.get("state") == "read_all":
+                found = True
+                assert task.get("no_log") is True, (
+                    "The canasta_env read_all in install_single_wiki.yml "
+                    "must set no_log: true — it registers the full .env, "
+                    "including MYSQL_PASSWORD."
+                )
+        assert found, (
+            "install_single_wiki.yml has no canasta_env read_all task — "
+            "the .env secret-logging guard cannot run."
+        )
+
+
+class TestExtractSecretKeyNotLogged:
+    """extract_secret_key.yml handles $wgSecretKey, the wiki's
+    session-signing secret; every task carrying it must be no_log."""
+
+    def _tasks(self):
+        with open(EXTRACT_SECRET_KEY) as f:
+            return list(_walk_tasks(yaml.safe_load(f)))
+
+    def test_grep_register_is_no_log(self):
+        """The shell grep registers the extracted secret."""
+        found = False
+        for task in self._tasks():
+            if task.get("register") == "_sk_grep":
+                found = True
+                assert task.get("no_log") is True, (
+                    "The wgSecretKey grep task must set no_log: true — "
+                    "it registers the wiki's session-signing secret."
+                )
+        assert found, "extract_secret_key.yml has no _sk_grep register task."
+
+    def test_secret_saves_are_no_log(self):
+        """Every canasta_env set of MW_SECRET_KEY must be no_log."""
+        found = False
+        for task in self._tasks():
+            env = task.get("canasta_env")
+            if isinstance(env, dict) and env.get("key") == "MW_SECRET_KEY":
+                found = True
+                assert task.get("no_log") is True, (
+                    "A canasta_env task saving MW_SECRET_KEY in "
+                    "extract_secret_key.yml must set no_log: true."
+                )
+        assert found, (
+            "extract_secret_key.yml has no MW_SECRET_KEY save task."
+        )


### PR DESCRIPTION
Addresses part of #965 — credential logging in the upgrade/install paths.

`roles/upgrade/tasks/migrations/extract_secret_key.yml` greps the live `$wgSecretKey` into a registered variable and passes it to two `canasta_env` save tasks with no `no_log` (its sibling `generate_secret_key.yml` does this correctly). And `roles/mediawiki/tasks/install_single_wiki.yml` registers the whole `.env` (including `MYSQL_PASSWORD`) via `read_all` with no `no_log`. With `-v` or on a task failure, these secrets reach terminal/CI logs.

Fix: `no_log: true` on the grep register, both secret-key saves, and the `.env` read_all. No user-facing status message was attached to any suppressed task, so none needed relocating.

Structural unit tests extended; full unit suite and lint pass.
