### PR TITLE
fix(create,add): scaffold per-wiki public_assets/<wiki-id>/ directory

### DIFF
--- a/playbooks/add.yml
+++ b/playbooks/add.yml
@@ -92,6 +92,25 @@
     state: directory
     mode: "0755"
 
+# Per-wiki public_assets subdir (logos/favicon). Canasta serves
+# /public_assets/* by rewriting to public_assets/<wiki-id>/, so the
+# added wiki needs its own dir. Created here so it exists in the
+# instance dir for the K8s user-dir sync to mirror and for gitops to
+# track (stage_new_wiki.yml stages public_assets/<id>). The .gitkeep
+# keeps the otherwise-empty dir under git.
+- name: Create per-wiki public_assets directory
+  ansible.builtin.file:
+    path: "{{ instance_path }}/public_assets/{{ wiki }}"
+    state: directory
+    mode: "0755"
+
+- name: Keep the per-wiki public_assets directory under git
+  ansible.builtin.copy:
+    dest: "{{ instance_path }}/public_assets/{{ wiki }}/.gitkeep"
+    content: ""
+    mode: "0644"
+    force: false
+
 - name: Copy per-wiki Settings.php if provided
   ansible.builtin.copy:
     src: "{{ wiki_settings }}"

--- a/roles/create/tasks/_settings_files.yml
+++ b/roles/create/tasks/_settings_files.yml
@@ -19,6 +19,29 @@
     mode: "0755"
   loop: "{{ _created_wikis.wiki_ids }}"
 
+# Per-wiki public_assets subdir: Canasta serves /public_assets/* by
+# rewriting to public_assets/<wiki-id>/, so each wiki needs its own dir
+# for logos/favicon. The container's create-storage-dirs.sh makes it at
+# runtime, but only inside the volume — on Compose that reflects back
+# through the bind mount, on K8s it lands in the PVC and never in the
+# instance dir. Create it here so users have a place to drop assets and
+# the K8s user-dir sync has a subdir to mirror. The .gitkeep keeps the
+# otherwise-empty dir under git/gitops tracking.
+- name: Create per-wiki public_assets directory
+  ansible.builtin.file:
+    path: "{{ instance_path }}/public_assets/{{ item }}"
+    state: directory
+    mode: "0755"
+  loop: "{{ _created_wikis.wiki_ids }}"
+
+- name: Keep the per-wiki public_assets directory under git
+  ansible.builtin.copy:
+    dest: "{{ instance_path }}/public_assets/{{ item }}/.gitkeep"
+    content: ""
+    mode: "0644"
+    force: false
+  loop: "{{ _created_wikis.wiki_ids }}"
+
 - name: Report copying per-wiki Settings.php
   when: wiki_settings is defined and wiki_settings != ''
   ansible.builtin.debug:


### PR DESCRIPTION
## Summary

`canasta create` and `canasta add` created the top-level `public_assets/` directory but never the per-wiki `public_assets/<wiki-id>/` subdirectory that the serving model requires.

Canasta serves `/public_assets/*` by rewriting to `public_assets/<wiki-id>/` (CanastaBase `config-subdir-wikis.sh`). That subdir was only ever created at runtime by CanastaBase's `create-storage-dirs.sh`:
- **Compose**: `public_assets/` is a bind mount, so the container-created subdir reflects back to the host instance dir — masking the gap.
- **Kubernetes**: `public_assets/` is a PVC, so the subdir is created inside the PVC only. The controller's instance dir never gets it, so users have nowhere to place a logo/favicon and `k8s_sync_user_dirs` has no per-wiki subdir to mirror — assets 404.

The rest of the codebase already assumes the subdir exists (`stage_new_wiki.yml` stages `public_assets/<id>` for gitops, paralleling `config/settings/wikis/<id>`).

## Changes

- `roles/create/tasks/_settings_files.yml` — create `public_assets/<wiki-id>/` (with `.gitkeep`) for every wiki, looping over `_created_wikis.wiki_ids` so farms are covered.
- `playbooks/add.yml` — same for a newly added wiki.

Mirrors the existing per-wiki settings-directory creation. Idempotent; no runtime change on Compose (dir already exists via the bind mount).

## Testing

- `make validate` — passes (83 commands, 66 playbooks)
- `make test-unit` — 1600 passed

Closes #1008