### PR TITLE
Add canasta image push / image prune for the in-cluster registry

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -107,6 +107,7 @@ SUBCOMMAND_GROUPS = {
     "host": ["add", "remove", "list"],
     "argocd": ["ui", "password", "apps"],
     "sidecar": ["add", "list", "remove", "migrate"],
+    "image": ["push", "prune"],
 }
 
 # Nested subcommand groups (backup schedule set|list|remove)
@@ -157,6 +158,20 @@ _VALIDATORS = {
         "'-' and '.' only, with each label starting and ending with an "
         "alphanumeric character (e.g. 'example.com').",
         _hostname_hint,
+    ),
+    # Docker image reference without a registry host: repository path
+    # components per the distribution spec, plus an optional tag. The
+    # registry host is not accepted — image push prepends the in-cluster
+    # registry's address itself.
+    "image_ref": (
+        re.compile(
+            r"^[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*"
+            r"(/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*"
+            r"(:[A-Za-z0-9_][A-Za-z0-9._-]{0,127})?$"
+        ),
+        "is not a valid image name. Expected a lowercase repository name "
+        "with an optional :tag (e.g. 'myapp-elasticsearch' or "
+        "'custom-web:v2'), without a registry host.",
     ),
 }
 

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -256,6 +256,16 @@ command_groups:
       (mounted config files, dependencies, healthchecks), edit
       `config/sidecars.yaml` directly.
 
+  - name: image
+    description: "Manage the in-cluster image registry (Kubernetes)"
+    long_description: |
+      Work with the in-cluster image registry of a Kubernetes host — the
+      registry that serves locally-built images (`canasta create
+      --build-from`, `build:` sidecars) to the cluster's pods. Subcommands
+      push a locally built image so pods can pull it, and garbage-collect
+      storage no tag references anymore. Kubernetes only: on Docker
+      Compose, a locally built tag is directly usable with no push.
+
 commands:
   # ---------------------------------------------------------------------------
   # Instance lifecycle
@@ -577,8 +587,9 @@ commands:
       `canasta rebuild` is the standalone form for cases where the
       operator wants to rebuild without an upgrade.
 
-      Compose only. Kubernetes instances must build and push their
-      custom image to a registry manually.
+      Compose only. On Kubernetes, push a locally built image to the
+      in-cluster registry with `canasta image push` and point the
+      instance at the printed reference via `canasta config set`.
     examples:
       - "canasta rebuild"
       - "canasta rebuild -i mywiki --no-cache"
@@ -2825,3 +2836,71 @@ commands:
         type: bool
         default: false
         description: "Show the migration plan without writing any files"
+
+  # ---------------------------------------------------------------------------
+  # In-cluster image registry
+  # ---------------------------------------------------------------------------
+  - name: image_push
+    description: "Build and push a local image to the in-cluster registry"
+    long_description: |
+      Build a Docker image from a local build context and push it to the
+      in-cluster image registry of a Kubernetes host, printing the
+      cluster-pullable reference (`10.43.0.2:5000/<name>:<tag>`).
+
+      Use the printed reference anywhere an instance takes an image:
+      `canasta config set CANASTA_IMAGE=...` for a custom web image,
+      `canasta config set CANASTA_ELASTICSEARCH_IMAGE=...` for a derived
+      Elasticsearch image (e.g. with an analysis plugin), or a sidecar's
+      `image:` in `config/sidecars.yaml`. Run `canasta restart` afterward
+      if the config change did not already trigger one.
+
+      The build runs on the target host, which must be the cluster's
+      control-plane node — the registry's push endpoint is a loopback-only
+      hostPort there (the same assumption as `canasta create
+      --build-from`). The build context path is resolved on that host. The
+      registry is deployed automatically if it is missing.
+
+      Kubernetes only: on Docker Compose, a locally built tag is directly
+      usable with no push.
+    examples:
+      - "canasta image push ./images/elasticsearch --name myapp-elasticsearch"
+      - "canasta image push ~/custom-web --name custom-web:v2"
+    playbook: image_push.yml
+    parameters:
+      - name: context
+        type: path
+        positional: true
+        required: true
+        description: "Docker build context directory (on the target host)"
+      - name: image_name
+        long: name
+        type: string
+        required: true
+        validator: image_ref
+        description: >-
+          Image name, optionally name:tag (default tag: local). Repeated
+          pushes to the same tag orphan the previous push's layers; run
+          `canasta image prune` occasionally to reclaim them.
+
+  - name: image_prune
+    description: "Garbage-collect the in-cluster image registry"
+    long_description: |
+      Reclaim in-cluster registry storage by deleting manifests no tag
+      references anymore, and their orphaned layers. Repeated pushes of the
+      same tag (e.g. the `:local` tags used by `--build-from` and `build:`
+      sidecars) orphan the previous push's layers, and nothing else ever
+      garbage-collects them — the registry volume only grows until this
+      runs.
+
+      Runs the registry's garbage collector (with `--delete-untagged`)
+      inside the registry pod, then restarts the registry deployment so
+      its in-memory blob cache matches the pruned store. Avoid pushing
+      images while the prune runs — a push racing the garbage collector
+      can be corrupted (a limitation of the registry itself).
+
+      Kubernetes only. A host with no in-cluster registry reports nothing
+      to prune.
+    examples:
+      - "canasta image prune"
+    playbook: image_prune.yml
+    parameters: []

--- a/playbooks/image_prune.yml
+++ b/playbooks/image_prune.yml
@@ -1,0 +1,74 @@
+---
+# canasta image prune - Garbage-collect the in-cluster image registry.
+#
+# Repeated pushes of the same tag (the :local tags used by --build-from,
+# build: sidecars, and image push) orphan the previous push's layers, and
+# nothing else ever garbage-collects them. This runs the registry's own
+# garbage collector (--delete-untagged) inside the registry pod, then
+# restarts the deployment so its in-memory blob cache matches the pruned
+# store.
+
+- name: Probe for a Kubernetes cluster on the host
+  ansible.builtin.command:
+    cmd: kubectl get nodes -o name
+  register: _prune_k8s
+  changed_when: false
+  failed_when: false
+
+- name: Fail when the host has no Kubernetes cluster
+  ansible.builtin.fail:
+    msg: >-
+      canasta image prune targets the in-cluster registry of a Kubernetes
+      host, and no cluster was found here.
+  when: _prune_k8s.rc != 0
+
+- name: Check the in-cluster registry is deployed
+  ansible.builtin.command:
+    cmd: kubectl -n canasta-registry get deploy/registry -o name
+  register: _prune_reg
+  changed_when: false
+  failed_when: false
+
+- name: Report when there is no registry to prune
+  ansible.builtin.debug:
+    msg: >-
+      No in-cluster registry is deployed on this cluster; nothing to
+      prune. (It is created by k8s-cp install, create --build-from, or
+      image push.)
+  when: _prune_reg.rc != 0
+
+- name: Garbage-collect manifests no tag references, and their layers
+  ansible.builtin.command:
+    cmd: >-
+      kubectl -n canasta-registry exec deploy/registry --
+      registry garbage-collect --delete-untagged
+      /etc/docker/registry/config.yml
+  register: _prune_gc
+  changed_when: true
+  when: _prune_reg.rc == 0
+
+# The running registry caches blob existence in memory; after an
+# on-disk GC it can serve stale metadata and reject re-pushes of
+# deleted blobs. A restart re-reads the pruned store.
+- name: Restart the registry
+  ansible.builtin.command:
+    cmd: kubectl -n canasta-registry rollout restart deploy/registry
+  changed_when: true
+  when: _prune_reg.rc == 0
+
+- name: Wait for the registry to come back
+  ansible.builtin.command:
+    cmd: >-
+      kubectl -n canasta-registry rollout status deploy/registry
+      --timeout=180s
+  changed_when: false
+  when: _prune_reg.rc == 0
+
+- name: Report the prune result
+  ansible.builtin.debug:
+    msg: >-
+      {{ (_prune_gc.stdout_lines | default([])
+          | select('search', 'eligible for deletion|blobs marked')
+          | list)
+         or ['Garbage collection completed.'] }}
+  when: _prune_reg.rc == 0

--- a/playbooks/image_push.yml
+++ b/playbooks/image_push.yml
@@ -1,0 +1,68 @@
+---
+# canasta image push - Build a local context and push it to the in-cluster
+# image registry, so Kubernetes pods can pull the image.
+#
+# The build and push run on the target host, which must be the cluster's
+# control-plane node: the registry's push endpoint is a loopback-only
+# hostPort there (localhost:5000, auto-insecure) — the same assumption as
+# create --build-from. Pods pull the pushed image via the registry's fixed
+# ClusterIP (10.43.0.2:5000).
+
+- name: Probe for a Kubernetes cluster on the host
+  ansible.builtin.command:
+    cmd: kubectl get nodes -o name
+  register: _img_k8s
+  changed_when: false
+  failed_when: false
+
+- name: Fail when the host has no Kubernetes cluster
+  ansible.builtin.fail:
+    msg: >-
+      canasta image push targets the in-cluster registry of a Kubernetes
+      host, and no cluster was found here. On Docker Compose a locally
+      built tag is directly usable — build it with `docker build -t <tag>`
+      and reference the tag; no push is needed.
+  when: _img_k8s.rc != 0
+
+- name: Check the build context exists
+  ansible.builtin.stat:
+    path: "{{ context }}"
+  register: _img_ctx
+
+- name: Fail when the build context is missing
+  ansible.builtin.fail:
+    msg: >-
+      Build context '{{ context }}' is not a directory on the target
+      host.
+  when: not (_img_ctx.stat.isdir | default(false))
+
+- name: Resolve the image reference (default tag :local)
+  ansible.builtin.set_fact:
+    _img_ref: >-
+      {{ image_name if ':' in image_name else image_name ~ ':local' }}
+
+# Idempotent: deploys the registry on a cluster that lacks it, an instant
+# no-op afterward. Blocks until the registry is ready to take the push.
+- name: Ensure the in-cluster image registry
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/k8s_ensure_registry.yml
+
+- name: Build the image from the context
+  ansible.builtin.command:
+    cmd: "docker build -t localhost:5000/{{ _img_ref }} {{ context | quote }}"
+  changed_when: true
+
+- name: Push the image to the in-cluster registry
+  ansible.builtin.command:
+    cmd: "docker push localhost:5000/{{ _img_ref }}"
+  changed_when: true
+
+- name: Report the cluster-pullable reference
+  ansible.builtin.debug:
+    msg: >-
+      Pushed {{ _img_ref }}. Pods can pull it as
+      10.43.0.2:5000/{{ _img_ref }} — use that reference with e.g.
+      `canasta config set -i <id>
+      CANASTA_ELASTICSEARCH_IMAGE=10.43.0.2:5000/{{ _img_ref }}`,
+      `canasta config set -i <id> CANASTA_IMAGE=...` for a custom web
+      image, or a sidecar's `image:` in config/sidecars.yaml.

--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -113,7 +113,9 @@ CMD_GROUPS = [
         "create", "delete", "list", "status", "upgrade", "version", "config",
     ]),
     ("Wiki management", ["add", "remove", "import", "export"]),
-    ("Container lifecycle", ["start", "stop", "restart", "reconcile", "rebuild", "scale"]),
+    ("Container lifecycle", [
+        "start", "stop", "restart", "reconcile", "rebuild", "image", "scale",
+    ]),
     ("Extensions & skins", ["extension", "skin"]),
     ("App sidecars", ["sidecar"]),
     ("Maintenance", ["maintenance", "sitemap"]),

--- a/tests/unit/test_image_ref_validation.py
+++ b/tests/unit/test_image_ref_validation.py
@@ -1,0 +1,68 @@
+"""Tests for the image_ref validator used by `canasta image push --name`.
+
+The value is a Docker repository name with an optional tag, per the
+distribution spec, and deliberately without a registry host — image push
+prepends the in-cluster registry's address itself.
+"""
+
+import os
+import sys
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+sys.path.insert(0, REPO_ROOT)
+
+import canasta  # noqa: E402
+
+
+REGEX = canasta._VALIDATORS["image_ref"][0]
+
+
+class TestImageRefAccepts:
+    def test_plain_name(self):
+        assert REGEX.match("myapp-elasticsearch")
+
+    def test_name_with_tag(self):
+        assert REGEX.match("custom-web:v2")
+
+    def test_path_components(self):
+        assert REGEX.match("myorg/myapp/web:1.0.0")
+
+    def test_separators(self):
+        assert REGEX.match("my_app.web--x:tag_1.2-rc")
+
+    def test_uppercase_tag(self):
+        # Tags allow uppercase; repository names do not.
+        assert REGEX.match("myapp:RC1")
+
+
+class TestImageRefRejects:
+    def test_uppercase_name(self):
+        assert not REGEX.match("MyApp")
+
+    def test_spaces_and_punctuation(self):
+        assert not REGEX.match("Bad Name!")
+
+    def test_leading_separator(self):
+        assert not REGEX.match("-myapp")
+        assert not REGEX.match(".myapp")
+
+    def test_empty_tag(self):
+        assert not REGEX.match("myapp:")
+
+    def test_registry_host_rejected(self):
+        # host:port/name would smuggle a registry address into the name;
+        # push targets the in-cluster registry only.
+        assert not REGEX.match("ghcr.io:443/myapp")
+
+    def test_digest_rejected(self):
+        assert not REGEX.match("myapp@sha256:abc123")
+
+
+class TestImageRefWiring:
+    def test_validator_registered(self):
+        validator = canasta._VALIDATORS["image_ref"]
+        assert len(validator) == 2, (
+            "image_ref has no hint function; keep the tuple at "
+            "(regex, message)"
+        )
+        assert "image name" in validator[1]


### PR DESCRIPTION
Closes #1021.

## What

A new `image` subcommand group for the in-cluster image registry (Kubernetes only):

- **`canasta image push <context> --name <name>[:tag]`** — build a local Docker context and push it to the in-cluster registry, printing the cluster-pullable reference (`10.43.0.2:5000/<name>:<tag>`) for use with `canasta config set CANASTA_IMAGE=…` / `CANASTA_ELASTICSEARCH_IMAGE=…` or a sidecar's `image:`. The registry is deployed automatically if missing (same `k8s_ensure_registry` used by `--build-from`); the default tag is `local`. On a host with no cluster it fails with a pointer to the Compose equivalent (plain `docker build`).
- **`canasta image prune`** — run the registry's garbage collector with `--delete-untagged` inside the registry pod, then restart the deployment so its in-memory blob cache matches the pruned store. Reclaims the layers orphaned by repeated same-tag pushes (`:local` from `--build-from`, `build:` sidecars, and `image push`), which nothing garbage-collected before. A cluster with no registry reports nothing to prune.

## Why

The registry was reachable only through internal side-channels (`create --build-from` at create time, `build:` sidecars at start). `canasta rebuild`'s docs told k8s operators to "build and push their custom image to a registry manually" — this is that missing primitive. It also unblocks derived Elasticsearch images (e.g. an analysis plugin for alternate collation) on k8s via `CANASTA_ELASTICSEARCH_IMAGE`, and post-create custom web image updates without recreating the instance.

## Details

- `--name` is validated CLI-side by a new `image_ref` validator (distribution-spec repository name + optional tag; registry hosts rejected since push targets the in-cluster registry only). Internally the parameter is `image_name` to avoid Ansible's reserved `name` variable.
- `rebuild`'s "push manually" note now points at `image push`.
- The wiki command index gains `image` under Container lifecycle (guarded by the existing structural test).
- 12 new unit tests for the validator; full suite 1640 passing, `make validate` and docs generation clean.

## Testing notes

Unit-tested and smoke-tested (help, name validation, missing/invalid context, no-cluster failure path). Not yet exercised against a live cluster — happy to run a k8s e2e (push a derived ES image, config set, prune) on the test hosts before or after review.