### PR TITLE
Wrap overlong line in config set; run CI yamllint with --strict

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -459,8 +459,6 @@ jobs:
           .venv/bin/pip install -r requirements.txt
           .venv/bin/pip install yamllint
 
-      # --strict matches `make lint`, so warnings (e.g. line-length) fail
-      # here the same way they fail locally.
       - name: YAML lint
         run: >-
           .venv/bin/yamllint --strict -c .yamllint.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -459,9 +459,11 @@ jobs:
           .venv/bin/pip install -r requirements.txt
           .venv/bin/pip install yamllint
 
+      # --strict matches `make lint`, so warnings (e.g. line-length) fail
+      # here the same way they fail locally.
       - name: YAML lint
         run: >-
-          .venv/bin/yamllint -c .yamllint.yml
+          .venv/bin/yamllint --strict -c .yamllint.yml
           meta/ roles/ playbooks/ inventory/ canasta.yml
 
       - name: Python unused-import check

--- a/roles/config/tasks/set.yml
+++ b/roles/config/tasks/set.yml
@@ -46,4 +46,7 @@
 
 - name: Report settings applied
   ansible.builtin.debug:
-    msg: "Settings updated.{{ (no_restart | default(false) | bool) | ternary(' Restart skipped — run `canasta reconcile` to apply the changes to the running instance.', '') }}"
+    msg: >-
+      Settings updated.{{ (no_restart | default(false) | bool)
+      | ternary(' Restart skipped — run `canasta reconcile` to apply
+      the changes to the running instance.', '') }}


### PR DESCRIPTION
Closes #1023.

`make lint` (strict yamllint) has been failing on main since #1013: the reconcile-hint message in `roles/config/tasks/set.yml` is 176 characters against the 140 limit. CI never caught it because its yamllint step runs without `--strict`, so line-length warnings exit 0 there while failing locally.

- Fold the message with `>-` — the rendered string is byte-identical (verified by parsing the YAML and comparing).
- Add `--strict` to the CI yamllint invocation so CI and the Makefile agree on what passes. The repo is otherwise warning-free, so this changes nothing else.

`make lint` now passes repo-wide; 1628 unit tests pass.