### PR TITLE
fix(k8s): mirror public_assets into the public-assets PVC on start

### DIFF
--- a/roles/orchestrator/tasks/k8s_sync_user_dirs.yml
+++ b/roles/orchestrator/tasks/k8s_sync_user_dirs.yml
@@ -1,6 +1,6 @@
 ---
-# Mirror the instance's extensions/ and skins/ directories into the
-# user-extensions / user-skins PVCs (Kubernetes).
+# Mirror the instance's extensions/, skins/, and public_assets/ directories
+# into the user-extensions / user-skins / public-assets PVCs (Kubernetes).
 #
 # On Compose the ./extensions and ./skins bind-mounts make custom
 # extensions/skins live in the container, and monitor-directories.sh's
@@ -16,8 +16,8 @@
 # the instance dir is now empty. A short-lived helper pod mounts the
 # PVCs, independent of the web pod's lifecycle. The PVCs always exist
 # here: this task only runs from start.yml, which acts on an
-# already-deployed Helm release (the chart's pvc-extensions/pvc-skins
-# are unconditional).
+# already-deployed Helm release (the chart's pvc-extensions / pvc-skins /
+# pvc-public-assets are unconditional).
 #
 # Runs BEFORE the Helm rollout so the new web pod starts with the PVC
 # already reconciled — avoids a CrashLoopBackOff when a settings fragment
@@ -30,8 +30,9 @@
     _ud_namespace: "{{ _k8s_namespace | default('canasta-' ~ (instance_id | default(id))) }}"
     _ud_release: "canasta-{{ instance_id | default(id) }}"
 
-# extensions -> <release>-extensions PVC @ /sync/extensions
-# skins      -> <release>-skins PVC      @ /sync/skins
+# extensions    -> <release>-extensions PVC    @ /sync/extensions
+# skins         -> <release>-skins PVC         @ /sync/skins
+# public_assets -> <release>-public-assets PVC @ /sync/public_assets
 - name: Render user-dir sync helper pod
   ansible.builtin.copy:
     dest: "{{ instance_path }}/.user-dir-sync-pod.yaml"
@@ -52,11 +53,14 @@
             volumeMounts:
               - { name: extensions, mountPath: /sync/extensions }
               - { name: skins, mountPath: /sync/skins }
+              - { name: public-assets, mountPath: /sync/public_assets }
         volumes:
           - name: extensions
             persistentVolumeClaim: { claimName: {{ _ud_release }}-extensions }
           - name: skins
             persistentVolumeClaim: { claimName: {{ _ud_release }}-skins }
+          - name: public-assets
+            persistentVolumeClaim: { claimName: {{ _ud_release }}-public-assets }
 
 - name: Replace any prior helper pod
   ansible.builtin.command:
@@ -86,7 +90,7 @@
     excludes: ['.gitignore', '.gitkeep', '.git']
     hidden: false
   register: _ud_entries
-  loop: ['extensions', 'skins']
+  loop: ['extensions', 'skins', 'public_assets']
 
 # Current PVC contents, to diff against the instance dir. `|| true` so an
 # empty dir doesn't fail the command.
@@ -97,11 +101,12 @@
       sh -c "ls -1 /sync/{{ item }} 2>/dev/null || true"
   register: _ud_pvc_ls
   changed_when: false
-  loop: ['extensions', 'skins']
+  loop: ['extensions', 'skins', 'public_assets']
 
 # Stale = present in the PVC but no longer in the instance dir. lost+found
 # (ext-family RWO volumes) is never a managed entry, so never prune it.
-# results[0] is extensions, results[1] is skins (loop order above).
+# results[0] is extensions, results[1] is skins, results[2] is public_assets
+# (loop order above).
 - name: Compute stale PVC entries to prune
   ansible.builtin.set_fact:
     _ud_prune: >-
@@ -111,7 +116,11 @@
          +
          (_ud_pvc_ls.results[1].stdout_lines | difference(['lost+found'])
           | difference(_ud_entries.results[1].files | map(attribute='path') | map('basename') | list)
-          | map('regex_replace', '^', 'skins/') | list) }}
+          | map('regex_replace', '^', 'skins/') | list)
+         +
+         (_ud_pvc_ls.results[2].stdout_lines | difference(['lost+found'])
+          | difference(_ud_entries.results[2].files | map(attribute='path') | map('basename') | list)
+          | map('regex_replace', '^', 'public_assets/') | list) }}
 
 - name: Prune removed entries from the PVCs
   ansible.builtin.command:

--- a/tests/unit/test_k8s_sync_user_dirs.py
+++ b/tests/unit/test_k8s_sync_user_dirs.py
@@ -1,13 +1,14 @@
-"""Structural guards for the K8s user-extensions/user-skins PVC mirror.
+"""Structural guards for the K8s user-extensions/user-skins/public-assets
+PVC mirror.
 
-On K8s, custom extensions/skins live in PVCs that only k8s_sync_user_dirs.yml
-populates. The sync must MIRROR the instance dirs — copy present entries AND
-prune entries removed from the instance dir — so that removing a custom
-extension/skin actually takes effect on the next start, matching the Compose
-inotify monitor. Earlier the sync was additive only (and gated on the dir
-having content), so a removal lingered in the PVC and got re-linked. These
-tests lock the mirror wiring in place; the runtime behavior is covered by the
-live K8s e2e.
+On K8s, custom extensions/skins and public_assets live in PVCs that only
+k8s_sync_user_dirs.yml populates. The sync must MIRROR the instance dirs —
+copy present entries AND prune entries removed from the instance dir — so that
+removing a custom extension/skin/asset actually takes effect on the next
+start, matching the Compose inotify monitor. Earlier the sync was additive
+only (and gated on the dir having content), so a removal lingered in the PVC
+and got re-linked. These tests lock the mirror wiring in place; the runtime
+behavior is covered by the live K8s e2e.
 """
 
 import os
@@ -75,6 +76,27 @@ def test_sync_still_copies_present_entries():
     cmd = cp["ansible.builtin.command"]["cmd"]
     assert "kubectl cp" in cmd
     assert cp["loop"] == "{{ _ud_entries.results | subelements('files', skip_missing=True) }}"
+
+
+def test_public_assets_is_mirrored():
+    # public_assets is a PVC on k8s like extensions/skins, and nothing else
+    # populates it, so the mirror must cover it too — otherwise logos/favicon
+    # referenced from settings ($wgLogos, $wgFavicon) 404 in the pod.
+    body = _text()
+    tasks = _tasks()
+    # Helper pod mounts the public-assets PVC at /sync/public_assets.
+    assert "public-assets" in body
+    assert "/sync/public_assets" in body
+    # The find + list loops include public_assets alongside extensions/skins.
+    find = next(t for t in tasks
+                if t.get("name") == "Find instance top-level entries per dir")
+    assert "public_assets" in find["loop"]
+    # Prune covers the public_assets PVC (results[2], loop order ext/skins/pa).
+    prune_fact = next(t for t in tasks
+                      if t.get("name") == "Compute stale PVC entries to prune")
+    expr = prune_fact["ansible.builtin.set_fact"]["_ud_prune"]
+    assert "public_assets/" in expr
+    assert "results[2]" in expr
 
 
 def test_managed_entry_cleared_before_copy():


### PR DESCRIPTION
## Summary

On Kubernetes the `<release>-public-assets` PVC is mounted into the web pod but nothing ever populated it, so an instance's `public_assets/` — a custom logo/favicon referenced via `$wgLogos` / `$wgFavicon` at `/w/public_assets/...` — 404'd in the pod. On Compose it works because `public_assets/` is a bind mount.

`k8s_sync_user_dirs.yml` already mirrors `extensions/` and `skins/` into their PVCs on start; this extends it to also mirror `public_assets/` into the `<release>-public-assets` PVC, copying present entries and pruning removed ones, run before the Helm rollout like the existing dirs.

## Changes

- `roles/orchestrator/tasks/k8s_sync_user_dirs.yml` — the sync helper pod mounts the public-assets PVC, and the find / list / prune loops include `public_assets`.
- `tests/unit/test_k8s_sync_user_dirs.py` — structural guard that `public_assets` is mirrored.

## Testing

- `make lint`, `make validate`, `make test-unit` (1590+ passing) all green.
- Verified live on a Kubernetes deploy where an app's logo was missing before the fix and rendered after it.

Closes #999
