### PR TITLE
fix(helpers): resolve ssh target before remote .env write

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -281,9 +281,11 @@ def _write_env_content(path, host, content):
             print("Error writing %s: %s" % (env_path, e), file=sys.stderr)
             return False
 
+    # Map short host names to their real SSH target, like the read path.
+    target = _resolve_ssh_target(host)
     ssh_cmd = (
         ["ssh"] + _ssh_args()
-        + [host, "cat > %s" % _shell_quote(env_path)]
+        + [target, "cat > %s" % _shell_quote(env_path)]
     )
     try:
         result = subprocess.run(

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1548,6 +1548,27 @@ class TestEnvFileWriter:
         with open(tmp_path / ".env") as f:
             assert f.read() == "K=v\n"
 
+    def test_write_env_content_remote_resolves_ssh_target(self, monkeypatch):
+        """A short-name remote host must be mapped to its real SSH target
+        before the ssh argv is built, matching the read path."""
+        captured = {}
+
+        monkeypatch.setattr(
+            direct_commands._helpers, "_resolve_ssh_target",
+            lambda host: "admin@cp.example.com" if host == "node1" else host,
+        )
+
+        def fake_run(ssh_cmd, **kwargs):
+            captured["cmd"] = ssh_cmd
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        ok = direct_commands._write_env_content("/srv/mysite", "node1", "K=v\n")
+        assert ok is True
+        # ssh target must be the resolved user@host, not the bare 'node1'.
+        assert "admin@cp.example.com" in captured["cmd"]
+        assert "node1" not in captured["cmd"]
+
 
 class TestEnvRawLineHelpers:
     """_set_env_lines rewrites only the target key, keeping other lines


### PR DESCRIPTION
Addresses part of #965 — remote `.env` write used an unresolved host.

`_write_env_content` built its ssh argv from the raw `host`, while the read path (`_ssh_run`) and `_write_remote_or_local_file` both map short host names to `user@ansible_host` via `_resolve_ssh_target`. If conf.json's `host` is a short name, reads of a drifted `.env` succeed but the corrective write fails ("Could not resolve hostname"), leaving profile drift unhealed while start proceeds.

Fix: resolve the target with `_resolve_ssh_target(host)` before building the ssh argv, exactly as the sibling helpers do — one call.

New unit test asserts the resolved target is used for a short-name remote host; localhost still writes locally. Full unit suite passes.
