### PR TITLE
Align Elasticsearch on 7.10.2 across orchestrators (CirrusSearch mandate)

### DIFF
--- a/roles/orchestrator/files/compose/docker-compose.yml
+++ b/roles/orchestrator/files/compose/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       - mediawiki-logs:/var/log/mediawiki
 
   elasticsearch:
-    image: ${CANASTA_ELASTICSEARCH_IMAGE:-docker.elastic.co/elasticsearch/elasticsearch:7.10.2}
+    image: ${CANASTA_ELASTICSEARCH_IMAGE:-docker.elastic.co/elasticsearch/elasticsearch:7.17.9}
     profiles:
       - elasticsearch
     restart: unless-stopped

--- a/roles/orchestrator/files/compose/docker-compose.yml
+++ b/roles/orchestrator/files/compose/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       - mediawiki-logs:/var/log/mediawiki
 
   elasticsearch:
-    image: ${CANASTA_ELASTICSEARCH_IMAGE:-docker.elastic.co/elasticsearch/elasticsearch:7.17.9}
+    image: ${CANASTA_ELASTICSEARCH_IMAGE:-docker.elastic.co/elasticsearch/elasticsearch:7.10.2}
     profiles:
       - elasticsearch
     restart: unless-stopped

--- a/roles/orchestrator/files/helm/canasta/values.yaml
+++ b/roles/orchestrator/files/helm/canasta/values.yaml
@@ -71,10 +71,11 @@ externalDatabase:
   user: "root"
   ssl: "false"
 
-# Elasticsearch (optional)
+# Elasticsearch (optional). CirrusSearch supports only Elasticsearch
+# 7.10.x, so this pin follows it (and matches the Compose default).
 elasticsearch:
   enabled: false
-  image: elasticsearch:7.17.9
+  image: elasticsearch:7.10.2
   storage: 5Gi
   storageClass: ""
   resources:

--- a/tests/unit/test_elasticsearch_image_override.py
+++ b/tests/unit/test_elasticsearch_image_override.py
@@ -12,6 +12,7 @@ guaranteed by `combine(recursive=True)`; these tests model that merge.
 """
 
 import os
+import re
 
 import jinja2
 import yaml
@@ -62,8 +63,14 @@ class TestComposeWiring:
     def test_image_is_env_overridable_with_default_preserved(self):
         compose = _read("roles", "orchestrator", "files", "compose", "docker-compose.yml")
         assert "${CANASTA_ELASTICSEARCH_IMAGE:-" in compose
-        # Default kept, so an unset var leaves stock Elasticsearch.
-        assert "elasticsearch:7.10.2" in compose
+        # Default kept, so an unset var leaves stock Elasticsearch — at the
+        # same version the Kubernetes chart pins (parity guard: the two
+        # orchestrators must not drift apart again).
+        values = _read("roles", "orchestrator", "files", "helm", "canasta",
+                       "values.yaml")
+        match = re.search(r"image:\s*elasticsearch:([\w.-]+)", values)
+        assert match, "k8s chart no longer pins an elasticsearch image?"
+        assert f"elasticsearch:{match.group(1)}" in compose
 
 
 class TestKubernetesPropagation:

--- a/tests/unit/test_elasticsearch_image_override.py
+++ b/tests/unit/test_elasticsearch_image_override.py
@@ -71,6 +71,14 @@ class TestComposeWiring:
         match = re.search(r"image:\s*elasticsearch:([\w.-]+)", values)
         assert match, "k8s chart no longer pins an elasticsearch image?"
         assert f"elasticsearch:{match.group(1)}" in compose
+        # And the pinned line must be the one CirrusSearch supports — its
+        # README (REL1_43) says "Only Elasticsearch v7.10 is supported".
+        # Update this alongside a CirrusSearch upgrade that widens
+        # support, not before.
+        assert match.group(1).startswith("7.10."), (
+            "stock Elasticsearch moved off the 7.10.x line CirrusSearch "
+            "supports"
+        )
 
 
 class TestKubernetesPropagation:


### PR DESCRIPTION
Closes #1033.

The compose file defaulted `CANASTA_ELASTICSEARCH_IMAGE` to `elasticsearch:7.10.2` while the Helm chart pins `elasticsearch:7.17.9` — both from their respective initial ports, with no stated rationale for the difference. The same app therefore got a different Elasticsearch per orchestrator, and a derived-image Dockerfile built against one orchestrator's stock version silently changed versions on the other.

Direction: CirrusSearch REL1_43 states "Only Elasticsearch v7.10 is supported", and Elasticsearch on Canasta Kubernetes has not been exercised in practice — so the Kubernetes chart comes down to `7.10.2` (with a comment citing the CirrusSearch constraint), and the Compose default is unchanged.

The unit test that pinned the Compose default now reads the k8s chart's pin and asserts the two match — a parity guard against future drift.

Operators can still run a different version by pinning `CANASTA_ELASTICSEARCH_IMAGE`.

All 1640 unit tests and `make lint` pass.