### PR TITLE
fix(k8s): restore uploaded media into the images PVC

### DIFF
--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -4,6 +4,12 @@
 # is dynamically included (via include_tasks with a when guard).
 # Compose-only controllers no longer need the collection installed.
 #
+# Restores config (-> host -> ConfigMaps), .env, the DB (streamed into the
+# web pod), managed Secrets, and uploaded media (the images PVC, mounted into
+# the restore pod so restic lands it directly). extensions/skins/public_assets
+# are NOT restored here — the host instance dir is their source of truth and
+# k8s_sync_user_dirs mirrors it on the next start.
+#
 # Inputs: instance_path, instance_id, _resolved_snapshot, _restore_dbpass
 
 - name: Set K8s namespace
@@ -42,6 +48,14 @@
   ansible.builtin.set_fact:
     _restore_volume_mounts:
       - { name: restore-data, mountPath: /currentsnapshot }
+      # The images PVC is the sole source of truth for uploaded media —
+      # nothing syncs it from the controller (unlike extensions/skins/
+      # public_assets, which k8s_sync_user_dirs mirrors from the host dir).
+      # Mount it writable at the snapshot's images path so `restic restore
+      # --target /` lands the backed-up media directly in the PVC; without
+      # this the restore brings back config + DB but silently drops all
+      # uploads (the backup captures them — see k8s_run_backup.yml).
+      - { name: images, mountPath: /currentsnapshot/images }
 
 - name: Add local-repo mount when RESTIC_REPOSITORY is a path
   ansible.builtin.set_fact:
@@ -55,6 +69,9 @@
     _restore_volumes:
       - name: restore-data
         emptyDir: {}
+      - name: images
+        persistentVolumeClaim:
+          claimName: "canasta-{{ instance_id }}-images"
 
 - name: Add local-repo hostPath volume when RESTIC_REPOSITORY is a path
   ansible.builtin.set_fact:

--- a/tests/unit/test_restore_k8s.py
+++ b/tests/unit/test_restore_k8s.py
@@ -1,0 +1,46 @@
+"""Structural guards for the Kubernetes restore path.
+
+The k8s backup captures the images PVC (uploaded media), but restore used to
+extract only config, .env, the DB, and Secrets — the media in the snapshot was
+restored into the restore pod's emptyDir and discarded, so a restore (and any
+clone into a fresh cluster) silently lost all uploads. The fix mounts the
+images PVC into the restore pod so `restic restore --target /` lands media
+directly in it. These tests lock that wiring; runtime behavior is covered by
+the live k8s e2e.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+RESTORE = os.path.join(
+    REPO_ROOT, "roles", "backup", "tasks", "restore_k8s.yml")
+
+
+def _tasks():
+    with open(RESTORE) as f:
+        return yaml.safe_load(f)
+
+
+def test_restore_pod_mounts_the_images_pvc():
+    tasks = _tasks()
+    mounts_task = next(
+        t for t in tasks if t.get("name") == "Build restore pod volume mounts")
+    mounts = mounts_task["ansible.builtin.set_fact"]["_restore_volume_mounts"]
+    assert any(m.get("name") == "images"
+               and m.get("mountPath") == "/currentsnapshot/images"
+               for m in mounts), (
+        "restore pod must mount the images PVC at the snapshot's images path, "
+        "or restic restores media into an emptyDir and it is discarded")
+
+
+def test_restore_declares_the_images_pvc_volume():
+    tasks = _tasks()
+    vols_task = next(
+        t for t in tasks if t.get("name") == "Build restore pod volumes")
+    vols = vols_task["ansible.builtin.set_fact"]["_restore_volumes"]
+    images = next((v for v in vols if v.get("name") == "images"), None)
+    assert images is not None, "restore pod is missing the images PVC volume"
+    assert images["persistentVolumeClaim"]["claimName"] == \
+        "canasta-{{ instance_id }}-images"


### PR DESCRIPTION
## Summary

On Kubernetes `canasta restore` restored config, `.env`, the DB, and Secrets, but silently dropped uploaded media: the backup captures the `images` PVC, yet the restore pod mounted only an `emptyDir`, so restic restored the media into ephemeral storage that was discarded with the pod. Restore-in-place couldn't roll media back, and a clone into a fresh cluster came up with an empty `images` PVC (all uploads lost).

This mounts the `images` PVC into the restore pod at the snapshot's images path (`/currentsnapshot/images`), so `restic restore --target /` writes the media straight into the PVC — mirroring how `k8s_run_backup.yml` mounts it on the backup side.

`extensions/skins/public_assets` are intentionally unaffected: the host instance dir is their source of truth and `k8s_sync_user_dirs` mirrors it on the next start.

## Changes

- `roles/backup/tasks/restore_k8s.yml` — the restore pod now mounts the `canasta-<id>-images` PVC (writable) at `/currentsnapshot/images`.
- `tests/unit/test_restore_k8s.py` — structural guards that the restore pod mounts and declares the images PVC.

## Testing

- `make lint`, `make validate`, `make test-unit` all green.
- Runtime behavior is covered by the live k8s backup/restore e2e.

Closes #1001

Related: #565 (`--images` on `create` wants the same write-into-images-PVC capability on k8s).
