### PR TITLE
fix(k8s): restore extensions/skins/public_assets + backup-restore parity guard

### DIFF
--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -4,11 +4,12 @@
 # is dynamically included (via include_tasks with a when guard).
 # Compose-only controllers no longer need the collection installed.
 #
-# Restores config (-> host -> ConfigMaps), .env, the DB (streamed into the
-# web pod), managed Secrets, and uploaded media (the images PVC, mounted into
-# the restore pod so restic lands it directly). extensions/skins/public_assets
-# are NOT restored here — the host instance dir is their source of truth and
-# k8s_sync_user_dirs mirrors it on the next start.
+# Restores everything the k8s backup captures: config (-> host -> ConfigMaps),
+# .env, the DB (streamed into the web pod), managed Secrets, uploaded media
+# (the images PVC, mounted into the restore pod so restic lands it directly),
+# and the extensions/skins/public_assets dirs (-> host; the post-restore
+# restart's k8s_sync_user_dirs mirrors them into their PVCs). Parity with the
+# Compose restore, which round-trips the same set to the host.
 #
 # Inputs: instance_path, instance_id, _resolved_snapshot, _restore_dbpass
 
@@ -242,6 +243,32 @@
       "{{ instance_path }}/.env"
   changed_when: true
   ignore_errors: true
+
+# Restore the declarative user dirs (extensions, skins, public_assets) to the
+# host instance dir, mirroring the Compose restore. They are NOT written to
+# their PVCs here: the host dir is their source of truth, and the post-restore
+# restart (restore.yml) runs k8s_sync_user_dirs, which mirrors the host dir
+# into each PVC (with prune). Without this, a k8s restore silently dropped
+# custom extensions/skins/public_assets — the backup captured them (see
+# k8s_run_backup.yml) but nothing brought them back. (images is different: it
+# has no host source of truth and is restored straight into its PVC above.)
+# `set -o pipefail` so a broken restic-restore side of the pipe fails loudly;
+# the `test -d` guard skips a dir absent from an older snapshot.
+- name: Restore extensions/skins/public_assets to host
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail;
+      if kubectl exec -n {{ _k8s_namespace }} restic-restore --
+      test -d /currentsnapshot/{{ item }}; then
+      mkdir -p "{{ instance_path }}/{{ item }}";
+      kubectl exec -n {{ _k8s_namespace }} restic-restore --
+      tar cf - -C /currentsnapshot/{{ item }} . |
+      tar xf - -C "{{ instance_path }}/{{ item }}/";
+      fi
+  args:
+    executable: /bin/bash
+  loop: ['extensions', 'skins', 'public_assets']
+  changed_when: true
 
 # Use the WEB pod (not a DB pod) as the import target. Reasons:
 #

--- a/tests/unit/test_restore_k8s.py
+++ b/tests/unit/test_restore_k8s.py
@@ -1,26 +1,38 @@
 """Structural guards for the Kubernetes restore path.
 
-The k8s backup captures the images PVC (uploaded media), but restore used to
-extract only config, .env, the DB, and Secrets — the media in the snapshot was
-restored into the restore pod's emptyDir and discarded, so a restore (and any
-clone into a fresh cluster) silently lost all uploads. The fix mounts the
-images PVC into the restore pod so `restic restore --target /` lands media
-directly in it. These tests lock that wiring; runtime behavior is covered by
-the live k8s e2e.
+The k8s backup captures config, .env, the DB, Secrets, uploaded media (images
+PVC), and the extensions/skins/public_assets dirs — but restore used to bring
+back only config, .env, the DB, and Secrets. Media in the snapshot was
+restored into the restore pod's emptyDir and discarded, and the user dirs were
+never restored at all, so a k8s restore (and any clone into a fresh cluster)
+silently lost uploads and custom extensions/skins/public_assets. The fix mounts
+the images PVC into the restore pod (restic lands media directly) and restores
+the user dirs to the host (the post-restore restart's k8s_sync_user_dirs
+mirrors them into their PVCs). These tests lock that wiring — including a
+parity guard against backup capturing something restore drops; runtime
+behavior is covered by the live k8s e2e.
 """
 
 import os
+import re
 
 import yaml
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 RESTORE = os.path.join(
     REPO_ROOT, "roles", "backup", "tasks", "restore_k8s.yml")
+BACKUP = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "k8s_run_backup.yml")
 
 
 def _tasks():
     with open(RESTORE) as f:
         return yaml.safe_load(f)
+
+
+def _text(path):
+    with open(path) as f:
+        return f.read()
 
 
 def test_restore_pod_mounts_the_images_pvc():
@@ -44,3 +56,33 @@ def test_restore_declares_the_images_pvc_volume():
     assert images is not None, "restore pod is missing the images PVC volume"
     assert images["persistentVolumeClaim"]["claimName"] == \
         "canasta-{{ instance_id }}-images"
+
+
+def test_restore_brings_back_user_dirs_to_host():
+    tasks = _tasks()
+    step = next((t for t in tasks
+                 if t.get("name")
+                 == "Restore extensions/skins/public_assets to host"), None)
+    assert step is not None, (
+        "restore must bring extensions/skins/public_assets back to the host "
+        "(the post-restore restart then syncs them into their PVCs)")
+    assert set(step["loop"]) == {"extensions", "skins", "public_assets"}
+
+
+def test_restore_covers_every_dir_the_backup_captures():
+    # Parity guard: every directory the k8s backup mounts under
+    # /currentsnapshot must be restored by restore_k8s. This is the class of
+    # bug that silently dropped images + extensions/skins/public_assets on
+    # restore — the backup saved them, but restore never brought them back.
+    captured = set(re.findall(r"/currentsnapshot/([A-Za-z_]+)", _text(BACKUP)))
+    captured &= {"config", "images", "extensions", "skins", "public_assets"}
+    # Sanity: the backup really does capture the media/user dirs.
+    assert {"images", "extensions", "skins", "public_assets"} <= captured
+    # Check the PARSED tasks (comments stripped) so a dir mentioned only in a
+    # comment cannot satisfy the guard — it must be in real restore logic.
+    restore_logic = yaml.safe_dump(_tasks())
+    missing = [d for d in captured if d not in restore_logic]
+    assert not missing, (
+        "k8s backup captures %s but restore_k8s never restores %s — restore "
+        "would silently drop it (the images/extensions/skins/public_assets "
+        "restore gap). Every captured dir must be restored." % (captured, missing))


### PR DESCRIPTION
## Summary

Follow-up to #1002 (images PVC restore). The k8s backup captures `extensions`, `skins`, and `public_assets` too, but `restore_k8s.yml` never restored them — so a k8s restore silently dropped custom extensions/skins/public_assets (worst on clone-into-a-fresh-cluster). The Compose restore round-trips the full set to the host; this closes the k8s asymmetry.

## Fix

- **extensions/skins/public_assets** — restore them to the host instance dir (mirroring the Compose restore). The post-restore restart (`restore.yml`) runs `k8s_sync_user_dirs`, which mirrors the host dirs into their PVCs. (`images` was handled in #1002 by mounting its PVC, since it has no host source of truth.)
- **backup↔restore parity guard** — a unit test that fails if the k8s backup captures a directory the restore never brings back. This is the check that would have caught the whole class of bug (verified to fail if the fix is removed).

## Why the class was missed

The only backup/restore integration test is Compose-only, drops the DB (not files), and asserts only that the wiki loads — so it never exercised k8s, never lost files, and never checked file restoration. The parity guard closes the unit-level hole; a real multi-node k8s backup/restore e2e asserting file survival is the remaining follow-up.

## Changes

- `roles/backup/tasks/restore_k8s.yml` — restore extensions/skins/public_assets to the host; header updated.
- `tests/unit/test_restore_k8s.py` — user-dir restore guard + backup↔restore parity guard.

## Testing

- `make lint`, `make validate`, `make test-unit` (1600) all green.

Closes #1004
