### PR TITLE
Point users to 'canasta reconcile' for applying config without a full restart

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -527,6 +527,12 @@ commands:
       starting anything missing and recreating only what changed, with no
       stop. Idempotent and safe to run anytime.
 
+      It is also how you apply local edits to an instance's configuration
+      (config/settings, wikis.yaml, .env) to the running instance without
+      a full restart: on Docker Compose it recreates only the changed
+      containers; on Kubernetes it re-syncs the ConfigMaps and runs
+      'helm upgrade', rolling only the pods whose config changed.
+
       This is the fix companion to 'canasta doctor': when doctor reports
       config/runtime drift (profiles out of sync with the flags, a
       container running unmanaged, search configured without its backend),

--- a/roles/config/tasks/set.yml
+++ b/roles/config/tasks/set.yml
@@ -46,4 +46,4 @@
 
 - name: Report settings applied
   ansible.builtin.debug:
-    msg: "Settings updated.{{ (no_restart | default(false) | bool) | ternary(' Restart skipped.', '') }}"
+    msg: "Settings updated.{{ (no_restart | default(false) | bool) | ternary(' Restart skipped — run `canasta reconcile` to apply the changes to the running instance.', '') }}"


### PR DESCRIPTION
Closes #1012.

`canasta reconcile` already applies local configuration edits to a running instance without a full stop/start — on Kubernetes it re-syncs the ConfigMaps and runs `helm upgrade`, rolling only the web pods whose config changed rather than recreating the whole stack. This change makes that discoverable so users don't reach for the heavier `canasta restart` (or miss the command entirely).

### Changes
- **`roles/config/tasks/set.yml`** — `canasta config set --no-restart` now reports: *Restart skipped — run `canasta reconcile` to apply the changes to the running instance.*
- **`meta/command_definitions.yml`** — the `reconcile` long_description now names the config-apply use case and describes behavior on both orchestrators (was Compose-only wording).
- **canasta.wiki `Help:Common tasks`** — added an *Applying configuration changes* subsection (published separately, rev 1150).

### Notes
`canasta doctor` already recommends `canasta reconcile` on detected drift, but only on the Compose path; adding real Kubernetes config-drift detection is a larger feature and is intentionally left as a possible follow-up.

Unit tests (1600) pass; `make validate` clean.