### PR TITLE
fix(gitops): prune deleted settings files from K8s config on push

### DIFF
--- a/roles/gitops/tasks/push_kubernetes.yml
+++ b/roles/gitops/tasks/push_kubernetes.yml
@@ -34,13 +34,23 @@
     src: "{{ instance_path }}/values-sidecars.yaml"
   register: _push_sidecars
 
+# values-configdata.yaml (configData, appSecretEnv) and values-sidecars.yaml
+# (sidecars) are complete, freshly-rebuilt snapshots that fully own those
+# keys. Merge them NON-recursively so each one REPLACES the copy already baked
+# into values.yaml by the previous push. A recursive merge would union the
+# configData maps instead, so a settings/caddy/crowdsec file deleted from the
+# instance dir would keep its stale ConfigMap key in the committed values.yaml
+# — and Argo CD would keep rendering it into the running config — forever.
+- name: Merge fresh configData + sidecars over the persisted values
+  ansible.builtin.set_fact:
+    _push_merged_values: >-
+      {{ _push_values.content | b64decode | from_yaml
+         | combine(_push_configdata.content | b64decode | from_yaml)
+         | combine(_push_sidecars.content | b64decode | from_yaml) }}
+
 - name: Merge configData + sidecars into values.yaml for git
   ansible.builtin.copy:
-    content: >-
-      {{ _push_values.content | b64decode | from_yaml
-         | combine(_push_configdata.content | b64decode | from_yaml, recursive=True)
-         | combine(_push_sidecars.content | b64decode | from_yaml, recursive=True)
-         | to_nice_yaml(indent=2) }}
+    content: "{{ _push_merged_values | to_nice_yaml(indent=2) }}"
     dest: "{{ instance_path }}/values.yaml"
     mode: "0644"
 
@@ -53,11 +63,7 @@
 
 - name: Update values.template.yaml from current values
   ansible.builtin.copy:
-    content: >-
-      {{ _push_values.content | b64decode | from_yaml
-         | combine(_push_configdata.content | b64decode | from_yaml, recursive=True)
-         | combine(_push_sidecars.content | b64decode | from_yaml, recursive=True)
-         | to_nice_yaml(indent=2) }}
+    content: "{{ _push_merged_values | to_nice_yaml(indent=2) }}"
     dest: "{{ instance_path }}/values.template.yaml"
     mode: "0644"
   when: _push_template_check.stat.exists

--- a/tests/unit/test_gitops_config_prune.py
+++ b/tests/unit/test_gitops_config_prune.py
@@ -1,0 +1,92 @@
+"""Guards for K8s config-file pruning on gitops push.
+
+On K8s, an instance's settings/caddy/crowdsec files are synced into the
+web/caddy/varnish/crowdsec ConfigMaps via configData in the committed
+values.yaml (Argo CD renders those ConfigMaps). push_kubernetes.yml rebuilds
+values-configdata.yaml fresh from the current files, then merges it over the
+previously-committed values.yaml.
+
+That merge MUST replace the configData maps, not deep-merge them: values.yaml
+already carries the previous push's configData keys, so a recursive merge
+unions the fresh configData into the stale one and a file deleted from the
+instance dir keeps its ConfigMap key forever — the removed setting keeps
+applying on K8s (unlike Compose, where the bind mount reflects the deletion).
+These tests lock the non-recursive merge in place; the runtime behavior is
+covered by the live K8s e2e.
+"""
+
+import os
+
+import yaml
+from ansible.plugins.filter.core import combine
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+PUSH = os.path.join(
+    REPO_ROOT, "roles", "gitops", "tasks", "push_kubernetes.yml")
+
+
+def _tasks():
+    with open(PUSH) as f:
+        return yaml.safe_load(f)
+
+
+def _merge_task():
+    task = next(
+        t for t in _tasks()
+        if t.get("name") == "Merge fresh configData + sidecars over the persisted values"
+    )
+    return task["ansible.builtin.set_fact"]["_push_merged_values"]
+
+
+def test_merge_is_not_recursive():
+    # A recursive combine unions the configData maps and never drops a key, so
+    # a deleted settings file lingers in the committed values.yaml. Guard
+    # against recursive=True creeping back into either combine.
+    expr = _merge_task()
+    assert "recursive=True" not in expr and "recursive = True" not in expr, (
+        "the configData/sidecars merge must be non-recursive so the fresh "
+        "values-configdata.yaml replaces (not unions) the persisted configData"
+    )
+    assert expr.count("combine(") == 2, (
+        "expected the merge to combine both values-configdata and "
+        "values-sidecars over the persisted values"
+    )
+
+
+def test_stale_configmap_key_is_pruned_by_the_merge():
+    # Reproduce the merge: a previous push baked Foo.php into the committed
+    # values.yaml; the fresh configData (Foo.php since deleted) must win.
+    persisted = {
+        "web": {"replicaCount": 1},
+        "configData": {
+            "web": {
+                "wikis.yaml": "x",
+                "settings--global--Foo.php": "wfLoadExtension('Foo');",
+            },
+            "db": {},
+        },
+        "sidecars": [{"name": "old"}],
+    }
+    fresh_configdata = {
+        "configData": {
+            "web": {"wikis.yaml": "x"},
+            "env": {},
+            "caddy": {},
+            "varnish": {},
+            "crowdsec": {},
+        },
+        "appSecretEnv": [],
+    }
+    fresh_sidecars = {"sidecars": []}
+
+    merged = combine(combine(persisted, fresh_configdata), fresh_sidecars)
+
+    web_keys = merged["configData"]["web"]
+    assert "settings--global--Foo.php" not in web_keys, (
+        "deleted settings file must not linger in the committed configData"
+    )
+    assert web_keys == {"wikis.yaml": "x"}
+    # Unrelated top-level values.yaml keys survive the merge.
+    assert merged["web"] == {"replicaCount": 1}
+    # A removed sidecar is likewise pruned (the fresh list replaces).
+    assert merged["sidecars"] == []


### PR DESCRIPTION
## Problem

On Kubernetes, deleting a file from an instance's `config/settings/` directory did not remove it from the running config. Repro:

1. Add `config/settings/global/Foo.php` and `canasta restart` — it syncs into the web ConfigMap (key `settings--global--Foo.php`) and applies.
2. Delete the file and `canasta restart`.
3. The key **remains** in the running config, so the removed setting keeps applying — until the instance is recreated.

## Root cause

`push_kubernetes.yml` rebuilds `values-configdata.yaml` fresh from the current files, then merges it into the **previously-committed** `values.yaml` with `combine(..., recursive=True)`. A recursive combine *unions* the nested `configData` maps and never drops a key, so a deleted settings file keeps its key in the committed `values.yaml` — and Argo CD keeps rendering it into the ConfigMap — forever.

The local-Helm path was already fine (`--reset-values` rebuilds values from scratch); this is gitops-specific, which is why it surfaced in a multi-node e2e.

## Fix

`values-configdata.yaml` (`configData`, `appSecretEnv`) and `values-sidecars.yaml` (`sidecars`) are complete, freshly-rebuilt snapshots that fully own those keys. Merge them **non-recursively** so each *replaces* its keys instead of unioning them — matching the extensions/skins prune the user-dir sync already does. The duplicated Jinja is factored into one `_push_merged_values` `set_fact`.

## Tests

Adds `tests/unit/test_gitops_config_prune.py`:
- a behavioral test using the real ansible `combine` filter that proves a stale `configData.web` key is dropped by the non-recursive merge (and kept by a recursive one), and
- a structural guard against `recursive=True` regressing into the merge.

`make test-unit` (1602), `make validate`, and `yamllint --strict` on the changed file all pass.

Fixes #1011