### PR TITLE
Clear the restore staging volume before restoring

### DIFF
--- a/roles/orchestrator/tasks/restore_instance.yml
+++ b/roles/orchestrator/tasks/restore_instance.yml
@@ -98,6 +98,19 @@
             exec_command: "rm -rf /mediawiki/config/backup"
           ignore_errors: true
 
+    # The safety backup above stages the CURRENT instance into this same volume,
+    # and `restic restore` does not prune its target — so any file present now
+    # but absent from the snapshot would survive the restore and be copied back
+    # to the host (a restore that doesn't fully revert). Clear the volume first
+    # so it reflects only the snapshot. Runs for full and single-wiki restores.
+    - name: Clear backup volume before restore
+      ansible.builtin.command:
+        cmd: >-
+          docker run --rm
+          -v "canasta-backup-{{ instance_path | basename }}:/currentsnapshot"
+          alpine sh -c 'rm -rf /currentsnapshot/* /currentsnapshot/.[!.]* 2>/dev/null || true'
+      changed_when: true
+
     - name: Restore snapshot into backup volume
       ansible.builtin.include_tasks: run_backup.yml
       vars:

--- a/tests/unit/test_restore_volume_clear.py
+++ b/tests/unit/test_restore_volume_clear.py
@@ -1,0 +1,40 @@
+"""Guard: the Compose restore clears its staging volume before restoring.
+
+The safety backup stages the current instance into the same
+`canasta-backup-<id>` volume, and `restic restore` does not prune its target.
+Without clearing the volume first, files present now but absent from the
+snapshot leak through the restore. This test locks in the clear step and its
+ordering (before the restic restore that reads the volume).
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+COMPOSE = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "restore_instance.yml")
+
+
+def _flatten(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for key in ("block", "rescue", "always"):
+            if key in t:
+                yield from _flatten(t[key])
+
+
+def _names_in_order():
+    with open(COMPOSE) as f:
+        return [t.get("name") for t in _flatten(yaml.safe_load(f))]
+
+
+def test_volume_cleared_before_restore():
+    names = _names_in_order()
+    assert "Clear backup volume before restore" in names, (
+        "restore must clear the staging volume or post-snapshot files leak")
+    assert names.index("Clear backup volume before restore") < \
+        names.index("Restore snapshot into backup volume"), (
+        "the clear must run before the restic restore that reads the volume")


### PR DESCRIPTION
## Summary

A restore reuses the `canasta-backup-<id>` volume that the safety backup just filled with the **current** instance, and `restic restore` does not prune its target. Files present now but absent from the snapshot therefore **survived the restore** and were copied back to the host — so a restore did not faithfully revert to the snapshot (post-snapshot additions leaked through).

Closes #1055.

## Fix

Add a "Clear backup volume before restore" step (`docker run … rm -rf /currentsnapshot`) before "Restore snapshot into backup volume", so the restic restore lands in a clean volume that reflects only the snapshot. Runs for both full and single-wiki restores.

**Kubernetes is unaffected** — its restore pod uses a fresh `emptyDir` per run. (The K8s images-PVC is not pruned either, but that's a separate, narrower nuance and not addressed here.)

## Tests

New `tests/unit/test_restore_volume_clear.py` (asserts the clear step exists and runs before the restic restore); full unit suite (1662) + lint + validate green.