### PR TITLE
Scope backup restore to a single wiki when -w is given

### DIFF
--- a/roles/backup/tasks/restore.yml
+++ b/roles/backup/tasks/restore.yml
@@ -17,6 +17,26 @@
   register: _restore_dbpass
   no_log: true
 
+# Single-wiki restore (-w) scopes the restore to one wiki's DB and
+# per-wiki files. The wiki must already exist in this instance — a
+# scoped restore updates an existing wiki, it does not recreate one.
+- name: Validate target wiki exists (single-wiki restore)
+  when: wiki is defined
+  block:
+    - name: Read current wikis for single-wiki restore validation
+      canasta_wikis_yaml:
+        instance_path: "{{ instance_path }}"
+        state: read
+      register: _restore_target_wikis
+
+    - name: Fail when the target wiki is not in this instance
+      ansible.builtin.fail:
+        msg: >-
+          Wiki '{{ wiki }}' is not in this instance's wikis.yaml, so there is
+          nothing to restore into. Present wikis:
+          {{ _restore_target_wikis.wiki_ids | join(', ') }}.
+      when: wiki not in _restore_target_wikis.wiki_ids
+
 # Resolve 'latest' to a concrete snapshot ID, filtering out
 # safety-before-restore snapshots. Restic's own "latest" keyword
 # doesn't know about our tags — without this filter, running restore
@@ -80,4 +100,6 @@
 
 - name: Display result
   ansible.builtin.debug:
-    msg: "Restored from snapshot {{ _resolved_snapshot }}."
+    msg: >-
+      Restored {{ ("wiki '" ~ wiki ~ "' from") if wiki is defined else "from" }}
+      snapshot {{ _resolved_snapshot }}.

--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -82,6 +82,26 @@
                       'type': 'DirectoryOrCreate'}}] }}
   when: _restore_local_repo | bool
 
+# Single-wiki restore (-w) constrains restic to the target wiki's paths so it
+# never writes other wikis' media into the shared images PVC — restic does not
+# prune the restore target, so their existing files stay put. Limiting the DB
+# dump to db_<id>.sql also means the downstream DB-import and Secret-restore
+# steps self-scope: only that wiki's dump (and no secrets-*.yaml) lands in the
+# pod. A full restore uses no filter.
+- name: Build restic include filters for single-wiki restore
+  ansible.builtin.set_fact:
+    _restore_include: >-
+      {{ ' --include /currentsnapshot/config/settings/wikis/' ~ wiki
+         ~ ' --include /currentsnapshot/config/backup/db_' ~ wiki ~ '.sql'
+         ~ ' --include /currentsnapshot/images/' ~ wiki
+         ~ ' --include /currentsnapshot/public_assets/' ~ wiki }}
+  when: wiki is defined
+
+- name: Default to a full (unfiltered) restore
+  ansible.builtin.set_fact:
+    _restore_include: ""
+  when: wiki is not defined
+
 # If a previous restore failed mid-run, the restic-restore pod may
 # still exist. kubernetes.core.k8s state: present then refuses to
 # update it because Pod spec changes are forbidden post-creation
@@ -130,7 +150,9 @@
                 # on EBS-backed PVCs whose selinux xattrs the overlay fs
                 # rejects. Sentinel still fires unconditionally so the wait
                 # can't hang; the controller inspects the rc + log below.
-                restic --cache-dir /tmp/restic-cache restore {{ _resolved_snapshot }} --target / > /tmp/restore-log 2>&1
+                restic --cache-dir /tmp/restic-cache \
+                  restore {{ _resolved_snapshot }}{{ _restore_include }} \
+                  --target / > /tmp/restore-log 2>&1
                 echo $? > /tmp/restore-rc
                 touch /tmp/restore-done
                 sleep 3600
@@ -227,7 +249,29 @@
     (_restore_rc.stdout | default('0') | trim) != '0'
     and not (_restore_log.stdout | default('') is search('Fatal'))
 
+# Restic restores only the included paths, so a wiki absent from the snapshot
+# yields an empty restore that would otherwise look like success. Fail loudly.
+- name: Confirm the target wiki is present in the snapshot (single-wiki restore)
+  when: wiki is defined
+  block:
+    - name: Check for the target wiki's DB dump in the restore pod
+      ansible.builtin.command:
+        cmd: >-
+          kubectl exec -n {{ _k8s_namespace }} restic-restore --
+          test -f /currentsnapshot/config/backup/db_{{ wiki }}.sql
+      register: _restore_k8s_wiki_present
+      changed_when: false
+      failed_when: false
+
+    - name: Fail when the target wiki is absent from the snapshot
+      ansible.builtin.fail:
+        msg: >-
+          Snapshot {{ _resolved_snapshot }} contains no backup for wiki
+          '{{ wiki }}' (no db_{{ wiki }}.sql). Nothing to restore.
+      when: _restore_k8s_wiki_present.rc != 0
+
 - name: Copy restored config to host
+  when: wiki is not defined
   ansible.builtin.shell:
     cmd: >-
       kubectl exec -n {{ _k8s_namespace }} restic-restore --
@@ -236,7 +280,23 @@
   changed_when: true
   ignore_errors: true
 
+# Single-wiki restore replaces only the target wiki's settings dir on the host;
+# k8s_sync_config below pushes it into the ConfigMap the pods read.
+- name: Copy restored single wiki settings to host
+  when: wiki is defined
+  ansible.builtin.shell:
+    cmd: >-
+      rm -rf "{{ instance_path }}/config/settings/wikis/{{ wiki }}";
+      mkdir -p "{{ instance_path }}/config/settings/wikis/{{ wiki }}";
+      kubectl exec -n {{ _k8s_namespace }} restic-restore --
+      tar cf - -C /currentsnapshot/config/settings/wikis/{{ wiki }} . 2>/dev/null |
+      tar xf - -C "{{ instance_path }}/config/settings/wikis/{{ wiki }}/"
+  changed_when: true
+  ignore_errors: true
+
+# Full restore round-trips the source host's .env; single-wiki leaves it alone.
 - name: Copy restored .env to host
+  when: wiki is not defined
   ansible.builtin.shell:
     cmd: >-
       kubectl cp {{ _k8s_namespace }}/restic-restore:/currentsnapshot/.env
@@ -255,6 +315,7 @@
 # `set -o pipefail` so a broken restic-restore side of the pipe fails loudly;
 # the `test -d` guard skips a dir absent from an older snapshot.
 - name: Restore extensions/skins/public_assets to host
+  when: wiki is not defined
   ansible.builtin.shell:
     cmd: >-
       set -o pipefail;
@@ -268,6 +329,27 @@
   args:
     executable: /bin/bash
   loop: ['extensions', 'skins', 'public_assets']
+  changed_when: true
+
+# Single-wiki restore: public_assets is per-wiki, so restore only this wiki's
+# subdir to the host (extensions/skins are shared and left untouched). The
+# post-restore restart's k8s_sync_user_dirs mirrors it into the PVC. images
+# for this wiki was already restored straight into the images PVC by restic.
+- name: Restore single wiki public assets to host
+  when: wiki is defined
+  ansible.builtin.shell:
+    cmd: >-
+      set -o pipefail;
+      if kubectl exec -n {{ _k8s_namespace }} restic-restore --
+      test -d /currentsnapshot/public_assets/{{ wiki }}; then
+      rm -rf "{{ instance_path }}/public_assets/{{ wiki }}";
+      mkdir -p "{{ instance_path }}/public_assets/{{ wiki }}";
+      kubectl exec -n {{ _k8s_namespace }} restic-restore --
+      tar cf - -C /currentsnapshot/public_assets/{{ wiki }} . |
+      tar xf - -C "{{ instance_path }}/public_assets/{{ wiki }}/";
+      fi
+  args:
+    executable: /bin/bash
   changed_when: true
 
 # Use the WEB pod (not a DB pod) as the import target. Reasons:

--- a/roles/orchestrator/tasks/restore_instance.yml
+++ b/roles/orchestrator/tasks/restore_instance.yml
@@ -113,6 +113,7 @@
     # (Dockerfile, build context dirs) staged by backup_discover_build_paths.yml - is
     # copied back generically, so the restore round-trips whatever was captured.
     - name: Copy files from volume to host
+      when: wiki is not defined
       ansible.builtin.shell:
         cmd: |
           docker run --rm \
@@ -138,7 +139,56 @@
             done'
       changed_when: true
 
+    # Single-wiki restore (-w) brings back only the target wiki's per-wiki
+    # files (settings, images, public assets) and its DB dump. Shared state —
+    # global config, extensions, skins, .env, and other wikis' data — is left
+    # untouched. The wiki id reaches the container via -e (env), never spliced
+    # into the single-quoted sh -c payload.
+    - name: Confirm the target wiki is present in the snapshot
+      when: wiki is defined
+      ansible.builtin.shell:
+        cmd: >-
+          docker run --rm
+          -e W={{ wiki | quote }}
+          -v "canasta-backup-{{ instance_path | basename }}:/currentsnapshot:ro"
+          alpine sh -c 'test -f "/currentsnapshot/config/backup/db_$W.sql"'
+      register: _restore_wiki_in_snapshot
+      changed_when: false
+      failed_when: false
+
+    - name: Fail when the target wiki is absent from the snapshot
+      when:
+        - wiki is defined
+        - _restore_wiki_in_snapshot.rc != 0
+      ansible.builtin.fail:
+        msg: >-
+          Snapshot {{ _resolved_snapshot }} contains no backup for wiki
+          '{{ wiki }}' (no db_{{ wiki }}.sql). Nothing to restore.
+
+    - name: Copy single wiki's files from volume to host
+      when: wiki is defined
+      ansible.builtin.shell:
+        cmd: |
+          docker run --rm \
+            -e W={{ wiki | quote }} \
+            -v "canasta-backup-{{ instance_path | basename }}:/currentsnapshot:ro" \
+            -v "{{ instance_path }}:/install" \
+            alpine sh -c '
+            for rel in "config/settings/wikis/$W" "images/$W" "public_assets/$W"; do
+              if [ -d "/currentsnapshot/$rel" ]; then
+                mkdir -p "/install/$rel";
+                rm -rf "/install/$rel"/* "/install/$rel"/.[!.]* 2>/dev/null;
+                cp -a "/currentsnapshot/$rel/." "/install/$rel/";
+              fi;
+            done;
+            mkdir -p /install/config/backup;
+            cp -a "/currentsnapshot/config/backup/db_$W.sql" /install/config/backup/db_$W.sql'
+      changed_when: true
+
+    # Full restore round-trips the source host's .env; single-wiki leaves the
+    # running instance's .env (and its DB password) untouched.
     - name: Preserve DB password in restored .env
+      when: wiki is not defined
       canasta_env:
         path: "{{ instance_path }}/.env"
         state: set
@@ -147,12 +197,14 @@
       no_log: true
 
     - name: Read wiki IDs for DB restore
+      when: wiki is not defined
       canasta_wikis_yaml:
         instance_path: "{{ instance_path }}"
         state: read
       register: _restore_wikis
 
     - name: Import each wiki database dump
+      when: wiki is not defined
       ansible.builtin.include_tasks: exec.yml
       vars:
         exec_service: web
@@ -163,6 +215,17 @@
           < /mediawiki/config/backup/db_{{ item | quote }}.sql
       loop: "{{ _restore_wikis.wiki_ids }}"
       no_log: true
+
+    - name: Import the single restored wiki's database dump
+      when: wiki is defined
+      ansible.builtin.include_tasks: exec.yml
+      vars:
+        exec_service: web
+        exec_no_log: true
+        exec_command: >-
+          mariadb -h "${MYSQL_HOST:-db}" -u "${MYSQL_USER:-root}"
+          -p{{ _restore_dbpass.value | quote }}
+          < /mediawiki/config/backup/db_{{ wiki | quote }}.sql
 
     - name: Clean up backup dump directory
       ansible.builtin.include_tasks: exec.yml
@@ -181,17 +244,23 @@
         path: "{{ instance_path }}/.gitops-host"
       register: _restore_gitops_stat
 
+    # Single-wiki restore does not touch shared rendered files (.env,
+    # wikis.yaml, Caddyfile), so there is nothing to re-render.
     - name: Re-render gitops templates against this host's vars
       ansible.builtin.include_role:
         name: gitops
         tasks_from: render_compose.yml
-      when: _restore_gitops_stat.stat.exists | default(false)
+      when:
+        - wiki is not defined
+        - _restore_gitops_stat.stat.exists | default(false)
 
     - name: Regenerate orchestrator config (e.g. Caddyfile)
       ansible.builtin.include_role:
         name: orchestrator
         tasks_from: update_config.yml
-      when: _restore_gitops_stat.stat.exists | default(false)
+      when:
+        - wiki is not defined
+        - _restore_gitops_stat.stat.exists | default(false)
 
 # --- Kubernetes restore path ---
 - name: Restore (Kubernetes)
@@ -204,7 +273,10 @@
       ansible.builtin.include_tasks: >-
         {{ canasta_root }}/roles/backup/tasks/restore_k8s.yml
 
+    # Full restore round-trips the source host's .env; single-wiki leaves the
+    # running instance's .env (and its DB password) untouched.
     - name: Preserve DB password in restored .env
+      when: wiki is not defined
       canasta_env:
         path: "{{ instance_path }}/.env"
         state: set

--- a/tests/unit/test_restore_single_wiki.py
+++ b/tests/unit/test_restore_single_wiki.py
@@ -1,0 +1,131 @@
+"""Structural guards for single-wiki restore (`canasta backup restore -w`).
+
+`-w`/`--wiki` used to be accepted by the CLI but ignored by every restore
+task, so a "single wiki" restore silently restored the whole instance —
+overwriting all wikis' databases plus shared state (.env, global config,
+extensions, skins). These tests lock the scoping wiring on both orchestrators:
+a scoped restore touches only the target wiki's DB and per-wiki files, and the
+shared-state steps are gated off when `wiki` is defined. Runtime behavior is
+covered by the live e2e.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+RESTORE = os.path.join(REPO_ROOT, "roles", "backup", "tasks", "restore.yml")
+COMPOSE = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "restore_instance.yml")
+K8S = os.path.join(REPO_ROOT, "roles", "backup", "tasks", "restore_k8s.yml")
+
+
+def _flatten(tasks):
+    """Yield every task, descending into block/rescue/always."""
+    for t in tasks or []:
+        yield t
+        for key in ("block", "rescue", "always"):
+            if key in t:
+                yield from _flatten(t[key])
+
+
+def _tasks(path):
+    with open(path) as f:
+        return list(_flatten(yaml.safe_load(f)))
+
+
+def _by_name(path, name):
+    return next((t for t in _tasks(path) if t.get("name") == name), None)
+
+
+def _when(task):
+    """Normalize a task's `when` (str or list) to one joined string."""
+    w = task.get("when", [])
+    if isinstance(w, list):
+        return " and ".join(str(x) for x in w)
+    return str(w)
+
+
+# --- shared validation (restore.yml) ---
+
+def test_restore_validates_target_wiki_exists():
+    fail = _by_name(RESTORE, "Fail when the target wiki is not in this instance")
+    assert fail is not None, (
+        "single-wiki restore must validate the wiki exists in the instance")
+    assert "wiki not in" in _when(fail)
+
+
+# --- Compose (restore_instance.yml) ---
+
+def test_compose_wholesale_copy_is_gated_off_for_single_wiki():
+    full = _by_name(COMPOSE, "Copy files from volume to host")
+    assert full is not None
+    assert "wiki is not defined" in _when(full), (
+        "the wholesale copy must not run for a single-wiki restore")
+
+
+def test_compose_has_scoped_single_wiki_copy():
+    scoped = _by_name(COMPOSE, "Copy single wiki's files from volume to host")
+    assert scoped is not None and "wiki is defined" in _when(scoped)
+    cmd = scoped["ansible.builtin.shell"]["cmd"]
+    # Only per-wiki paths, addressed via the $W env var (never the shared dirs).
+    for rel in ("config/settings/wikis/$W", "images/$W", "public_assets/$W"):
+        assert rel in cmd, "scoped copy must restore %s" % rel
+
+
+def test_compose_db_import_is_scoped():
+    full = _by_name(COMPOSE, "Import each wiki database dump")
+    assert full is not None and "wiki is not defined" in _when(full)
+    one = _by_name(COMPOSE, "Import the single restored wiki's database dump")
+    assert one is not None and "wiki is defined" in _when(one)
+
+
+def test_compose_env_password_preserve_gated_off_for_single_wiki():
+    # There are two "Preserve DB password in restored .env" tasks (Compose +
+    # K8s block); both must be gated off for a single-wiki restore.
+    preserves = [t for t in _tasks(COMPOSE)
+                 if t.get("name") == "Preserve DB password in restored .env"]
+    assert len(preserves) == 2
+    assert all("wiki is not defined" in _when(t) for t in preserves), (
+        "single-wiki restore must not rewrite the shared .env")
+
+
+# --- Kubernetes (restore_k8s.yml) ---
+
+def test_k8s_builds_include_filters_for_single_wiki():
+    inc = _by_name(K8S, "Build restic include filters for single-wiki restore")
+    assert inc is not None and "wiki is defined" in _when(inc)
+    val = inc["ansible.builtin.set_fact"]["_restore_include"]
+    for path in ("config/settings/wikis/", "config/backup/db_",
+                 "images/", "public_assets/"):
+        assert path in val, "include filter must cover %s" % path
+
+
+def test_k8s_restic_restore_uses_the_include_filter():
+    with open(K8S) as f:
+        text = f.read()
+    assert "restore {{ _resolved_snapshot }}{{ _restore_include }}" in text, (
+        "restic restore must apply the single-wiki include filter")
+
+
+def test_k8s_full_host_copies_are_gated_off_for_single_wiki():
+    for name in ("Copy restored config to host",
+                 "Copy restored .env to host",
+                 "Restore extensions/skins/public_assets to host"):
+        t = _by_name(K8S, name)
+        assert t is not None, "missing task: %s" % name
+        assert "wiki is not defined" in _when(t), (
+            "%s must be gated off for single-wiki restore" % name)
+
+
+def test_k8s_has_scoped_single_wiki_restores():
+    settings = _by_name(K8S, "Copy restored single wiki settings to host")
+    assert settings is not None and "wiki is defined" in _when(settings)
+    assets = _by_name(K8S, "Restore single wiki public assets to host")
+    assert assets is not None and "wiki is defined" in _when(assets)
+
+
+def test_k8s_fails_when_wiki_absent_from_snapshot():
+    fail = _by_name(K8S, "Fail when the target wiki is absent from the snapshot")
+    assert fail is not None, (
+        "a wiki missing from the snapshot must fail, not silently no-op")


### PR DESCRIPTION
## Summary

`canasta backup restore -s <id> -w <wiki>` was documented as restoring only a single wiki, but the `-w`/`--wiki` flag was accepted by the CLI and read by no restore task — restore always restored the whole instance, overwriting every wiki's database plus shared state (`.env`, global config, extensions, skins). On a multi-wiki farm that is silent data loss for the wikis the operator did not intend to touch. The flag has been advertised-but-unimplemented since the first commit of the Ansible CLI.

Closes #1053.

## What changed

When `-w` is given, restore now scopes to just that wiki's database and per-wiki files (`config/settings/wikis/<id>`, `images/<id>`, `public_assets/<id>`), leaving shared state and other wikis untouched — on both orchestrators:

- Validate the wiki exists in the instance; **fail loudly** when the wiki is absent from the snapshot instead of a silent no-op.
- **Compose**: gate the wholesale copy + all-wikis DB import behind full-restore; add a per-wiki copy + single DB import; skip the `.env` password preserve and the gitops re-render.
- **Kubernetes**: constrain `restic` with `--include` so it only writes the wiki's paths — never other wikis' media into the shared images PVC (`restic` does not prune the target). The DB-import and Secret-restore steps then self-scope because only `db_<id>.sql` lands in the pod. Restore only the wiki's settings + public_assets to the host; skip `.env` and extensions/skins.

## Tests

- New `tests/unit/test_restore_single_wiki.py` (10 structural guards); full unit suite (1661) + lint + validate green.
- **Hands-on e2e (Docker Compose, remote host):** created a 3-wiki farm, backed it up, diverged all three (a `site_stats` value + an existing per-wiki file), then `restore -w main`. Only `main` reverted; `alpha`/`beta` and shared state (`.env`, `wikis.yaml`) were untouched, `.env` ownership was preserved, and a bogus `-w` failed loudly.

## Not covered here

- **Kubernetes single-wiki restore is not yet live-validated** (the code is in place; needs a two-host cluster to exercise the `restic --include` / images-PVC path).
- Two adjacent, pre-existing restore bugs surfaced during this work and are tracked separately: restore clobbering file ownership on a cross-host restore (#1054) and the restore staging volume not being cleared, leaking post-snapshot files (#1055).