### PR TITLE
maintenance exec: reach remote Kubernetes instances via ssh

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -925,8 +925,50 @@ def handle_interactive_exec(args):
                    "else exec sh; fi"]
 
     if orchestrator in ("kubernetes", "k8s"):
-        # Find the pod for this service
         ns = "canasta-%s" % inst["id"]
+        # With --stdin-file the exec is non-interactive: keep stdin open
+        # (-i) but drop the TTY (-t), which would otherwise mangle a piped
+        # payload. Without it, preserve the interactive -it behavior.
+        stdin_file = getattr(args, "stdin_file", None)
+        tty_flags = "-i" if stdin_file else "-it"
+        host = inst.get("host", "localhost")
+        if host and host != "localhost":
+            # kubectl and the cluster live on the instance's host, not the
+            # controller — run the pod lookup and the exec there via ssh,
+            # mirroring the Compose branch below. ssh forwards our stdin,
+            # so a --stdin-file payload flows through to `kubectl exec -i`.
+            import shlex
+            lookup = (
+                "kubectl get pods -n %s "
+                "-l app.kubernetes.io/component=%s "
+                "--field-selector=status.phase=Running "
+                "-o 'jsonpath={.items[0].metadata.name}'"
+                % (shlex.quote(ns), shlex.quote(service))
+            )
+            remote_cmd = (
+                'pod="$(%s 2>/dev/null)"; '
+                'if [ -z "$pod" ]; then '
+                "echo \"Error: no running pod found for service '%s'\" >&2; "
+                "exit 1; fi; "
+                'exec kubectl exec %s "$pod" -n %s -- %s'
+                % (lookup, service, tty_flags, shlex.quote(ns),
+                   " ".join(shlex.quote(a) for a in command))
+            )
+            try:
+                ssh_args = ["ssh", "-T" if stdin_file else "-t",
+                            "-o", "LogLevel=ERROR"]
+                # Include any custom SSH args (e.g. from ANSIBLE_SSH_ARGS)
+                extra_ssh = os.environ.get("ANSIBLE_SSH_ARGS", "")
+                if extra_ssh:
+                    ssh_args.extend(extra_ssh.split())
+                ssh_args.extend([host, remote_cmd])
+                _redirect_stdin_from_file(stdin_file)
+                os.execvp("ssh", ssh_args)
+            except FileNotFoundError:
+                print("Error: ssh not found on PATH", file=sys.stderr)
+                sys.exit(1)
+            return True  # unreachable: execvp replaced the process
+        # Find the pod for this service.
         # Select only a Running pod, matching roles/orchestrator/tasks/
         # k8s_get_pod.yml. Without the phase filter, items[0] during a
         # rollout/scale/crash-loop can be a Pending/Terminating/Failed pod,
@@ -947,11 +989,6 @@ def handle_interactive_exec(args):
             )
             sys.exit(1)
         pod = result.stdout.strip()
-        # With --stdin-file the exec is non-interactive: keep stdin open
-        # (-i) but drop the TTY (-t), which would otherwise mangle a piped
-        # payload. Without it, preserve the interactive -it behavior.
-        stdin_file = getattr(args, "stdin_file", None)
-        tty_flags = "-i" if stdin_file else "-it"
         exec_args = ["kubectl", "exec", tty_flags, pod, "-n", ns, "--"]
         exec_args.extend(command)
         _redirect_stdin_from_file(stdin_file)

--- a/tests/unit/test_exec_path_parity.py
+++ b/tests/unit/test_exec_path_parity.py
@@ -204,3 +204,69 @@ class TestShellFallbackParity:
                                  exec_args=["redis-cli", "ping"])
         assert argv[-2:] == ["redis-cli", "ping"]
         assert "bash" not in " ".join(argv)
+
+
+class TestRemoteK8sExec:
+    """A remote Kubernetes instance must run the pod lookup and the exec on
+    its registered host via ssh (issue #1043) — kubectl on the controller
+    has no kubeconfig for the instance's cluster, so the previous local
+    invocation always failed with 'no running pod found'."""
+
+    def _capture(self, monkeypatch, **arg_overrides):
+        captured = {}
+        monkeypatch.setattr(canasta, "resolve_instance", lambda _id: {
+            "id": "rsdev", "orchestrator": "k8s",
+            "host": "op@cp.example.com", "path": "/tmp/i"})
+        monkeypatch.setattr(
+            canasta, "_redirect_stdin_from_file", lambda p: None)
+
+        def fake_execvp(f, argv):
+            captured["file"] = f
+            captured["argv"] = argv
+
+        monkeypatch.setattr(canasta.os, "execvp", fake_execvp)
+
+        def no_local_kubectl(*a, **k):
+            raise AssertionError(
+                "local kubectl must not run for a remote instance")
+
+        monkeypatch.setattr(canasta.subprocess, "run", no_local_kubectl)
+        args = Namespace(id="rsdev", service="web",
+                         exec_args=["php", "version"], stdin_file=None)
+        for key, val in arg_overrides.items():
+            setattr(args, key, val)
+        canasta.handle_interactive_exec(args)
+        return captured
+
+    def test_remote_runs_via_ssh_not_local_kubectl(self, monkeypatch):
+        cap = self._capture(monkeypatch)
+        assert cap["file"] == "ssh"
+        assert "op@cp.example.com" in cap["argv"]
+        remote = cap["argv"][-1]
+        assert "kubectl exec" in remote
+        assert "canasta-rsdev" in remote
+
+    def test_remote_pod_lookup_keeps_selector_parity(self, monkeypatch):
+        # The ssh'd lookup must select a pod the same way as the local
+        # path and k8s_get_pod.yml.
+        remote = self._capture(monkeypatch)["argv"][-1]
+        for fragment in TestK8sPodResolutionParity.SHARED:
+            assert fragment in remote, "remote lookup missing %r" % fragment
+
+    def test_remote_stdin_file_drops_the_tty(self, monkeypatch):
+        cap = self._capture(monkeypatch, stdin_file="/tmp/payload.txt")
+        assert "-T" in cap["argv"]
+        remote = cap["argv"][-1]
+        assert "kubectl exec -i " in remote
+        assert "-it" not in remote
+
+    def test_remote_interactive_allocates_a_tty(self, monkeypatch):
+        cap = self._capture(monkeypatch)
+        assert "-t" in cap["argv"]
+        assert "kubectl exec -it " in cap["argv"][-1]
+
+    def test_remote_missing_pod_fails_inside_the_ssh_command(self, monkeypatch):
+        # The remote snippet, not the controller, reports the no-pod case.
+        remote = self._capture(monkeypatch)["argv"][-1]
+        assert "no running pod found for service 'web'" in remote
+        assert "exit 1" in remote


### PR DESCRIPTION
Closes #1043.

Found in the hands-on CirrusSearch-on-k8s e2e: every `canasta maintenance exec/script/extension/update` against a remote Kubernetes instance failed with `no running pod found for service 'web'`. The k8s branch of `handle_interactive_exec` ran `kubectl get pods` and `kubectl exec` on the controller — which has no kubeconfig for a remote instance's cluster — while the Compose branch has always wrapped its `docker compose exec` in ssh. The k8s path only ever worked with the controller as the control-plane node.

Fix mirrors the Compose branch: when the instance's registered host is not localhost, both the Running-pod lookup and the `kubectl exec` run on that host via a single ssh invocation. `--stdin-file` keeps working (ssh `-T` + `kubectl exec -i`, payload forwarded over ssh stdin, same as Compose); interactive sessions keep their TTY (`-t` + `-it`). The no-pod error is raised from inside the remote command with the same message as the local path.

Tests: a new `TestRemoteK8sExec` class asserts remote instances go through ssh and never local kubectl, the ssh'd pod lookup keeps selector parity with the local path and `k8s_get_pod.yml`, the stdin-file/TTY split is preserved, and the no-pod failure is reported remotely. All 1648 unit tests and `make lint` pass.

Not exercised against a live cluster (the e2e cluster is torn down); the failing case and the manual ssh+kubectl equivalent of this fix were both observed live during the e2e. Happy to re-validate live on request.