### PR TITLE
direct commands: reach remote Kubernetes instances via ssh

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -595,6 +595,28 @@ def _k8s_get_pod(namespace, component="web"):
         return None
 
 
+def _k8s_remote_exec_cmd(inst_id, service, command, forward_stdin=True):
+    """Shell command that resolves a Running pod and execs `command` in it,
+    for running on the instance's host via ssh — the controller has no
+    kubeconfig for a remote cluster, so both the pod lookup and the exec
+    must happen on the host. Pod selection matches _k8s_get_pod."""
+    ns = _k8s_namespace(inst_id)
+    lookup = (
+        "kubectl get pods -n %s -l app.kubernetes.io/component=%s "
+        "--field-selector=status.phase=Running "
+        "-o 'jsonpath={.items[0].metadata.name}'" % (ns, service)
+    )
+    return (
+        'pod="$(%s 2>/dev/null)"; '
+        'if [ -z "$pod" ]; then '
+        "echo \"Error: no running pod found for service '%s'\" >&2; "
+        "exit 1; fi; "
+        'exec kubectl exec%s "$pod" -n %s -- /bin/bash -c %s'
+        % (lookup, service, " -i" if forward_stdin else "",
+           ns, _shell_quote(command))
+    )
+
+
 def _exec_in_container(inst_id, inst, command, service="web"):
     """Execute a command inside a container/pod. Returns (rc, stdout)."""
     host = inst.get("host") or "localhost"
@@ -602,6 +624,9 @@ def _exec_in_container(inst_id, inst, command, service="web"):
     orchestrator = inst.get("orchestrator", "compose")
 
     if orchestrator in ("kubernetes", "k8s"):
+        if not _is_localhost(host):
+            return _ssh_run(host, _k8s_remote_exec_cmd(
+                inst_id, service, command, forward_stdin=False))
         ns = _k8s_namespace(inst_id)
         pod = _k8s_get_pod(ns, service)
         if not pod:
@@ -665,22 +690,34 @@ def _stream_in_container(inst_id, inst, command, service="web",
     wrapped = "stdbuf -oL %s" % command
 
     if orchestrator in ("kubernetes", "k8s"):
-        ns = _k8s_namespace(inst_id)
-        pod = _k8s_get_pod(ns, service)
-        if not pod:
-            print(
-                "Error: no running pod found for service '%s'" % service,
-                file=sys.stderr,
-            )
-            return 1
-        # -i forwards the CLI's stdin, matching `docker compose exec`
-        # on the Compose paths, so redirects like
-        # `canasta maintenance script eval < probe.php` work on K8s too.
-        argv = [
-            "kubectl", "exec", "-i", pod, "-n", ns, "--",
-            "/bin/bash", "-c", wrapped,
-        ]
-        cwd = None
+        if not _is_localhost(host):
+            # kubectl and the cluster live on the instance's host — run
+            # the pod lookup and the exec there via ssh, mirroring the
+            # remote Compose branch below. ssh forwards stdin, so
+            # `... < probe.php` redirects still reach the pod.
+            target = _resolve_ssh_target(host)
+            argv = ["ssh"] + _ssh_args() + [
+                target, _k8s_remote_exec_cmd(inst_id, service, wrapped),
+            ]
+            cwd = None
+        else:
+            ns = _k8s_namespace(inst_id)
+            pod = _k8s_get_pod(ns, service)
+            if not pod:
+                print(
+                    "Error: no running pod found for service '%s'" % service,
+                    file=sys.stderr,
+                )
+                return 1
+            # -i forwards the CLI's stdin, matching `docker compose exec`
+            # on the Compose paths, so redirects like
+            # `canasta maintenance script eval < probe.php` work on K8s
+            # too.
+            argv = [
+                "kubectl", "exec", "-i", pod, "-n", ns, "--",
+                "/bin/bash", "-c", wrapped,
+            ]
+            cwd = None
     elif _is_localhost(host):
         argv = [
             "docker", "compose", "exec", "-T", service,

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 
 import pytest
+from types import SimpleNamespace
 
 # Ensure direct_commands is importable from the repo root.
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
@@ -4063,8 +4064,7 @@ class TestResolveInstanceByCwd:
 
     @staticmethod
     def _args(instance_id=None):
-        import types
-        return types.SimpleNamespace(id=instance_id)
+        return SimpleNamespace(id=instance_id)
 
     def test_top_level_dir(self, registry, monkeypatch):
         _, data = registry
@@ -4215,3 +4215,88 @@ class TestMaintenanceStreamRetriesOnSshReset:
         rc = direct_commands._helpers._stream_in_container("x", inst, "cmd")
         assert rc == 255
         assert calls["n"] == 1, "localhost must not retry on 255"
+
+
+class TestRemoteK8sStreamAndExec:
+    """maintenance script/extension/update stream through
+    _stream_in_container, and lighter helpers use _exec_in_container; for a
+    remote Kubernetes instance both must run the pod lookup and the exec on
+    the instance's host via ssh (issue #1047) — kubectl on the controller
+    has no kubeconfig for the cluster."""
+
+    INST = {"id": "rsdev", "orchestrator": "k8s",
+            "host": "op@cp.example.com", "path": "/tmp/i"}
+
+    def test_stream_remote_goes_via_ssh(self, monkeypatch):
+        captured = {}
+
+        def fake_popen_run(argv, cwd):
+            captured["argv"] = argv
+            return 0
+
+        monkeypatch.setattr(
+            direct_commands._helpers, "_k8s_get_pod",
+            lambda *a, **k: pytest.fail(
+                "local pod lookup must not run for a remote instance"))
+        monkeypatch.setattr(direct_commands._helpers, "_stream_argv", fake_popen_run,
+                            raising=False)
+        # _stream_in_container drives the argv through an inner _run();
+        # patch subprocess.Popen to capture without spawning.
+        class FakeProc:
+            returncode = 0
+
+            def __init__(self):
+                import io
+                self.stdout = io.StringIO("")
+
+            def wait(self):
+                return 0
+
+        def fake_popen(argv, **kw):
+            captured["argv"] = argv
+            return FakeProc()
+
+        monkeypatch.setattr(direct_commands._helpers.subprocess, "Popen", fake_popen)
+        rc = direct_commands._helpers._stream_in_container("rsdev", self.INST, "php x.php")
+        assert rc == 0
+        assert captured["argv"][0] == "ssh"
+        assert "op@cp.example.com" in captured["argv"]
+        remote = captured["argv"][-1]
+        assert "kubectl get pods" in remote
+        assert "app.kubernetes.io/component=web" in remote
+        assert "--field-selector=status.phase=Running" in remote
+        assert "kubectl exec -i" in remote
+        assert "canasta-rsdev" in remote
+        assert "stdbuf -oL" in remote
+
+    def test_exec_remote_goes_via_ssh_run(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(
+            direct_commands._helpers, "_k8s_get_pod",
+            lambda *a, **k: pytest.fail(
+                "local pod lookup must not run for a remote instance"))
+
+        def fake_ssh_run(host, cmd):
+            captured["host"] = host
+            captured["cmd"] = cmd
+            return 0, "ok"
+
+        monkeypatch.setattr(direct_commands._helpers, "_ssh_run", fake_ssh_run)
+        rc, out = direct_commands._helpers._exec_in_container("rsdev", self.INST, "true")
+        assert (rc, out) == (0, "ok")
+        assert captured["host"] == "op@cp.example.com"
+        assert "kubectl get pods" in captured["cmd"]
+        assert "no running pod found for service 'web'" in captured["cmd"]
+
+    def test_local_k8s_path_unchanged(self, monkeypatch):
+        inst = dict(self.INST, host="localhost")
+        monkeypatch.setattr(direct_commands._helpers, "_k8s_get_pod", lambda *a, **k: "pod-1")
+
+        def fake_run(argv, **kw):
+            fake_run.argv = argv
+            return SimpleNamespace(returncode=0, stdout="out")
+
+        monkeypatch.setattr(direct_commands._helpers.subprocess, "run", fake_run)
+        rc, out = direct_commands._helpers._exec_in_container("rsdev", inst, "true")
+        assert rc == 0
+        assert fake_run.argv[0] == "kubectl"


### PR DESCRIPTION
Closes #1047.

Found while live-validating #1046 for 4.9.1: `maintenance exec` now reaches remote Kubernetes instances, but `maintenance extension` (and `script`/`update`) still failed — they stream through `_stream_in_container` in `direct_commands/_helpers.py`, which had the same controller-local kubectl as the path #1046 fixed. `_exec_in_container` had it too.

A shared `_k8s_remote_exec_cmd` builds the on-host Running-pod lookup + `kubectl exec` (same selection as `_k8s_get_pod`, same no-pod error message, raised from inside the remote command); both helpers now ssh it to the instance's registered host when it isn't localhost, exactly like their existing remote Compose branches. Streaming keeps the `stdbuf -oL` wrap and stdin forwarding, so `maintenance script eval < probe.php` still works remotely.

Live-validated against a running remote cluster from a laptop controller: `canasta maintenance extension -i val491 CirrusSearch:ExpectedIndices` — previously an instant `no running pod found` — now streams the script's output. New unit tests assert remote instances go through ssh (never local kubectl) for both helpers and that the local path is unchanged.

All 1651 unit tests and `make lint` pass.