### PR TITLE
fix(gitops): give a clear error when 'gitops add' rejects a path

### DIFF
--- a/roles/gitops/tasks/add.yml
+++ b/roles/gitops/tasks/add.yml
@@ -26,13 +26,36 @@
     _add_other_files: "{{ _add_files | reject('equalto', 'config/wikis.yaml') | list }}"
 
 # Stage each explicitly named file other than the rendered wikis.yaml.
+# Keep the loop non-fatal so a bad path does not abort with the opaque
+# generic "non-zero return code"; the next task turns any failure into a
+# legible message.
 - name: Stage requested files
   ansible.builtin.command:
     cmd: "git add -- {{ item }}"
     chdir: "{{ instance_path }}"
   register: _git_add_file
   changed_when: _git_add_file.rc == 0
+  failed_when: false
   loop: "{{ _add_other_files }}"
+
+# git add exits non-zero for a path outside the repository (e.g. a
+# shell-relative '../wikis.yaml.template' typed from a subdirectory) or a
+# path that does not exist. Name each rejected file, show git's own
+# reason, and remind that paths are relative to the instance root.
+- name: Fail clearly when a requested file could not be staged
+  ansible.builtin.fail:
+    msg: |-
+      Could not stage the following file(s). Paths are relative to the
+      instance root ({{ instance_path }}), not your current directory.
+      {% for f in _git_add_failures %}
+      - {{ f.item }}: {{ f.stderr | default('git add failed', true) | trim }}
+      {% endfor %}
+  vars:
+    _git_add_failures: >-
+      {{ _git_add_file.results | default([])
+         | selectattr('rc', 'defined')
+         | rejectattr('rc', 'equalto', 0) | list }}
+  when: _git_add_failures | length > 0
 
 # config/wikis.yaml: capture the literal edit into the template rather
 # than staging the rendered file.

--- a/tests/unit/test_gitops_add_scope.py
+++ b/tests/unit/test_gitops_add_scope.py
@@ -46,3 +46,36 @@ class TestGitopsAddScope:
             "gitops add must stage explicit paths, not whole-tree "
             "`git add -A` (chdir-ignored since Git 2.0); found: %r" % offenders
         )
+
+    def test_requested_files_loop_is_non_fatal(self):
+        """The per-file `git add` loop must not abort on a bad path with
+        the opaque generic 'non-zero return code'. It carries
+        `failed_when: false` so the follow-up fail task can emit a legible
+        message instead."""
+        loop_task = next(
+            t for t in _load_tasks()
+            if "git add -- {{ item }}" in _cmd(t)
+        )
+        assert loop_task.get("failed_when") is False, (
+            "the requested-files git add loop must set failed_when: false "
+            "so a rejected path yields a clear message, not 'non-zero "
+            "return code'"
+        )
+
+    def test_clear_failure_message_task_present(self):
+        """A fail task must surface rejected paths with git's own reason
+        and the instance-root-relative reminder."""
+        fail_tasks = [
+            t for t in _load_tasks()
+            if "ansible.builtin.fail" in t or "fail" in t
+        ]
+        msgs = []
+        for t in fail_tasks:
+            f = t.get("ansible.builtin.fail") or t.get("fail") or {}
+            if isinstance(f, dict):
+                msgs.append(f.get("msg", ""))
+        joined = "\n".join(msgs)
+        assert "relative to the" in joined and "instance root" in joined, (
+            "add.yml must fail with a message reminding that paths are "
+            "relative to the instance root"
+        )


### PR DESCRIPTION
Fixes #991.

## Problem

`canasta gitops add <path>` interprets each path relative to the instance root and runs `git add` from there. A shell-relative path such as `../wikis.yaml.template` typed from a subdirectory (e.g. `~/wikifarm/config`) resolves outside the repository, and git's rejection surfaced only as the opaque generic:

```
Error: non-zero return code
```

## Fix

- Make the per-file staging loop non-fatal (`failed_when: false`) so a bad path no longer aborts with the generic message.
- Add a follow-up `fail` task that names each rejected file, shows git's own reason, and reminds that paths are relative to the instance root. Successfully-staged files in the same batch are excluded.

New output:

```
Error: Could not stage the following file(s). Paths are relative to the
instance root (/home/wikiworks/wikifarm), not your current directory.

- ../wikis.yaml.template: fatal: ".../wikis.yaml.template" is outside repository at ".../wikifarm"
```

## Scope

Only the requested-files loop is touched — that is the path that produced the opaque error. The `wikis.yaml` / `wikis.yaml.template` staging tasks below it are not loops and only run for the `config/wikis.yaml` case.

A deeper contributing factor is left for a separate change: the `canasta_minimal` callback drops `stderr`/`stdout` for loop-item command failures (it surfaces them for non-loop failures), noted in #991.

## Tests

- Two new guards in `tests/unit/test_gitops_add_scope.py`: the staging loop is non-fatal, and the clear-message fail task is present.
- Full suite: 1585 passed. `make validate` and `make lint` green.