### PR TITLE
fix(callback): surface stderr/stdout for loop-item command failures

### DIFF
--- a/callback_plugins/canasta_minimal.py
+++ b/callback_plugins/canasta_minimal.py
@@ -92,15 +92,24 @@ class CallbackModule(CallbackBase):
         ignore_errors = kwargs.get("ignore_errors", False)
         if ignore_errors:
             return
+        # Suppress the generic "One or more items failed" — the individual
+        # item failures were already displayed via v2_runner_item_on_failed.
+        if result._result.get("msg", "") == "One or more items failed":
+            return
+        self._display_failure(result)
+
+    def _display_failure(self, result):
+        """Render a failed command/task result: the message (with cmd +
+        exception diagnostics for spawn failures), the command's stdout
+        when the message is the generic 'non-zero return code', and
+        stderr. Shared by task-level and loop-item failures so both
+        surface the underlying command output, not just the opaque
+        generic message."""
         msg = result._result.get("msg", "")
         stderr = result._result.get("stderr", "")
         stdout = result._result.get("stdout", "")
         cmd = result._result.get("cmd", "")
         exc = result._result.get("exception", "")
-        # Suppress the generic "One or more items failed" — the individual
-        # item failures were already displayed via v2_runner_item_on_failed.
-        if msg == "One or more items failed":
-            return
         # For command failures, msg is generic "non-zero return code"
         # but stdout/stderr have the actual error from the command.
         if stdout and msg and "non-zero return code" in msg:
@@ -168,11 +177,12 @@ class CallbackModule(CallbackBase):
                 or result._result.get("_ansible_ignore_errors")
                 or getattr(getattr(result, "_task", None), "ignore_errors", None)):
             return
-        # Display the specific item's failure message (e.g., missing
-        # required parameter in a loop over param definitions).
-        msg = result._result.get("msg", "")
-        if msg:
-            self._display.display("Error: %s" % msg, color="red", stderr=True)
+        # Display the specific item's failure the same way as a task-level
+        # failure: the message plus the command's stdout/stderr. A looped
+        # command that fails (e.g. 'git add' on a path outside the repo)
+        # otherwise surfaces only the opaque generic "non-zero return
+        # code", dropping git's own reason on stderr.
+        self._display_failure(result)
 
     def v2_playbook_on_no_hosts_matched(self):
         self._display.display("Error: No matching hosts found", color="red", stderr=True)

--- a/tests/unit/test_canasta_minimal_callback.py
+++ b/tests/unit/test_canasta_minimal_callback.py
@@ -212,6 +212,46 @@ class TestRunnerItemOnFailed:
         )
         assert cb._captured == []
 
+    def test_item_command_failure_surfaces_stderr(self):
+        """A looped command that exits non-zero (e.g. 'git add' on a path
+        outside the repo) must surface the command's stderr, not just the
+        opaque generic 'non-zero return code'."""
+        cb = _make_callback()
+        cb.v2_runner_item_on_failed(_item_result(
+            ignore_errors=None,
+            msg="non-zero return code",
+            cmd=["git", "add", "--", "../wikis.yaml.template"],
+            stdout="",
+            stderr="fatal: '../wikis.yaml.template' is outside repository",
+        ))
+        msgs = [m for (m, _, _) in cb._captured]
+        assert any("cmd: git add -- ../wikis.yaml.template" in m for m in msgs)
+        assert any("outside repository" in m for m in msgs)
+
+    def test_item_command_failure_surfaces_stdout(self):
+        """When the command wrote the error to stdout, that is shown in
+        place of the generic message (mirrors the task-level path)."""
+        cb = _make_callback()
+        cb.v2_runner_item_on_failed(_item_result(
+            ignore_errors=None,
+            msg="non-zero return code",
+            cmd=["foo"],
+            stdout="something failed on stdout",
+            stderr="",
+        ))
+        msgs = [m for (m, _, _) in cb._captured]
+        assert msgs == ["Error: something failed on stdout"]
+
+    def test_item_plain_message_still_shown(self):
+        """A non-command item failure (e.g. a fail task in a loop) with
+        just a msg is unchanged: the message is displayed as-is."""
+        cb = _make_callback()
+        cb.v2_runner_item_on_failed(
+            _item_result(ignore_errors=None, msg="missing required parameter")
+        )
+        msgs = [m for (m, _, _) in cb._captured]
+        assert msgs == ["Error: missing required parameter"]
+
 
 class TestRunnerOnOkDebug:
     """v2_runner_on_ok renders debug task 'msg' output. A list msg (one


### PR DESCRIPTION
Fixes #993.

## Problem

The `canasta_minimal` stdout callback renders a failed command's `stdout` and `stderr` for **task-level** failures (`v2_runner_on_failed`), but for **loop-item** failures (`v2_runner_item_on_failed`) it displayed only `msg`.

Ansible sets `msg` to the generic `"non-zero return code"` for command failures and puts the real error on `stdout`/`stderr`, so any looped command that fails surfaced only `Error: non-zero return code` — the command's own reason was silently dropped. This is what made the `gitops add` error in #991 so opaque.

## Fix

Extract the task-level rendering into a shared `_display_failure` helper and call it from both `v2_runner_on_failed` and `v2_runner_item_on_failed`. Loop-item failures now surface the command's `stdout`/`stderr` and `cmd`/exception diagnostics, exactly as task-level failures already did. The ignore-errors guards on the item handler are unchanged.

## Tests

Three new cases in `tests/unit/test_canasta_minimal_callback.py`: a looped command failure surfaces stderr + cmd; a stdout-only failure shows stdout in place of the generic message; a plain-message item failure is unchanged. Full suite: 1588 passed. `make lint` / `make validate` green.

## Relationship to #992

Complementary. #992 gives `gitops add` a tailored message at the task layer; this fixes the underlying callback gap for **all** looped commands. They do not conflict — with #992's `failed_when: false`, the `gitops add` loop no longer raises an item failure, so this callback path is exercised by other looped commands.