### PR TITLE
Pin the k8s Elasticsearch image by its full registry ref

### DIFF
--- a/roles/orchestrator/files/helm/canasta/values.yaml
+++ b/roles/orchestrator/files/helm/canasta/values.yaml
@@ -73,9 +73,11 @@ externalDatabase:
 
 # Elasticsearch (optional). CirrusSearch supports only Elasticsearch
 # 7.10.x, so this pin follows it (and matches the Compose default).
+# The fully qualified registry is required: Docker Hub's library/
+# elasticsearch never published a 7.10.2 tag.
 elasticsearch:
   enabled: false
-  image: elasticsearch:7.10.2
+  image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
   storage: 5Gi
   storageClass: ""
   resources:

--- a/tests/unit/test_elasticsearch_image_override.py
+++ b/tests/unit/test_elasticsearch_image_override.py
@@ -12,7 +12,6 @@ guaranteed by `combine(recursive=True)`; these tests model that merge.
 """
 
 import os
-import re
 
 import jinja2
 import yaml
@@ -63,19 +62,23 @@ class TestComposeWiring:
     def test_image_is_env_overridable_with_default_preserved(self):
         compose = _read("roles", "orchestrator", "files", "compose", "docker-compose.yml")
         assert "${CANASTA_ELASTICSEARCH_IMAGE:-" in compose
-        # Default kept, so an unset var leaves stock Elasticsearch — at the
-        # same version the Kubernetes chart pins (parity guard: the two
-        # orchestrators must not drift apart again).
-        values = _read("roles", "orchestrator", "files", "helm", "canasta",
-                       "values.yaml")
-        match = re.search(r"image:\s*elasticsearch:([\w.-]+)", values)
-        assert match, "k8s chart no longer pins an elasticsearch image?"
-        assert f"elasticsearch:{match.group(1)}" in compose
+        # Default kept, so an unset var leaves stock Elasticsearch — the
+        # IDENTICAL full image reference the Kubernetes chart pins (parity
+        # guard: the two orchestrators must not drift apart again, in
+        # version or in registry — Docker Hub never published a 7.10.2
+        # tag, so a bare `elasticsearch:` repo is unpullable).
+        values = yaml.safe_load(_read("roles", "orchestrator", "files",
+                                      "helm", "canasta", "values.yaml"))
+        ref = values["elasticsearch"]["image"]
+        assert "/" in ref.split(":")[0], (
+            "k8s elasticsearch image must be a fully qualified registry ref"
+        )
+        assert f"${{CANASTA_ELASTICSEARCH_IMAGE:-{ref}}}" in compose
         # And the pinned line must be the one CirrusSearch supports — its
         # README (REL1_43) says "Only Elasticsearch v7.10 is supported".
         # Update this alongside a CirrusSearch upgrade that widens
         # support, not before.
-        assert match.group(1).startswith("7.10."), (
+        assert ref.rsplit(":", 1)[1].startswith("7.10."), (
             "stock Elasticsearch moved off the 7.10.x line CirrusSearch "
             "supports"
         )


### PR DESCRIPTION
Closes #1041.

Found in the hands-on CirrusSearch-on-k8s e2e — the first real exercise of Elasticsearch on Canasta Kubernetes. Enabling ES went straight to `ImagePullBackOff`: #1034 aligned the version on 7.10.2 but kept the chart's bare-repository image form, and Docker Hub's `library/elasticsearch` never published a 7.10.2 tag (the old 7.17.9 pin happened to exist there, so the form never failed to pull before — though nothing had ever run the pod either).

- The chart now pins `docker.elastic.co/elasticsearch/elasticsearch:7.10.2` — byte-identical to the Compose default.
- The parity guard now parses the chart's ref as YAML and requires the exact same full reference inside Compose's `${CANASTA_ELASTICSEARCH_IMAGE:-…}` default (it previously compared bare versions and couldn't parse a qualified ref at all), still anchored to the CirrusSearch-supported 7.10.x line, plus a fully-qualified-registry check.

Live-validated in the running e2e via the `CANASTA_ELASTICSEARCH_IMAGE` override with this exact ref. All 1643 unit tests and `make lint` pass.