### PR TITLE
image push: support --build-arg

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -2890,6 +2890,13 @@ commands:
           Image name, optionally name:tag (default tag: local). Repeated
           pushes to the same tag orphan the previous push's layers; run
           `canasta image prune` occasionally to reclaim them.
+      - name: build_arg
+        type: string
+        multi: true
+        description: >-
+          Build argument KEY=VALUE forwarded to the docker build
+          (repeatable, e.g. --build-arg BASE_IMAGE=ghcr.io/canastawiki/canasta:latest
+          for a web overlay Dockerfile that derives FROM ${BASE_IMAGE})
 
   - name: image_prune
     description: "Garbage-collect the in-cluster image registry"

--- a/playbooks/image_push.yml
+++ b/playbooks/image_push.yml
@@ -47,9 +47,24 @@
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/orchestrator/tasks/k8s_ensure_registry.yml
 
+- name: Fail on a malformed --build-arg
+  ansible.builtin.fail:
+    msg: "Invalid --build-arg '{{ item }}': expected KEY=VALUE"
+  loop: "{{ build_arg | default([]) }}"
+  when: "'=' not in item"
+
+- name: Assemble build-arg flags
+  ansible.builtin.set_fact:
+    _img_build_arg_flags: >-
+      {{ build_arg | default([])
+         | map('regex_replace', '^(.+)$', '--build-arg \1')
+         | join(' ') }}
+
 - name: Build the image from the context
   ansible.builtin.command:
-    cmd: "docker build -t localhost:5000/{{ _img_ref }} {{ context | quote }}"
+    cmd: >-
+      docker build -t localhost:5000/{{ _img_ref }}
+      {{ _img_build_arg_flags }} {{ context | quote }}
   changed_when: true
 
 - name: Push the image to the in-cluster registry

--- a/tests/unit/test_image_push_build_args.py
+++ b/tests/unit/test_image_push_build_args.py
@@ -1,0 +1,43 @@
+"""Structural guards for --build-arg passthrough on `canasta image push`
+(issue #1037), mirroring test_build_from_build_args.py.
+
+A real image build needs Docker, which unit CI can't assume, so these lock
+in the wiring instead:
+
+  - `image push` exposes a repeatable --build-arg;
+  - the args are validated (KEY=VALUE) before anything runs;
+  - the flags are forwarded to the `docker build`, before the context.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+PLAYBOOK = os.path.join(REPO_ROOT, "playbooks", "image_push.yml")
+CMD_DEFS = os.path.join(REPO_ROOT, "meta", "command_definitions.yml")
+
+
+def _text(path):
+    with open(path) as f:
+        return f.read()
+
+
+def test_image_push_exposes_repeatable_build_arg():
+    with open(CMD_DEFS) as f:
+        defs = yaml.safe_load(f)
+    push = next(c for c in defs["commands"] if c["name"] == "image_push")
+    ba = next(p for p in push["parameters"] if p["name"] == "build_arg")
+    assert ba.get("multi") is True
+
+
+def test_playbook_validates_key_value():
+    txt = _text(PLAYBOOK)
+    # Rejects a bare token with no '='.
+    assert "'=' not in item" in txt
+
+
+def test_build_args_forwarded_to_the_build_before_the_context():
+    txt = _text(PLAYBOOK)
+    assert "docker build -t localhost:5000/{{ _img_ref }}" in txt
+    assert "{{ _img_build_arg_flags }} {{ context | quote }}" in txt


### PR DESCRIPTION
Closes #1037.

Adds a repeatable `--build-arg KEY=VALUE` to `canasta image push`, forwarded to the `docker build` — same validation and semantics as `create --build-arg` (malformed values fail fast; user flags are appended, so a user-supplied `BASE_IMAGE` wins).

This is the missing piece for delivering a changed web image to a running Kubernetes instance without recreating it: web overlay Dockerfiles derive `FROM ${BASE_IMAGE}` (the `--build-from` pattern), so pushing one without build args silently builds against the ARG's default base. With this, `image push --build-arg BASE_IMAGE=<base> <context> --name <name>` + `config set CANASTA_IMAGE=<printed ref>` completes the flow (`CANASTA_IMAGE`'s k8s values side-effect already exists). It's also what `wicker upgrade` needs to close its "web image not delivered on k8s" warning.

`make validate`, `make lint`, and all 1640 unit tests pass.