### PR TITLE
fix(maintenance): forward stdin through kubectl exec in _stream_in_container

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -673,8 +673,11 @@ def _stream_in_container(inst_id, inst, command, service="web",
                 file=sys.stderr,
             )
             return 1
+        # -i forwards the CLI's stdin, matching `docker compose exec`
+        # on the Compose paths, so redirects like
+        # `canasta maintenance script eval < probe.php` work on K8s too.
         argv = [
-            "kubectl", "exec", pod, "-n", ns, "--",
+            "kubectl", "exec", "-i", pod, "-n", ns, "--",
             "/bin/bash", "-c", wrapped,
         ]
         cwd = None

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2568,6 +2568,49 @@ class TestExecInContainer:
         assert rc == 1
 
 
+class TestStreamInContainerStdin:
+    """_stream_in_container must leave stdin attached on every
+    orchestrator so redirects like `canasta maintenance script eval
+    < probe.php` reach the script (#986)."""
+
+    @staticmethod
+    def _fake_popen(captured):
+        def fake(argv, **kw):
+            captured["argv"] = argv
+            captured["kwargs"] = kw
+            return type("P", (), {
+                "stdout": __import__("io").StringIO(""),
+                "wait": lambda self: 0,
+            })()
+        return fake
+
+    def test_k8s_exec_forwards_stdin(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(direct_commands._helpers, "_k8s_get_pod",
+            lambda ns, svc: "canasta-test-web-abc123",
+        )
+        monkeypatch.setattr(subprocess, "Popen", self._fake_popen(captured))
+        rc = direct_commands._helpers._stream_in_container(
+            "test", {"orchestrator": "kubernetes"}, "php maintenance/run.php eval",
+        )
+        assert rc == 0
+        assert captured["argv"][:3] == ["kubectl", "exec", "-i"]
+        # stdin must not be overridden away from inheritance.
+        assert "stdin" not in captured["kwargs"]
+
+    def test_compose_local_inherits_stdin(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(subprocess, "Popen", self._fake_popen(captured))
+        rc = direct_commands._helpers._stream_in_container(
+            "test", {"path": "/srv/test", "orchestrator": "compose"},
+            "php maintenance/run.php eval",
+        )
+        assert rc == 0
+        # -T disables the TTY but keeps stdin attached.
+        assert captured["argv"][:5] == ["docker", "compose", "exec", "-T", "web"]
+        assert "stdin" not in captured["kwargs"]
+
+
 class TestExtensionSkinList:
     def test_extension_list_registered(self):
         assert direct_commands.is_direct_command("extension_list")


### PR DESCRIPTION
Fixes #986

The Kubernetes branch of `_stream_in_container()` ran `kubectl exec` without `-i`, so maintenance scripts that read standard input — e.g. `canasta maintenance script eval < probe.php` — saw immediate EOF and exited silently on K8s instances, while the same redirect worked on Compose (local `docker compose exec -T` and the ssh path both inherit stdin).

**Change**
- Add `-i` to the `kubectl exec` argv, matching `docker compose exec`'s stdin behavior. Commands that do not read stdin ignore it, so this is safe for all current callers (`maintenance script`, `maintenance extension`, `maintenance update`).

**Tests**
- New `TestStreamInContainerStdin` pins the K8s argv (`kubectl exec -i …`), the Compose argv (`docker compose exec -T web …`), and that neither branch overrides stdin away from inheritance.
- `make test-unit`: 1583 passed. `make validate` / `make lint` clean.