### PR TITLE
image prune: fix registry restart deadlock (Recreate strategy + manifest re-apply)

### DIFF
--- a/playbooks/image_prune.yml
+++ b/playbooks/image_prune.yml
@@ -37,6 +37,14 @@
       image push.)
   when: _prune_reg.rc != 0
 
+# Re-apply the registry manifests before pruning so a registry deployed
+# by an older CLI picks up spec fixes (e.g. the Recreate strategy the
+# restart below depends on) instead of deadlocking its rollout.
+- name: Ensure the registry manifests are current
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/k8s_ensure_registry.yml
+  when: _prune_reg.rc == 0
+
 - name: Garbage-collect manifests no tag references, and their layers
   ansible.builtin.command:
     cmd: >-

--- a/roles/orchestrator/files/k8s_registry.yaml
+++ b/roles/orchestrator/files/k8s_registry.yaml
@@ -37,6 +37,12 @@ metadata:
   namespace: canasta-registry
 spec:
   replicas: 1
+  # A rolling update can never complete: the surge pod needs the same
+  # loopback hostPort (and the RWO data PVC) the old pod holds, so it
+  # stays Pending while the old pod waits for it. Recreate is the only
+  # strategy a single-replica hostPort deployment can roll with.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: canasta-registry


### PR DESCRIPTION
Closes #1027.

Found in the hands-on k8s e2e of #1021: `image prune`'s garbage collection works, but its final registry restart deadlocked every run — the registry Deployment used the default RollingUpdate strategy, and its surge pod can never schedule because the old pod holds the loopback hostPort (and the RWO data PVC). The rollout waits until timeout; the registry keeps serving but prune exits with an error and leaves a stuck ReplicaSet.

- Set `strategy: Recreate` on the registry Deployment — the only strategy a single-replica hostPort deployment can roll with.
- `image prune` now re-applies the registry manifests (the idempotent `k8s_ensure_registry`) before collecting, so a registry deployed by an older CLI picks up the strategy change on its next prune instead of deadlocking. The no-registry check stays first: prune on a registry-less cluster still reports nothing-to-prune rather than deploying one.

Live-validated: with this fix the previously-deadlocked prune completed cleanly on a real cluster — strategy updated in place, GC reported the reclaimed blobs, the registry pod recreated in seconds, and pushes worked immediately after.

`make validate`, `make lint`, and all 1640 unit tests pass.