### PR TITLE
Apply ignore_errors to included tasks, not the inert include

### DIFF
--- a/playbooks/remove.yml
+++ b/playbooks/remove.yml
@@ -20,19 +20,26 @@
 
 # Clean up wiki images inside container (owned by www-data on Linux)
 - name: Remove wiki images inside container
-  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+  ansible.builtin.include_tasks:
+    file: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+    # ignore_errors must be applied to the included tasks, not the include
+    # itself (where it is inert) — OK if the images dir doesn't exist.
+    apply:
+      ignore_errors: true
   vars:
     exec_service: web
     exec_command: "rm -rf /mediawiki/images/{{ wiki | quote }}"
-  ignore_errors: true  # OK if images dir doesn't exist
 
 # Clean up public assets (sitemaps etc.)
 - name: Remove wiki public assets
-  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+  ansible.builtin.include_tasks:
+    file: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+    # Apply to the included tasks — OK if the assets dir doesn't exist.
+    apply:
+      ignore_errors: true
   vars:
     exec_service: web
     exec_command: "rm -rf /mediawiki/public_assets/{{ wiki | quote }}"
-  ignore_errors: true  # OK if assets dir doesn't exist
 
 - name: Remove wiki from wikis.yaml
   canasta_wikis_yaml:
@@ -41,13 +48,16 @@
     wiki_id: "{{ wiki }}"
 
 - name: Drop wiki database
-  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+  ansible.builtin.include_tasks:
+    file: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+    # Apply to the included tasks — OK if the database doesn't exist.
+    apply:
+      ignore_errors: true
   vars:
     exec_service: db
     exec_command: >-
       mariadb -u root -p{{ _remove_dbpass.value | default('mediawiki') | quote }}
       -e 'DROP DATABASE IF EXISTS {{ wiki | quote }}'
-  ignore_errors: true  # OK if database doesn't exist
 
 - name: Remove per-wiki settings directory
   ansible.builtin.file:

--- a/roles/orchestrator/tasks/backup_cleanup_db_dumps.yml
+++ b/roles/orchestrator/tasks/backup_cleanup_db_dumps.yml
@@ -8,9 +8,12 @@
 # Input: instance_path, instance_orchestrator
 
 - name: Clean up backup staging directory (Compose)
-  ansible.builtin.include_tasks: exec.yml
+  ansible.builtin.include_tasks:
+    file: exec.yml
+    # Apply to the included tasks — OK if backup dir doesn't exist.
+    apply:
+      ignore_errors: true
   vars:
     exec_service: web
     exec_command: "rm -rf /mediawiki/config/backup"
   when: instance_orchestrator | default('compose') == 'compose'
-  ignore_errors: true  # OK if backup dir doesn't exist

--- a/roles/orchestrator/tasks/delete_cleanup_files.yml
+++ b/roles/orchestrator/tasks/delete_cleanup_files.yml
@@ -31,9 +31,12 @@
       ignore_errors: true  # OK if pods not running
 
     - name: Remove files inside K8s pod
-      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+      ansible.builtin.include_tasks:
+        file: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+        # Apply to the included tasks — OK if dirs already empty or missing.
+        apply:
+          ignore_errors: true
       vars:
         exec_service: web
         exec_command: "find /mediawiki/images /mediawiki/config /mediawiki/public_assets -mindepth 1 -delete 2>/dev/null || true"
-      ignore_errors: true  # OK if dirs already empty or missing
       when: _container_running | default(false) | bool

--- a/roles/orchestrator/tasks/restore_instance.yml
+++ b/roles/orchestrator/tasks/restore_instance.yml
@@ -92,11 +92,14 @@
             backup_volumes: "{{ _safety_volumes }}"
 
         - name: Clean up safety DB dump directory
-          ansible.builtin.include_tasks: exec.yml
+          ansible.builtin.include_tasks:
+            file: exec.yml
+            # Apply to the included tasks — best-effort cleanup.
+            apply:
+              ignore_errors: true
           vars:
             exec_service: web
             exec_command: "rm -rf /mediawiki/config/backup"
-          ignore_errors: true
 
     - name: Restore snapshot into backup volume
       ansible.builtin.include_tasks: run_backup.yml
@@ -165,11 +168,14 @@
       no_log: true
 
     - name: Clean up backup dump directory
-      ansible.builtin.include_tasks: exec.yml
+      ansible.builtin.include_tasks:
+        file: exec.yml
+        # Apply to the included tasks — OK if backup dir doesn't exist.
+        apply:
+          ignore_errors: true
       vars:
         exec_service: web
         exec_command: "rm -rf /mediawiki/config/backup"
-      ignore_errors: true  # OK if backup dir doesn't exist
 
     # When the instance is under gitops, the snapshot just restored contains
     # the SOURCE host's rendered files (.env, wikis.yaml, Caddyfile). On this

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -183,11 +183,14 @@
         tasks_from: start.yml
 
     - name: Flush MediaWiki cache
-      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+      ansible.builtin.include_tasks:
+        file: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+        # Apply to the included tasks — OK if the container isn't ready yet.
+        apply:
+          ignore_errors: true
       vars:
         exec_service: web
         exec_command: "touch /var/www/mediawiki/w/LocalSettings.php"
-      ignore_errors: true  # OK if container not ready yet
 
     - name: Report instance upgraded
       ansible.builtin.debug:

--- a/tests/unit/test_ignore_errors_apply.py
+++ b/tests/unit/test_ignore_errors_apply.py
@@ -1,0 +1,56 @@
+"""Guard against inert `ignore_errors` on `include_tasks`.
+
+`ignore_errors: true` placed directly on a dynamic `include_tasks` is inert —
+it applies to the include operation, not to the tasks inside the included file,
+so a non-zero result there aborts the whole play. This silently broke
+`canasta remove` (its first exec aborted the play before the wiki was removed).
+The correct form puts the flag under the include's `apply:`. This test fails if
+any task file reintroduces the top-level pattern.
+"""
+
+import glob
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+
+INCLUDE_KEYS = ("ansible.builtin.include_tasks", "include_tasks")
+
+
+def _task_files():
+    files = glob.glob(
+        os.path.join(REPO_ROOT, "roles", "**", "tasks", "**", "*.yml"),
+        recursive=True)
+    files += glob.glob(os.path.join(REPO_ROOT, "playbooks", "*.yml"))
+    return files
+
+
+def _flatten(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for key in ("block", "rescue", "always"):
+            if key in t:
+                yield from _flatten(t[key])
+
+
+def test_no_inert_ignore_errors_on_include_tasks():
+    offenders = []
+    for path in _task_files():
+        with open(path) as f:
+            try:
+                doc = yaml.safe_load(f)
+            except yaml.YAMLError:
+                continue
+        if not isinstance(doc, list):
+            continue
+        for task in _flatten(doc):
+            has_include = any(k in task for k in INCLUDE_KEYS)
+            if has_include and "ignore_errors" in task:
+                rel = os.path.relpath(path, REPO_ROOT)
+                offenders.append("%s: %s" % (rel, task.get("name", "?")))
+    assert not offenders, (
+        "include_tasks with a task-level ignore_errors (inert — move it under "
+        "the include's `apply:`):\n  " + "\n  ".join(offenders))


### PR DESCRIPTION
## Summary

`ignore_errors: true` placed directly on a dynamic `ansible.builtin.include_tasks` is **inert** — it applies to the include operation, not to the tasks inside the included file. So a non-zero result from an included task aborts the **whole play**, defeating the intended best-effort behavior.

Most visibly, this broke `canasta remove -w <wiki>`: its first container step (`rm -rf /mediawiki/images/<wiki>` via `exec.yml`) aborted the play on any non-zero rc — before the wikis.yaml-removal and `DROP DATABASE` steps ran. The error goes to stderr and the only stdout line is the final (never-reached) success message, so the command looked like it did nothing.

Closes #1057.

## What changed

Move the flag under each include's `apply:` so it reaches the included tasks, at all eight sites:

- `playbooks/remove.yml` (remove images, remove public assets, drop database)
- `roles/upgrade/tasks/main.yml` (flush MediaWiki cache)
- `roles/orchestrator/tasks/restore_instance.yml` (safety DB dump cleanup, backup dump cleanup)
- `roles/orchestrator/tasks/delete_cleanup_files.yml` (remove files inside K8s pod)
- `roles/orchestrator/tasks/backup_cleanup_db_dumps.yml` (clean up backup staging)

`when:` guards stay at the task level (they correctly gate the include); only `ignore_errors` moves into `apply:`.

## Tests

New `tests/unit/test_ignore_errors_apply.py` scans every task file and fails if any `include_tasks` carries a task-level `ignore_errors`. Full unit suite (1652) + lint + validate green.