### PR TITLE
fix(k8s): clear PVC entry before kubectl cp so updated extensions replace, not nest

### DIFF
--- a/roles/orchestrator/tasks/k8s_sync_user_dirs.yml
+++ b/roles/orchestrator/tasks/k8s_sync_user_dirs.yml
@@ -124,9 +124,25 @@
     label: "{{ item }}"
 
 # item.0 is the per-dir find result (item.0.item = 'extensions'|'skins');
-# item.1 is a top-level entry under it. kubectl cp copies the dir/file as
-# /sync/<dir>/<name> (i.e. user-extensions/<name>). Existing entries are
-# overwritten; the prune step above handles removals.
+# item.1 is a top-level entry under it, copied to /sync/<dir>/<name> (i.e.
+# user-extensions/<name>).
+#
+# kubectl cp of a DIRECTORY onto an existing directory nests it as
+# /sync/<dir>/<name>/<name> rather than replacing it, so a re-synced (updated)
+# extension/skin would leave the stale copy at the top level and orphan the
+# new code one level deep. Remove each managed entry first so the copy always
+# lands on a clean path. (The prune step above only removes entries no longer
+# in the instance dir, never one that is present-but-updated.)
+- name: Clear each managed entry before copy
+  ansible.builtin.command:
+    cmd: >-
+      kubectl exec -n {{ _ud_namespace }} user-dir-sync -c sync --
+      rm -rf /sync/{{ item.0.item }}/{{ item.1.path | basename }}
+  changed_when: true
+  loop: "{{ _ud_entries.results | subelements('files', skip_missing=True) }}"
+  loop_control:
+    label: "{{ item.0.item }}/{{ item.1.path | basename }}"
+
 - name: kubectl cp each entry into its PVC
   ansible.builtin.command:
     cmd: >-

--- a/tests/unit/test_k8s_sync_user_dirs.py
+++ b/tests/unit/test_k8s_sync_user_dirs.py
@@ -75,3 +75,23 @@ def test_sync_still_copies_present_entries():
     cmd = cp["ansible.builtin.command"]["cmd"]
     assert "kubectl cp" in cmd
     assert cp["loop"] == "{{ _ud_entries.results | subelements('files', skip_missing=True) }}"
+
+
+def test_managed_entry_cleared_before_copy():
+    # kubectl cp of a dir onto an existing dir NESTS it (/sync/<dir>/<name>/<name>)
+    # instead of replacing it, so an updated entry must be removed before the
+    # copy or its new code is orphaned one level deep. Guard the clear step and
+    # its order (clear must precede the cp).
+    tasks = _tasks()
+    names = _names(tasks)
+    assert "Clear each managed entry before copy" in names, (
+        "re-synced (updated) entries must be removed before kubectl cp, else "
+        "the copy nests under the existing dir and the old code keeps loading"
+    )
+    clear = next(t for t in tasks if t.get("name") == "Clear each managed entry before copy")
+    cmd = clear["ansible.builtin.command"]["cmd"]
+    assert "rm -rf" in cmd
+    # Clears exactly the entries about to be copied (same loop as the cp step).
+    assert clear["loop"] == "{{ _ud_entries.results | subelements('files', skip_missing=True) }}"
+    assert names.index("Clear each managed entry before copy") < \
+        names.index("kubectl cp each entry into its PVC")


### PR DESCRIPTION
Fixes #984.

## Problem

On Kubernetes, updating a custom extension/skin and re-running `canasta restart` did not push the new code to the pod — MediaWiki kept loading the previous version.

## Root cause

`k8s_sync_user_dirs.yml` mirrors each instance entry into the PVC with `kubectl cp <instance>/extensions/<name> <ns>/user-dir-sync:/sync/extensions/<name>`. The prune step only removes entries no longer present in the instance dir, so a present-but-**updated** entry is copied straight onto its existing PVC directory. `kubectl cp` of a directory onto an existing directory nests it as `/sync/<dir>/<name>/<name>` rather than replacing it, leaving the stale copy at the top level (which `create-symlinks.sh` links) and orphaning the new code one level deep.

`canasta restart` scales deployments to 0 and back up, so the web pod is recreated with a cold opcache — the pod lifecycle was fine; the PVC contents were wrong.

## Evidence (live 2-node instance)

`user-extensions/ReceiptScanner` after an update + restart:

```
-rw-r--r-- 1 1000 1000 5090 Jul  2 06:16 extension.json      <- old, top level (loaded)
drwxr-xr-x 7 root root  4096 Jul  2 14:43 ReceiptScanner     <- nested re-sync
ReceiptScanner/extension.json: 5416 bytes, Jul  2 14:43      <- new, orphaned one level deep
```

## Fix

Remove each managed entry from the PVC immediately before the `kubectl cp`, so the copy always lands on a clean, non-existent path. This makes every re-sync deterministic and also clears files removed within an extension between versions. It is self-healing: the first sync after this change removes both the stale top-level tree and the nested dir, then copies the new tree correctly.

## Tests

Added a structural guard (`test_managed_entry_cleared_before_copy`) asserting the clear step exists, uses `rm -rf` over the same entries as the copy, and runs before the `kubectl cp`. Full unit suite passes; runtime behavior is covered by the live k8s e2e.
