### PR TITLE
Skip absent wiki databases in the pre-restore safety backup

### DIFF
--- a/roles/orchestrator/tasks/restore_instance.yml
+++ b/roles/orchestrator/tasks/restore_instance.yml
@@ -29,7 +29,36 @@
             exec_service: web
             exec_command: "mkdir -p /mediawiki/config/backup"
 
-        - name: Dump each wiki database for safety backup
+        # A wiki listed in wikis.yaml may have no database (dropped or corrupted
+        # — the very disaster a restore recovers from). Dumping a missing DB
+        # fails mariadb-dump and would abort the whole restore, so dump only the
+        # wikis whose database is present and warn about the rest.
+        - name: List existing databases for the safety backup
+          ansible.builtin.include_tasks: exec.yml
+          vars:
+            exec_service: web
+            exec_no_log: true
+            exec_command: >-
+              mariadb -h "${MYSQL_HOST:-db}" -u "${MYSQL_USER:-root}"
+              -p{{ _restore_dbpass.value | quote }} -N -e "SHOW DATABASES"
+
+        - name: Partition wikis into present and missing databases
+          ansible.builtin.set_fact:
+            _safety_present_wikis: >-
+              {{ _safety_wikis.wiki_ids
+                 | intersect(exec_result.stdout_lines | default([])) }}
+            _safety_missing_wikis: >-
+              {{ _safety_wikis.wiki_ids
+                 | difference(exec_result.stdout_lines | default([])) }}
+
+        - name: Warn about wikis skipped from the safety backup
+          ansible.builtin.debug:
+            msg: >-
+              Skipping the pre-restore safety backup for wiki(s)
+              {{ _safety_missing_wikis | join(', ') }}: no database present.
+          when: _safety_missing_wikis | length > 0
+
+        - name: Dump each present wiki database for safety backup
           ansible.builtin.include_tasks: exec.yml
           vars:
             exec_service: web
@@ -40,7 +69,7 @@
               --single-transaction
               --databases {{ item | quote }}
               > /mediawiki/config/backup/db_{{ item | quote }}.sql
-          loop: "{{ _safety_wikis.wiki_ids }}"
+          loop: "{{ _safety_present_wikis }}"
           no_log: true
 
         - name: Build safety backup volume map

--- a/tests/unit/test_safety_backup_missing_db.py
+++ b/tests/unit/test_safety_backup_missing_db.py
@@ -1,0 +1,55 @@
+"""Guard: the pre-restore safety backup tolerates a missing wiki database.
+
+The safety backup used to dump every wiki in wikis.yaml, so a single missing
+database (the very disaster a restore recovers from) failed mariadb-dump and
+aborted the whole restore. The dump must run only over wikis whose database is
+present, and warn about the rest.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+COMPOSE = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "restore_instance.yml")
+
+
+def _flatten(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for key in ("block", "rescue", "always"):
+            if key in t:
+                yield from _flatten(t[key])
+
+
+def _tasks():
+    with open(COMPOSE) as f:
+        return list(_flatten(yaml.safe_load(f)))
+
+
+def _by_name(name):
+    return next((t for t in _tasks() if t.get("name") == name), None)
+
+
+def test_safety_dump_loops_only_over_present_wikis():
+    dump = _by_name("Dump each present wiki database for safety backup")
+    assert dump is not None, "safety dump task missing/renamed"
+    assert dump.get("loop") == "{{ _safety_present_wikis }}", (
+        "safety dump must loop over wikis with a present DB, not all wiki_ids "
+        "(a missing DB otherwise aborts the whole restore)")
+
+
+def test_present_missing_partition_is_computed():
+    part = _by_name("Partition wikis into present and missing databases")
+    assert part is not None
+    facts = part["ansible.builtin.set_fact"]
+    assert "intersect" in facts["_safety_present_wikis"]
+    assert "difference" in facts["_safety_missing_wikis"]
+
+
+def test_missing_wikis_are_warned_about():
+    warn = _by_name("Warn about wikis skipped from the safety backup")
+    assert warn is not None and "_safety_missing_wikis" in str(warn.get("when"))


### PR DESCRIPTION
## Summary

Before a Compose restore, Canasta takes a safety backup that dumps **every** wiki in `wikis.yaml` via `mariadb-dump --databases <id>`. The loop is all-or-nothing: if one wiki's database is missing — the very disaster a restore recovers from — `mariadb-dump` fails and the whole restore **aborts** before restoring anything.

Closes #1061.

## Fix

In the safety-backup block (`roles/orchestrator/tasks/restore_instance.yml`):

1. `SHOW DATABASES` once, then partition the wiki list into present vs. missing (`intersect`/`difference`).
2. Emit a visible warning naming the wikis whose DB is absent (IDs only — the dump command carries the password under `no_log`, so the warning is a separate un-logged task).
3. Dump only the wikis whose database is present.

The restore keeps a rollback snapshot covering every wiki that can be protected and never aborts on a missing DB. `--skip-safety-backup` stays the explicit "no safety snapshot" option. **Kubernetes is unaffected** — its restore path takes no pre-restore safety backup.

## Tests

New `tests/unit/test_safety_backup_missing_db.py` (3 guards: dump loops over present wikis only, present/missing partition computed, missing wikis warned). Full unit suite (1667) + lint + validate green.

**Live validation deferred:** reproducing end-to-end (drop a wiki DB, then a default `backup restore` succeeds) needs a live Compose host; unit-tested here, live e2e to follow.