### PR TITLE
fix(build-from): fail fast when BASE_IMAGE collides with the canasta:local output tag

### DIFF
--- a/roles/imagebuild/tasks/build_from_source.yml
+++ b/roles/imagebuild/tasks/build_from_source.yml
@@ -55,6 +55,29 @@
     _base_image_arg: "ghcr.io/canastawiki/canasta-base:latest"
   when: not _base_dockerfile.stat.exists
 
+# The effective base is the last BASE_IMAGE build-arg (a user-supplied one
+# wins over the built-in), else the auto-detected base. The output tag is
+# fixed at canasta:local, so if the effective base resolves to canasta:local
+# the overlay would build FROM its own output tag — overwriting the base and,
+# on a repeat build, silently layering the overlay on top of itself. Guard it.
+- name: Resolve effective BASE_IMAGE
+  ansible.builtin.set_fact:
+    _effective_base_image: >-
+      {{ (build_arg | default([]) | select('match', '^BASE_IMAGE=')
+          | map('regex_replace', '^BASE_IMAGE=', '') | list | last)
+         if (build_arg | default([]) | select('match', '^BASE_IMAGE=') | list | length > 0)
+         else _base_image_arg }}
+
+- name: Fail if the base image collides with the build-from output tag
+  ansible.builtin.fail:
+    msg: >-
+      --build-arg BASE_IMAGE=canasta:local collides with the build-from output
+      tag (canasta:local): the overlay would build FROM its own output and
+      overwrite it (and double-layer on a repeat build). Tag the base under a
+      distinct name, e.g. `docker tag canasta:local canasta:merged`, and pass
+      --build-arg BASE_IMAGE=canasta:merged.
+  when: _effective_base_image == 'canasta:local'
+
 - name: Build Canasta image from source
   ansible.builtin.command:
     cmd: "docker build --build-arg BASE_IMAGE={{ _base_image_arg }} {{ _build_arg_flags }} -t canasta:local ."

--- a/tests/unit/test_build_from_build_args.py
+++ b/tests/unit/test_build_from_build_args.py
@@ -73,3 +73,19 @@ def test_register_passes_build_args():
 def test_upgrade_replays_build_args():
     txt = _text(UPGRADE_MAIN)
     assert "buildArgs" in txt
+
+
+def test_build_from_guards_output_tag_collision():
+    # A user --build-arg BASE_IMAGE=canasta:local collides with the fixed
+    # canasta:local output tag (the overlay builds FROM its own output). The
+    # task must fail fast rather than silently overwrite the base / double-layer
+    # on a repeat build (#983). Guard the collision check and its order.
+    with open(BUILD_FROM) as f:
+        tasks = yaml.safe_load(f)
+    names = [t.get("name", "") for t in tasks]
+    assert "Resolve effective BASE_IMAGE" in names
+    guard_name = "Fail if the base image collides with the build-from output tag"
+    guard = next(t for t in tasks if t.get("name") == guard_name)
+    assert "ansible.builtin.fail" in guard
+    assert guard["when"] == "_effective_base_image == 'canasta:local'"
+    assert names.index(guard_name) < names.index("Build Canasta image from source")


### PR DESCRIPTION
Fixes #983.

## Problem

`roles/imagebuild/tasks/build_from_source.yml` fixes the built image's output tag at `canasta:local`. Since #905 lets a caller pass `--build-arg BASE_IMAGE=<ref>` (user args are appended last, so they win), passing `--build-arg BASE_IMAGE=canasta:local` makes the overlay build `FROM canasta:local` **and** retag its result `canasta:local`, overwriting the base tag.

One-shot builds happen to work (Docker resolves `FROM` before retagging), but a repeated deploy without rebuilding the base then builds `FROM` the previous overlay, silently double-layering.

## Fix

Resolve the effective `BASE_IMAGE` (the last `BASE_IMAGE` build-arg, else the auto-detected base) and fail fast with an actionable message when it equals the output tag. The built-in base is only ever `canasta-base:local` or the ghcr base, so this triggers only on an explicit `--build-arg BASE_IMAGE=canasta:local` — every normal build is unaffected.

```
--build-arg BASE_IMAGE=canasta:local collides with the build-from output tag
(canasta:local): the overlay would build FROM its own output and overwrite it
(and double-layer on a repeat build). Tag the base under a distinct name, e.g.
`docker tag canasta:local canasta:merged`, and pass
--build-arg BASE_IMAGE=canasta:merged.
```

## Alternative considered

The issue also suggested making the output tag configurable so `BASE_IMAGE=canasta:local` could work by emitting a distinct output tag. That is a larger change (a new flag, and the output tag flows into the registry and k8s values), so this PR takes the minimal guard route for a low-severity edge case. Happy to switch if preferred.

## Tests

Added a structural guard (`test_build_from_guards_output_tag_collision`) asserting the resolve + fail tasks exist, the `when` compares the effective base to `canasta:local`, and the guard runs before the build. The effective-base Jinja was also validated at runtime across cases (user BASE_IMAGE wins, last-wins on repeats, no false positive on `MY_BASE_IMAGE=`, empty/absent falls back to the auto-detected base). Full unit suite, lint, and definition validation pass.
