### PR TITLE
fix(validate): enforce alphanumeric/underscore allowlist for wiki IDs

### DIFF
--- a/roles/common/module_utils/canasta_validate.py
+++ b/roles/common/module_utils/canasta_validate.py
@@ -23,6 +23,12 @@ import re
 # Identical list shared by both modules.
 RESERVED_WIKI_IDS = ["settings", "images", "w", "wiki", "wikis"]
 
+# A wiki ID becomes a MariaDB database name, a per-wiki settings directory
+# (config/settings/wikis/<id>/), and a URL path component. Restrict it to
+# alphanumerics and underscores. Unlike instance IDs, hyphens are NOT
+# allowed.
+_WIKI_ID_RE = re.compile(r"^[a-zA-Z0-9_]+$")
+
 
 def validate_wiki_id(value):
     """Return None if `value` is a valid wiki ID, otherwise an error
@@ -31,6 +37,11 @@ def validate_wiki_id(value):
         return "wiki ID cannot be empty"
     if "-" in value:
         return "wiki ID '%s' cannot contain hyphens" % value
+    if not _WIKI_ID_RE.match(value):
+        return (
+            "wiki ID '%s' is invalid: use letters, digits, and underscores "
+            "only" % value
+        )
     if value in RESERVED_WIKI_IDS:
         return "wiki ID '%s' is reserved (cannot be: %s)" % (
             value, ", ".join(RESERVED_WIKI_IDS),

--- a/tests/unit/test_canasta_validate.py
+++ b/tests/unit/test_canasta_validate.py
@@ -19,6 +19,34 @@ class TestValidateWikiId:
     def test_valid_alphanumeric(self):
         assert canasta_validate.validate_wiki_id("wiki2") is None
 
+    def test_valid_mixed_case(self):
+        assert canasta_validate.validate_wiki_id("Wiki2") is None
+
+    def test_space_rejected(self):
+        err = canasta_validate.validate_wiki_id("my wiki")
+        assert err is not None
+        assert "invalid" in err
+
+    def test_slash_rejected(self):
+        err = canasta_validate.validate_wiki_id("foo/bar")
+        assert err is not None
+        assert "invalid" in err
+
+    def test_dot_rejected(self):
+        err = canasta_validate.validate_wiki_id("foo.bar")
+        assert err is not None
+        assert "invalid" in err
+
+    def test_dotdot_rejected(self):
+        err = canasta_validate.validate_wiki_id("..")
+        assert err is not None
+        assert "invalid" in err
+
+    def test_unicode_rejected(self):
+        err = canasta_validate.validate_wiki_id("wikí")
+        assert err is not None
+        assert "invalid" in err
+
     def test_empty_rejected(self):
         err = canasta_validate.validate_wiki_id("")
         assert err is not None


### PR DESCRIPTION
Addresses part of #965 — weak wiki-ID validation.

`validate_wiki_id` only checked empty/hyphen/reserved names, so `my wiki`, `foo/bar`, `foo.bar`, `..` all passed — then became a MariaDB database name, a `config/settings/wikis/<id>/` path, and a URL component, failing deep in install.php or leaving nested dirs.

Fix: add an `^[a-zA-Z0-9_]+$` allowlist (letters, digits, underscores; hyphens still rejected with their specific message), matching the documented rule on Help:General concepts / Help:Best practices and the compiled-regex idiom already used for sidecar and instance IDs. This gates only new-wiki write paths (`generate`/`add` + the farmsettings field validator); read/list/remove over existing wikis never call it, so existing instances are unaffected.

New unit cases (spaces, slash, dot, `..`, unicode rejected; mixed-case valid) added; full unit suite passes.
