### PR TITLE
Unify secret classification and encrypt K8s gitops Secrets with SOPS+age

### DIFF
--- a/canasta.yml
+++ b/canasta.yml
@@ -56,6 +56,11 @@
       ansible.builtin.include_vars:
         file: vars/secret_classification.yml
 
+    # Pinned tool versions (SOPS toolchain) shared across roles — one source.
+    - name: Load pinned tool versions
+      ansible.builtin.include_vars:
+        file: vars/tool_versions.yml
+
     - name: Validate command exists
       ansible.builtin.assert:
         that: command in (canasta_commands.commands | map(attribute='name'))

--- a/canasta.yml
+++ b/canasta.yml
@@ -50,6 +50,12 @@
         file: meta/command_definitions.yml
         name: canasta_commands
 
+    # Canonical secret classifier, play-global so config/gitops/orchestrator
+    # all share one definition of "secret" (roles/*/defaults are role-scoped).
+    - name: Load canonical secret classification
+      ansible.builtin.include_vars:
+        file: vars/secret_classification.yml
+
     - name: Validate command exists
       ansible.builtin.assert:
         that: command in (canasta_commands.commands | map(attribute='name'))

--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -31,7 +31,9 @@ df -h / | awk 'NR==2{print $4}' 2>/dev/null || echo unknown; echo "$D"
 cat /proc/sys/net/ipv4/ip_unprivileged_port_start 2>/dev/null || echo unknown; echo "$D"
 runtime="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"; _sock=""; for s in "$runtime/podman/podman.sock" "$runtime/docker.sock"; do if [ -S "$s" ]; then _sock="unix://$s"; break; fi; done; echo "$_sock"; echo "$D"
 command -v canasta >/dev/null 2>&1 && { canasta version >/dev/null 2>&1 && echo OK || echo BROKEN; } || echo MISSING; echo "$D"
-cdir="$(dirname "$(readlink -f "$(command -v canasta 2>/dev/null)" 2>/dev/null)" 2>/dev/null)"; if [ -n "$cdir" ] && [ -d "$cdir/.git" ]; then { [ -w "$cdir/.git" ] && echo WRITABLE || echo NOT_WRITABLE; } else echo NA; fi
+cdir="$(dirname "$(readlink -f "$(command -v canasta 2>/dev/null)" 2>/dev/null)" 2>/dev/null)"; if [ -n "$cdir" ] && [ -d "$cdir/.git" ]; then { [ -w "$cdir/.git" ] && echo WRITABLE || echo NOT_WRITABLE; } else echo NA; fi; echo "$D"
+command -v sops >/dev/null 2>&1 && echo OK || echo MISSING; echo "$D"
+command -v age-keygen >/dev/null 2>&1 && echo OK || echo MISSING
 """
 
 
@@ -66,6 +68,11 @@ def _parse_doctor(stdout, hostname):
     # Writability of the native install dir's .git — the precondition for
     # `canasta upgrade`'s self-update (git fetch). NA on docker installs.
     selfupdate = p(19) if len(parts) > 19 else "NA"
+    # SOPS toolchain for encrypted K8s gitops secrets (appended, so it didn't
+    # shift the positional indices above): sops on the gitops host, age on the
+    # controller.
+    sops = p(20) if len(parts) > 20 else "MISSING"
+    age = p(21) if len(parts) > 21 else "MISSING"
 
     lines = [
         "Canasta Dependency Check (%s)" % hostname,
@@ -132,6 +139,17 @@ def _parse_doctor(stdout, hostname):
         "OK (%s)" % git if "git version" in git else "not installed"))
     lines.append("  git-crypt:       %s" % (
         "OK" if gitcrypt == "OK" else "not installed"))
+    # SOPS toolchain: sops encrypts Secret manifests on the gitops host; age
+    # manages the operator key on the controller. Needed only for K8s gitops
+    # with gitops_sops_secrets enabled. Install both with 'canasta install sops'.
+    lines.append("  sops:            %s" % (
+        "OK" if sops == "OK"
+        else "not installed (needed on the gitops host for encrypted K8s "
+             "secrets; 'canasta install sops')"))
+    lines.append("  age:             %s" % (
+        "OK" if age == "OK"
+        else "not installed (operator key tool for encrypted K8s secrets; "
+             "'canasta install sops')"))
 
     lines.append("")
     # Backup scheduling writes a host crontab entry on the host where the

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -743,11 +743,15 @@ commands:
       kubectl can verify the cert when reaching the cluster over that
       address. Repeat to add more than one (e.g. an IP and a hostname).
 
-      `sops` installs the SOPS toolchain (sops + age) on the target,
-      required for encrypted secrets in Kubernetes gitops
-      (gitops_sops_secrets): sops encrypts Secret manifests on the
-      gitops host, and age-keygen manages the operator key on the
-      controller. Idempotent — skips a binary already present.
+      `sops` installs the SOPS toolchain (sops + age), required for
+      encrypted secrets in Kubernetes gitops (`gitops init
+      --encrypt-secrets`). Two hosts need it: the controller (where the
+      CLI runs) uses age-keygen to manage the operator key, and the
+      gitops target host uses sops to encrypt Secret manifests. Run it
+      once per role: `canasta install sops` (no --host) for the
+      controller and `canasta install -H <host> sops` for the target
+      (they may be the same machine). Idempotent — skips a binary
+      already present.
 
       `canasta` installs the Canasta CLI (canasta-native) on the target
       host, so an instance deployed remotely from a controller can also

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -2203,6 +2203,17 @@ commands:
         type: bool
         default: false
         description: "Require pull requests instead of pushing to main"
+      - name: encrypt_secrets
+        type: bool
+        default: false
+        description: >-
+          Kubernetes only. Encrypt the instance's Secrets in git with
+          SOPS+age instead of leaving them out of version control. The
+          operator age key is generated on the controller (portable via
+          --key for DR); Argo CD's repo-server gains a helm-sops sidecar
+          that decrypts at render time. Requires sops on the target and
+          age on the controller ('canasta install sops'). No effect on
+          Compose, which already encrypts vars with git-crypt.
       - name: git_user_name
         type: string
         description: "Git user.name for commits on the target host (set if not already configured)"

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -690,8 +690,8 @@ commands:
       Verify that the target host has the tools required for its
       orchestrator: Docker + Docker Compose for Compose installs,
       or kubectl + Helm for Kubernetes installs. Also reports
-      status of optional tools (git, git-crypt, crontab) and system
-      resources (memory, disk space).
+      status of optional tools (git, git-crypt, sops, age, crontab) and
+      system resources (memory, disk space).
     examples:
       - "canasta doctor"
       - "canasta doctor --host prod1.example.com"
@@ -721,7 +721,7 @@ commands:
     description: "Install dependencies on the target host"
     long_description: |
       Install one or more dependencies on the target host. Supported
-      packages: docker, k8s-cp, k8s-worker, git-crypt, canasta.
+      packages: docker, k8s-cp, k8s-worker, git-crypt, sops, canasta.
 
       `k8s-cp` installs k3s as a control-plane node — the cluster's
       API server, scheduler, etc., plus kubectl + helm on the same
@@ -743,6 +743,12 @@ commands:
       kubectl can verify the cert when reaching the cluster over that
       address. Repeat to add more than one (e.g. an IP and a hostname).
 
+      `sops` installs the SOPS toolchain (sops + age) on the target,
+      required for encrypted secrets in Kubernetes gitops
+      (gitops_sops_secrets): sops encrypts Secret manifests on the
+      gitops host, and age-keygen manages the operator key on the
+      controller. Idempotent — skips a binary already present.
+
       `canasta` installs the Canasta CLI (canasta-native) on the target
       host, so an instance deployed remotely from a controller can also
       be operated directly on its own host. This is required before
@@ -762,6 +768,7 @@ commands:
       - "canasta install --host node2 k8s-worker --cp-host node1"
       - "canasta install docker git-crypt"
       - "canasta install -i mysite git-crypt"
+      - "canasta install -i mysite sops"
       - "canasta install -i mysite canasta"
     playbook: install.yml
     parameters:

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -25,8 +25,8 @@
   ansible.builtin.fail:
     msg: >-
       Unknown package '{{ item }}'. Supported: docker, k8s-cp,
-      k8s-worker, git-crypt, canasta.
-  when: item not in ['docker', 'k3s', 'k3s-worker', 'git-crypt', 'canasta']
+      k8s-worker, git-crypt, sops, canasta.
+  when: item not in ['docker', 'k3s', 'k3s-worker', 'git-crypt', 'sops', 'canasta']
   loop: "{{ _install_packages }}"
 
 - name: Validate k8s-cp + k8s-worker not requested together
@@ -72,6 +72,12 @@
     name: install
     tasks_from: git_crypt.yml
   when: "'git-crypt' in _install_packages"
+
+- name: Install the SOPS toolchain (sops + age)
+  ansible.builtin.include_role:
+    name: install
+    tasks_from: sops_age.yml
+  when: "'sops' in _install_packages"
 
 - name: Install canasta-native
   ansible.builtin.include_role:

--- a/roles/config/defaults/main.yml
+++ b/roles/config/defaults/main.yml
@@ -117,21 +117,7 @@ canasta_known_keys:
     group: Backup (Restic)
     description: Restic repo password
 
-# Key prefixes that are always accepted (backup and mail credentials)
-canasta_known_prefixes:
-  - "AWS_"
-  - "AZURE_"
-  - "B2_"
-  - "GOOGLE_"
-  - "OS_"
-  - "ST_"
-  - "RCLONE_"
-  - "SMTP_"
-
-# Keys whose value is a secret. The .env write (and gitops vars write)
-# that carries one of these runs with no_log so the value can't leak via
-# -v, the stock callback, or a task-failure dump. A substring match keeps
-# it fail-safe for future keys (over-suppression is harmless); covers
-# CROWDSEC_BOUNCER_API_KEY, MYSQL_PASSWORD, RESTIC_PASSWORD, MW_SECRET_KEY,
-# and the credential-prefix keys above.
-canasta_secret_key_pattern: "(PASSWORD|SECRET|TOKEN|KEY)"
+# Secret classification (canasta_secret_key_pattern, canasta_secret_prefixes,
+# canasta_secret_key_regex, canasta_backup_backend_prefixes, ...) lives
+# play-global in vars/secret_classification.yml so config, gitops, and the K8s
+# sync share one definition. Config validation + no_log reference it from there.

--- a/roles/config/tasks/_ensure_env_template_placeholder.yml
+++ b/roles/config/tasks/_ensure_env_template_placeholder.yml
@@ -1,8 +1,8 @@
 ---
 # Ensure env.template has a placeholder line for a single credential key.
 # Input: _ep_setting (str: "KEY=VALUE" or "KEY=...")
-# Requires: instance_path, gitops_placeholder_keys,
-#           gitops_secret_prefix_pattern
+# Requires: instance_path + the canonical classifier
+#           (canasta_secret_key_regex, canasta_host_specific_nonsecret)
 
 - name: Parse key
   ansible.builtin.set_fact:
@@ -11,8 +11,8 @@
 - name: Decide whether key should be a placeholder
   ansible.builtin.set_fact:
     _ep_needs_placeholder: >-
-      {{ _ep_key in gitops_placeholder_keys
-         or (_ep_key | regex_search(gitops_secret_prefix_pattern)) is not none }}
+      {{ (_ep_key | regex_search(canasta_secret_key_regex)) is not none
+         or _ep_key in canasta_host_specific_nonsecret }}
 
 - name: Add placeholder line to env.template
   ansible.builtin.lineinfile:

--- a/roles/config/tasks/_remove_gitops_var.yml
+++ b/roles/config/tasks/_remove_gitops_var.yml
@@ -24,7 +24,7 @@
       ansible.builtin.slurp:
         src: "{{ _rgv_vars_file }}"
       register: _rgv_vars_raw
-      no_log: "{{ _config_key is search(canasta_secret_key_pattern) }}"
+      no_log: "{{ _config_key is match(canasta_secret_key_regex) }}"
 
     - name: Drop placeholder from vars
       ansible.builtin.set_fact:
@@ -32,7 +32,7 @@
           {{ (_rgv_vars_raw.content | b64decode | from_yaml | default({}, true))
              | dict2items | rejectattr('key', 'equalto', _rgv_placeholder)
              | items2dict }}
-      no_log: "{{ _config_key is search(canasta_secret_key_pattern) }}"
+      no_log: "{{ _config_key is match(canasta_secret_key_regex) }}"
 
     - name: Write updated vars.yaml
       ansible.builtin.copy:

--- a/roles/config/tasks/_set_single.yml
+++ b/roles/config/tasks/_set_single.yml
@@ -19,7 +19,7 @@
     state: set
     key: "{{ _config_key }}"
     value: "{{ _config_value }}"
-  # Suppress only secret-bearing writes (e.g. CROWDSEC_BOUNCER_API_KEY).
-  # no_log on the enclosing include_role does NOT propagate to this task,
-  # so the suppression has to live here. See canasta_secret_key_pattern.
-  no_log: "{{ _config_key is search(canasta_secret_key_pattern) }}"
+  # Suppress secret-bearing writes (e.g. CROWDSEC_BOUNCER_API_KEY). no_log on
+  # the enclosing include_role does NOT propagate here, so it lives on the task.
+  # Uses the canonical classifier so every secret is covered.
+  no_log: "{{ _config_key is match(canasta_secret_key_regex) }}"

--- a/roles/config/tasks/_update_gitops_var.yml
+++ b/roles/config/tasks/_update_gitops_var.yml
@@ -27,14 +27,14 @@
       ansible.builtin.slurp:
         src: "{{ _ugv_vars_file }}"
       register: _ugv_vars_raw
-      no_log: "{{ _ugv_key is search(canasta_secret_key_pattern) }}"
+      no_log: "{{ _ugv_key is match(canasta_secret_key_regex) }}"
 
     - name: Update var value
       ansible.builtin.set_fact:
         _ugv_updated_vars: >-
           {{ (_ugv_vars_raw.content | b64decode | from_yaml)
              | combine({_ugv_placeholder: _ugv_value}) }}
-      no_log: "{{ _ugv_key is search(canasta_secret_key_pattern) }}"
+      no_log: "{{ _ugv_key is match(canasta_secret_key_regex) }}"
 
     - name: Write updated vars.yaml
       ansible.builtin.copy:

--- a/roles/config/tasks/_validate_key.yml
+++ b/roles/config/tasks/_validate_key.yml
@@ -74,8 +74,8 @@
       Unrecognized key '{{ _config_key }}'.
       Use --force to set unrecognized keys.
       Known keys: {{ canasta_known_keys | map(attribute='name') | join(', ') }}
-      (Also accepted: keys starting with {{ canasta_known_prefixes | join(', ') }})
+      (Also accepted: keys starting with {{ canasta_secret_prefixes | join(', ') }})
   when:
     - not (force | default(false) | bool)
     - _config_key not in (canasta_known_keys | map(attribute='name') | list)
-    - not (_config_key | regex_search('^(' + canasta_known_prefixes | join('|') + ')'))
+    - not (_config_key | regex_search('^(' + canasta_secret_prefixes | join('|') + ')'))

--- a/roles/gitops/defaults/main.yml
+++ b/roles/gitops/defaults/main.yml
@@ -1,2 +1,8 @@
 ---
 # Defaults for the gitops role.
+
+# Encrypt K8s instance secrets into the gitops repo with SOPS+age and let the
+# Argo repo-server CMP decrypt them at render (git becomes the source of truth
+# for those Secrets). Off until the repo-server CMP sidecar is bootstrapped on
+# the cluster; when off, K8s secrets are created imperatively by Ansible.
+gitops_sops_secrets: false

--- a/roles/gitops/tasks/_detect_settings_secrets.yml
+++ b/roles/gitops/tasks/_detect_settings_secrets.yml
@@ -1,0 +1,39 @@
+---
+# Heuristic detection of inline secrets in committed per-wiki Settings.php.
+# Inline PHP secrets ($wg...Password/Secret/Token/Key = 'literal') are committed
+# in cleartext — outside git-crypt on Compose, folded into configData on K8s.
+# The sanctioned path is `canasta config set --secret`, which routes the value
+# to a K8s Secret / gitignored secrets.env. Warn by default; fail if strict.
+#
+# Reports FILE names only (grep -l), never the matched value.
+# Requires: instance_path. Optional: gitops_strict_secrets (bool).
+
+- name: Scan committed Settings.php for likely inline secrets
+  ansible.builtin.command:
+    cmd: >-
+      grep -rlEi
+      "\$wg[A-Za-z0-9_]*(password|secret|token|apikey|api_key|clientsecret|consumersecret)[[:space:]]*=[[:space:]]*['\"][^'\"[:space:]]"
+      config/settings
+    chdir: "{{ instance_path }}"
+  register: _sps_hits
+  failed_when: false
+  changed_when: false
+
+- name: Handle inline Settings.php secrets
+  when: _sps_hits.stdout | trim | length > 0
+  block:
+    - name: Warn about inline Settings.php secrets
+      ansible.builtin.debug:
+        msg: >-
+          WARNING — possible inline secret(s) in committed Settings.php:
+          {{ _sps_hits.stdout_lines | join(', ') }}. These commit in cleartext.
+          Move each to `canasta config set --secret KEY=VALUE` (routed to a
+          K8s Secret / gitignored secrets.env) and read the env var from
+          Settings.php instead.
+
+    - name: Fail on inline Settings.php secrets (strict mode)
+      ansible.builtin.fail:
+        msg: >-
+          Inline Settings.php secret(s) detected and gitops_strict_secrets is
+          set. Remediate the files listed above, or drop strict to warn only.
+      when: gitops_strict_secrets | default(false) | bool

--- a/roles/gitops/tasks/_init_sops.yml
+++ b/roles/gitops/tasks/_init_sops.yml
@@ -38,9 +38,21 @@
         ansible_user: ""
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
-    - name: Ensure age-keygen is installed on the controller
+    - name: Check age-keygen is installed on the controller
       ansible.builtin.command: "age-keygen --version"
+      register: _sops_agekeygen_check
       changed_when: false
+      failed_when: false
+
+    - name: Fail with guidance when age-keygen is missing on the controller
+      ansible.builtin.fail:
+        msg: >-
+          --encrypt-secrets needs age-keygen on the controller (where the CLI
+          runs) to manage the SOPS operator key, but it was not found. Install
+          the toolchain with `canasta install sops` (no --host installs on this
+          controller). The gitops target host also needs sops:
+          `canasta install -H {{ target_host | default(host_name) }} sops`.
+      when: _sops_agekeygen_check.rc != 0
 
     - name: Determine controller config dir
       ansible.builtin.set_fact:

--- a/roles/gitops/tasks/_init_sops.yml
+++ b/roles/gitops/tasks/_init_sops.yml
@@ -61,4 +61,23 @@
       stringData:
         keys.txt: "{{ lookup('file', key + '.age') }}"
   when: _sops_age_secret.resources | length == 0
+  register: _sops_age_provision
   no_log: true
+
+# The repo-server mounts sops-age optionally, so a running pod predating the
+# Secret won't have the key until it restarts. Only needed on first provision.
+- name: Restart argocd-repo-server to load the newly provisioned age key
+  ansible.builtin.command:
+    cmd: >-
+      kubectl -n {{ argocd_namespace | default('argocd') }}
+      rollout restart deployment argocd-repo-server
+  when: _sops_age_provision is changed
+  changed_when: true
+
+- name: Wait for argocd-repo-server to be ready after the restart
+  ansible.builtin.command:
+    cmd: >-
+      kubectl -n {{ argocd_namespace | default('argocd') }}
+      rollout status deployment argocd-repo-server --timeout=120s
+  when: _sops_age_provision is changed
+  changed_when: false

--- a/roles/gitops/tasks/_init_sops.yml
+++ b/roles/gitops/tasks/_init_sops.yml
@@ -1,0 +1,64 @@
+---
+# SOPS+age bootstrap for a K8s gitops instance (gated on gitops_sops_secrets).
+# Generates/reuses the operator age keypair, writes .sops.yaml (recipient = the
+# age public key), and provisions the sops-age Secret the repo-server CMP mounts
+# to decrypt. The private key is exported to the controller at "{{ key }}.age"
+# (alongside the "{{ key }}.ssh" deploy key) — git-crypt parity for `--key`.
+#
+# The operator key is CLUSTER-GLOBAL: generated once and reused. Reusing the
+# same `--key` basename across instances keeps one recipient; the sops-age
+# Secret is only created when absent so a second instance never clobbers it.
+#
+# Requires: instance_path, key, argocd_namespace; age + sops on the target.
+
+- name: Ensure age + sops are installed
+  ansible.builtin.command: "{{ item }} --version"
+  loop:
+    - age-keygen
+    - sops
+  changed_when: false
+
+- name: Generate the operator age keypair (reused if it already exists)
+  ansible.builtin.command: "age-keygen -o {{ key }}.age"
+  args:
+    creates: "{{ key }}.age"
+  no_log: true
+
+- name: Read the age public recipient
+  ansible.builtin.command: "age-keygen -y {{ key }}.age"
+  register: _sops_age_pub
+  changed_when: false
+  no_log: true
+
+- name: Write .sops.yaml (encrypt only the Secret payload; keep the rest readable)
+  ansible.builtin.copy:
+    content: |
+      creation_rules:
+        - path_regex: hosts/[^/]+/secrets/.*\.enc\.ya?ml$
+          encrypted_regex: '^(data|stringData)$'
+          age: "{{ _sops_age_pub.stdout | trim }}"
+    dest: "{{ instance_path }}/.sops.yaml"
+    mode: "0644"
+
+- name: Check for an existing sops-age Secret
+  kubernetes.core.k8s_info:
+    kind: Secret
+    name: sops-age
+    namespace: "{{ argocd_namespace | default('argocd') }}"
+  register: _sops_age_secret
+  no_log: true
+
+- name: Provision the sops-age Secret for the repo-server CMP (only if absent)
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: sops-age
+        namespace: "{{ argocd_namespace | default('argocd') }}"
+      type: Opaque
+      stringData:
+        keys.txt: "{{ lookup('file', key + '.age') }}"
+  when: _sops_age_secret.resources | length == 0
+  no_log: true

--- a/roles/gitops/tasks/_init_sops.yml
+++ b/roles/gitops/tasks/_init_sops.yml
@@ -83,9 +83,14 @@
         - (key ~ '.age') is exists
       no_log: true
 
+    # argv form (not a shell string) so a config-dir path containing spaces
+    # — e.g. macOS "~/Library/Application Support/canasta" — is one argument.
     - name: Generate the canonical operator age key (once per cluster; reused if present)
-      ansible.builtin.command: "age-keygen -o {{ _sops_age_key }}"
-      args:
+      ansible.builtin.command:
+        argv:
+          - age-keygen
+          - -o
+          - "{{ _sops_age_key }}"
         creates: "{{ _sops_age_key }}"
       no_log: true
 
@@ -100,7 +105,11 @@
       no_log: true
 
     - name: Read the age public recipient
-      ansible.builtin.command: "age-keygen -y {{ _sops_age_key }}"
+      ansible.builtin.command:
+        argv:
+          - age-keygen
+          - -y
+          - "{{ _sops_age_key }}"
       register: _sops_age_pub
       changed_when: false
       no_log: true

--- a/roles/gitops/tasks/_init_sops.yml
+++ b/roles/gitops/tasks/_init_sops.yml
@@ -1,34 +1,116 @@
 ---
-# SOPS+age bootstrap for a K8s gitops instance (gated on gitops_sops_secrets).
-# Generates/reuses the operator age keypair, writes .sops.yaml (recipient = the
-# age public key), and provisions the sops-age Secret the repo-server CMP mounts
-# to decrypt. The private key is exported to the controller at "{{ key }}.age"
-# (alongside the "{{ key }}.ssh" deploy key) — git-crypt parity for `--key`.
+# SOPS+age key lifecycle for a K8s gitops instance (gated on gitops_sops_secrets).
 #
-# The operator key is CLUSTER-GLOBAL: generated once and reused. Reusing the
-# same `--key` basename across instances keeps one recipient; the sops-age
-# Secret is only created when absent so a second instance never clobbers it.
+# The operator age key is CLUSTER-GLOBAL: every instance on a cluster must
+# encrypt to the same recipient, because a single sops-age Secret in the argocd
+# namespace decrypts them all. Its canonical home is on the CONTROLLER at
+# <config_dir>/sops/<host>.age (one cluster per host), auto-generated once and
+# reused — the tool, not the operator, enforces one key per cluster.
 #
-# Requires: instance_path, key, argocd_namespace; age + sops on the target.
+# --key is the portable DR channel (mirrors git-crypt export-key): on init it
+# also exports a copy to <key>.age; on join/restore to a fresh controller it
+# imports <key>.age as the canonical key instead of minting a new recipient, so
+# the rebuilt controller decrypts the existing repo.
+#
+# Only the PUBLIC recipient reaches the target: .sops.yaml (for `sops -e`) and
+# the Secret is populated by reading the controller key via lookup at template
+# time, so the private key never lands on the target filesystem.
+#
+# Requires: instance_path, host_name, argocd_namespace; age-keygen on the
+# controller. All key-material tasks are no_log.
 
-- name: Ensure age + sops are installed
-  ansible.builtin.command: "{{ item }} --version"
-  loop:
-    - age-keygen
-    - sops
-  changed_when: false
+# --- Controller-side key material (save/switch/restore dance; delegate_to does
+# NOT reliably override the host-level connection set_fact this play plants —
+# same reason the SSH deploy key block above uses the dance). ---
+- name: Save connection state before controller-side SOPS key work
+  ansible.builtin.set_fact:
+    _sops_saved:
+      host: "{{ ansible_host | default('localhost') }}"
+      conn: "{{ ansible_connection | default('local') }}"
+      user: "{{ ansible_user | default('') }}"
+      python: "{{ ansible_python_interpreter | default(ansible_playbook_python) }}"
 
-- name: Generate the operator age keypair (reused if it already exists)
-  ansible.builtin.command: "age-keygen -o {{ key }}.age"
-  args:
-    creates: "{{ key }}.age"
-  no_log: true
+- block:
+    - name: Switch to local for SOPS key generation
+      ansible.builtin.set_fact:
+        ansible_host: "localhost"
+        ansible_connection: "local"
+        ansible_user: ""
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
-- name: Read the age public recipient
-  ansible.builtin.command: "age-keygen -y {{ key }}.age"
-  register: _sops_age_pub
-  changed_when: false
-  no_log: true
+    - name: Ensure age-keygen is installed on the controller
+      ansible.builtin.command: "age-keygen --version"
+      changed_when: false
+
+    - name: Determine controller config dir
+      ansible.builtin.set_fact:
+        _canasta_config_dir: >-
+          {{ lookup('ansible.builtin.env', 'CANASTA_CONFIG_DIR')
+             or (
+                 (lookup('ansible.builtin.env', 'USER') == 'root')
+                 | ternary(
+                     '/etc/canasta',
+                     lookup('ansible.builtin.env', 'HOME') ~ '/.config/canasta'
+                   )
+                ) }}
+
+    - name: Set the canonical operator age key path (one per cluster/host)
+      ansible.builtin.set_fact:
+        _sops_age_key: "{{ _canasta_config_dir }}/sops/{{ host_name }}.age"
+
+    - name: Ensure the controller sops key directory exists
+      ansible.builtin.file:
+        path: "{{ _sops_age_key | dirname }}"
+        state: directory
+        mode: "0700"
+
+    - name: Check whether the canonical operator age key exists
+      ansible.builtin.stat:
+        path: "{{ _sops_age_key }}"
+      register: _sops_age_stat
+
+    # DR/join: adopt a supplied --key as the canonical key so a fresh
+    # controller decrypts an existing repo instead of minting a new recipient.
+    - name: Import the supplied --key as the canonical operator age key (DR/join)
+      ansible.builtin.copy:
+        src: "{{ key }}.age"
+        dest: "{{ _sops_age_key }}"
+        mode: "0600"
+        remote_src: true
+      when:
+        - not _sops_age_stat.stat.exists
+        - key is defined and (key | length > 0)
+        - (key ~ '.age') is exists
+      no_log: true
+
+    - name: Generate the canonical operator age key (once per cluster; reused if present)
+      ansible.builtin.command: "age-keygen -o {{ _sops_age_key }}"
+      args:
+        creates: "{{ _sops_age_key }}"
+      no_log: true
+
+    # Portability/DR: export a copy of the canonical key to the --key path.
+    - name: Export the operator age key to the --key path (portable DR copy)
+      ansible.builtin.copy:
+        src: "{{ _sops_age_key }}"
+        dest: "{{ key }}.age"
+        mode: "0600"
+        remote_src: true
+      when: key is defined and (key | length > 0)
+      no_log: true
+
+    - name: Read the age public recipient
+      ansible.builtin.command: "age-keygen -y {{ _sops_age_key }}"
+      register: _sops_age_pub
+      changed_when: false
+      no_log: true
+  always:
+    - name: Restore connection state after SOPS key generation
+      ansible.builtin.set_fact:
+        ansible_host: "{{ _sops_saved.host }}"
+        ansible_connection: "{{ _sops_saved.conn }}"
+        ansible_user: "{{ _sops_saved.user }}"
+        ansible_python_interpreter: "{{ _sops_saved.python }}"
 
 - name: Write .sops.yaml (encrypt only the Secret payload; keep the rest readable)
   ansible.builtin.copy:
@@ -48,6 +130,8 @@
   register: _sops_age_secret
   no_log: true
 
+# Reads the controller-side key via lookup at template time, so the private
+# key is pushed straight into the cluster Secret without touching the target FS.
 - name: Provision the sops-age Secret for the repo-server CMP (only if absent)
   kubernetes.core.k8s:
     state: present
@@ -59,7 +143,7 @@
         namespace: "{{ argocd_namespace | default('argocd') }}"
       type: Opaque
       stringData:
-        keys.txt: "{{ lookup('file', key + '.age') }}"
+        keys.txt: "{{ lookup('file', _sops_age_key) }}"
   when: _sops_age_secret.resources | length == 0
   register: _sops_age_provision
   no_log: true

--- a/roles/gitops/tasks/_join_sops.yml
+++ b/roles/gitops/tasks/_join_sops.yml
@@ -1,0 +1,138 @@
+---
+# Provision SOPS decryption for a cluster JOINING a SOPS-encrypted gitops repo
+# (included by join_kubernetes.yml when the clone carries a .sops.yaml).
+#
+# The repo's .sops.yaml already holds the operator recipient (public), so
+# `gitops push` can encrypt this host's Secrets without any local key. What
+# this cluster's Argo repo-server sidecar needs is the operator PRIVATE key to
+# DECRYPT at render time — supplied via --key (<key>.age, the copy that
+# `gitops init --encrypt-secrets` exported). We verify it matches the repo's
+# recipient (a wrong key would leave Secrets undecryptable), then provision the
+# sops-age Secret; the caller adds the sidecar.
+#
+# Requires: instance_path, key, argocd_namespace; age-keygen on the controller.
+
+- name: Read the repo's SOPS recipient
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/.sops.yaml"
+  register: _join_sops_yaml
+
+- name: Extract the repo recipient
+  ansible.builtin.set_fact:
+    _join_repo_recipient: >-
+      {{ (_join_sops_yaml.content | b64decode | from_yaml).creation_rules[0].age }}
+
+# Controller-side key work uses the save/switch/restore dance (delegate_to does
+# not reliably override the play's host-level connection switch — same reason
+# the SSH deploy-key block uses it).
+- name: Save connection state before controller-side SOPS key read
+  ansible.builtin.set_fact:
+    _js_saved:
+      host: "{{ ansible_host | default('localhost') }}"
+      conn: "{{ ansible_connection | default('local') }}"
+      user: "{{ ansible_user | default('') }}"
+      python: "{{ ansible_python_interpreter | default(ansible_playbook_python) }}"
+
+- block:
+    - name: Switch to local for SOPS key read
+      ansible.builtin.set_fact:
+        ansible_host: localhost
+        ansible_connection: local
+        ansible_user: ""
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
+
+    - name: Check age-keygen is installed on the controller
+      ansible.builtin.command: "age-keygen --version"
+      register: _js_agekeygen
+      changed_when: false
+      failed_when: false
+
+    - name: Fail with guidance when age-keygen is missing on the controller
+      ansible.builtin.fail:
+        msg: >-
+          Joining a SOPS-encrypted repo needs age-keygen on the controller to
+          read the operator key. Install it with `canasta install sops`.
+      when: _js_agekeygen.rc != 0
+
+    - name: Check the operator age key was supplied via --key
+      ansible.builtin.stat:
+        path: "{{ key }}.age"
+      register: _js_keyfile
+
+    - name: Fail with guidance when the operator key is missing
+      ansible.builtin.fail:
+        msg: >-
+          This gitops repository uses SOPS secret encryption, so joining it
+          needs the operator age key to decrypt its Secrets. Re-run with
+          --key <path> pointing at the .age file that the repo's
+          `gitops init --encrypt-secrets` exported. Not found at {{ key }}.age.
+      when: not _js_keyfile.stat.exists
+
+    # argv form so a --key path containing spaces (macOS controller) is one arg.
+    - name: Read the supplied key's recipient
+      ansible.builtin.command:
+        argv:
+          - age-keygen
+          - -y
+          - "{{ key }}.age"
+      register: _js_key_recipient
+      changed_when: false
+      no_log: true
+  always:
+    - name: Restore connection state after SOPS key read
+      ansible.builtin.set_fact:
+        ansible_host: "{{ _js_saved.host }}"
+        ansible_connection: "{{ _js_saved.conn }}"
+        ansible_user: "{{ _js_saved.user }}"
+        ansible_python_interpreter: "{{ _js_saved.python }}"
+
+- name: Fail if the supplied key does not match the repo recipient
+  ansible.builtin.fail:
+    msg: >-
+      The operator key at {{ key }}.age does not match this repository's SOPS
+      recipient — its Secrets were encrypted for a different key, so this
+      cluster could not decrypt them. Supply the --key exported by the repo's
+      own `gitops init --encrypt-secrets`.
+  when: (_js_key_recipient.stdout | trim) != (_join_repo_recipient | trim)
+
+- name: Check for an existing sops-age Secret
+  kubernetes.core.k8s_info:
+    kind: Secret
+    name: sops-age
+    namespace: "{{ argocd_namespace | default('argocd') }}"
+  register: _js_sops_secret
+  no_log: true
+
+# Reads the controller-side key via lookup at template time, so the private key
+# is pushed straight into the cluster Secret without touching the target FS.
+- name: Provision the sops-age Secret for the repo-server CMP (only if absent)
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: sops-age
+        namespace: "{{ argocd_namespace | default('argocd') }}"
+      type: Opaque
+      stringData:
+        keys.txt: "{{ lookup('file', key + '.age') }}"
+  when: _js_sops_secret.resources | length == 0
+  register: _js_sops_provision
+  no_log: true
+
+- name: Restart argocd-repo-server to load the newly provisioned age key
+  ansible.builtin.command:
+    cmd: >-
+      kubectl -n {{ argocd_namespace | default('argocd') }}
+      rollout restart deployment argocd-repo-server
+  when: _js_sops_provision is changed
+  changed_when: true
+
+- name: Wait for argocd-repo-server to be ready after the restart
+  ansible.builtin.command:
+    cmd: >-
+      kubectl -n {{ argocd_namespace | default('argocd') }}
+      rollout status deployment argocd-repo-server --timeout=120s
+  when: _js_sops_provision is changed
+  changed_when: false

--- a/roles/gitops/tasks/_migrate_reclassified_secrets.yml
+++ b/roles/gitops/tasks/_migrate_reclassified_secrets.yml
@@ -1,0 +1,76 @@
+---
+# Move any secret still sitting as a cleartext literal in env.template into the
+# git-crypted host vars.yaml, and re-placeholder its template line. These are
+# pre-canonical-classifier leaks (a secret the old prefix list missed and left
+# literal); running on push lets in-the-wild repos self-heal. Idempotent: once
+# no literal secret remains, _rc_moves is empty and the block is skipped.
+#
+# Only SECRETS migrate — host-specific keys were already placeholdered, so a
+# literal one (if any) is not a leak and is left alone.
+#
+# Requires: instance_path, _push_hostname, the canonical classifier.
+
+- name: Read env.template for secret reclassification
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/env.template"
+  register: _rc_template
+  no_log: true
+
+# Valid `KEY=value` lines (not comments/blanks), not already a {{placeholder}},
+# whose key the canonical classifier calls a secret.
+- name: Find literal secret lines in env.template
+  ansible.builtin.set_fact:
+    _rc_lines: >-
+      {{ (_rc_template.content | b64decode).split('\n')
+         | select('match', '^[A-Za-z_][A-Za-z0-9_]*=')
+         | reject('search', '=[{][{]')
+         | select('match', canasta_secret_key_regex)
+         | list }}
+  no_log: true
+
+- name: Build reclassification move map (placeholder name -> value)
+  ansible.builtin.set_fact:
+    _rc_moves: >-
+      {{ dict(_rc_lines | map('regex_replace', '=.*$', '') | map('lower')
+              | zip(_rc_lines | map('regex_replace', '^[^=]*=', ''))) }}
+  no_log: true
+
+- name: Migrate reclassified secrets into the git-crypted vars.yaml
+  when: _rc_moves | length > 0
+  block:
+    - name: Read current host vars
+      ansible.builtin.slurp:
+        src: "{{ instance_path }}/hosts/{{ _push_hostname }}/vars.yaml"
+      register: _rc_host_vars_raw
+      no_log: true
+
+    - name: Merge reclassified secrets into host vars
+      ansible.builtin.copy:
+        content: >-
+          {{ (_rc_host_vars_raw.content | b64decode | from_yaml | default({}, true))
+             | combine(_rc_moves) | to_nice_yaml(indent=2) }}
+        dest: "{{ instance_path }}/hosts/{{ _push_hostname }}/vars.yaml"
+        mode: "0644"
+      no_log: true
+
+    - name: Re-placeholder each migrated key in env.template
+      ansible.builtin.lineinfile:
+        path: "{{ instance_path }}/env.template"
+        regexp: "^{{ item | upper }}="
+        line: "{{ item | upper }}={{ '{{' }}{{ item }}{{ '}}' }}"
+        state: present
+      loop: "{{ _rc_moves.keys() | list }}"
+      no_log: true
+
+    - name: Stage reclassified files
+      ansible.builtin.command:
+        cmd: "git add env.template hosts/{{ _push_hostname }}/vars.yaml"
+        chdir: "{{ instance_path }}"
+      changed_when: true
+
+    - name: Report reclassification migration
+      ansible.builtin.debug:
+        msg: >-
+          Moved {{ _rc_moves | length }} secret key(s) out of cleartext
+          env.template into the git-crypted vars.yaml:
+          {{ _rc_moves.keys() | map('upper') | join(', ') }}

--- a/roles/gitops/tasks/_migrate_reclassified_secrets.yml
+++ b/roles/gitops/tasks/_migrate_reclassified_secrets.yml
@@ -53,10 +53,14 @@
         mode: "0644"
       no_log: true
 
+    # Case-insensitive match: the literal line may be mixed-case (e.g.
+    # Smtp_PASSWORD=), but _rc_moves keys are lowercased. An anchored
+    # upper-cased regexp would miss it and append a duplicate placeholder while
+    # leaving the cleartext line committed. (?i) replaces the original line.
     - name: Re-placeholder each migrated key in env.template
       ansible.builtin.lineinfile:
         path: "{{ instance_path }}/env.template"
-        regexp: "^{{ item | upper }}="
+        regexp: "(?i)^{{ item }}="
         line: "{{ item | upper }}={{ '{{' }}{{ item }}{{ '}}' }}"
         state: present
       loop: "{{ _rc_moves.keys() | list }}"

--- a/roles/gitops/tasks/_reinit_cleanup.yml
+++ b/roles/gitops/tasks/_reinit_cleanup.yml
@@ -48,4 +48,9 @@
     - values-configdata.yaml
     - values-sidecars.yaml
     - argocd
+    # The SOPS marker must go too: gitops_sops_secrets comes only from the CLI
+    # flag, so a surviving .sops.yaml would keep push encrypting Secrets while a
+    # re-init without --encrypt-secrets regenerates a plain-helm Application
+    # that never renders them.
+    - .sops.yaml
   when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']

--- a/roles/gitops/tasks/_write_one_sops_secret.yml
+++ b/roles/gitops/tasks/_write_one_sops_secret.yml
@@ -1,0 +1,63 @@
+---
+# Write + SOPS-encrypt one Secret manifest, skipping it when the cluster data
+# is unchanged. Included per-Secret by _write_sops_secrets.yml (loop_var _sec).
+#
+# The hash is over the Secret data only and lives in a metadata annotation,
+# which SOPS leaves cleartext — so the target reads it back without the private
+# key and re-encrypts only when the data actually changed.
+
+- name: Set paths and desired data hash for {{ _sec.metadata.name }}
+  ansible.builtin.set_fact:
+    _sec_file: "{{ instance_path }}/hosts/{{ host_name }}/secrets/{{ _sec.metadata.name }}.enc.yaml"
+    _sec_hash: "{{ _sec.data | default({}) | dictsort | to_json | hash('sha256') }}"
+  no_log: true
+
+- name: Check existing encrypted manifest for {{ _sec.metadata.name }}
+  ansible.builtin.stat:
+    path: "{{ _sec_file }}"
+  register: _sec_stat
+
+- name: Read existing manifest metadata (cleartext under SOPS)
+  ansible.builtin.slurp:
+    src: "{{ _sec_file }}"
+  register: _sec_existing
+  when: _sec_stat.stat.exists
+  no_log: true
+
+- name: Determine the recorded data hash
+  ansible.builtin.set_fact:
+    _sec_existing_hash: >-
+      {{ ((_sec_existing.content | b64decode | from_yaml).metadata.annotations
+          | default({}))['canasta.io/gitops-secret-hash'] | default('')
+         if _sec_stat.stat.exists else '' }}
+  no_log: true
+
+- name: Write + encrypt {{ _sec.metadata.name }} (only when changed)
+  when: (not _sec_stat.stat.exists) or (_sec_existing_hash != _sec_hash)
+  block:
+    - name: Write cleartext Secret manifest for {{ _sec.metadata.name }}
+      ansible.builtin.copy:
+        dest: "{{ _sec_file }}"
+        mode: "0600"
+        content: |
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: {{ _sec.metadata.name }}
+            namespace: {{ _k8s_namespace }}
+            annotations:
+              canasta.io/gitops-secret-hash: "{{ _sec_hash }}"
+          type: Opaque
+          data:
+          {% for k, v in (_sec.data | default({}) | dictsort) %}
+            {{ k }}: {{ v }}
+          {% endfor %}
+      no_log: true
+
+    # Run from the repo root so SOPS resolves .sops.yaml and the relative path
+    # matches its path_regex (validated on kind).
+    - name: Encrypt {{ _sec.metadata.name }} in place with SOPS
+      ansible.builtin.command:
+        cmd: "sops -e -i hosts/{{ host_name }}/secrets/{{ _sec.metadata.name }}.enc.yaml"
+        chdir: "{{ instance_path }}"
+      changed_when: true

--- a/roles/gitops/tasks/_write_one_sops_secret.yml
+++ b/roles/gitops/tasks/_write_one_sops_secret.yml
@@ -24,16 +24,21 @@
   when: _sec_stat.stat.exists
   no_log: true
 
-- name: Determine the recorded data hash
+- name: Determine the recorded data hash and whether the file is encrypted
   ansible.builtin.set_fact:
     _sec_existing_hash: >-
       {{ ((_sec_existing.content | b64decode | from_yaml).metadata.annotations
           | default({}))['canasta.io/gitops-secret-hash'] | default('')
          if _sec_stat.stat.exists else '' }}
+    # A hash match is only trustworthy if the file is actually encrypted; a
+    # cleartext manifest left by an interrupted encrypt carries a matching
+    # hash, and skipping it would republish the cleartext on the next push.
+    _sec_encrypted: >-
+      {{ _sec_stat.stat.exists and ('ENC[' in (_sec_existing.content | b64decode)) }}
   no_log: true
 
-- name: Write + encrypt {{ _sec.metadata.name }} (only when changed)
-  when: (not _sec_stat.stat.exists) or (_sec_existing_hash != _sec_hash)
+- name: Write + encrypt {{ _sec.metadata.name }} (when changed or not encrypted)
+  when: (not _sec_stat.stat.exists) or (not _sec_encrypted) or (_sec_existing_hash != _sec_hash)
   block:
     - name: Write cleartext Secret manifest for {{ _sec.metadata.name }}
       ansible.builtin.copy:
@@ -61,3 +66,13 @@
         cmd: "sops -e -i hosts/{{ host_name }}/secrets/{{ _sec.metadata.name }}.enc.yaml"
         chdir: "{{ instance_path }}"
       changed_when: true
+  rescue:
+    # Never leave a cleartext manifest behind for a later push to commit.
+    - name: Remove the cleartext manifest left by a failed encryption
+      ansible.builtin.file:
+        path: "{{ _sec_file }}"
+        state: absent
+
+    - name: Re-raise the SOPS encryption failure
+      ansible.builtin.fail:
+        msg: "Failed to SOPS-encrypt secret {{ _sec.metadata.name }}; cleartext removed."

--- a/roles/gitops/tasks/_write_sops_secrets.yml
+++ b/roles/gitops/tasks/_write_sops_secrets.yml
@@ -18,9 +18,19 @@
 #
 # Requires: instance_path, host_name, _k8s_namespace; sops on the target.
 
-- name: Ensure sops is installed on the target
+- name: Check sops is installed on the target
   ansible.builtin.command: "sops --version"
+  register: _sops_bin_check
   changed_when: false
+  failed_when: false
+
+- name: Fail with guidance when sops is missing on the target
+  ansible.builtin.fail:
+    msg: >-
+      sops is required on the gitops host to encrypt Secret manifests, but it
+      was not found. Install it with
+      `canasta install -H {{ target_host | default(host_name) }} sops`.
+  when: _sops_bin_check.rc != 0
 
 - name: Read the namespace Secrets
   kubernetes.core.k8s_info:
@@ -59,6 +69,10 @@
   register: _sops_existing_files
 
 # Prune manifests for Secrets no longer in the cluster so git stays accurate.
+# Guarded on a non-empty result: an empty/absent namespace (deleted, or not yet
+# restored) returns zero Secrets, and pruning then would erase every encrypted
+# DR copy from git — inverting "git is the source of truth" exactly when DR
+# needs it. Only individual removals are pruned, never a wholesale wipe.
 - name: Prune encrypted manifests for removed Secrets
   ansible.builtin.file:
     path: "{{ item.path }}"
@@ -67,5 +81,17 @@
   loop_control:
     label: "{{ item.path | basename }}"
   when:
+    - _sops_secrets | length > 0
     - (item.path | basename | regex_replace('\.enc\.yaml$', ''))
       not in (_sops_secrets | map(attribute='metadata.name') | list)
+
+- name: Warn that no Secrets were found, so encrypted manifests were kept
+  ansible.builtin.debug:
+    msg: >-
+      No Opaque Secrets found in namespace {{ _k8s_namespace }}; kept the
+      {{ _sops_existing_files.files | length }} existing encrypted manifest(s)
+      in git rather than pruning them (the namespace may be deleted or not yet
+      restored).
+  when:
+    - _sops_secrets | length == 0
+    - _sops_existing_files.files | length > 0

--- a/roles/gitops/tasks/_write_sops_secrets.yml
+++ b/roles/gitops/tasks/_write_sops_secrets.yml
@@ -1,0 +1,67 @@
+---
+# Capture the instance's gitops-managed Secrets into git as SOPS-encrypted
+# manifests (gated on gitops_sops_secrets). Argo's helm-sops CMP decrypts them
+# at render time, so git — not cluster/etcd state — is the source of truth for
+# gitops-managed Secrets.
+#
+# Only type=Opaque Secrets in the instance namespace are captured; that
+# excludes the helm-release (helm.sh/release.v1), TLS (kubernetes.io/tls) and
+# service-account-token Secrets, which are managed/regenerated, not ours.
+#
+# Encryption uses only the public recipient in .sops.yaml (written by
+# _init_sops) — no private key on the target. A cleartext hash annotation
+# (metadata stays readable under SOPS) lets a re-push skip unchanged Secrets so
+# encrypted blobs don't churn every push; the target can't decrypt to diff.
+#
+# Requires: instance_path, host_name, _k8s_namespace; sops on the target.
+
+- name: Ensure sops is installed on the target
+  ansible.builtin.command: "sops --version"
+  changed_when: false
+
+- name: Read the namespace Secrets
+  kubernetes.core.k8s_info:
+    kind: Secret
+    namespace: "{{ _k8s_namespace }}"
+  register: _sops_ns_secrets
+  no_log: true
+
+- name: Select the gitops-managed (Opaque) Secrets to version in git
+  ansible.builtin.set_fact:
+    _sops_secrets: >-
+      {{ _sops_ns_secrets.resources
+         | selectattr('type', 'defined')
+         | selectattr('type', 'equalto', 'Opaque')
+         | list }}
+  no_log: true
+
+- name: Ensure the secrets directory exists
+  ansible.builtin.file:
+    path: "{{ instance_path }}/hosts/{{ host_name }}/secrets"
+    state: directory
+    mode: "0755"
+
+- name: Encrypt each Secret into git (skips unchanged)
+  ansible.builtin.include_tasks: _write_one_sops_secret.yml
+  loop: "{{ _sops_secrets }}"
+  loop_control:
+    loop_var: _sec
+    label: "{{ _sec.metadata.name }}"
+
+- name: Find existing encrypted manifests
+  ansible.builtin.find:
+    paths: "{{ instance_path }}/hosts/{{ host_name }}/secrets"
+    patterns: "*.enc.yaml"
+  register: _sops_existing_files
+
+# Prune manifests for Secrets no longer in the cluster so git stays accurate.
+- name: Prune encrypted manifests for removed Secrets
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ _sops_existing_files.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+  when:
+    - (item.path | basename | regex_replace('\.enc\.yaml$', ''))
+      not in (_sops_secrets | map(attribute='metadata.name') | list)

--- a/roles/gitops/tasks/_write_sops_secrets.yml
+++ b/roles/gitops/tasks/_write_sops_secrets.yml
@@ -4,9 +4,12 @@
 # at render time, so git — not cluster/etcd state — is the source of truth for
 # gitops-managed Secrets.
 #
-# Only type=Opaque Secrets in the instance namespace are captured; that
-# excludes the helm-release (helm.sh/release.v1), TLS (kubernetes.io/tls) and
-# service-account-token Secrets, which are managed/regenerated, not ours.
+# Only type=Opaque Secrets we own are captured. The type filter drops the
+# helm-release (helm.sh/release.v1), TLS (kubernetes.io/tls) and
+# service-account-token Secrets; the ownerReferences filter drops Opaque
+# Secrets another controller manages and regenerates — notably cert-manager's
+# ACME key Secrets (owned by a Certificate). Canasta's own Secrets are created
+# standalone, with no owner, so they survive both filters.
 #
 # Encryption uses only the public recipient in .sops.yaml (written by
 # _init_sops) — no private key on the target. A cleartext hash annotation
@@ -26,12 +29,13 @@
   register: _sops_ns_secrets
   no_log: true
 
-- name: Select the gitops-managed (Opaque) Secrets to version in git
+- name: Select the gitops-managed (Opaque, unowned) Secrets to version in git
   ansible.builtin.set_fact:
     _sops_secrets: >-
       {{ _sops_ns_secrets.resources
          | selectattr('type', 'defined')
          | selectattr('type', 'equalto', 'Opaque')
+         | rejectattr('metadata.ownerReferences', 'defined')
          | list }}
   no_log: true
 

--- a/roles/gitops/tasks/init_compose.yml
+++ b/roles/gitops/tasks/init_compose.yml
@@ -200,9 +200,10 @@
     state: absent
 
 # --- Step 9: Create env.template and wikis.yaml.template ---
-# env.template replaces secret/host-specific values with {{placeholder}} syntax.
-# Other values are kept as literals. Placeholder key list and secret
-# prefixes are defined in roles/gitops/vars/main.yml.
+# env.template replaces secret + host-specific values with {{placeholder}}
+# syntax; other values stay literal. Classification is the canonical one
+# (canasta_secret_key_regex + canasta_host_specific_nonsecret) so any secret
+# is encrypted into vars.yaml, never left literal in the committed template.
 
 - name: Read raw .env file for template extraction
   ansible.builtin.slurp:
@@ -223,7 +224,7 @@
       {{ line }}
       {% elif '=' in line %}
       {% set key = line.split('=', 1)[0] %}
-      {% if key in gitops_placeholder_keys or key | regex_search(gitops_secret_prefix_pattern) %}
+      {% if (key | regex_search(canasta_secret_key_regex)) or (key in canasta_host_specific_nonsecret) %}
       {{ key }}={{ '{{' }}{{ key | lower }}{{ '}}' }}
       {% else %}
       {{ line }}
@@ -274,15 +275,9 @@
 - name: Build vars content (placeholder values + wiki URLs + admin passwords)
   ansible.builtin.copy:
     content: |
-      # Host-specific values for placeholder keys in env.template
-      {% for k in gitops_placeholder_keys %}
-      {% if k in _gitops_env.variables %}
-      {{ k | lower }}: "{{ _gitops_env.variables[k] }}"
-      {% endif %}
-      {% endfor %}
-      # Secret-prefix keys
+      # Secret + host-specific values (the keys placeholdered in env.template)
       {% for k, v in _gitops_env.variables.items() %}
-      {% if k | regex_search(gitops_secret_prefix_pattern) %}
+      {% if (k | regex_search(canasta_secret_key_regex)) or (k in canasta_host_specific_nonsecret) %}
       {{ k | lower }}: "{{ v }}"
       {% endif %}
       {% endfor %}

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -462,6 +462,9 @@
             env:
               - name: HELM_ARGS
                 value: "-f hosts/{{ host_name }}/rendered-values.yaml"
+              # Scope decryption to THIS host's secrets, not every host's.
+              - name: SECRETS_DIR
+                value: "hosts/{{ host_name }}/secrets"
       {% else %}
           helm:
             valueFiles:

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -16,8 +16,9 @@
 #
 # Input: host_name, role, repo, key, force, pull_requests
 #   key is the SSH deploy key path basename (private at <key>.ssh,
-#   public at <key>.ssh.pub). Despite the name, it has no git-crypt
-#   meaning on K8s.
+#   public at <key>.ssh.pub). It carries no git-crypt meaning on K8s;
+#   with SOPS enabled it doubles as the operator age key's portable DR
+#   path (<key>.age) — see _init_sops.yml.
 # Requires: instance_path, instance_id (set by dispatcher)
 
 # --- Validate prerequisites ---

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -21,6 +21,13 @@
 #   path (<key>.age) — see _init_sops.yml.
 # Requires: instance_path, instance_id (set by dispatcher)
 
+# The --encrypt-secrets flag is the on-switch for SOPS secret encryption.
+# It drives gitops_sops_secrets, which gates the Argo app's plugin source,
+# the operator-key work, and the repo-server sidecar below.
+- name: Enable SOPS secret encryption when --encrypt-secrets is set
+  ansible.builtin.set_fact:
+    gitops_sops_secrets: "{{ encrypt_secrets | default(false) | bool }}"
+
 # --- Validate prerequisites ---
 - name: Check git is installed
   ansible.builtin.command:
@@ -472,11 +479,17 @@
     dest: "{{ instance_path }}/argocd/application.yaml"
     mode: "0644"
 
-# --- SOPS+age secret encryption (gated; off until the repo-server CMP is
-# bootstrapped). Writes .sops.yaml + provisions the operator age key so the
-# initial commit below carries them. ---
-- name: Bootstrap SOPS+age secret encryption
+# --- SOPS+age secret encryption (gated on --encrypt-secrets) ---
+# Provision the operator age key + .sops.yaml + sops-age Secret, then add the
+# helm-sops CMP sidecar to the (already-installed) Argo CD repo-server so it can
+# decrypt at render time. The Argo Application above already points at the
+# plugin source when enabled; the initial commit below carries .sops.yaml.
+- name: Provision the operator age key and .sops.yaml
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/gitops/tasks/_init_sops.yml"
+  when: gitops_sops_secrets | default(false) | bool
+
+- name: Ensure the Argo CD repo-server has the helm-sops sidecar
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_ensure_sops_sidecar.yml"
   when: gitops_sops_secrets | default(false) | bool
 
 # --- Save host identity ---

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -448,9 +448,17 @@
           repoURL: {{ repo }}
           targetRevision: HEAD
           path: .
+      {% if gitops_sops_secrets | default(false) | bool %}
+          plugin:
+            name: helm-sops
+            env:
+              - name: HELM_ARGS
+                value: "-f hosts/{{ host_name }}/rendered-values.yaml"
+      {% else %}
           helm:
             valueFiles:
               - hosts/{{ host_name }}/rendered-values.yaml
+      {% endif %}
         destination:
           server: https://kubernetes.default.svc
           namespace: canasta-{{ instance_id }}
@@ -462,6 +470,13 @@
             - CreateNamespace=true
     dest: "{{ instance_path }}/argocd/application.yaml"
     mode: "0644"
+
+# --- SOPS+age secret encryption (gated; off until the repo-server CMP is
+# bootstrapped). Writes .sops.yaml + provisions the operator age key so the
+# initial commit below carries them. ---
+- name: Bootstrap SOPS+age secret encryption
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/gitops/tasks/_init_sops.yml"
+  when: gitops_sops_secrets | default(false) | bool
 
 # --- Save host identity ---
 - name: Save .gitops-host

--- a/roles/gitops/tasks/join.yml
+++ b/roles/gitops/tasks/join.yml
@@ -240,19 +240,13 @@
   changed_when: true
 
 # --- Step 6: Extract vars from current .env ---
-- name: Define placeholder keys
+# Classify via the canonical secret classifier so join and init agree — a
+# host that joins must placeholder exactly the keys init would (secrets +
+# host-specific), or it silently diverges from the rest of the farm.
+- name: Classify keys via the canonical secret classifier
   ansible.builtin.set_fact:
-    _join_placeholder_keys:
-      - MYSQL_PASSWORD
-      - WIKI_DB_PASSWORD
-      - MW_SECRET_KEY
-      - RESTIC_REPOSITORY
-      - RESTIC_PASSWORD
-      - MW_SITE_SERVER
-      - MW_SITE_FQDN
-      - HTTPS_PORT
-      - HTTP_PORT
-    _join_secret_prefixes: "^(AWS_|AZURE_|B2_|GOOGLE_|OS_|ST_|RCLONE_)"
+    _join_host_specific_keys: "{{ canasta_host_specific_nonsecret }}"
+    _join_secret_regex: "{{ canasta_secret_key_regex }}"
 
 - name: Read current .env
   canasta_env:
@@ -272,12 +266,12 @@
       {{
         dict(
           _join_env.variables | dict2items
-          | selectattr('key', 'in', _join_placeholder_keys)
+          | selectattr('key', 'in', _join_host_specific_keys)
           | map(attribute='key')
           | map('lower')
           | zip(
               _join_env.variables | dict2items
-              | selectattr('key', 'in', _join_placeholder_keys)
+              | selectattr('key', 'in', _join_host_specific_keys)
               | map(attribute='value')
               | list)
           | list
@@ -285,12 +279,12 @@
         | combine(
             dict(
               _join_env.variables | dict2items
-              | selectattr('key', 'match', _join_secret_prefixes)
+              | selectattr('key', 'match', _join_secret_regex)
               | map(attribute='key')
               | map('lower')
               | zip(
                   _join_env.variables | dict2items
-                  | selectattr('key', 'match', _join_secret_prefixes)
+                  | selectattr('key', 'match', _join_secret_regex)
                   | map(attribute='value')
                   | list)
               | list

--- a/roles/gitops/tasks/join_kubernetes.yml
+++ b/roles/gitops/tasks/join_kubernetes.yml
@@ -119,6 +119,26 @@
       -o UserKnownHostsFile=~/.ssh/known_hosts
   changed_when: true
 
+# SOPS-managed repos aren't joinable yet: the joining cluster is a separate
+# cluster that would need the operator age key imported and its own helm-sops
+# sidecar, and pushing from it would otherwise encrypt Secrets to a recipient
+# it can't decrypt. Detect from the fresh clone and refuse before mutating the
+# instance, rather than produce a broken hybrid. (Full join+SOPS is a
+# follow-up; it needs multi-cluster validation.)
+- name: Detect a SOPS-managed repo in the clone
+  ansible.builtin.stat:
+    path: "{{ _join_tmpdir.path }}/.sops.yaml"
+  register: _join_sops_marker
+
+- name: Refuse to join a SOPS-managed gitops repo
+  ansible.builtin.fail:
+    msg: >-
+      This gitops repository uses SOPS secret encryption (.sops.yaml present),
+      which `gitops join` does not yet support. Set up the additional
+      environment with `gitops init --encrypt-secrets` on its own host, or
+      manage it from the initializing controller.
+  when: _join_sops_marker.stat.exists
+
 # --- Validate host name not already in config ---
 - name: Read hosts.yaml from cloned repo
   ansible.builtin.slurp:

--- a/roles/gitops/tasks/join_kubernetes.yml
+++ b/roles/gitops/tasks/join_kubernetes.yml
@@ -6,9 +6,11 @@
 # values.yaml, renders rendered-values.yaml, creates an Argo CD
 # Application pointing at the new rendered file.
 #
-# No git-crypt: K8s gitops repos are cleartext (see #508 / #509).
-# The Compose join path (gitops/tasks/join.yml) still uses git-crypt
-# unlock since Compose's repo encrypts hosts/<host>/vars.yaml.
+# No git-crypt on K8s. A K8s repo is cleartext unless it was initialized with
+# --encrypt-secrets, in which case a .sops.yaml marks it and this join
+# provisions the operator key (via --key) + a helm-sops sidecar on the joining
+# cluster so its Argo can decrypt (see _join_sops.yml). The Compose join path
+# (gitops/tasks/join.yml) still uses git-crypt unlock instead.
 #
 # Input: host_name, role, repo, key, force
 #   key is the SSH deploy key path basename (private at <key>.ssh,
@@ -119,25 +121,19 @@
       -o UserKnownHostsFile=~/.ssh/known_hosts
   changed_when: true
 
-# SOPS-managed repos aren't joinable yet: the joining cluster is a separate
-# cluster that would need the operator age key imported and its own helm-sops
-# sidecar, and pushing from it would otherwise encrypt Secrets to a recipient
-# it can't decrypt. Detect from the fresh clone and refuse before mutating the
-# instance, rather than produce a broken hybrid. (Full join+SOPS is a
-# follow-up; it needs multi-cluster validation.)
+# A SOPS-managed repo (.sops.yaml at the root) means this joining cluster must
+# render encrypted Secrets: it needs the operator age key (to decrypt) and its
+# own helm-sops sidecar. Detected from the fresh clone; the provisioning +
+# key-match check happen below (after the tree is materialized), and the Argo
+# Application is generated with the plugin source accordingly.
 - name: Detect a SOPS-managed repo in the clone
   ansible.builtin.stat:
     path: "{{ _join_tmpdir.path }}/.sops.yaml"
   register: _join_sops_marker
 
-- name: Refuse to join a SOPS-managed gitops repo
-  ansible.builtin.fail:
-    msg: >-
-      This gitops repository uses SOPS secret encryption (.sops.yaml present),
-      which `gitops join` does not yet support. Set up the additional
-      environment with `gitops init --encrypt-secrets` on its own host, or
-      manage it from the initializing controller.
-  when: _join_sops_marker.stat.exists
+- name: Enable SOPS for this environment when the repo is SOPS-managed
+  ansible.builtin.set_fact:
+    gitops_sops_secrets: "{{ _join_sops_marker.stat.exists }}"
 
 # --- Validate host name not already in config ---
 - name: Read hosts.yaml from cloned repo
@@ -323,9 +319,19 @@
           repoURL: {{ repo }}
           targetRevision: HEAD
           path: .
+      {% if gitops_sops_secrets | default(false) | bool %}
+          plugin:
+            name: helm-sops
+            env:
+              - name: HELM_ARGS
+                value: "-f hosts/{{ host_name }}/rendered-values.yaml"
+              - name: SECRETS_DIR
+                value: "hosts/{{ host_name }}/secrets"
+      {% else %}
           helm:
             valueFiles:
               - hosts/{{ host_name }}/rendered-values.yaml
+      {% endif %}
         destination:
           server: https://kubernetes.default.svc
           namespace: canasta-{{ instance_id }}
@@ -343,6 +349,18 @@
 # host. Without this the Application can't authenticate and never syncs.
 - name: Apply Argo CD repo credential Secret + known-hosts trust
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/gitops/tasks/_apply_argo_repo_secret.yml"
+
+# --- SOPS decryption for a joined SOPS-managed repo (gated) ---
+# Verify the operator key matches the repo, provision the sops-age Secret, and
+# add the helm-sops sidecar so this cluster's Argo can decrypt at render — must
+# precede applying the plugin-source Application below.
+- name: Provision SOPS decryption on the joining cluster
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/gitops/tasks/_join_sops.yml"
+  when: gitops_sops_secrets | default(false) | bool
+
+- name: Ensure the Argo CD repo-server has the helm-sops sidecar
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_ensure_sops_sidecar.yml"
+  when: gitops_sops_secrets | default(false) | bool
 
 - name: Apply Argo CD Application to cluster
   kubernetes.core.k8s:

--- a/roles/gitops/tasks/push.yml
+++ b/roles/gitops/tasks/push.yml
@@ -4,5 +4,10 @@
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
+# Nudge inline Settings.php secrets toward `config set --secret` (both
+# orchestrators). Warn-only unless gitops_strict_secrets is set.
+- name: Detect inline Settings.php secrets
+  ansible.builtin.include_tasks: "_detect_settings_secrets.yml"
+
 - name: Dispatch gitops push
   ansible.builtin.include_tasks: "push_{{ instance_orchestrator | default('compose') }}.yml"

--- a/roles/gitops/tasks/push_compose.yml
+++ b/roles/gitops/tasks/push_compose.yml
@@ -43,6 +43,13 @@
       does not allow pushing. Only 'source' and 'both' roles can push.
   when: _push_role not in ['source', 'both']
 
+# --- Migrate pre-classifier cleartext secret literals into vars.yaml ---
+# Runs before the shared-key migration so a freshly-encrypted secret can still
+# be promoted to _shared if it qualifies.
+- name: Migrate reclassified secret literals from env.template
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/gitops/tasks/_migrate_reclassified_secrets.yml
+
 # --- Auto-migrate shared-category keys to _shared/vars.yaml ---
 # Keys named in gitops_shared_keys (vars/main.yml) belong in the
 # shared file so all hosts inherit them. On every push, any such key

--- a/roles/gitops/tasks/push_kubernetes.yml
+++ b/roles/gitops/tasks/push_kubernetes.yml
@@ -14,6 +14,23 @@
 - name: Sync config files
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_sync_config.yml"
 
+# --- Version gitops-managed Secrets into git as SOPS-encrypted manifests
+# (gated). Git becomes the source of truth for the Secrets Argo renders. ---
+- name: Version gitops-managed Secrets with SOPS
+  when: gitops_sops_secrets | default(false) | bool
+  block:
+    - name: Resolve gitops host name
+      ansible.builtin.slurp:
+        src: "{{ instance_path }}/.gitops-host"
+      register: _push_host_file
+
+    - name: Set gitops host name
+      ansible.builtin.set_fact:
+        host_name: "{{ _push_host_file.content | b64decode | trim }}"
+
+    - name: Encrypt Secrets into git
+      ansible.builtin.include_tasks: _write_sops_secrets.yml
+
 - name: Render sidecars to Helm values
   canasta_render_sidecars:
     instance_path: "{{ instance_path }}"

--- a/roles/gitops/tasks/push_kubernetes.yml
+++ b/roles/gitops/tasks/push_kubernetes.yml
@@ -14,10 +14,18 @@
 - name: Sync config files
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_sync_config.yml"
 
-# --- Version gitops-managed Secrets into git as SOPS-encrypted manifests
-# (gated). Git becomes the source of truth for the Secrets Argo renders. ---
+# --- Version gitops-managed Secrets into git as SOPS-encrypted manifests.
+# Self-describing: a .sops.yaml at the repo root (written by gitops init
+# --encrypt-secrets) is the marker that this instance encrypts its Secrets, so
+# push needs no flag of its own. Git becomes the source of truth for the
+# Secrets Argo renders. ---
+- name: Check whether the instance uses SOPS secret encryption
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/.sops.yaml"
+  register: _push_sops_marker
+
 - name: Version gitops-managed Secrets with SOPS
-  when: gitops_sops_secrets | default(false) | bool
+  when: _push_sops_marker.stat.exists
   block:
     - name: Resolve gitops host name
       ansible.builtin.slurp:

--- a/roles/gitops/tasks/push_kubernetes.yml
+++ b/roles/gitops/tasks/push_kubernetes.yml
@@ -120,10 +120,18 @@
         chdir: "{{ instance_path }}"
       changed_when: true
 
+    # Authenticate with the staged deploy key (or --ssh-key), like init/join —
+    # not the ambient ssh/agent, which isn't present on every gitops host
+    # (a joined host authenticates only via its .gitops-deploy-key).
     - name: Push to remote
       ansible.builtin.command:
         cmd: "git push"
         chdir: "{{ instance_path }}"
+      environment:
+        GIT_SSH_COMMAND: >-
+          ssh -i {{ ssh_key | default(instance_path + '/.gitops-deploy-key', true) }}
+          -o StrictHostKeyChecking=accept-new
+          -o UserKnownHostsFile=~/.ssh/known_hosts
       changed_when: true
 
 - name: Report result

--- a/roles/gitops/vars/main.yml
+++ b/roles/gitops/vars/main.yml
@@ -1,35 +1,11 @@
 ---
-# Keys whose values are secrets or host-specific; rendered as
-# {{ placeholder }} in env.template and stored in hosts/<host>/vars.yaml.
-gitops_placeholder_keys:
-  - MYSQL_PASSWORD
-  - WIKI_DB_PASSWORD
-  - MW_SECRET_KEY
-  - RESTIC_REPOSITORY
-  - RESTIC_PASSWORD
-  - MW_SITE_SERVER
-  - MW_SITE_FQDN
-  - HTTPS_PORT
-  - HTTP_PORT
-  - CADDY_AUTO_HTTPS
-  # Per-host feature toggles that drive COMPOSE_PROFILES, plus the CrowdSec
-  # bouncer key and trusted-proxy setting. A gitops render/pull must preserve
-  # these rather than reset them to the off state captured at init time —
-  # otherwise sync_compose_profiles derives the profile off and silently
-  # disables the feature on the next restart. CANASTA_CADDY_IMAGE and
-  # COMPOSE_PROFILES are intentionally absent: both are re-derived from these
-  # flags on every start, so storing them would only freeze a value the start
-  # sequence already reconciles.
-  - CANASTA_ENABLE_CROWDSEC
-  - CANASTA_ENABLE_ELASTICSEARCH
-  - CANASTA_ENABLE_OBSERVABILITY
-  - CANASTA_ENABLE_VARNISH
-  - CROWDSEC_BOUNCER_API_KEY
-  - CADDY_TRUSTED_PROXIES
-
-# Keys whose name starts with any of these prefixes are treated as
-# credentials and get placeholders in env.template.
-gitops_secret_prefix_pattern: "^(AWS_|AZURE_|B2_|GOOGLE_|OS_|ST_|RCLONE_|SMTP_)"
+# Which keys gitops placeholders (secrets + host-specific) is decided by the
+# canonical classifier in vars/secret_classification.yml:
+# canasta_secret_key_regex for secrets, and canasta_host_specific_nonsecret for
+# the per-host toggles / ports / URLs a gitops render must preserve
+# (CANASTA_ENABLE_*, CADDY_TRUSTED_PROXIES, ...). CANASTA_CADDY_IMAGE and
+# COMPOSE_PROFILES are intentionally neither — both are re-derived from the
+# feature flags on every start, so storing them would freeze a reconciled value.
 
 # Keys (lowercase) whose values belong in hosts/_shared/vars.yaml
 # rather than per-host vars.yaml. Auto-migrated on gitops push.

--- a/roles/install/tasks/sops_age.yml
+++ b/roles/install/tasks/sops_age.yml
@@ -1,0 +1,69 @@
+---
+# Install the SOPS toolchain (sops + age) on the target host for the K8s
+# gitops SOPS secret flow: sops encrypts Secret manifests on the gitops host at
+# push; age-keygen manages the operator key on the controller. Idempotent —
+# skips a binary already present. Versions pinned in vars/tool_versions.yml.
+
+- name: Check if sops is already installed
+  ansible.builtin.command: sops --version
+  register: _sops_installed
+  changed_when: false
+  ignore_errors: true
+
+- name: Check if age-keygen is already installed
+  ansible.builtin.command: age-keygen --version
+  register: _age_installed
+  changed_when: false
+  ignore_errors: true
+
+- name: Skip if the SOPS toolchain is already available
+  ansible.builtin.debug:
+    msg: "sops and age are already installed."
+  when: _sops_installed.rc == 0 and _age_installed.rc == 0
+
+- name: Install the SOPS toolchain
+  when: _sops_installed.rc != 0 or _age_installed.rc != 0
+  become: true
+  block:
+    - name: Gather architecture
+      ansible.builtin.setup:
+        gather_subset:
+          - "!all"
+          - "!min"
+          - hardware
+
+    - name: Map architecture to the release suffix
+      ansible.builtin.set_fact:
+        _tool_arch: >-
+          {{ {'x86_64': 'amd64', 'aarch64': 'arm64', 'arm64': 'arm64'}[ansible_architecture]
+             | default('amd64') }}
+
+    - name: Report installing the SOPS toolchain
+      ansible.builtin.debug:
+        msg: "Installing sops {{ sops_version }} + age {{ age_version }} ({{ _tool_arch }})..."
+
+    - name: Install the sops binary
+      ansible.builtin.get_url:
+        url: >-
+          https://github.com/getsops/sops/releases/download/{{ sops_version }}/sops-{{ sops_version }}.linux.{{ _tool_arch }}
+        dest: /usr/local/bin/sops
+        mode: "0755"
+      when: _sops_installed.rc != 0
+
+    - name: Install age + age-keygen
+      ansible.builtin.unarchive:
+        src: >-
+          https://github.com/FiloSottile/age/releases/download/{{ age_version }}/age-{{ age_version }}-linux-{{ _tool_arch }}.tar.gz
+        dest: /usr/local/bin
+        remote_src: true
+        include:
+          - age/age
+          - age/age-keygen
+        extra_opts:
+          - "--strip-components=1"
+        mode: "0755"
+      when: _age_installed.rc != 0
+
+    - name: Report the SOPS toolchain installed
+      ansible.builtin.debug:
+        msg: "sops + age installed."

--- a/roles/install/tasks/sops_age.yml
+++ b/roles/install/tasks/sops_age.yml
@@ -48,6 +48,7 @@
           https://github.com/getsops/sops/releases/download/{{ sops_version }}/sops-{{ sops_version }}.linux.{{ _tool_arch }}
         dest: /usr/local/bin/sops
         mode: "0755"
+        checksum: "sha256:{{ sops_sha256[_tool_arch] }}"
       when: _sops_installed.rc != 0
 
     - name: Install age + age-keygen

--- a/roles/orchestrator/defaults/main.yml
+++ b/roles/orchestrator/defaults/main.yml
@@ -16,8 +16,6 @@ canasta_db_wait_timeout: 10
 canasta_k3s_version: "v1.34.8+k3s1"
 canasta_helm_version: "v3.20.1"
 
-# helm-sops CMP sidecar for the Argo CD repo-server (gitops_sops_secrets). The
-# injected sops version is sops_version (vars/tool_versions.yml, play-global);
-# the sidecar image should track the argo-cd chart's appVersion. Bumped per
-# release, validated on kind.
-argocd_sops_sidecar_image: "quay.io/argoproj/argocd:v3.3.9"
+# The helm-sops CMP sidecar (gitops_sops_secrets) is configured from
+# play-global vars/tool_versions.yml (sops_version + argocd_sops_sidecar_image),
+# so the gitops role's cross-role include of the sidecar task can resolve them.

--- a/roles/orchestrator/defaults/main.yml
+++ b/roles/orchestrator/defaults/main.yml
@@ -15,3 +15,9 @@ canasta_db_wait_timeout: 10
 # (all nodes in a cluster must use the same one).
 canasta_k3s_version: "v1.34.8+k3s1"
 canasta_helm_version: "v3.20.1"
+
+# helm-sops CMP sidecar for the Argo CD repo-server (gitops_sops_secrets).
+# sops binary injected into the sidecar; sidecar image should track the
+# argo-cd chart's appVersion. Bumped per release, validated on kind.
+sops_version: "v3.13.2"
+argocd_sops_sidecar_image: "quay.io/argoproj/argocd:v3.3.9"

--- a/roles/orchestrator/defaults/main.yml
+++ b/roles/orchestrator/defaults/main.yml
@@ -16,8 +16,8 @@ canasta_db_wait_timeout: 10
 canasta_k3s_version: "v1.34.8+k3s1"
 canasta_helm_version: "v3.20.1"
 
-# helm-sops CMP sidecar for the Argo CD repo-server (gitops_sops_secrets).
-# sops binary injected into the sidecar; sidecar image should track the
-# argo-cd chart's appVersion. Bumped per release, validated on kind.
-sops_version: "v3.13.2"
+# helm-sops CMP sidecar for the Argo CD repo-server (gitops_sops_secrets). The
+# injected sops version is sops_version (vars/tool_versions.yml, play-global);
+# the sidecar image should track the argo-cd chart's appVersion. Bumped per
+# release, validated on kind.
 argocd_sops_sidecar_image: "quay.io/argoproj/argocd:v3.3.9"

--- a/roles/orchestrator/files/helm_sops_plugin.yaml
+++ b/roles/orchestrator/files/helm_sops_plugin.yaml
@@ -8,10 +8,19 @@ spec:
     args:
       # Render the Helm chart, then append the decrypted Secret manifests.
       # Argo prefixes the Application's plugin.env with ARGOCD_ENV_, so the
-      # values override arrives as ARGOCD_ENV_HELM_ARGS (not HELM_ARGS).
+      # values override arrives as ARGOCD_ENV_HELM_ARGS and the per-host secrets
+      # directory as ARGOCD_ENV_SECRETS_DIR (scoped to THIS host — a repo can
+      # hold several hosts' secrets, and rendering another host's would apply
+      # the wrong Secrets or collide on name/namespace).
+      #
+      # set -e so a failed `helm template` aborts the whole script: without it,
+      # sh returns the last loop command's status, a successful `sops -d` would
+      # mask the failure, and Argo (selfHeal+prune) would prune the instance
+      # down to just the Secrets.
       - |
+        set -e
         helm template "$ARGOCD_APP_NAME" . $ARGOCD_ENV_HELM_ARGS
-        for f in hosts/*/secrets/*.enc.yaml; do
+        for f in "$ARGOCD_ENV_SECRETS_DIR"/*.enc.yaml; do
           [ -e "$f" ] || continue
           echo "---"
           sops -d "$f"

--- a/roles/orchestrator/files/helm_sops_plugin.yaml
+++ b/roles/orchestrator/files/helm_sops_plugin.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ConfigManagementPlugin
+metadata:
+  name: helm-sops
+spec:
+  generate:
+    command: [sh, -c]
+    args:
+      # Render the Helm chart, then append the decrypted Secret manifests.
+      # Argo prefixes the Application's plugin.env with ARGOCD_ENV_, so the
+      # values override arrives as ARGOCD_ENV_HELM_ARGS (not HELM_ARGS).
+      - |
+        helm template "$ARGOCD_APP_NAME" . $ARGOCD_ENV_HELM_ARGS
+        for f in hosts/*/secrets/*.enc.yaml; do
+          [ -e "$f" ] || continue
+          echo "---"
+          sops -d "$f"
+        done

--- a/roles/orchestrator/tasks/k8s_apply_backup_env_secret.yml
+++ b/roles/orchestrator/tasks/k8s_apply_backup_env_secret.yml
@@ -22,7 +22,8 @@
     _be_env_data: >-
       {{ _be_env.variables | default({}) | dict2items
          | selectattr('key', 'match',
-             '^(RESTIC_|AWS_|B2_|AZURE_|GOOGLE_|OS_|ST_|MYSQL_HOST$|MYSQL_USER$|MYSQL_PASSWORD$)')
+             '^(' ~ canasta_backup_backend_prefixes | join('|')
+             ~ '|MYSQL_HOST$|MYSQL_USER$|MYSQL_PASSWORD$)')
          | items2dict }}
   no_log: true
 

--- a/roles/orchestrator/tasks/k8s_argocd_bootstrap.yml
+++ b/roles/orchestrator/tasks/k8s_argocd_bootstrap.yml
@@ -36,50 +36,13 @@
             params:
               server.insecure: false
 
-    # --- helm-sops CMP sidecar (gated). The plugin ConfigMap the sidecar
-    # mounts must exist before the repo-server pod starts, so provision it
-    # (and the namespace) before the install. The sops-age Secret is created
-    # later by per-instance gitops init. ---
-    - name: Provision the helm-sops CMP sidecar
-      when: gitops_sops_secrets | default(false) | bool
-      block:
-        - name: Ensure the Argo CD namespace exists
-          kubernetes.core.k8s:
-            state: present
-            definition:
-              apiVersion: v1
-              kind: Namespace
-              metadata:
-                name: "{{ argocd_namespace | default('argocd') }}"
-
-        - name: Apply the helm-sops CMP plugin ConfigMap
-          kubernetes.core.k8s:
-            state: present
-            namespace: "{{ argocd_namespace | default('argocd') }}"
-            definition:
-              apiVersion: v1
-              kind: ConfigMap
-              metadata:
-                name: helm-sops-plugin
-              data:
-                plugin.yaml: "{{ lookup('file', canasta_root + '/roles/orchestrator/files/helm_sops_plugin.yaml') }}"
-
-        - name: Stage the SOPS repo-server sidecar Helm values
-          ansible.builtin.template:
-            src: "{{ canasta_root }}/roles/orchestrator/templates/argocd_sops_repo_server_values.yaml.j2"
-            dest: /tmp/canasta-argocd-sops-values.yaml
-            mode: "0600"
-
-    - name: Compose the Argo CD Helm values arguments
-      ansible.builtin.set_fact:
-        _argocd_values_args: >-
-          -f /tmp/canasta-argocd-values.yaml
-          {{ '-f /tmp/canasta-argocd-sops-values.yaml'
-             if (gitops_sops_secrets | default(false) | bool) else '' }}
-
     # Launched detached and polled (resilient_exec) so a controller-side SSH
     # reset during the up-to-10m `--wait` doesn't abort an install still
     # progressing on the target. helm upgrade --install is idempotent.
+    #
+    # The helm-sops CMP sidecar for encrypted secrets is NOT added here — it is
+    # overlaid onto this release at `gitops init --encrypt-secrets`
+    # (k8s_ensure_sops_sidecar.yml) so create stays orchestration-agnostic.
     - name: Install Argo CD via Helm
       ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/resilient_exec.yml"
       vars:
@@ -89,7 +52,7 @@
           helm upgrade --install argocd argo/argo-cd
           --namespace {{ argocd_namespace | default('argocd') }} --create-namespace
           --wait --timeout 10m
-          {{ _argocd_values_args }}
+          -f /tmp/canasta-argocd-values.yaml
 
     - name: Report Argo CD installed
       ansible.builtin.debug:

--- a/roles/orchestrator/tasks/k8s_argocd_bootstrap.yml
+++ b/roles/orchestrator/tasks/k8s_argocd_bootstrap.yml
@@ -36,6 +36,47 @@
             params:
               server.insecure: false
 
+    # --- helm-sops CMP sidecar (gated). The plugin ConfigMap the sidecar
+    # mounts must exist before the repo-server pod starts, so provision it
+    # (and the namespace) before the install. The sops-age Secret is created
+    # later by per-instance gitops init. ---
+    - name: Provision the helm-sops CMP sidecar
+      when: gitops_sops_secrets | default(false) | bool
+      block:
+        - name: Ensure the Argo CD namespace exists
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: "{{ argocd_namespace | default('argocd') }}"
+
+        - name: Apply the helm-sops CMP plugin ConfigMap
+          kubernetes.core.k8s:
+            state: present
+            namespace: "{{ argocd_namespace | default('argocd') }}"
+            definition:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: helm-sops-plugin
+              data:
+                plugin.yaml: "{{ lookup('file', canasta_root + '/roles/orchestrator/files/helm_sops_plugin.yaml') }}"
+
+        - name: Stage the SOPS repo-server sidecar Helm values
+          ansible.builtin.template:
+            src: "{{ canasta_root }}/roles/orchestrator/templates/argocd_sops_repo_server_values.yaml.j2"
+            dest: /tmp/canasta-argocd-sops-values.yaml
+            mode: "0600"
+
+    - name: Compose the Argo CD Helm values arguments
+      ansible.builtin.set_fact:
+        _argocd_values_args: >-
+          -f /tmp/canasta-argocd-values.yaml
+          {{ '-f /tmp/canasta-argocd-sops-values.yaml'
+             if (gitops_sops_secrets | default(false) | bool) else '' }}
+
     # Launched detached and polled (resilient_exec) so a controller-side SSH
     # reset during the up-to-10m `--wait` doesn't abort an install still
     # progressing on the target. helm upgrade --install is idempotent.
@@ -48,7 +89,7 @@
           helm upgrade --install argocd argo/argo-cd
           --namespace {{ argocd_namespace | default('argocd') }} --create-namespace
           --wait --timeout 10m
-          -f /tmp/canasta-argocd-values.yaml
+          {{ _argocd_values_args }}
 
     - name: Report Argo CD installed
       ansible.builtin.debug:

--- a/roles/orchestrator/tasks/k8s_ensure_sops_sidecar.yml
+++ b/roles/orchestrator/tasks/k8s_ensure_sops_sidecar.yml
@@ -31,6 +31,19 @@
     dest: /tmp/canasta-argocd-sops-values.yaml
     mode: "0600"
 
+# Pin the upgrade to the chart version already installed. --reuse-values
+# suppresses new-chart value defaults, so an unpinned `helm upgrade` here would
+# silently jump Argo CD to the latest chart on a months-old cluster.
+- name: Read the installed Argo CD chart version
+  ansible.builtin.command:
+    cmd: "helm -n {{ argocd_namespace | default('argocd') }} get metadata argocd -o json"
+  register: _argocd_meta
+  changed_when: false
+
+- name: Set the installed Argo CD chart version
+  ansible.builtin.set_fact:
+    _argocd_chart_version: "{{ (_argocd_meta.stdout | from_json).version }}"
+
 # --reuse-values overlays the sidecar onto whatever the install set, so we add
 # repoServer without knowing (or resetting) the original values. Launched
 # detached + polled so a controller SSH reset during --wait can't abort it;
@@ -43,5 +56,6 @@
     rx_cmd: >-
       helm upgrade argocd argo/argo-cd
       --namespace {{ argocd_namespace | default('argocd') }}
+      --version {{ _argocd_chart_version }}
       --reuse-values --wait --timeout 10m
       -f /tmp/canasta-argocd-sops-values.yaml

--- a/roles/orchestrator/tasks/k8s_ensure_sops_sidecar.yml
+++ b/roles/orchestrator/tasks/k8s_ensure_sops_sidecar.yml
@@ -1,0 +1,47 @@
+---
+# Add the helm-sops CMP sidecar to an already-installed Argo CD repo-server so
+# it can decrypt SOPS-encrypted Secret manifests at render time. Invoked from
+# gitops init when --encrypt-secrets is set. Idempotent: applies the plugin
+# ConfigMap and helm-upgrades the existing release with --reuse-values, so it
+# only overlays repoServer without disturbing the install-time values, and
+# uniformly bootstraps both new and pre-existing clusters.
+#
+# Input: argocd_namespace (default: argocd); helm on the target.
+
+- name: Ensure the Argo CD Helm repository is present
+  kubernetes.core.helm_repository:
+    name: argo
+    repo_url: https://argoproj.github.io/argo-helm
+
+- name: Apply the helm-sops CMP plugin ConfigMap
+  kubernetes.core.k8s:
+    state: present
+    namespace: "{{ argocd_namespace | default('argocd') }}"
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: helm-sops-plugin
+      data:
+        plugin.yaml: "{{ lookup('file', canasta_root + '/roles/orchestrator/files/helm_sops_plugin.yaml') }}"
+
+- name: Stage the SOPS repo-server sidecar Helm values
+  ansible.builtin.template:
+    src: "{{ canasta_root }}/roles/orchestrator/templates/argocd_sops_repo_server_values.yaml.j2"
+    dest: /tmp/canasta-argocd-sops-values.yaml
+    mode: "0600"
+
+# --reuse-values overlays the sidecar onto whatever the install set, so we add
+# repoServer without knowing (or resetting) the original values. Launched
+# detached + polled so a controller SSH reset during --wait can't abort it;
+# helm upgrade is idempotent.
+- name: Add the helm-sops sidecar to the Argo CD repo-server
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/resilient_exec.yml"
+  vars:
+    rx_name: "add helm-sops sidecar to Argo CD"
+    rx_async: 720
+    rx_cmd: >-
+      helm upgrade argocd argo/argo-cd
+      --namespace {{ argocd_namespace | default('argocd') }}
+      --reuse-values --wait --timeout 10m
+      -f /tmp/canasta-argocd-sops-values.yaml

--- a/roles/orchestrator/tasks/k8s_sync_config.yml
+++ b/roles/orchestrator/tasks/k8s_sync_config.yml
@@ -86,19 +86,17 @@
   loop_control:
     label: "{{ item.path | regex_replace('^.*/config/settings/', 'settings/') }}"
 
-# Strip secret-bearing keys from the .env content before embedding
-# it in the web ConfigMap. The chart's web/jobrunner deployments read
-# MYSQL_PASSWORD / MW_SECRET_KEY exclusively via secretKeyRef from the
-# canonical K8s Secrets (<id>-db-credentials, <id>-mw-secrets); the
-# .env file at /mediawiki/config/.env is never sourced. Leaving the
-# secrets in the ConfigMap-backed file duplicated them in plaintext
-# and forced the gitops repo to encrypt rendered-values.yaml, which
-# Argo CD couldn't read. See #507.
+# Strip EVERY secret from the .env before embedding it in the web/jobrunner
+# ConfigMap (and, on gitops, the committed values). Pods receive secrets only
+# via secretKeyRef from K8s Secrets; this ConfigMap-backed /config/.env is
+# never sourced for them, so stripping the full secret surface is safe and
+# keeps all secrets out of the gitops repo. Classification is the canonical
+# one (canasta_secret_key_regex) so no key can slip through a stale list.
 - name: Filter secret-bearing keys out of .env for ConfigMap embedding
   ansible.builtin.set_fact:
     _sync_env_no_secrets: >-
       {{ (_sync_env.content | b64decode).splitlines()
-         | reject('match', '^(MYSQL_PASSWORD|MW_SECRET_KEY)=')
+         | reject('match', canasta_secret_key_regex)
          | join('\n') + '\n' }}
 
 - name: Build web config data
@@ -241,7 +239,8 @@
     _backup_env_data: >-
       {{ _sync_env_dict.variables | default({}) | dict2items
          | selectattr('key', 'match',
-             '^(RESTIC_|AWS_|B2_|AZURE_|GOOGLE_|OS_|ST_|MYSQL_HOST$|MYSQL_USER$|MYSQL_PASSWORD$)')
+             '^(' ~ canasta_backup_backend_prefixes | join('|')
+             ~ '|MYSQL_HOST$|MYSQL_USER$|MYSQL_PASSWORD$)')
          | items2dict }}
   no_log: true
 

--- a/roles/orchestrator/tasks/k8s_sync_config.yml
+++ b/roles/orchestrator/tasks/k8s_sync_config.yml
@@ -25,13 +25,16 @@
     # This is an allowlist by design, not a gap: Compose likewise passes
     # only a curated `environment:` block, so an arbitrary app-defined
     # key (e.g. `config set --force MY_APP_KEY=...`) is NOT exported to
-    # the web container's getenv() on either orchestrator. The full .env
-    # (minus the secrets above) is still written to the web ConfigMap and
-    # mounted at /mediawiki/config/.env, so app config and shared secrets
-    # reach the web tier via a settings fragment under
-    # config/settings/global/ (all wikis) or
-    # config/settings/wikis/<wiki id>/ (one wiki) — synced to both
-    # orchestrators — rather than pod env.
+    # the web container's getenv() on either orchestrator. NON-SECRET .env
+    # keys still reach the web tier via the ConfigMap mounted at
+    # /mediawiki/config/.env (read by a settings fragment under
+    # config/settings/global/ or .../wikis/<id>/, synced to both
+    # orchestrators). SECRET-classified keys are stripped from that
+    # ConfigMap .env (see the filter below) and reach pods only via
+    # secretKeyRef from K8s Secrets — so a secret an app expects in the
+    # process environment must be wired as a Secret, not read from .env.
+    # (Compose still delivers secret .env keys to the container env; this
+    # is a deliberate K8s-side hardening divergence.)
     _k8s_pod_env_allowlist:
       - PHP_UPLOAD_MAX_FILESIZE
       - PHP_POST_MAX_SIZE

--- a/roles/orchestrator/templates/argocd_sops_repo_server_values.yaml.j2
+++ b/roles/orchestrator/templates/argocd_sops_repo_server_values.yaml.j2
@@ -19,15 +19,24 @@ repoServer:
       image: alpine:3.19
       command: [sh, -c]
       args:
+        # Fetch sops with retries (transient GitHub blips at pod start would
+        # otherwise stall the shared repo-server) and verify a pinned sha256 so
+        # a corrupted or substituted binary fails closed. A longer-term
+        # hardening is to serve this from the in-cluster registry Canasta
+        # already deploys, removing the pod-start dependency on GitHub.
         - |
           set -e
           case "$(uname -m)" in
-            x86_64) A=amd64 ;;
-            aarch64|arm64) A=arm64 ;;
-            *) A="$(uname -m)" ;;
+            x86_64) A=amd64; SUM="{{ sops_sha256.amd64 }}" ;;
+            aarch64|arm64) A=arm64; SUM="{{ sops_sha256.arm64 }}" ;;
+            *) echo "unsupported arch $(uname -m)" >&2; exit 1 ;;
           esac
-          wget -qO /custom-tools/sops \
-            "https://github.com/getsops/sops/releases/download/{{ sops_version }}/sops-{{ sops_version }}.linux.$A"
+          for i in 1 2 3 4 5; do
+            wget -qO /custom-tools/sops \
+              "https://github.com/getsops/sops/releases/download/{{ sops_version }}/sops-{{ sops_version }}.linux.$A" && break
+            echo "sops download attempt $i failed; retrying" >&2; sleep 5
+          done
+          echo "$SUM  /custom-tools/sops" | sha256sum -c -
           chmod +x /custom-tools/sops
       volumeMounts:
         - name: custom-tools

--- a/roles/orchestrator/templates/argocd_sops_repo_server_values.yaml.j2
+++ b/roles/orchestrator/templates/argocd_sops_repo_server_values.yaml.j2
@@ -1,0 +1,71 @@
+---
+# Argo CD repo-server values adding the helm-sops CMP sidecar (gitops_sops_secrets).
+# Merged as an extra `-f` on the argo/argo-cd install, so it only touches
+# repoServer and leaves the base install values intact.
+#
+# The sidecar runs the argocd-cmp-server binary that the chart's copyutil
+# initContainer stages into the shared var-files volume, so it decrypts with
+# the same Argo version regardless of this image. helm ships in the argocd
+# image; only sops is injected (initContainer -> emptyDir on PATH).
+#
+# The sops-age Secret mount is optional so the repo-server starts before the
+# operator key is provisioned (per-instance gitops init creates it, then
+# restarts the repo-server). Until the key is present, decryption fails
+# closed — the plugin errors rather than emitting cleartext or dropping the
+# Secret.
+repoServer:
+  initContainers:
+    - name: install-sops
+      image: alpine:3.19
+      command: [sh, -c]
+      args:
+        - |
+          set -e
+          case "$(uname -m)" in
+            x86_64) A=amd64 ;;
+            aarch64|arm64) A=arm64 ;;
+            *) A="$(uname -m)" ;;
+          esac
+          wget -qO /custom-tools/sops \
+            "https://github.com/getsops/sops/releases/download/{{ sops_version }}/sops-{{ sops_version }}.linux.$A"
+          chmod +x /custom-tools/sops
+      volumeMounts:
+        - name: custom-tools
+          mountPath: /custom-tools
+
+  extraContainers:
+    - name: helm-sops
+      image: {{ argocd_sops_sidecar_image }}
+      command: [/var/run/argocd/argocd-cmp-server]
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+      env:
+        - name: SOPS_AGE_KEY_FILE
+          value: /home/argocd/.config/sops/age/keys.txt
+        - name: PATH
+          value: /custom-tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      volumeMounts:
+        - name: var-files
+          mountPath: /var/run/argocd
+        - name: plugins
+          mountPath: /home/argocd/cmp-server/plugins
+        - name: helm-sops-plugin
+          mountPath: /home/argocd/cmp-server/config/plugin.yaml
+          subPath: plugin.yaml
+        - name: custom-tools
+          mountPath: /custom-tools
+        - name: sops-age
+          mountPath: /home/argocd/.config/sops/age
+          readOnly: true
+
+  volumes:
+    - name: custom-tools
+      emptyDir: {}
+    - name: helm-sops-plugin
+      configMap:
+        name: helm-sops-plugin
+    - name: sops-age
+      secret:
+        secretName: sops-age
+        optional: true

--- a/tests/unit/_classifier.py
+++ b/tests/unit/_classifier.py
@@ -1,0 +1,29 @@
+"""Shared test helper: render the REAL canonical secret-classifier regex from
+vars/secret_classification.yml, using the file's own Jinja expression rather
+than a hand-rebuilt mirror. A shape change in the vars file then flows into the
+tests automatically — the exact drift the canonical classifier exists to end.
+"""
+import os
+
+import yaml
+from jinja2 import Environment
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+CLASSIFIER = os.path.join(REPO_ROOT, "vars", "secret_classification.yml")
+
+
+def classifier():
+    """The parsed vars/secret_classification.yml dict."""
+    with open(CLASSIFIER) as fh:
+        return yaml.safe_load(fh)
+
+
+def secret_key_regex(cls=None):
+    """Render canasta_secret_key_regex exactly as Ansible resolves it."""
+    cls = cls or classifier()
+    return (
+        Environment(autoescape=False)
+        .from_string(cls["canasta_secret_key_regex"])
+        .render(**cls)
+        .strip()
+    )

--- a/tests/unit/test_backup_schedule_k8s.py
+++ b/tests/unit/test_backup_schedule_k8s.py
@@ -58,19 +58,25 @@ class TestBackupEnvSecretSyncTask:
         )
 
     def test_filter_covers_known_backup_env_prefixes(self):
-        """The filter regex must match every prefix the consumers
-        rely on. Keeping the assertion explicit makes a future
-        accidental tightening of the filter visible in tests."""
+        """The backup-env filter must cover every backup-backend prefix (via
+        the canonical list) plus the DB keys the dump-databases init container
+        needs. RCLONE_ was historically absent and broke restic rclone on K8s."""
         with open(self.SYNC_PATH) as f:
             content = f.read()
-        for prefix_or_key in (
-            "RESTIC_", "AWS_", "B2_", "AZURE_", "GOOGLE_", "OS_", "ST_",
-            "MYSQL_HOST", "MYSQL_USER", "MYSQL_PASSWORD",
-        ):
-            assert prefix_or_key in content, (
-                "k8s_sync_config.yml's backup-env filter must "
-                "cover %r (used by restic backends or the "
-                "dump-databases init container)." % prefix_or_key
+        assert "canasta_backup_backend_prefixes" in content, (
+            "backup-env filter must build from the canonical backend list"
+        )
+        for db_key in ("MYSQL_HOST", "MYSQL_USER", "MYSQL_PASSWORD"):
+            assert db_key in content, (
+                "backup-env filter must include %r for the dump-databases "
+                "init container." % db_key
+            )
+        classifier = yaml.safe_load(open(os.path.join(
+            REPO_ROOT, "vars", "secret_classification.yml")).read())
+        for prefix in ("RESTIC_", "AWS_", "B2_", "AZURE_", "GOOGLE_", "OS_",
+                       "ST_", "RCLONE_"):
+            assert prefix in classifier["canasta_backup_backend_prefixes"], (
+                "%r must be a backup-backend prefix." % prefix
             )
 
 

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -555,11 +555,11 @@ class TestCrowdsecEnrollRole:
             REPO_ROOT, "roles", "config", "tasks", "_set_single.yml",
         ))
         assert "no_log:" in set_single
-        assert "canasta_secret_key_pattern" in set_single
-        defaults = yaml.safe_load(
-            _read(os.path.join(REPO_ROOT, "roles", "config", "defaults", "main.yml"))
+        assert "canasta_secret_key_regex" in set_single
+        classifier = yaml.safe_load(
+            _read(os.path.join(REPO_ROOT, "vars", "secret_classification.yml"))
         )
-        pattern = defaults["canasta_secret_key_pattern"]
+        pattern = classifier["canasta_secret_key_pattern"]
         assert re.search(pattern, "CROWDSEC_BOUNCER_API_KEY"), (
             "secret pattern must match the bouncer key"
         )

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -289,14 +289,11 @@ class TestCrowdsecGitopsDurability:
 
     def _is_placeholder(self, key):
         # A key is placeholdered in gitops when the canonical classifier calls
-        # it secret or host-specific.
-        cls = yaml.safe_load(
-            _read(os.path.join(REPO_ROOT, "vars", "secret_classification.yml"))
-        )
-        prefixes = cls["canasta_secret_prefixes"] + cls["canasta_secret_explicit"]
-        regex = ("^([^=]*" + cls["canasta_secret_key_pattern"]
-                 + "|" + "|".join(prefixes) + ")")
-        return (re.match(regex, key) is not None
+        # it secret or host-specific. Uses the shared helper that renders the
+        # real classifier regex, so this can't drift from the vars file.
+        from _classifier import classifier, secret_key_regex
+        cls = classifier()
+        return (re.match(secret_key_regex(cls), key) is not None
                 or key in cls["canasta_host_specific_nonsecret"])
 
     def test_crowdsec_inputs_are_placeholder_keys(self):

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -287,31 +287,35 @@ class TestCrowdsecGitopsDurability:
     render resets it to the off state captured at init time, silently
     disabling CrowdSec on the next restart."""
 
-    def _placeholder_keys(self):
-        gitops_vars = yaml.safe_load(
-            _read(os.path.join(REPO_ROOT, "roles", "gitops", "vars", "main.yml"))
+    def _is_placeholder(self, key):
+        # A key is placeholdered in gitops when the canonical classifier calls
+        # it secret or host-specific.
+        cls = yaml.safe_load(
+            _read(os.path.join(REPO_ROOT, "vars", "secret_classification.yml"))
         )
-        return gitops_vars["gitops_placeholder_keys"]
+        prefixes = cls["canasta_secret_prefixes"] + cls["canasta_secret_explicit"]
+        regex = ("^([^=]*" + cls["canasta_secret_key_pattern"]
+                 + "|" + "|".join(prefixes) + ")")
+        return (re.match(regex, key) is not None
+                or key in cls["canasta_host_specific_nonsecret"])
 
     def test_crowdsec_inputs_are_placeholder_keys(self):
-        keys = self._placeholder_keys()
         for k in (
             "CANASTA_ENABLE_CROWDSEC",
             "CROWDSEC_BOUNCER_API_KEY",
             "CADDY_TRUSTED_PROXIES",
         ):
-            assert k in keys, (
-                "%s must be a gitops placeholder key or it is dropped from "
-                ".env on the next gitops render/pull" % k
+            assert self._is_placeholder(k), (
+                "%s must classify as secret or host-specific, or it is dropped "
+                "from .env on the next gitops render/pull" % k
             )
 
     def test_derived_keys_not_persisted(self):
         # CANASTA_CADDY_IMAGE and COMPOSE_PROFILES are re-derived from the
         # feature flags by sync_compose_profiles on start; persisting them
         # would freeze a value the start sequence already reconciles.
-        keys = self._placeholder_keys()
-        assert "CANASTA_CADDY_IMAGE" not in keys
-        assert "COMPOSE_PROFILES" not in keys
+        assert not self._is_placeholder("CANASTA_CADDY_IMAGE")
+        assert not self._is_placeholder("COMPOSE_PROFILES")
 
 
 class TestCrowdsecProfileSync:

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2896,6 +2896,20 @@ class TestDoctor:
         assert "usermod -aG canasta" in result
         assert "Self-update:     BLOCKED" in result
 
+    def test_parse_doctor_reports_sops_and_age(self):
+        d = direct_commands._SENTINEL
+        # 20 base parts (through self-update) + sops (20) + age (21).
+        base = self._doctor_parts("user docker www-data", "WRITABLE")
+        for sops, age, want in [
+            ("OK", "OK", ["sops:            OK", "age:             OK"]),
+            ("MISSING", "MISSING",
+             ["sops:            not installed", "age:             not installed"]),
+        ]:
+            stdout = ("\n" + d + "\n").join(base + [sops, age]) + "\n"
+            result = direct_commands._parse_doctor(stdout, "myhost")
+            for w in want:
+                assert w in result
+
     def test_parse_doctor_missing_deps(self):
         d = direct_commands._SENTINEL
         parts = [

--- a/tests/unit/test_gitops_feature_flag_durability.py
+++ b/tests/unit/test_gitops_feature_flag_durability.py
@@ -1,7 +1,8 @@
-"""A feature-enable flag must be a gitops placeholder key, or a `config set`
-of it updates only the live .env: the next gitops pull re-renders .env from
-env.template's init-time literal, and sync_compose_profiles then derives the
-profile off — silently disabling the feature."""
+"""A feature-enable flag must be classified host-specific (and so placeholdered
+in gitops), or a `config set` of it updates only the live .env: the next gitops
+pull re-renders .env from env.template's init-time literal, and
+sync_compose_profiles then derives the profile off — silently disabling the
+feature."""
 
 import os
 
@@ -9,16 +10,16 @@ import yaml
 
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
-GITOPS_VARS = os.path.join(REPO_ROOT, "roles", "gitops", "vars", "main.yml")
+CLASSIFIER = os.path.join(REPO_ROOT, "vars", "secret_classification.yml")
 
 
-def _placeholder_keys():
-    with open(GITOPS_VARS) as f:
-        return yaml.safe_load(f)["gitops_placeholder_keys"]
+def _host_specific_keys():
+    with open(CLASSIFIER) as f:
+        return yaml.safe_load(f)["canasta_host_specific_nonsecret"]
 
 
-def test_profile_feature_flags_are_placeholder_keys():
-    keys = _placeholder_keys()
+def test_profile_feature_flags_are_placeholdered():
+    keys = _host_specific_keys()
     for flag in (
         "CANASTA_ENABLE_CROWDSEC",
         "CANASTA_ENABLE_ELASTICSEARCH",
@@ -26,7 +27,8 @@ def test_profile_feature_flags_are_placeholder_keys():
         "CANASTA_ENABLE_VARNISH",
     ):
         assert flag in keys, (
-            "%s must be a gitops placeholder key so 'config set' of it persists "
-            "to the gitops source; otherwise a pull renders it back to the "
-            "init-time literal and the profile derives off" % flag
+            "%s must be classified host-specific so gitops placeholders it and "
+            "'config set' persists to the gitops source; otherwise a pull "
+            "renders it back to the init-time literal and the profile derives "
+            "off" % flag
         )

--- a/tests/unit/test_gitops_reclassify_migration.py
+++ b/tests/unit/test_gitops_reclassify_migration.py
@@ -1,0 +1,53 @@
+"""The push-time reclassification migration moves pre-classifier cleartext
+secret literals out of env.template into the git-crypted vars.yaml. It must use
+the canonical classifier, re-placeholder the template, and never leak a value."""
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+MIG = os.path.join(REPO_ROOT, "roles", "gitops", "tasks",
+                   "_migrate_reclassified_secrets.yml")
+PUSH = os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "push_compose.yml")
+
+
+def _read(p):
+    with open(p) as f:
+        return f.read()
+
+
+def _walk(tasks):
+    for t in tasks:
+        yield t
+        if isinstance(t, dict) and "block" in t:
+            yield from _walk(t["block"])
+
+
+def test_push_runs_reclassification_migration():
+    assert "_migrate_reclassified_secrets.yml" in _read(PUSH)
+
+
+def test_migration_uses_canonical_classifier_and_replaceholders():
+    c = _read(MIG)
+    assert "canasta_secret_key_regex" in c, "must classify via the canonical regex"
+    assert "lineinfile" in c, "must re-placeholder the migrated key in env.template"
+
+
+def test_migration_report_lists_names_not_values():
+    for t in _walk(yaml.safe_load(_read(MIG))):
+        debug = t.get("ansible.builtin.debug") or t.get("debug")
+        if debug:
+            assert "keys()" in debug.get("msg", ""), (
+                "migration report must list key names only, never values"
+            )
+
+
+def test_migration_value_bearing_tasks_are_no_log():
+    flagged = 0
+    for t in _walk(yaml.safe_load(_read(MIG))):
+        name = (t.get("name") or "").lower()
+        if any(s in name for s in ("env.template", "move map", "host vars",
+                                   "literal secret")):
+            flagged += 1
+            assert t.get("no_log") is True, "%r must be no_log" % name
+    assert flagged >= 3, "expected the value-bearing tasks to be guarded"

--- a/tests/unit/test_gitops_settings_secret_detection.py
+++ b/tests/unit/test_gitops_settings_secret_detection.py
@@ -1,0 +1,43 @@
+"""The gitops push path warns when a committed Settings.php looks like it holds
+an inline secret, steering the operator to `config set --secret`. It must be
+warn-only by default (fail only in strict mode) and never print the value."""
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+DET = os.path.join(REPO_ROOT, "roles", "gitops", "tasks",
+                   "_detect_settings_secrets.yml")
+PUSH = os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "push.yml")
+
+
+def _read(p):
+    with open(p) as f:
+        return f.read()
+
+
+def _walk(tasks):
+    for t in tasks:
+        yield t
+        if isinstance(t, dict) and "block" in t:
+            yield from _walk(t["block"])
+
+
+def test_push_runs_detection():
+    assert "_detect_settings_secrets.yml" in _read(PUSH)
+
+
+def test_detection_reports_files_only_not_values():
+    # grep -l lists matching files without emitting the matched line/value.
+    assert "grep -rlEi" in _read(DET)
+
+
+def test_detection_warns_and_only_fails_when_strict():
+    tasks = list(_walk(yaml.safe_load(_read(DET))))
+    fails = [t for t in tasks if "ansible.builtin.fail" in t]
+    assert fails, "must have a strict-mode fail"
+    for f in fails:
+        assert "gitops_strict_secrets" in str(f.get("when", "")), (
+            "the fail must be gated on strict mode; default is warn-only"
+        )
+    assert [t for t in tasks if "ansible.builtin.debug" in t], "must warn"

--- a/tests/unit/test_gitops_sops_scaffold.py
+++ b/tests/unit/test_gitops_sops_scaffold.py
@@ -42,6 +42,20 @@ def test_init_kubernetes_gates_sops_include():
     assert "gitops_sops_secrets" in str(inc[0].get("when", ""))
 
 
+def _flatten(tasks):
+    """Yield tasks recursively, descending into block/rescue/always."""
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        nested = False
+        for k in ("block", "rescue", "always"):
+            if k in t:
+                nested = True
+                yield from _flatten(t[k])
+        if not nested:
+            yield t
+
+
 def test_init_sops_structure():
     c = _read(INITSOPS)
     assert "age-keygen" in c
@@ -50,12 +64,28 @@ def test_init_sops_structure():
     assert "sops-age" in c
 
 
+def test_init_sops_key_is_cluster_global_on_controller():
+    c = _read(INITSOPS)
+    # Canonical key lives on the controller, keyed by host = one per cluster.
+    assert "sops/{{ host_name }}.age" in c
+    assert "CANASTA_CONFIG_DIR" in c
+    # --key is the DR import/export channel, not the runtime location.
+    assert "{{ key }}.age" in c or "key ~ '.age'" in c
+
+
 def test_init_sops_never_logs_key_material():
-    for t in yaml.safe_load(_read(INITSOPS)):
+    # Tasks that read/write/generate key CONTENT must be no_log (not the
+    # path set_fact / stat / mkdir, which only touch the location).
+    sensitive = ("import the supplied", "generate the canonical operator age key",
+                 "export the operator age key", "public recipient",
+                 "sops-age secret")
+    seen = 0
+    for t in _flatten(yaml.safe_load(_read(INITSOPS))):
         name = (t.get("name") or "").lower()
-        if any(s in name for s in ("age keypair", "public recipient",
-                                   "sops-age secret")):
+        if any(s in name for s in sensitive):
             assert t.get("no_log") is True, "%r must be no_log" % name
+            seen += 1
+    assert seen >= 4, "expected the key-material tasks to be present + checked"
 
 
 def test_init_sops_restarts_repo_server_after_provision():

--- a/tests/unit/test_gitops_sops_scaffold.py
+++ b/tests/unit/test_gitops_sops_scaffold.py
@@ -1,0 +1,51 @@
+"""C3 scaffolding: SOPS+age secret encryption for K8s gitops. Gated off by
+default; the Argo app switches to the CMP plugin source only when enabled; the
+age key material is never logged."""
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+INITK8S = os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "init_kubernetes.yml")
+INITSOPS = os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "_init_sops.yml")
+GDEFAULTS = os.path.join(REPO_ROOT, "roles", "gitops", "defaults", "main.yml")
+
+
+def _read(p):
+    with open(p) as f:
+        return f.read()
+
+
+def test_sops_off_by_default():
+    assert yaml.safe_load(_read(GDEFAULTS))["gitops_sops_secrets"] is False
+
+
+def test_argo_app_source_is_gated_plugin_vs_helm():
+    c = _read(INITK8S)
+    assert "gitops_sops_secrets | default(false) | bool" in c
+    # CMP plugin branch (enabled) + native helm branch (default) both present.
+    assert "plugin:" in c and "helm-sops" in c
+    assert "valueFiles:" in c
+
+
+def test_init_kubernetes_gates_sops_include():
+    inc = [t for t in yaml.safe_load(_read(INITK8S))
+           if "_init_sops.yml" in str(t.get("ansible.builtin.include_tasks", ""))]
+    assert inc, "init_kubernetes must include _init_sops.yml"
+    assert "gitops_sops_secrets" in str(inc[0].get("when", ""))
+
+
+def test_init_sops_structure():
+    c = _read(INITSOPS)
+    assert "age-keygen" in c
+    # Encrypt only the Secret payload; keep apiVersion/kind/metadata readable.
+    assert "encrypted_regex" in c and "(data|stringData)" in c
+    assert "sops-age" in c
+
+
+def test_init_sops_never_logs_key_material():
+    for t in yaml.safe_load(_read(INITSOPS)):
+        name = (t.get("name") or "").lower()
+        if any(s in name for s in ("age keypair", "public recipient",
+                                   "sops-age secret")):
+            assert t.get("no_log") is True, "%r must be no_log" % name

--- a/tests/unit/test_gitops_sops_scaffold.py
+++ b/tests/unit/test_gitops_sops_scaffold.py
@@ -74,6 +74,17 @@ def test_init_sops_structure():
     assert "sops-age" in c
 
 
+def test_init_sops_age_commands_use_argv_for_space_safe_paths():
+    # The config dir can contain spaces (macOS "~/Library/Application
+    # Support/canasta"), so age-keygen must run via argv, never a shell string.
+    for t in _flatten(yaml.safe_load(_read(INITSOPS))):
+        cmd = t.get("ansible.builtin.command")
+        if isinstance(cmd, str) and "age-keygen" in cmd and "--version" not in cmd:
+            raise AssertionError("age-keygen path command must use argv: %r" % cmd)
+    txt = _read(INITSOPS)
+    assert "argv:" in txt and "- age-keygen" in txt
+
+
 def test_init_sops_key_is_cluster_global_on_controller():
     c = _read(INITSOPS)
     # Canonical key lives on the controller, keyed by host = one per cluster.
@@ -139,19 +150,23 @@ def test_sidecar_values_template():
     assert rs["initContainers"][0]["name"] == "install-sops"
 
 
-def test_sidecar_defaults_present():
-    # Sidecar image is role-scoped; the sops version is shared play-global
-    # (one definition, used by both the install and orchestrator roles).
-    assert yaml.safe_load(_read(ODEFAULTS))["argocd_sops_sidecar_image"]
+def test_sidecar_config_is_play_global():
+    # sops version, age version, and the sidecar image are all play-global
+    # (one definition), so the gitops role's cross-role include of the sidecar
+    # task resolves them — role defaults would be out of scope there.
     versions = yaml.safe_load(_read(TOOLVERSIONS))
     assert versions["sops_version"]
     assert versions["age_version"]
+    assert versions["argocd_sops_sidecar_image"]
 
 
-def test_write_sops_secrets_captures_only_opaque():
+def test_write_sops_secrets_captures_only_opaque_unowned():
     c = _read(WRITESECRETS)
     # Only type=Opaque Secrets are versioned (excludes helm-release/TLS/SA-token).
     assert "equalto', 'Opaque'" in c or "equalto\", \"Opaque" in c
+    # And only unowned ones — drops cert-manager's ACME key Secrets (owned by
+    # a Certificate) and any other controller-managed Opaque Secret.
+    assert "rejectattr('metadata.ownerReferences', 'defined')" in c
     assert "k8s_info" in c
     # Prunes manifests for Secrets no longer present.
     assert "Prune encrypted manifests" in c

--- a/tests/unit/test_gitops_sops_scaffold.py
+++ b/tests/unit/test_gitops_sops_scaffold.py
@@ -23,6 +23,9 @@ WRITEONE = os.path.join(REPO_ROOT, "roles", "gitops", "tasks",
 PUSHK8S = os.path.join(REPO_ROOT, "roles", "gitops", "tasks",
                        "push_kubernetes.yml")
 TOOLVERSIONS = os.path.join(REPO_ROOT, "vars", "tool_versions.yml")
+ENSURE = os.path.join(REPO_ROOT, "roles", "orchestrator", "tasks",
+                      "k8s_ensure_sops_sidecar.yml")
+CMDDEFS = os.path.join(REPO_ROOT, "meta", "command_definitions.yml")
 
 
 def _read(p):
@@ -167,10 +170,13 @@ def test_write_one_sops_secret_hashes_and_encrypts():
     assert wrote_clear and wrote_clear[0].get("no_log") is True
 
 
-def test_push_gates_secret_capture_on_sops():
+def test_push_gates_secret_capture_on_sops_marker():
     c = _read(PUSHK8S)
     assert "_write_sops_secrets.yml" in c
-    assert "gitops_sops_secrets" in c
+    # Self-describing: push keys off the .sops.yaml marker, not a flag/var,
+    # so it needs no --encrypt-secrets of its own.
+    assert "_push_sops_marker.stat.exists" in c
+    assert ".sops.yaml" in c
     # host_name is resolved from .gitops-host before capture.
     assert ".gitops-host" in c
 
@@ -188,11 +194,24 @@ def test_install_supports_sops_toolchain():
     assert "sops_version" in task and "age_version" in task
 
 
-def test_bootstrap_gates_sidecar_provisioning():
-    tasks = yaml.safe_load(_read(BOOTSTRAP))
-    txt = _read(BOOTSTRAP)
-    assert "helm-sops-plugin" in txt
-    assert "argocd_sops_repo_server_values.yaml.j2" in txt
-    # The sops values file is only appended to the helm args when enabled.
-    assert "canasta-argocd-sops-values.yaml" in txt
-    assert "gitops_sops_secrets" in txt
+def test_encrypt_secrets_flag_drives_the_gate():
+    # The CLI flag exists on gitops init and maps to gitops_sops_secrets.
+    cmds = yaml.safe_load(_read(CMDDEFS))["commands"]
+    gi = [c for c in cmds if c["name"] == "gitops_init"][0]
+    assert any(p["name"] == "encrypt_secrets" for p in gi["parameters"])
+    ik = _read(INITK8S)
+    assert "encrypt_secrets | default(false) | bool" in ik
+    assert "gitops_sops_secrets:" in ik
+
+
+def test_sidecar_ensured_at_init_not_create():
+    # The sidecar is overlaid at gitops init via helm upgrade --reuse-values,
+    # not baked into the create-time Argo CD install.
+    ensure = _read(ENSURE)
+    assert "helm-sops-plugin" in ensure
+    assert "argocd_sops_repo_server_values.yaml.j2" in ensure
+    assert "--reuse-values" in ensure
+    ik = _read(INITK8S)
+    assert "k8s_ensure_sops_sidecar.yml" in ik
+    # create's Argo CD install must NOT carry the sidecar values anymore.
+    assert "argocd_sops_repo_server_values" not in _read(BOOTSTRAP)

--- a/tests/unit/test_gitops_sops_scaffold.py
+++ b/tests/unit/test_gitops_sops_scaffold.py
@@ -184,13 +184,26 @@ def test_application_scopes_secrets_dir_to_host():
     assert "hosts/{{ host_name }}/secrets" in c
 
 
-def test_join_refuses_sops_repo():
+def test_join_wires_sops():
     c = _read(os.path.join(REPO_ROOT, "roles", "gitops", "tasks",
                            "join_kubernetes.yml"))
-    # Join detects a .sops.yaml in the clone and refuses rather than making a
-    # broken hybrid.
+    # Join detects a .sops.yaml clone, enables SOPS, provisions decryption +
+    # the sidecar, and writes a plugin-source Application scoped to this host.
     assert ".sops.yaml" in c
-    assert "Refuse to join a SOPS-managed" in c
+    assert "_join_sops.yml" in c
+    assert "k8s_ensure_sops_sidecar.yml" in c
+    assert "SECRETS_DIR" in c
+
+
+def test_join_sops_verifies_key_and_provisions_secret():
+    c = _read(os.path.join(REPO_ROOT, "roles", "gitops", "tasks",
+                           "_join_sops.yml"))
+    # Refuses without the operator key; verifies it matches the repo recipient;
+    # provisions the sops-age Secret. Uses argv for the (possibly spaced) path.
+    assert "does not match this repository" in c
+    assert "{{ key }}.age" in c
+    assert "sops-age" in c
+    assert "argv:" in c
 
 
 def test_reinit_cleanup_removes_sops_marker():

--- a/tests/unit/test_gitops_sops_scaffold.py
+++ b/tests/unit/test_gitops_sops_scaffold.py
@@ -9,6 +9,13 @@ REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 INITK8S = os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "init_kubernetes.yml")
 INITSOPS = os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "_init_sops.yml")
 GDEFAULTS = os.path.join(REPO_ROOT, "roles", "gitops", "defaults", "main.yml")
+BOOTSTRAP = os.path.join(REPO_ROOT, "roles", "orchestrator", "tasks",
+                         "k8s_argocd_bootstrap.yml")
+ODEFAULTS = os.path.join(REPO_ROOT, "roles", "orchestrator", "defaults", "main.yml")
+PLUGIN = os.path.join(REPO_ROOT, "roles", "orchestrator", "files",
+                      "helm_sops_plugin.yaml")
+SIDECAR = os.path.join(REPO_ROOT, "roles", "orchestrator", "templates",
+                       "argocd_sops_repo_server_values.yaml.j2")
 
 
 def _read(p):
@@ -49,3 +56,60 @@ def test_init_sops_never_logs_key_material():
         if any(s in name for s in ("age keypair", "public recipient",
                                    "sops-age secret")):
             assert t.get("no_log") is True, "%r must be no_log" % name
+
+
+def test_init_sops_restarts_repo_server_after_provision():
+    # An optionally-mounted key only reaches a running repo-server on restart,
+    # and only on first provision (guarded by the register's changed state).
+    c = _read(INITSOPS)
+    assert "rollout restart deployment argocd-repo-server" in c
+    assert "_sops_age_provision is changed" in c
+
+
+def test_helm_sops_plugin_is_named_and_uses_argocd_env_prefix():
+    p = yaml.safe_load(_read(PLUGIN))
+    assert p["kind"] == "ConfigManagementPlugin"
+    assert p["metadata"]["name"] == "helm-sops"
+    # No spec.version keeps the plugin name exactly "helm-sops" so it matches
+    # the Application's spec.source.plugin.name.
+    assert "version" not in p["spec"]
+    gen = "\n".join(p["spec"]["generate"]["args"])
+    # Argo prefixes Application plugin.env with ARGOCD_ENV_ — the values
+    # override arrives as ARGOCD_ENV_HELM_ARGS, not HELM_ARGS.
+    assert "ARGOCD_ENV_HELM_ARGS" in gen
+    assert "$HELM_ARGS" not in gen
+    assert "sops -d" in gen
+    assert "hosts/*/secrets/*.enc.yaml" in gen
+
+
+def test_sidecar_values_template():
+    # Jinja template; substitute the two vars and parse.
+    r = yaml.safe_load(_read(SIDECAR)
+                       .replace("{{ sops_version }}", "v3.13.2")
+                       .replace("{{ argocd_sops_sidecar_image }}", "img"))
+    rs = r["repoServer"]
+    sc = [c for c in rs["extraContainers"] if c["name"] == "helm-sops"][0]
+    assert sc["command"] == ["/var/run/argocd/argocd-cmp-server"]
+    assert sc["securityContext"]["runAsUser"] == 999
+    env = {e["name"]: e["value"] for e in sc["env"]}
+    assert env["SOPS_AGE_KEY_FILE"] == "/home/argocd/.config/sops/age/keys.txt"
+    vols = {v["name"]: v for v in rs["volumes"]}
+    # Optional so the repo-server starts before the operator key is provisioned.
+    assert vols["sops-age"]["secret"]["optional"] is True
+    assert rs["initContainers"][0]["name"] == "install-sops"
+
+
+def test_sidecar_defaults_present():
+    d = yaml.safe_load(_read(ODEFAULTS))
+    assert d["sops_version"]
+    assert d["argocd_sops_sidecar_image"]
+
+
+def test_bootstrap_gates_sidecar_provisioning():
+    tasks = yaml.safe_load(_read(BOOTSTRAP))
+    txt = _read(BOOTSTRAP)
+    assert "helm-sops-plugin" in txt
+    assert "argocd_sops_repo_server_values.yaml.j2" in txt
+    # The sops values file is only appended to the helm args when enabled.
+    assert "canasta-argocd-sops-values.yaml" in txt
+    assert "gitops_sops_secrets" in txt

--- a/tests/unit/test_gitops_sops_scaffold.py
+++ b/tests/unit/test_gitops_sops_scaffold.py
@@ -16,6 +16,12 @@ PLUGIN = os.path.join(REPO_ROOT, "roles", "orchestrator", "files",
                       "helm_sops_plugin.yaml")
 SIDECAR = os.path.join(REPO_ROOT, "roles", "orchestrator", "templates",
                        "argocd_sops_repo_server_values.yaml.j2")
+WRITESECRETS = os.path.join(REPO_ROOT, "roles", "gitops", "tasks",
+                            "_write_sops_secrets.yml")
+WRITEONE = os.path.join(REPO_ROOT, "roles", "gitops", "tasks",
+                        "_write_one_sops_secret.yml")
+PUSHK8S = os.path.join(REPO_ROOT, "roles", "gitops", "tasks",
+                       "push_kubernetes.yml")
 
 
 def _read(p):
@@ -133,6 +139,36 @@ def test_sidecar_defaults_present():
     d = yaml.safe_load(_read(ODEFAULTS))
     assert d["sops_version"]
     assert d["argocd_sops_sidecar_image"]
+
+
+def test_write_sops_secrets_captures_only_opaque():
+    c = _read(WRITESECRETS)
+    # Only type=Opaque Secrets are versioned (excludes helm-release/TLS/SA-token).
+    assert "equalto', 'Opaque'" in c or "equalto\", \"Opaque" in c
+    assert "k8s_info" in c
+    # Prunes manifests for Secrets no longer present.
+    assert "Prune encrypted manifests" in c
+
+
+def test_write_one_sops_secret_hashes_and_encrypts():
+    c = _read(WRITEONE)
+    # Cleartext hash annotation (metadata stays readable under SOPS) drives
+    # skip-if-unchanged so encrypted blobs don't churn.
+    assert "canasta.io/gitops-secret-hash" in c
+    assert "hash('sha256')" in c
+    assert "sops -e -i" in c
+    # The cleartext-manifest write must never be logged.
+    wrote_clear = [t for t in _flatten(yaml.safe_load(c))
+                   if "cleartext secret manifest" in (t.get("name") or "").lower()]
+    assert wrote_clear and wrote_clear[0].get("no_log") is True
+
+
+def test_push_gates_secret_capture_on_sops():
+    c = _read(PUSHK8S)
+    assert "_write_sops_secrets.yml" in c
+    assert "gitops_sops_secrets" in c
+    # host_name is resolved from .gitops-host before capture.
+    assert ".gitops-host" in c
 
 
 def test_bootstrap_gates_sidecar_provisioning():

--- a/tests/unit/test_gitops_sops_scaffold.py
+++ b/tests/unit/test_gitops_sops_scaffold.py
@@ -184,6 +184,14 @@ def test_application_scopes_secrets_dir_to_host():
     assert "hosts/{{ host_name }}/secrets" in c
 
 
+def test_push_authenticates_with_deploy_key():
+    # push must use the staged deploy key (or --ssh-key), not ambient ssh —
+    # a joined host authenticates to the forge only via .gitops-deploy-key.
+    c = _read(PUSHK8S)
+    assert "GIT_SSH_COMMAND" in c
+    assert ".gitops-deploy-key" in c
+
+
 def test_join_wires_sops():
     c = _read(os.path.join(REPO_ROOT, "roles", "gitops", "tasks",
                            "join_kubernetes.yml"))

--- a/tests/unit/test_gitops_sops_scaffold.py
+++ b/tests/unit/test_gitops_sops_scaffold.py
@@ -22,6 +22,7 @@ WRITEONE = os.path.join(REPO_ROOT, "roles", "gitops", "tasks",
                         "_write_one_sops_secret.yml")
 PUSHK8S = os.path.join(REPO_ROOT, "roles", "gitops", "tasks",
                        "push_kubernetes.yml")
+TOOLVERSIONS = os.path.join(REPO_ROOT, "vars", "tool_versions.yml")
 
 
 def _read(p):
@@ -136,9 +137,12 @@ def test_sidecar_values_template():
 
 
 def test_sidecar_defaults_present():
-    d = yaml.safe_load(_read(ODEFAULTS))
-    assert d["sops_version"]
-    assert d["argocd_sops_sidecar_image"]
+    # Sidecar image is role-scoped; the sops version is shared play-global
+    # (one definition, used by both the install and orchestrator roles).
+    assert yaml.safe_load(_read(ODEFAULTS))["argocd_sops_sidecar_image"]
+    versions = yaml.safe_load(_read(TOOLVERSIONS))
+    assert versions["sops_version"]
+    assert versions["age_version"]
 
 
 def test_write_sops_secrets_captures_only_opaque():
@@ -169,6 +173,19 @@ def test_push_gates_secret_capture_on_sops():
     assert "gitops_sops_secrets" in c
     # host_name is resolved from .gitops-host before capture.
     assert ".gitops-host" in c
+
+
+def test_install_supports_sops_toolchain():
+    inst = _read(os.path.join(REPO_ROOT, "playbooks", "install.yml"))
+    assert "'sops' in _install_packages" in inst
+    assert "sops_age.yml" in inst
+    task = _read(os.path.join(REPO_ROOT, "roles", "install", "tasks",
+                              "sops_age.yml"))
+    # Installs both binaries from pinned release versions, idempotently.
+    assert "getsops/sops/releases" in task
+    assert "FiloSottile/age/releases" in task
+    assert "age-keygen" in task
+    assert "sops_version" in task and "age_version" in task
 
 
 def test_bootstrap_gates_sidecar_provisioning():

--- a/tests/unit/test_gitops_sops_scaffold.py
+++ b/tests/unit/test_gitops_sops_scaffold.py
@@ -130,7 +130,11 @@ def test_helm_sops_plugin_is_named_and_uses_argocd_env_prefix():
     assert "ARGOCD_ENV_HELM_ARGS" in gen
     assert "$HELM_ARGS" not in gen
     assert "sops -d" in gen
-    assert "hosts/*/secrets/*.enc.yaml" in gen
+    # set -e so a failed helm template aborts (else Argo prunes the instance).
+    assert "set -e" in gen
+    # Decrypt only THIS host's secrets, not every host's (host-blind glob bug).
+    assert "$ARGOCD_ENV_SECRETS_DIR" in gen
+    assert "hosts/*/secrets" not in gen
 
 
 def test_sidecar_values_template():
@@ -170,6 +174,63 @@ def test_write_sops_secrets_captures_only_opaque_unowned():
     assert "k8s_info" in c
     # Prunes manifests for Secrets no longer present.
     assert "Prune encrypted manifests" in c
+
+
+def test_application_scopes_secrets_dir_to_host():
+    c = _read(INITK8S)
+    # Plugin env carries a per-host SECRETS_DIR so the CMP decrypts only this
+    # host's secrets.
+    assert "SECRETS_DIR" in c
+    assert "hosts/{{ host_name }}/secrets" in c
+
+
+def test_join_refuses_sops_repo():
+    c = _read(os.path.join(REPO_ROOT, "roles", "gitops", "tasks",
+                           "join_kubernetes.yml"))
+    # Join detects a .sops.yaml in the clone and refuses rather than making a
+    # broken hybrid.
+    assert ".sops.yaml" in c
+    assert "Refuse to join a SOPS-managed" in c
+
+
+def test_reinit_cleanup_removes_sops_marker():
+    c = _read(os.path.join(REPO_ROOT, "roles", "gitops", "tasks",
+                           "_reinit_cleanup.yml"))
+    assert ".sops.yaml" in c
+
+
+def test_prune_guarded_against_empty_namespace():
+    c = _read(WRITESECRETS)
+    # Prune only runs when the namespace actually returned Secrets, so an
+    # empty/absent namespace can't wipe every DR copy from git.
+    assert "_sops_secrets | length > 0" in c
+
+
+def test_skip_gate_requires_encrypted_file():
+    c = _read(WRITEONE)
+    # A hash match is only trusted when the file is actually encrypted.
+    assert "_sec_encrypted" in c and "ENC[" in c
+    # A failed encryption removes the cleartext rather than leaving it.
+    assert "rescue:" in c
+
+
+def test_sidecar_verifies_sops_checksum():
+    tv = yaml.safe_load(_read(TOOLVERSIONS))
+    assert tv["sops_sha256"]["amd64"] and tv["sops_sha256"]["arm64"]
+    t = _read(SIDECAR)
+    assert "sha256sum -c" in t and "sops_sha256" in t
+
+
+def test_ensure_sidecar_pins_chart_version():
+    c = _read(ENSURE)
+    assert "get metadata argocd" in c
+    assert "--version {{ _argocd_chart_version }}" in c
+
+
+def test_migration_replaceholder_is_case_insensitive():
+    c = _read(os.path.join(REPO_ROOT, "roles", "gitops", "tasks",
+                           "_migrate_reclassified_secrets.yml"))
+    assert "(?i)^{{ item }}=" in c
 
 
 def test_write_one_sops_secret_hashes_and_encrypts():

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -326,21 +326,19 @@ class TestK8sSyncConfigSecretsStripped:
             "breaks Argo CD reconciliation (#507)."
         )
 
-    def test_sync_env_no_secrets_rejects_password_and_secret_key(self):
-        """The filter must specifically drop MYSQL_PASSWORD and
-        MW_SECRET_KEY — those are the keys the chart pulls via
-        secretKeyRef and therefore the keys that would be duplicated
-        if left in the .env content."""
+    def test_sync_env_no_secrets_uses_canonical_classifier(self):
+        """The filter must drop the FULL secret surface via the canonical
+        classifier (canasta_secret_key_regex), not a hand-maintained key list —
+        otherwise a secret outside the list (RESTIC_*, AWS_*, WIKI_DB_PASSWORD,
+        SMTP_*, ...) leaks into configData.web['.env'] / the committed values."""
         for task in self._walk_tasks(self._load()):
             sf = task.get("ansible.builtin.set_fact") or task.get("set_fact")
             if not (isinstance(sf, dict) and "_sync_env_no_secrets" in sf):
                 continue
             expr = sf["_sync_env_no_secrets"]
-            assert "MYSQL_PASSWORD" in expr, (
-                "_sync_env_no_secrets filter must drop MYSQL_PASSWORD"
-            )
-            assert "MW_SECRET_KEY" in expr, (
-                "_sync_env_no_secrets filter must drop MW_SECRET_KEY"
+            assert "canasta_secret_key_regex" in expr, (
+                "_sync_env_no_secrets must reject via the canonical "
+                "canasta_secret_key_regex, not a literal key list"
             )
             return
 

--- a/tests/unit/test_secret_classifier.py
+++ b/tests/unit/test_secret_classifier.py
@@ -1,25 +1,12 @@
 """The canonical secret classifier is the single source of truth for
 "this key is a secret". These tests lock the full secret surface (so a
 future key can't silently leak) and the non-secret exclusions."""
-import os
 import re
 
-import yaml
-
-REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-CLASSIFIER = os.path.join(REPO_ROOT, "vars", "secret_classification.yml")
-
-
-def _load():
-    with open(CLASSIFIER) as fh:
-        return yaml.safe_load(fh)
-
-
-def _secret_regex(cls):
-    # Mirror canasta_secret_key_regex's Jinja construction so the test checks
-    # the same effective pattern the playbook uses.
-    prefixes = cls["canasta_secret_prefixes"] + cls["canasta_secret_explicit"]
-    return "^([^=]*" + cls["canasta_secret_key_pattern"] + "|" + "|".join(prefixes) + ")"
+# Render the real classifier regex from the vars file (shared helper), rather
+# than re-mirroring its Jinja construction here where it could drift.
+from _classifier import classifier as _load
+from _classifier import secret_key_regex as _secret_regex
 
 
 # Genuine secrets — must ALL classify as secret (kept out of ConfigMaps/gitops).

--- a/tests/unit/test_secret_classifier.py
+++ b/tests/unit/test_secret_classifier.py
@@ -1,0 +1,69 @@
+"""The canonical secret classifier is the single source of truth for
+"this key is a secret". These tests lock the full secret surface (so a
+future key can't silently leak) and the non-secret exclusions."""
+import os
+import re
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+CLASSIFIER = os.path.join(REPO_ROOT, "vars", "secret_classification.yml")
+
+
+def _load():
+    with open(CLASSIFIER) as fh:
+        return yaml.safe_load(fh)
+
+
+def _secret_regex(cls):
+    # Mirror canasta_secret_key_regex's Jinja construction so the test checks
+    # the same effective pattern the playbook uses.
+    prefixes = cls["canasta_secret_prefixes"] + cls["canasta_secret_explicit"]
+    return "^([^=]*" + cls["canasta_secret_key_pattern"] + "|" + "|".join(prefixes) + ")"
+
+
+# Genuine secrets — must ALL classify as secret (kept out of ConfigMaps/gitops).
+SECRETS = [
+    "MYSQL_PASSWORD", "MYSQL_ROOT_PASSWORD", "WIKI_DB_PASSWORD", "MW_SECRET_KEY",
+    "RESTIC_PASSWORD", "RESTIC_REPOSITORY", "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY", "AZURE_ACCOUNT_KEY", "B2_APPLICATION_KEY",
+    "RCLONE_CONFIG_REMOTE_PASS", "SMTP_PASSWORD", "SMTP_USER",
+    "CROWDSEC_BOUNCER_API_KEY", "SOME_VENDOR_TOKEN", "PARTNER_CREDENTIAL",
+]
+
+# Operational config — must NOT be suppressed/stripped (stays cleartext).
+NON_SECRETS = [
+    "MW_SITE_SERVER", "MW_SITE_FQDN", "HTTP_PORT", "HTTPS_PORT",
+    "CADDY_AUTO_HTTPS", "CANASTA_ENABLE_CROWDSEC", "PHP_UPLOAD_MAX_FILESIZE",
+    "MYSQL_HOST", "MYSQL_USER", "MW_SITEMAP_PAUSE_DAYS",
+]
+
+
+def test_classifier_parses_and_defines_the_pieces():
+    cls = _load()
+    for key in ("canasta_secret_key_pattern", "canasta_secret_prefixes",
+                "canasta_secret_explicit", "canasta_backup_backend_prefixes",
+                "canasta_host_specific_nonsecret"):
+        assert key in cls, f"{key} missing from the classifier"
+
+
+def test_all_secrets_classified_as_secret():
+    regex = _secret_regex(_load())
+    for key in SECRETS:
+        assert re.match(regex, key), f"{key} must classify as secret"
+        # Same when applied to a `KEY=value` .env line (only the key inspected).
+        assert re.match(regex, key + "=somevalue"), f"{key}= line must match"
+
+
+def test_non_secrets_not_classified():
+    regex = _secret_regex(_load())
+    for key in NON_SECRETS:
+        assert not re.match(regex, key), f"{key} must NOT classify as secret"
+
+
+def test_rclone_covered_but_smtp_excluded_in_backup_backends():
+    cls = _load()
+    # RCLONE_ was the historical omission that broke restic rclone on K8s.
+    assert "RCLONE_" in cls["canasta_backup_backend_prefixes"]
+    # SMTP is a secret but not a backup backend, so it stays out of backup-env.
+    assert "SMTP_" not in cls["canasta_backup_backend_prefixes"]

--- a/vars/secret_classification.yml
+++ b/vars/secret_classification.yml
@@ -1,0 +1,60 @@
+---
+# Canonical secret classification — the ONE definition of "this key's value is
+# a secret." Consumed by config (no_log), gitops (encrypt / placeholder), and
+# the K8s sync (strip from ConfigMap, route to Secrets). Loaded play-global by
+# canasta.yml so config, gitops, and orchestrator roles all resolve it.
+#
+# Deny-by-default: a key is secret if its name matches the word pattern, starts
+# with a credential prefix, or is explicitly listed. Unknown future keys are
+# caught automatically — never add a per-path list again.
+
+# Word-substring match on the key name.
+canasta_secret_key_pattern: "(PASSWORD|SECRET|TOKEN|KEY|CREDENTIAL)"
+
+# Credential key prefixes (backup backends + mail). Also the config accept-list.
+canasta_secret_prefixes:
+  - "AWS_"
+  - "AZURE_"
+  - "B2_"
+  - "GOOGLE_"
+  - "OS_"
+  - "ST_"
+  - "RCLONE_"
+  - "SMTP_"
+
+# Genuine secrets the word pattern misses (a repo URL can embed credentials).
+canasta_secret_explicit:
+  - "RESTIC_REPOSITORY"
+
+# Backup-backend credential prefixes — the subset the backup/restore Job's
+# restic env needs. SMTP is a secret but not a backup backend, so it is not
+# here; RESTIC_ covers both RESTIC_REPOSITORY and RESTIC_PASSWORD.
+canasta_backup_backend_prefixes:
+  - "RESTIC_"
+  - "AWS_"
+  - "AZURE_"
+  - "B2_"
+  - "GOOGLE_"
+  - "OS_"
+  - "ST_"
+  - "RCLONE_"
+
+# Host/instance-specific keys that gitops placeholders per-host but that are NOT
+# secret (safe to keep cleartext). Kept distinct so gitops still templates them.
+canasta_host_specific_nonsecret:
+  - "MW_SITE_SERVER"
+  - "MW_SITE_FQDN"
+  - "HTTP_PORT"
+  - "HTTPS_PORT"
+  - "CADDY_AUTO_HTTPS"
+  - "CADDY_TRUSTED_PROXIES"
+  - "CANASTA_ENABLE_CROWDSEC"
+  - "CANASTA_ENABLE_ELASTICSEARCH"
+  - "CANASTA_ENABLE_OBSERVABILITY"
+  - "CANASTA_ENABLE_VARNISH"
+
+# One regex, anchored for `match` on either a bare key name or a `KEY=value`
+# line ([^=]* stops at the separator, so only the key is inspected). Built from
+# the lists above so there is a single place to maintain.
+canasta_secret_key_regex: >-
+  ^([^=]*{{ canasta_secret_key_pattern }}|{{ (canasta_secret_prefixes + canasta_secret_explicit) | join('|') }})

--- a/vars/tool_versions.yml
+++ b/vars/tool_versions.yml
@@ -5,3 +5,9 @@
 # pre_tasks. Reviewed and bumped per release; validated on kind.
 sops_version: "v3.13.2"
 age_version: "v1.3.1"
+
+# Argo CD repo-server sidecar image for the helm-sops CMP. Should track the
+# argo-cd chart's appVersion. Play-global (not an orchestrator default) because
+# gitops init includes the sidecar task cross-role, where role defaults are
+# out of scope.
+argocd_sops_sidecar_image: "quay.io/argoproj/argocd:v3.3.9"

--- a/vars/tool_versions.yml
+++ b/vars/tool_versions.yml
@@ -6,6 +6,12 @@
 sops_version: "v3.13.2"
 age_version: "v1.3.1"
 
+# sha256 of the sops release binaries, verified after download (the repo-server
+# sidecar fetches sops at pod start). Update alongside sops_version.
+sops_sha256:
+  amd64: "154dfe4cd70554bdd82b98e4cd4acf191d43d01ead6f00a73477aa44c4ac42ef"
+  arm64: "78abf2e15c86250a1553ae6f53aba96be6b2a8126f160b1534959add3467ad76"
+
 # Argo CD repo-server sidecar image for the helm-sops CMP. Should track the
 # argo-cd chart's appVersion. Play-global (not an orchestrator default) because
 # gitops init includes the sidecar task cross-role, where role defaults are

--- a/vars/tool_versions.yml
+++ b/vars/tool_versions.yml
@@ -1,0 +1,7 @@
+---
+# Pinned versions for the SOPS toolchain, shared across roles so there is ONE
+# definition (the install role provisions them; the orchestrator role injects
+# sops into the Argo CD repo-server sidecar). Loaded play-global in canasta.yml
+# pre_tasks. Reviewed and bumped per release; validated on kind.
+sops_version: "v3.13.2"
+age_version: "v1.3.1"


### PR DESCRIPTION
Closes #1063.

Ends the recurring gitops secret-handling gaps by collapsing the divergent
definitions of "secret" to one canonical classifier and giving Kubernetes
encrypted-secrets-in-git parity with Compose. Off by default; existing
instances are unaffected until `gitops init --encrypt-secrets` is used.

## What changed

**Canonical classifier**
- One `is_secret` definition in a play-global `vars/secret_classification.yml`,
  consumed by every path (config `no_log`, the K8s env strip, the backup-env
  filter, the Compose `env.template` split, `join`). Removes the previously
  divergent copies. Deny-by-default so new keys are covered.
- Compose keeps git-crypt unchanged; pre-classifier cleartext literals are
  migrated into the git-crypted vars on the next push.

**Kubernetes SOPS + age**
- `gitops init --encrypt-secrets` is the on-switch: provisions a cluster-global
  operator age key (canonical on the controller, exported to `--key` for DR /
  imported there on restore), writes `.sops.yaml`, and points the Argo CD
  Application at a `helm-sops` plugin source.
- `helm-sops` CMP sidecar is overlaid on the existing Argo CD repo-server via
  `helm upgrade --reuse-values` (pinned to the installed chart version), so
  create stays orchestration-agnostic and the same path bootstraps new and
  pre-existing clusters. It runs `helm template … && sops -d` over this host's
  `secrets/*.enc.yaml`.
- On push, the instance's own Opaque Secrets (excluding controller-owned ones
  like cert-manager's) are captured as SOPS-encrypted manifests under
  `hosts/<host>/secrets/*.enc.yaml`; git becomes the source of truth and Argo
  decrypts at render. Only the payload is encrypted (metadata stays diffable);
  a cleartext data-hash annotation skips re-encrypting unchanged Secrets.
- `gitops join` supports SOPS repos: it imports the operator key (via `--key`),
  verifies the recipient matches the repo, provisions the joining cluster's
  `sops-age` Secret + sidecar, and writes a per-host plugin Application.

**Tooling & lint**
- `canasta install sops` installs the sops + age binaries (pinned + sha256
  verified); `canasta doctor` reports their status; controller/target
  preflights fail with actionable guidance.
- Non-blocking warning on inline `$wg…Password/Secret/Token/Key` literals in
  staged `Settings.php`.

## Validation

- Unit: 1690 tests + lint + `validate` green.
- kind: encrypt → Argo decrypt → render; fail-closed without the key; recovery.
- Live single-node K8s: full `install sops` → `create` → `init
  --encrypt-secrets` → `push`; Argo adopts the decrypted Secrets.
- Live **multi-host** (two clusters): `init --encrypt-secrets` on one, `gitops
  join` on the other; the joined cluster imports the key and decrypts + renders
  only its own host's Secrets.

## Review + hardening

A multi-agent review and the live runs surfaced and fixed several issues in the
SOPS path (all in this branch): CMP `set -e` so a failed `helm template` can't
let Argo prune the instance; the skip-gate requires the file be encrypted (no
cleartext republish); prune is skipped on an empty namespace (no DR wipe); the
decrypt glob is host-scoped; `--reinit` clears the `.sops.yaml` marker; the
sops binary is sha256-verified; and `gitops push` authenticates with the deploy
key (was ambient ssh, failed on joined hosts). Cross-platform fixes too:
`age-keygen` via argv (spaced macOS config-dir path) and the sidecar image pin
moved play-global for cross-role resolution.

## Notes for reviewers / operators

- **Shared Argo CD infra:** enabling encryption on an existing cluster runs one
  `helm upgrade --reuse-values` to add the sidecar (brief repo-server rollout).
- Reviewable commit-by-commit; each commit is self-contained and green.
- macOS controllers: pass `--key` under a normal writable directory (not
  `/tmp`, which is root-owned there).
