### PR TITLE
Normalize restored file ownership on Compose restore

### DIFF
--- a/roles/orchestrator/tasks/restore_instance.yml
+++ b/roles/orchestrator/tasks/restore_instance.yml
@@ -112,6 +112,15 @@
     # - .env, docker-compose.override.yml, my.cnf, and any custom build inputs
     # (Dockerfile, build context dirs) staged by backup_discover_build_paths.yml - is
     # copied back generically, so the restore round-trips whatever was captured.
+    #
+    # cp -a preserves the snapshot's NUMERIC uids. On a cross-host restore those
+    # ids need not map to a real user here, so restored top-level files (notably
+    # .env, mode 0600) come back owned by an unmapped uid and become unreadable
+    # by the CLI user — which aborts the very next step (preserving the DB
+    # password) and leaves the instance broken. Normalize the restored top-level
+    # files to the instance dir's owner (the CLI user), mirroring 'gitops join';
+    # the web entrypoint re-establishes www-data on the content dirs at the
+    # post-restore restart.
     - name: Copy files from volume to host
       when: wiki is not defined
       ansible.builtin.shell:
@@ -136,6 +145,10 @@
               [ "$skip" = "1" ] && continue;
               [ -d "$e" ] && rm -rf "/install/$name";
               cp -a "$e" "/install/$name";
+            done;
+            own=$(stat -c "%u:%g" /install);
+            for f in /install/* /install/.[!.]*; do
+              [ -f "$f" ] && chown "$own" "$f";
             done'
       changed_when: true
 

--- a/tests/unit/test_restore_ownership.py
+++ b/tests/unit/test_restore_ownership.py
@@ -1,0 +1,43 @@
+"""Guard for restore file-ownership normalization (Compose).
+
+The Compose restore copies files to the host with `cp -a`, which preserves the
+snapshot's numeric uids. On a cross-host restore those ids need not map to a
+real user, so `.env` (mode 0600) came back unreadable by the CLI user and
+aborted the restore before the DB import. The copy step must chown restored
+top-level files back to the instance dir's owner. This locks that in.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+COMPOSE = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "restore_instance.yml")
+
+
+def _flatten(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for key in ("block", "rescue", "always"):
+            if key in t:
+                yield from _flatten(t[key])
+
+
+def _copy_task():
+    with open(COMPOSE) as f:
+        tasks = list(_flatten(yaml.safe_load(f)))
+    return next(t for t in tasks if t.get("name") == "Copy files from volume to host")
+
+
+def test_copy_step_normalizes_ownership_to_instance_owner():
+    cmd = _copy_task()["ansible.builtin.shell"]["cmd"]
+    # Derives the target from the instance dir owner (not a hard-coded uid)...
+    assert 'stat -c "%u:%g" /install' in cmd, (
+        "restore must derive ownership from the instance dir, not assume a uid")
+    # ...and chowns restored files to it.
+    assert "chown" in cmd, (
+        "restore must chown restored files or a cross-host restore leaves .env "
+        "owned by an unmapped uid and unreadable by the CLI user")


### PR DESCRIPTION
## Summary

The Compose restore copies files to the host with `cp -a`, which preserves the snapshot's **numeric uids**. On a **cross-host** restore (e.g. a migration to a new server) those ids need not map to a real user on the target, so `.env` comes back owned by an unmapped uid at mode `0600` — unreadable by the CLI user. The next step (preserving the DB password in `.env`) then fails with permission denied and the restore **aborts before importing the wiki databases**, leaving a multi-wiki instance with only the wiki the fresh instance was created with.

Closes #1054.

## Fix

In the copy container (already root, with the instance dir mounted), after `cp -a`, chown the restored **top-level files** to the instance dir's owner (the CLI user) — derived from `stat -c %u:%g /install`, not a hard-coded uid. This mirrors what `gitops join` already does for brought-in files. Content dirs (config/images/public_assets/…) keep their uids; the web entrypoint re-establishes `www-data` on them at the post-restore restart.

**Kubernetes is unaffected** — its host copies extract via `tar`/`kubectl cp` as the host user, which does not restore ownership.

## Tests

- New `tests/unit/test_restore_ownership.py`; full unit suite (1662) + lint + validate green.
- **Validation note:** this bug is a cross-host uid mismatch and cannot be reproduced same-host. Being validated with a live cross-host migration e2e (backup on one host → create + full restore on another); results to follow.