### PR TITLE
Report non-GitOps instances as unmanaged in gitops status

### DIFF
--- a/direct_commands/gitops.py
+++ b/direct_commands/gitops.py
@@ -148,6 +148,21 @@ def _parse_gitops_status(stdout, instance_id):
     except (ValueError, IndexError):
         ahead, behind = 0, 0
 
+    # No .gitops-host marker and no git repository means the instance is simply
+    # not under GitOps management. Reporting "No changes / Up to date with
+    # remote" here would falsely imply a healthy, in-sync managed instance —
+    # there is no remote to be in sync with.
+    if hostname == "unknown" and commit == "none":
+        return "\n".join([
+            "Canasta ID:     %s" % instance_id,
+            "GitOps:         not configured for this instance.",
+            "",
+            "This instance is not under GitOps management (no .gitops-host "
+            "marker and no git repository).",
+            "Set it up with 'canasta gitops init' (new repo) or "
+            "'canasta gitops join' (existing repo).",
+        ])
+
     lines = [
         "Host:           %s" % hostname,
         "Role:           %s" % role,

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2120,6 +2120,17 @@ class TestParseGitopsStatus:
         assert "No changes." in result
         assert "Up to date with remote." in result
 
+    def test_unmanaged_instance_reported_not_managed(self):
+        # No .gitops-host marker (hostname MISSING -> unknown) and no git repo
+        # (commit none): must say the instance isn't GitOps-managed, not claim
+        # "No changes / Up to date with remote" (there is no remote).
+        out = self._make_output(hostname="MISSING", commit="none", applied="none")
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "not under GitOps management" in result
+        assert "gitops init" in result and "gitops join" in result
+        assert "Up to date with remote." not in result
+        assert "No changes." not in result
+
     def test_with_staged_files(self):
         out = self._make_output(staged="config/.env\nconfig/wikis.yaml")
         result = direct_commands._parse_gitops_status(out, "mysite")


### PR DESCRIPTION
## Summary

`canasta gitops status` on an instance that is **not** under GitOps management printed the managed-instance summary and ended with `No changes.` + `Up to date with remote.` — falsely implying a healthy, in-sync instance. There is no `.gitops-host` marker and no git repository, so there is no remote to be in sync with.

Closes #1065.

## Root cause

In `direct_commands/gitops.py` (`_parse_gitops_status`), an unmanaged instance yields `hostname = unknown` (no marker) and `commit = none` (no repo), with nothing staged and `ahead == behind == 0`, so the code fell straight through to the clean/in-sync lines without ever checking whether the instance is GitOps-managed.

## Fix

Before building the managed summary, detect the unmanaged state (`hostname == "unknown" and commit == "none"`) and return a clear message instead:

```
Canasta ID:     <id>
GitOps:         not configured for this instance.

This instance is not under GitOps management (no .gitops-host marker and no git repository).
Set it up with 'canasta gitops init' (new repo) or 'canasta gitops join' (existing repo).
```

## Tests

New `test_unmanaged_instance_reported_not_managed` (asserts the unmanaged message appears and the misleading `No changes`/`Up to date with remote` lines do not). Full unit suite (1668) + lint + validate green.

Surfaced migrating a single wiki to a new instance: the new instance wasn't GitOps-managed, but `gitops status` reported it as up to date.