### PR TITLE
feat(create,add): --images to restore a wiki's uploaded media (#565)

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -379,6 +379,15 @@ commands:
         short: d
         type: path
         description: "Path to existing database dump (.sql or .sql.gz)"
+      - name: images
+        short: I
+        type: path
+        description: >-
+          Path to a tar (.tar or .tar.gz) of a wiki's images directory at the
+          hash-directory level (0/, 1/, archive/, ...). Its files are copied
+          into the wiki's uploads (images/<wiki>/) as www-data — a placement
+          restore, not importImages. Pairs with --database, which supplies the
+          File: page rows; a leading images/ parent in the tar is elided.
       - name: wiki_settings
         short: l
         type: path
@@ -883,6 +892,15 @@ commands:
         short: d
         type: path
         description: "Path to existing database dump"
+      - name: images
+        short: I
+        type: path
+        description: >-
+          Path to a tar (.tar or .tar.gz) of the new wiki's images directory at
+          the hash-directory level (0/, 1/, archive/, ...). Its files are
+          copied into the wiki's uploads (images/<wiki>/) as www-data — a
+          placement restore, not importImages. Pairs with --database, which
+          supplies the File: page rows; a leading images/ parent is elided.
       - name: wiki_settings
         short: l
         type: path

--- a/playbooks/add.yml
+++ b/playbooks/add.yml
@@ -174,6 +174,18 @@
         mode: "0600"
       no_log: true
 
+# Import uploaded media for the new wiki (--images), after its DB is ready so
+# the File: page rows (from --database) are present; this only places the
+# files. A placement restore, not importImages.
+- name: Import images tarball for the new wiki
+  ansible.builtin.include_role:
+    name: mediawiki
+    tasks_from: import_images.yml
+  vars:
+    import_wiki_id: "{{ wiki }}"
+    import_images_path: "{{ images }}"
+  when: images is defined and images != ''
+
 # NOW add to wikis.yaml (after successful install/import)
 - name: Add wiki to wikis.yaml
   canasta_wikis_yaml:

--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -170,6 +170,18 @@
 - name: Wait for DB and import dump or run installer
   ansible.builtin.include_tasks: _database.yml
 
+# --- Step 12b: Import uploaded media (--images) ---
+# After the DB so the File: page rows (from --database) are already present;
+# this only places the files. A placement restore, not importImages.
+- name: Import images tarball into the wiki's uploads
+  ansible.builtin.include_role:
+    name: mediawiki
+    tasks_from: import_images.yml
+  vars:
+    import_wiki_id: "{{ wiki }}"
+    import_images_path: "{{ images }}"
+  when: images is defined and images != ''
+
 # --- Step 13: Register instance ---
 - name: Register instance in controller and target host
   ansible.builtin.include_tasks: _register.yml

--- a/roles/mediawiki/tasks/import_images.yml
+++ b/roles/mediawiki/tasks/import_images.yml
@@ -1,0 +1,57 @@
+---
+# Restore a wiki's uploaded media into its per-wiki images directory.
+#
+# The File: page rows come from the database (--database); this only places
+# the files. `import_images_path` is a tar (.tar or .tar.gz — the content is
+# sniffed, so the extension does not matter) of a wiki's images dir at the
+# hash-directory level (0/, 1/, archive/, ...). A single leading images/
+# parent is elided. Files land in images/<wiki-id>/ — the per-wiki
+# $wgUploadDirectory ($MW_HOME/images/<id>, symlinked to the images
+# volume/PVC) — owned by www-data, matching create-storage-dirs.sh.
+#
+# Input: instance_path, instance_orchestrator, instance_id,
+#        import_wiki_id, import_images_path
+
+- name: Transfer images tarball to target host
+  ansible.builtin.copy:
+    src: "{{ import_images_path }}"
+    dest: "/tmp/canasta-images-import.tar"
+    mode: "0644"
+
+# Orchestrator dispatch (docker compose cp vs kubectl cp) into the web
+# container, which mounts the images volume/PVC.
+- name: Copy images tarball into the web container
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/copy_into_container.yml"
+  vars:
+    copy_service: web
+    copy_src: "/tmp/canasta-images-import.tar"
+    copy_dest: "/tmp/canasta-images-import.tar"
+
+- name: Clean up transferred tarball from target host
+  ansible.builtin.file:
+    path: "/tmp/canasta-images-import.tar"
+    state: absent
+
+# Extract the hash-dir tree into the wiki's uploads dir and fix ownership.
+# A single leading images/ parent (someone tarred the parent dir instead of
+# its contents) is elided so files always land at the hash-directory level.
+# exec_long: a large media tree can take a while, so run detached + polled
+# (survives a controller-side SSH reset).
+- name: Extract images into the wiki's uploads dir (owned by www-data)
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+  vars:
+    exec_service: web
+    exec_long: true
+    exec_command: >-
+      set -e;
+      dest="/var/www/mediawiki/w/images/{{ import_wiki_id }}";
+      mkdir -p "$dest";
+      stage="$(mktemp -d)";
+      tar xf /tmp/canasta-images-import.tar -C "$stage";
+      if [ -d "$stage/images" ] && [ "$(ls -A "$stage" | wc -l)" = "1" ];
+      then src="$stage/images";
+      else src="$stage";
+      fi;
+      cp -a "$src/." "$dest/";
+      chown -R www-data:www-data "$dest";
+      rm -rf "$stage" /tmp/canasta-images-import.tar

--- a/tests/unit/test_import_images.py
+++ b/tests/unit/test_import_images.py
@@ -1,0 +1,90 @@
+"""Structural guards for `canasta create --images` (media placement restore).
+
+`--images` extracts a wiki's hashed-directory image tree into its per-wiki
+uploads dir (images/<wiki-id>/) as www-data. The File: page rows come from
+`--database`; this only places the files (not importImages). One code path
+serves both orchestrators via the web service (bind mount on Compose, PVC on
+k8s). These tests lock the wiring; runtime behavior is covered by the e2e.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+IMPORT = os.path.join(
+    REPO_ROOT, "roles", "mediawiki", "tasks", "import_images.yml")
+CREATE_MAIN = os.path.join(
+    REPO_ROOT, "roles", "create", "tasks", "main.yml")
+ADD = os.path.join(REPO_ROOT, "playbooks", "add.yml")
+DEFS = os.path.join(REPO_ROOT, "meta", "command_definitions.yml")
+
+
+def _images_import_task(tasks):
+    return next((t for t in tasks
+                 if (t.get("ansible.builtin.include_role") or {}).get(
+                     "tasks_from") == "import_images.yml"), None)
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _text(path):
+    with open(path) as f:
+        return f.read()
+
+
+def _has_images_param(defs, command):
+    cmd = next(c for c in defs["commands"] if c["name"] == command)
+    return next((p for p in cmd["parameters"]
+                 if p["name"] == "images"), None)
+
+
+def test_create_and_add_define_images_param():
+    defs = _load(DEFS)
+    for command in ("create", "add"):
+        images = _has_images_param(defs, command)
+        assert images is not None, f"{command} must define an --images param"
+        assert images["type"] == "path"
+
+
+def test_import_places_media_per_wiki_as_www_data():
+    body = _text(IMPORT)
+    # Per-wiki uploads dir (Canasta farm layout: images/<wiki-id>/), never the
+    # images/ root.
+    assert "images/{{ import_wiki_id }}" in body
+    # Ownership matches create-storage-dirs.sh.
+    assert "chown -R www-data:www-data" in body
+    # Placement restore, not importImages (the rows come from --database).
+    assert "importImages" not in body
+    # A single leading images/ parent is elided.
+    assert "stage/images" in body
+
+
+def test_import_routes_through_the_web_service():
+    tasks = _load(IMPORT)
+    services = [(t.get("vars") or {}).get("exec_service")
+                or (t.get("vars") or {}).get("copy_service")
+                for t in tasks]
+    assert "web" in services, "media must be placed via the web container"
+
+
+def test_create_wires_images_after_database_conditionally():
+    tasks = _load(CREATE_MAIN)
+    img = _images_import_task(tasks)
+    assert img is not None, "create must include the import_images task"
+    assert "images is defined" in (img.get("when") or "")
+    names = [t.get("name", "") for t in tasks]
+    db_idx = next(i for i, n in enumerate(names)
+                  if "import dump or run installer" in n)
+    assert tasks.index(img) > db_idx, "images import must run after the DB"
+
+
+def test_add_wires_images_import_conditionally():
+    tasks = _load(ADD)
+    img = _images_import_task(tasks)
+    assert img is not None, "add must include the import_images task"
+    assert "images is defined" in (img.get("when") or "")
+    assert (img["vars"]["import_wiki_id"]) == "{{ wiki }}"


### PR DESCRIPTION
## Summary

Implements #565: an `--images` (`-I`) option on `canasta create` and `canasta add` that restores a wiki's uploaded media, mirroring `--database`.

`--images <tar>` takes a tar (.tar/.tar.gz) of a wiki's images directory at the hash-directory level (`0/`, `1/`, `archive/`, ...). Its files are copied into the wiki's per-wiki uploads dir (`images/<wiki>/`, the Canasta farm layout) as `www-data`. It's a **placement restore, not `importImages`**: the `File:` page rows come from `--database`, and `--images` just drops the files where MediaWiki expects them. A single leading `images/` parent (someone tarred the parent dir instead of its contents) is elided.

One task, `roles/mediawiki/tasks/import_images.yml`, runs the extraction in the **web** container, so a single code path covers both orchestrators — `/mediawiki/images` is the bind mount on Compose and the PVC on k8s. It reuses the existing `copy_into_container.yml` + `exec.yml` docker/kubectl dispatch (no new plumbing). Both `create` and `add` wire it after the DB is ready, `when: images is defined`.

## Usage

```
canasta create -w main --database dump.sql --images media.tar.gz ...
canasta add -i myinstance -w docs --database docs.sql --images docs-media.tar.gz ...
```

## Changes

- `meta/command_definitions.yml` — `-I/--images` on `create` and `add`.
- `roles/mediawiki/tasks/import_images.yml` (new) — per-wiki placement, elide a leading `images/` parent, `chown www-data:www-data`, web-service dispatch.
- `roles/create/tasks/main.yml`, `playbooks/add.yml` — wire after the DB import, `when: images is defined`.
- `tests/unit/test_import_images.py` (new) — structural guards for both commands.

## Testing

- `make validate` (83 commands), `make lint`, `make test-unit` (1595 passing) all green.
- Runtime behavior covered by the live Compose + k8s e2e.

## Notes

- Scope is the wiki being created/added (`-w`); it pairs with `--database`.
- On k8s this shares the same "write into the images PVC" need as the restore path (#1001) — a future refactor could factor a single primitive.

Closes #565
