### PR TITLE
feat(create): forward --build-arg through --build-from image builds

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -368,6 +368,13 @@ commands:
         type: path
         mutual_exclusion: canasta_image
         description: "Build from local source directory"
+      - name: build_arg
+        type: string
+        multi: true
+        description: >-
+          Build argument KEY=VALUE forwarded to the --build-from image
+          builds (repeatable, e.g. --build-arg MW_VERSION=master). A
+          user-supplied BASE_IMAGE overrides the auto-detected base.
       - name: database
         short: d
         type: path

--- a/roles/common/library/canasta_registry.py
+++ b/roles/common/library/canasta_registry.py
@@ -58,6 +58,10 @@ options:
   build_from:
     description: Local source directory for image builds.
     type: str
+  build_args:
+    description: Build args (list of KEY=VALUE) to replay on rebuild.
+    type: list
+    elements: str
   host:
     description: SSH host (user@host or host) for instances on a remote machine.
     type: str
@@ -125,6 +129,8 @@ def instance_to_dict(instance):
         result["kindCluster"] = instance["kindCluster"]
     if instance.get("buildFrom"):
         result["buildFrom"] = instance["buildFrom"]
+    if instance.get("buildArgs"):
+        result["buildArgs"] = instance["buildArgs"]
     if instance.get("dockerHost"):
         result["dockerHost"] = instance["dockerHost"]
     return result
@@ -146,6 +152,7 @@ def run_module():
         registry=dict(type="str", required=False),
         kind_cluster=dict(type="str", required=False),
         build_from=dict(type="str", required=False),
+        build_args=dict(type="list", elements="str", required=False),
         host=dict(type="str", required=False),
         docker_host=dict(type="str", required=False),
         filter_host=dict(type="str", required=False),
@@ -229,6 +236,7 @@ def run_module():
             "registry": module.params.get("registry"),
             "kindCluster": module.params.get("kind_cluster"),
             "buildFrom": module.params.get("build_from"),
+            "buildArgs": module.params.get("build_args"),
             "dockerHost": module.params.get("docker_host"),
         })
 

--- a/roles/create/tasks/_register.yml
+++ b/roles/create/tasks/_register.yml
@@ -23,6 +23,7 @@
     docker_host: "{{ docker_host | default(_detected_docker_host | default(''), true) | default(omit, true) }}"
     managed_cluster: false
     build_from: "{{ build_from | default(omit) }}"
+    build_args: "{{ build_arg | default(omit, true) }}"
     state: present
   delegate_to: localhost
   vars:
@@ -37,5 +38,6 @@
     docker_host: "{{ docker_host | default(_detected_docker_host | default(''), true) | default(omit, true) }}"
     managed_cluster: false
     build_from: "{{ build_from | default(omit) }}"
+    build_args: "{{ build_arg | default(omit, true) }}"
     state: present
   when: inventory_hostname != "localhost"

--- a/roles/imagebuild/tasks/build_from_source.yml
+++ b/roles/imagebuild/tasks/build_from_source.yml
@@ -1,7 +1,9 @@
 ---
 # Build Canasta image from local source.
 #
-# Input: build_from (path to workspace containing Canasta/ and optionally CanastaBase/)
+# Input:
+#   build_from (path to workspace containing Canasta/ and optionally CanastaBase/)
+#   build_arg  (optional list of "KEY=VALUE" strings forwarded to the builds)
 # Output fact: _built_image (str: "canasta:local")
 
 - name: Verify Canasta source exists
@@ -14,6 +16,22 @@
     msg: "Canasta Dockerfile not found at {{ build_from }}/Canasta/Dockerfile"
   when: not _canasta_dockerfile.stat.exists
 
+- name: Validate build-arg format (KEY=VALUE)
+  ansible.builtin.fail:
+    msg: "Invalid --build-arg '{{ item }}': expected KEY=VALUE"
+  loop: "{{ build_arg | default([]) }}"
+  when: "'=' not in item"
+
+# Render the user's build args as "--build-arg KEY=VALUE ..." tokens. They
+# are appended after any built-in --build-arg, so a user-supplied BASE_IMAGE
+# wins (docker uses the last value for a repeated build-arg key).
+- name: Assemble build-arg flags
+  ansible.builtin.set_fact:
+    _build_arg_flags: >-
+      {{ build_arg | default([])
+         | map('regex_replace', '^(.+)$', '--build-arg \1')
+         | join(' ') }}
+
 - name: Check for CanastaBase source
   ansible.builtin.stat:
     path: "{{ build_from }}/CanastaBase/Dockerfile"
@@ -24,7 +42,7 @@
   block:
     - name: Build CanastaBase image
       ansible.builtin.command:
-        cmd: "docker build -t canasta-base:local ."
+        cmd: "docker build {{ _build_arg_flags }} -t canasta-base:local ."
         chdir: "{{ build_from }}/CanastaBase"
       changed_when: true
 
@@ -39,7 +57,7 @@
 
 - name: Build Canasta image from source
   ansible.builtin.command:
-    cmd: "docker build --build-arg BASE_IMAGE={{ _base_image_arg }} -t canasta:local ."
+    cmd: "docker build --build-arg BASE_IMAGE={{ _base_image_arg }} {{ _build_arg_flags }} -t canasta:local ."
     chdir: "{{ build_from }}/Canasta"
   changed_when: true
 

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -85,6 +85,7 @@
         tasks_from: build_from_source.yml
       vars:
         build_from: "{{ _upgrade_inst.instance.buildFrom }}"
+        build_arg: "{{ _upgrade_inst.instance.buildArgs | default([]) }}"
 
     - name: Publish rebuilt image for the orchestrator
       ansible.builtin.include_tasks: >-

--- a/tests/unit/test_build_from_build_args.py
+++ b/tests/unit/test_build_from_build_args.py
@@ -1,0 +1,75 @@
+"""Structural guards for --build-arg passthrough on `canasta create
+--build-from` (issue #905).
+
+A real image build needs Docker, which unit CI can't assume, so these lock
+in the wiring instead:
+
+  - `create` exposes a repeatable --build-arg;
+  - the args are validated (KEY=VALUE) and forwarded to BOTH the CanastaBase
+    and Canasta `docker build` invocations;
+  - a user-supplied BASE_IMAGE wins over the auto-detected base (user args
+    are appended after the built-in --build-arg, and docker takes the last);
+  - the args are persisted in the registry and replayed on upgrade, so a
+    rebuild doesn't silently revert to defaults.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+BUILD_FROM = os.path.join(
+    REPO_ROOT, "roles", "imagebuild", "tasks", "build_from_source.yml")
+CMD_DEFS = os.path.join(REPO_ROOT, "meta", "command_definitions.yml")
+REGISTRY = os.path.join(
+    REPO_ROOT, "roles", "common", "library", "canasta_registry.py")
+REGISTER = os.path.join(REPO_ROOT, "roles", "create", "tasks", "_register.yml")
+UPGRADE_MAIN = os.path.join(REPO_ROOT, "roles", "upgrade", "tasks", "main.yml")
+
+
+def _text(path):
+    with open(path) as f:
+        return f.read()
+
+
+def test_create_exposes_repeatable_build_arg():
+    with open(CMD_DEFS) as f:
+        defs = yaml.safe_load(f)
+    create = next(c for c in defs["commands"] if c["name"] == "create")
+    ba = next(p for p in create["parameters"] if p["name"] == "build_arg")
+    assert ba.get("multi") is True
+
+
+def test_build_from_validates_key_value():
+    txt = _text(BUILD_FROM)
+    # Rejects a bare token with no '='.
+    assert "'=' not in item" in txt
+
+
+def test_build_args_forwarded_to_canasta_base_build():
+    txt = _text(BUILD_FROM)
+    assert "docker build {{ _build_arg_flags }} -t canasta-base:local" in txt
+
+
+def test_build_args_forwarded_to_canasta_build_after_base_image():
+    # user args come AFTER --build-arg BASE_IMAGE so a user BASE_IMAGE wins
+    # (docker uses the last value for a repeated key).
+    txt = _text(BUILD_FROM)
+    assert ("--build-arg BASE_IMAGE={{ _base_image_arg }} "
+            "{{ _build_arg_flags }} -t canasta:local") in txt
+
+
+def test_registry_persists_build_args():
+    txt = _text(REGISTRY)
+    assert "build_args=dict(type=\"list\"" in txt
+    assert "\"buildArgs\"" in txt
+
+
+def test_register_passes_build_args():
+    txt = _text(REGISTER)
+    assert "build_args:" in txt
+
+
+def test_upgrade_replays_build_args():
+    txt = _text(UPGRADE_MAIN)
+    assert "buildArgs" in txt


### PR DESCRIPTION
## Summary
Adds a repeatable `--build-arg KEY=VALUE` to `canasta create`, forwarded to the `--build-from` image builds. This lets a custom or unreleased base (or MediaWiki version) be driven through the CLI instead of hand-editing a Dockerfile.

- `meta/command_definitions.yml`: new repeatable `--build-arg` on `create`.
- `roles/imagebuild/tasks/build_from_source.yml`: validate `KEY=VALUE`; thread the args into **both** the CanastaBase and Canasta `docker build` invocations. User args are appended after the built-in `--build-arg BASE_IMAGE=…`, so a user-supplied `BASE_IMAGE` wins (docker takes the last value for a repeated key).
- `roles/common/library/canasta_registry.py`: persist `buildArgs` next to `buildFrom`.
- `roles/upgrade/tasks/main.yml`: replay persisted `buildArgs` on rebuild so an upgrade doesn't revert to defaults.

## Testing
- New `tests/unit/test_build_from_build_args.py` (structural guards, 7 tests).
- `make validate`, `make lint`, `make test-unit` (1580 passed) all green.

Closes #905