### PR TITLE
image push/prune: accept --host; treat the push context as a remote path

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -2864,14 +2864,23 @@ commands:
       usable with no push.
     examples:
       - "canasta image push ./images/elasticsearch --name myapp-elasticsearch"
-      - "canasta image push ~/custom-web --name custom-web:v2"
+      - "canasta image push ~/es-icu --name es-icu -H prod1"
     playbook: image_push.yml
     parameters:
+      - name: host
+        short: H
+        type: string
+        description: >-
+          Target host (a saved host name or user@hostname; default:
+          localhost)
       - name: context
         type: path
+        path_kind: remote
         positional: true
         required: true
-        description: "Docker build context directory (on the target host)"
+        description: >-
+          Docker build context directory on the target host (with --host,
+          an absolute path or one starting with '~')
       - name: image_name
         long: name
         type: string
@@ -2902,5 +2911,12 @@ commands:
       to prune.
     examples:
       - "canasta image prune"
+      - "canasta image prune -H prod1"
     playbook: image_prune.yml
-    parameters: []
+    parameters:
+      - name: host
+        short: H
+        type: string
+        description: >-
+          Target host (a saved host name or user@hostname; default:
+          localhost)


### PR DESCRIPTION
Closes #1025.

Found in the hands-on k8s e2e of #1021: `--host` is per-command, not global, and the image commands didn't declare it — so they could only target localhost. Add the standard `host` parameter (`-H`) to both `image push` and `image prune`, and mark the push `context` as `path_kind: remote` so with `--host` it is taken as a path on the target host (relative paths rejected, matching `create --path`) instead of being resolved against the controller's filesystem.

Live-validated on a real single-node cluster: `canasta image push /home/<user>/e2e-es-icu --name e2e-es-icu -H big` built a derived elasticsearch image (analysis-icu) on the host, pushed it to the in-cluster registry, and an elasticsearch pod pulled the printed ref (`10.43.0.2:5000/e2e-es-icu:local`) by digest with the plugin present.

`make validate`, `make lint`, and all 1640 unit tests pass.