### PR TITLE
feat(create,add): --skip-install for existing external databases

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -211,6 +211,43 @@ def _validate_orchestrator_only(cmd_def, get_value):
     return errors
 
 
+def _validate_mutual_exclusion(cmd_def, get_value):
+    """Flag params set together with their declared mutual_exclusion partner.
+
+    Both partners typically declare the relationship, so the conflicting
+    pair is reported once (keyed on the sorted name pair).
+    """
+    errors = []
+    params_by_name = {p["name"]: p for p in cmd_def.get("parameters", [])}
+
+    def _is_set(param):
+        if param is None:
+            return False
+        value = get_value(param["name"])
+        if value is None or value == "":
+            return False
+        # A param left at its default (e.g. a bool flag not passed) is
+        # not "provided" and so does not conflict.
+        return value != param.get("default")
+
+    seen = set()
+    for param in cmd_def.get("parameters", []):
+        partner_name = param.get("mutual_exclusion")
+        if not partner_name:
+            continue
+        pair = tuple(sorted((param["name"], partner_name)))
+        if pair in seen:
+            continue
+        if _is_set(param) and _is_set(params_by_name.get(partner_name)):
+            seen.add(pair)
+            errors.append((
+                1,
+                "Error: --%s cannot be combined with --%s"
+                % (pair[0].replace("_", "-"), pair[1].replace("_", "-")),
+            ))
+    return errors
+
+
 def _validate_named_validators(cmd_def, get_value, validators=None):
     """Check params tagged `validator: <name>` against the named regex.
 
@@ -265,6 +302,7 @@ def collect_cli_param_errors(cmd_def, args):
     return (
         _validate_required_unless(cmd_def, get_value)
         + _validate_orchestrator_only(cmd_def, get_value)
+        + _validate_mutual_exclusion(cmd_def, get_value)
         + _validate_named_validators(cmd_def, get_value)
     )
 

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -264,11 +264,14 @@ commands:
     description: "Create a new Canasta instance"
     long_description: |
       Create a new Canasta MediaWiki instance. Generates configuration files,
-      starts the containers, and runs the MediaWiki installer.
+      starts the containers, and runs the MediaWiki installer. With
+      --skip-install, the installer is skipped and the instance is connected
+      to an external database that already holds a MediaWiki schema.
     examples:
       - "canasta create -i mysite -w main -n example.com"
       - "canasta create -i mysite -w main -n example.com -d /path/to/dump.sql"
       - "canasta create -i mysite -w main -n localhost"
+      - "canasta create -i mysite -w main -n example.com -e prod.env --skip-install"
     playbook: create.yml
     parameters:
       - name: host
@@ -378,7 +381,19 @@ commands:
       - name: database
         short: d
         type: path
+        mutual_exclusion: skip_install
         description: "Path to existing database dump (.sql or .sql.gz)"
+      - name: skip_install
+        type: bool
+        default: false
+        mutual_exclusion: database
+        description: >-
+          Skip the MediaWiki installer (install.php) and connect to a
+          database that already has a MediaWiki schema. Requires
+          USE_EXTERNAL_DB=true (set via -e envfile) and cannot be
+          combined with --database. Use this when an external database
+          (e.g. RDS/Aurora) was provisioned separately and already
+          holds the wiki's tables.
       - name: images
         short: I
         type: path
@@ -871,7 +886,9 @@ commands:
       wiki farm. The new wiki is registered in `wikis.yaml`, the
       Caddyfile is regenerated, and the MediaWiki installer runs
       for the new wiki. You can also import an existing database
-      dump instead of running the installer.
+      dump instead of running the installer, or pass --skip-install
+      to connect to an external database that already holds the new
+      wiki's schema.
     examples:
       - "canasta add -w docs -u localhost/docs"
     playbook: add.yml
@@ -897,7 +914,17 @@ commands:
       - name: database
         short: d
         type: path
+        mutual_exclusion: skip_install
         description: "Path to existing database dump"
+      - name: skip_install
+        type: bool
+        default: false
+        mutual_exclusion: database
+        description: >-
+          Skip the MediaWiki installer (install.php) and connect to a
+          database that already has the new wiki's schema. Requires the
+          instance to use USE_EXTERNAL_DB=true and cannot be combined
+          with --database.
       - name: images
         short: I
         type: path

--- a/playbooks/add.yml
+++ b/playbooks/add.yml
@@ -70,6 +70,37 @@
     key: MYSQL_USER
   register: _add_dbuser
 
+# --skip-install connects to a database that already holds the new wiki's
+# schema, so there is no dump to import and it only makes sense against an
+# external database.
+- name: Fail if --skip-install is combined with --database
+  ansible.builtin.fail:
+    msg: >-
+      --skip-install cannot be combined with --database. --skip-install
+      connects to a database that already holds the wiki's schema, so
+      there is no dump to import.
+  when:
+    - skip_install | default(false) | bool
+    - database is defined and database != ''
+
+- name: Read .env for external DB flag
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read
+    key: USE_EXTERNAL_DB
+  register: _add_ext_db
+  when: skip_install | default(false) | bool
+
+- name: Fail if --skip-install without USE_EXTERNAL_DB
+  ansible.builtin.fail:
+    msg: >-
+      --skip-install requires the instance to use an external database
+      (USE_EXTERNAL_DB=true). The bundled database has no schema for
+      wiki '{{ wiki }}', so install.php cannot be skipped.
+  when:
+    - skip_install | default(false) | bool
+    - not (_add_ext_db.value | default('false') | lower == 'true')
+
 - name: Generate admin password if not provided
   when: password is not defined or password == ''
   block:
@@ -147,8 +178,30 @@
         import_database_path: "{{ database }}"
         import_db_password: "{{ _add_dbpass.value }}"
 
+# --skip-install: the external database already holds this wiki's schema,
+# so register it in the farm without running install.php. Still wait for
+# the database so a farm addition against an unreachable DB fails clearly.
+- name: Skip installer for existing database
+  when:
+    - database is not defined or database == ''
+    - skip_install | default(false) | bool
+  block:
+    - name: Report skipping installer for existing database
+      ansible.builtin.debug:
+        msg: >-
+          Skipping MediaWiki installer for wiki '{{ wiki }}'
+          (--skip-install); connecting to an external database that
+          already holds the schema.
+
+    - name: Wait for database
+      ansible.builtin.include_role:
+        name: mediawiki
+        tasks_from: wait_for_db.yml
+
 - name: Run install.php for new wiki
-  when: database is not defined or database == ''
+  when:
+    - database is not defined or database == ''
+    - not (skip_install | default(false) | bool)
   block:
     - name: Wait for database
       ansible.builtin.include_role:

--- a/roles/create/tasks/_database.yml
+++ b/roles/create/tasks/_database.yml
@@ -5,9 +5,12 @@
 #     dump and regenerates MW_SECRET_KEY from the imported
 #     LocalSettings.php; or
 #   - run the MediaWiki installer (no dump): creates schema,
-#     installs core, and writes LocalSettings.php for each wiki.
+#     installs core, and writes LocalSettings.php for each wiki; or
+#   - skip both (--skip-install): connect to an external database that
+#     already holds a MediaWiki schema, without touching it.
 #
-# Both paths are mutually exclusive on `database is defined`.
+# The import and installer paths are mutually exclusive on
+# `database is defined`; --skip-install suppresses the installer.
 
 - name: Report waiting for database
   ansible.builtin.debug:
@@ -39,13 +42,24 @@
         name: mediawiki
         tasks_from: generate_secret_key.yml
 
+- name: Report skipping installer for existing database
+  ansible.builtin.debug:
+    msg: >-
+      Skipping MediaWiki installer (--skip-install); connecting to an
+      external database that already holds the schema.
+  when: skip_install | default(false) | bool
+
 - name: Report running installer
   ansible.builtin.debug:
     msg: "Configuring MediaWiki installation"
-  when: database is not defined or database == ''
+  when:
+    - database is not defined or database == ''
+    - not (skip_install | default(false) | bool)
 
 - name: Run MediaWiki installer
-  when: database is not defined or database == ''
+  when:
+    - database is not defined or database == ''
+    - not (skip_install | default(false) | bool)
   ansible.builtin.include_role:
     name: mediawiki
     tasks_from: install.yml

--- a/roles/create/tasks/_env_update.yml
+++ b/roles/create/tasks/_env_update.yml
@@ -114,11 +114,29 @@
       {{ (_ext_db_check.found and _ext_db_check.value | lower == 'true')
          | ternary('', 'internal-db') }}
 
+# --skip-install only makes sense against an external database that was
+# provisioned separately and already holds a MediaWiki schema. The bundled
+# database starts from an empty volume, so skipping install.php there would
+# leave the wiki with no tables.
+- name: Fail if --skip-install without USE_EXTERNAL_DB
+  ansible.builtin.fail:
+    msg: >-
+      --skip-install requires USE_EXTERNAL_DB=true. Point the instance at
+      an external database that already has a MediaWiki schema by setting
+      USE_EXTERNAL_DB=true and MYSQL_HOST in your env file (-e).
+  when:
+    - skip_install | default(false) | bool
+    - not (_ext_db_check.found and _ext_db_check.value | lower == 'true')
+
 # Generate a placeholder MW_SECRET_KEY so docker compose variable substitution
 # doesn't warn about it being empty during the first 'docker compose up'.
 # install.php later replaces this with the key from LocalSettings.php,
-# or the import-database path regenerates it.
+# or the import-database path regenerates it. A MW_SECRET_KEY supplied in the
+# -e envfile is preserved (not overwritten) so a --skip-install reconnect to
+# an existing wiki keeps its existing sessions valid.
 - name: Generate initial MW_SECRET_KEY
   ansible.builtin.include_role:
     name: mediawiki
     tasks_from: generate_secret_key.yml
+  vars:
+    secret_key_preserve_existing: true

--- a/roles/create/tasks/_validate_inputs.yml
+++ b/roles/create/tasks/_validate_inputs.yml
@@ -10,6 +10,20 @@
   ansible.builtin.debug:
     msg: "Validating inputs..."
 
+# --skip-install connects to an already-populated database, so there is
+# no dump to import. The two options are mutually exclusive. The
+# USE_EXTERNAL_DB=true requirement is checked later in _env_update.yml,
+# once the -e envfile has been merged into .env.
+- name: Fail if --skip-install is combined with --database
+  ansible.builtin.fail:
+    msg: >-
+      --skip-install cannot be combined with --database. --skip-install
+      connects to a database that already holds the wiki's schema, so
+      there is no dump to import.
+  when:
+    - skip_install | default(false) | bool
+    - database is defined and database != ''
+
 - name: Validate instance ID
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/validate_instance_id.yml"
 

--- a/roles/mediawiki/tasks/generate_secret_key.yml
+++ b/roles/mediawiki/tasks/generate_secret_key.yml
@@ -5,12 +5,33 @@
 # When install.php runs, it extracts the real key from LocalSettings.php
 # and overwrites this placeholder.
 # Input: instance_path
+# Optional: secret_key_preserve_existing (default false) — when true, keep a
+#   MW_SECRET_KEY already present in .env (e.g. supplied via -e envfile so a
+#   --skip-install reconnect to an existing wiki keeps its sessions valid)
+#   instead of overwriting it.
+
+- name: Read existing MW_SECRET_KEY from .env
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read
+    key: MW_SECRET_KEY
+  register: _existing_secret_key
+  when: secret_key_preserve_existing | default(false) | bool
+  no_log: true
+
+- name: Set whether to keep the existing MW_SECRET_KEY
+  ansible.builtin.set_fact:
+    _keep_existing_secret_key: >-
+      {{ (secret_key_preserve_existing | default(false) | bool)
+         and (_existing_secret_key.found | default(false))
+         and ((_existing_secret_key.value | default('')) | trim | length > 0) }}
 
 - name: Generate random secret key (64 hex chars)
   ansible.builtin.command:
     cmd: "python3 -c \"import secrets; print(secrets.token_hex(32))\""
   register: _secret_key_result
   changed_when: false
+  when: not _keep_existing_secret_key
 
 - name: Save MW_SECRET_KEY to .env
   canasta_env:
@@ -18,4 +39,5 @@
     state: set
     key: MW_SECRET_KEY
     value: "{{ _secret_key_result.stdout | trim }}"
+  when: not _keep_existing_secret_key
   no_log: true

--- a/tests/unit/test_cli_param_validation.py
+++ b/tests/unit/test_cli_param_validation.py
@@ -119,6 +119,81 @@ class TestNamedValidators:
                 "validator 'nope'")]
 
 
+class TestMutualExclusion:
+    CMD = {"parameters": [
+        {"name": "database"},
+        {"name": "skip_install", "mutual_exclusion": "database",
+         "default": False},
+    ]}
+
+    def test_both_set_fails_once(self):
+        vals = {"database": "/tmp/dump.sql", "skip_install": True}
+        errs = canasta._validate_mutual_exclusion(self.CMD, lambda n: vals.get(n))
+        assert errs == [
+            (1, "Error: --database cannot be combined with --skip-install")]
+
+    def test_only_one_set_passes(self):
+        vals = {"database": "/tmp/dump.sql", "skip_install": False}
+        errs = canasta._validate_mutual_exclusion(self.CMD, lambda n: vals.get(n))
+        assert errs == []
+
+    def test_neither_set_passes(self):
+        vals = {"database": None, "skip_install": False}
+        errs = canasta._validate_mutual_exclusion(self.CMD, lambda n: vals.get(n))
+        assert errs == []
+
+    def test_reported_once_when_both_sides_declare(self):
+        cmd = {"parameters": [
+            {"name": "database", "mutual_exclusion": "skip_install"},
+            {"name": "skip_install", "mutual_exclusion": "database",
+             "default": False},
+        ]}
+        vals = {"database": "/tmp/dump.sql", "skip_install": True}
+        errs = canasta._validate_mutual_exclusion(cmd, lambda n: vals.get(n))
+        assert len(errs) == 1
+
+    def test_default_bool_does_not_conflict(self):
+        # skip_install left at its default False must not trip even when the
+        # partner is set.
+        vals = {"database": "/tmp/dump.sql", "skip_install": False}
+        errs = canasta._validate_mutual_exclusion(self.CMD, lambda n: vals.get(n))
+        assert errs == []
+
+
+class TestSkipInstallDefinitionParity:
+    """The --skip-install/--database exclusivity is declared in metadata.
+
+    The CLI helper and the playbook-layer checks both rely on
+    command_definitions.yml declaring the mutual_exclusion relationship for
+    both `create` and `add`. Guard that the metadata stays in place.
+    """
+
+    @staticmethod
+    def _command(name):
+        path = os.path.join(REPO_ROOT, "meta", "command_definitions.yml")
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        return next(c for c in data["commands"] if c["name"] == name)
+
+    def test_create_declares_skip_install_exclusion(self):
+        params = {p["name"]: p for p in self._command("create")["parameters"]}
+        assert params["skip_install"]["mutual_exclusion"] == "database"
+        assert params["database"]["mutual_exclusion"] == "skip_install"
+
+    def test_add_declares_skip_install_exclusion(self):
+        params = {p["name"]: p for p in self._command("add")["parameters"]}
+        assert params["skip_install"]["mutual_exclusion"] == "database"
+        assert params["database"]["mutual_exclusion"] == "skip_install"
+
+    def test_collect_catches_skip_install_with_database(self):
+        cmd = self._command("create")
+        args = _args(database="/tmp/dump.sql", skip_install=True,
+                     orchestrator="compose")
+        errs = canasta.collect_cli_param_errors(cmd, args)
+        assert (1, "Error: --database cannot be combined with "
+                   "--skip-install") in errs
+
+
 class TestCollectOrderAndExitCodes:
     def test_required_unless_reported_before_validator(self):
         # required_unless is evaluated before the named validators, so when


### PR DESCRIPTION
## Summary
Adds a `--skip-install` flag to `canasta create` and `canasta add` that skips the MediaWiki installer (`install.php`) and connects to an external database that already holds a MediaWiki schema. This is for operators who provision the database separately (e.g. RDS/Aurora via OpenTofu/Terraform) and want Canasta to manage containers, configuration, extensions, and maintenance — not recreate the database.

Closes #830.

## Details
- `--skip-install` requires `USE_EXTERNAL_DB=true` (the bundled database starts from an empty volume) and is mutually exclusive with `--database`; both are validated at the CLI layer (fast fail) and the playbook layer.
- `wait_for_db` still runs so a skip-install against an unreachable database fails clearly.
- An operator-supplied `MW_SECRET_KEY` (via `-e` envfile) is now preserved instead of overwritten, so reconnecting to an existing wiki keeps its sessions valid.
- Activates the previously documentation-only `mutual_exclusion` metadata field as a CLI-layer check.

## Testing
- `make validate`, `make test-unit` (1608 passed, +8 new), `yamllint`, `ansible-playbook --syntax-check canasta.yml`.
- Added `TestMutualExclusion` and `TestSkipInstallDefinitionParity` unit tests.

## Out of scope
Making `--database` *import* work against an external DB (issue's solution #3) is a separate, larger change and not needed for the skip-install path.