### PR TITLE
k8s jobrunner: create the localisation cache dir before the job loop

### DIFF
--- a/roles/orchestrator/files/helm/canasta/templates/deployment-jobrunner.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/deployment-jobrunner.yaml
@@ -52,6 +52,13 @@ spec:
           command: ["/bin/bash", "-c"]
           args:
             - |
+              # This command overrides the image entrypoint, which is what
+              # prepares /mediawiki on the web pod — so create the
+              # localisation cache dir here or LC-dependent jobs (e.g.
+              # cirrusSearchLinksUpdate) fail on the dangling w/cache
+              # symlink.
+              mkdir -p /mediawiki/cache
+              chown www-data:www-data /mediawiki/cache
               while true; do
                 php maintenance/runJobs.php --wait --maxjobs=10
                 sleep 5


### PR DESCRIPTION
Closes #1044.

Found in the hands-on CirrusSearch-on-k8s e2e: every `cirrusSearchLinksUpdate` job failed with `Unable to create the localisation store directory "/var/www/mediawiki/w/cache/main"`, so new edits never reached the search index — while lighter jobs kept succeeding, making the queue look healthy. Not CirrusSearch-specific: any LC-store-dependent job hits it.

The jobrunner Deployment's command overrides the image entrypoint, which is what creates `/mediawiki/cache` (www-data-owned) on the web pod. Without it the image's `w/cache` symlink dangles, and PHP's recursive mkdir fails on the dangling path component even as root. The fix prepares the directory before the job loop, matching what the entrypoint gives the web pod.

Verified live on a two-node cluster: with the directory prepped in the running jobrunner pod, the next edit's cirrus job indexed the page and the search API returned it (job-queue path, no ForceSearchIndex).

All 1643 unit tests and `make lint` pass.