### PR TITLE
k8s: add a startup probe so elasticsearch survives slow starts

### DIFF
--- a/roles/orchestrator/files/helm/canasta/templates/statefulset-elasticsearch.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/statefulset-elasticsearch.yaml
@@ -42,11 +42,20 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          # Elasticsearch under the CPU limit can take minutes to open
+          # its port on first start; the liveness probe alone would kill
+          # it at ~90s forever. The startup probe owns that window (up
+          # to 5 minutes) and liveness takes over only once it passes.
+          startupProbe:
+            httpGet:
+              path: /_cluster/health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 30
           readinessProbe:
             httpGet:
               path: /_cluster/health
               port: http
-            initialDelaySeconds: 30
             periodSeconds: 10
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Closes #1026.

On Kubernetes, the elasticsearch container had only a liveness probe (`/_cluster/health`, period 30s, failureThreshold 3, no initial delay), giving it ~90 seconds from container start to serve HTTP. Under the chart's 500m CPU limit, ES 7.17 routinely takes longer than that on modest hosts, so the kubelet killed it on a permanent loop (exit 143, `failed liveness probe, will be restarted`) — the pod never became Ready. The image itself is fine: the identical image served `/_cat/plugins` in ~15s when run unconstrained on the same host.

Fix: a `startupProbe` (same endpoint, period 10s, failureThreshold 30) owns the boot window — up to 5 minutes — and the liveness probe only takes over once it passes, the standard pattern for slow-starting JVM containers. The readiness probe's `initialDelaySeconds` is dropped since readiness doesn't run until the startup probe succeeds.

Found in the hands-on k8s e2e of #1021 while validating a derived ES image (`analysis-icu`) delivered via `canasta image push` + `CANASTA_ELASTICSEARCH_IMAGE`; stock ES crash-loops identically under these probe settings. Live validation of this fix on the same host/cluster is completing now — result will be posted as a comment.

`make validate` and all 1640 unit tests pass; helm template changes only.