### PR TITLE
gitops push (K8s): retry a commit stranded by a failed push

### DIFF
--- a/roles/gitops/tasks/push_kubernetes.yml
+++ b/roles/gitops/tasks/push_kubernetes.yml
@@ -111,32 +111,44 @@
   changed_when: false
   ignore_errors: true
 
-- name: Commit and push
+- name: Commit staged changes
+  ansible.builtin.command:
+    cmd: "git -c commit.gpgsign=false commit -m 'Configuration update'"
+    chdir: "{{ instance_path }}"
   when: _git_staged.rc != 0
-  block:
-    - name: Commit changes
-      ansible.builtin.command:
-        cmd: "git -c commit.gpgsign=false commit -m 'Configuration update'"
-        chdir: "{{ instance_path }}"
-      changed_when: true
+  changed_when: true
 
-    # Authenticate with the staged deploy key (or --ssh-key), like init/join —
-    # not the ambient ssh/agent, which isn't present on every gitops host
-    # (a joined host authenticates only via its .gitops-deploy-key).
-    - name: Push to remote
-      ansible.builtin.command:
-        cmd: "git push"
-        chdir: "{{ instance_path }}"
-      environment:
-        GIT_SSH_COMMAND: >-
-          ssh -i {{ ssh_key | default(instance_path + '/.gitops-deploy-key', true) }}
-          -o StrictHostKeyChecking=accept-new
-          -o UserKnownHostsFile=~/.ssh/known_hosts
-      changed_when: true
+# Push whenever the local branch is ahead of its upstream — this run's commit
+# OR a commit left behind by an earlier push whose `git push` failed after the
+# commit (a transient drop / SSH reset). Gating the push on freshly-staged
+# changes alone stranded that earlier commit: the next push staged nothing, so
+# it never retried and the config was silently never published.
+- name: Count commits not yet pushed
+  ansible.builtin.command:
+    cmd: "git rev-list --count @{u}..HEAD"
+    chdir: "{{ instance_path }}"
+  register: _unpushed
+  changed_when: false
+  failed_when: false
+
+# Authenticate with the staged deploy key (or --ssh-key), like init/join — not
+# the ambient ssh/agent, which isn't present on every gitops host (a joined
+# host authenticates only via its .gitops-deploy-key).
+- name: Push to remote
+  ansible.builtin.command:
+    cmd: "git push"
+    chdir: "{{ instance_path }}"
+  when: (_unpushed.stdout | default('0', true) | int) > 0
+  environment:
+    GIT_SSH_COMMAND: >-
+      ssh -i {{ ssh_key | default(instance_path + '/.gitops-deploy-key', true) }}
+      -o StrictHostKeyChecking=accept-new
+      -o UserKnownHostsFile=~/.ssh/known_hosts
+  changed_when: true
 
 - name: Report result
   ansible.builtin.debug:
     msg: >-
-      {{ (_git_staged.rc != 0)
+      {{ ((_unpushed.stdout | default('0', true) | int) > 0)
          | ternary('Configuration pushed. Argo CD will sync shortly.',
                    'No changes to push.') }}

--- a/tests/unit/test_gitops_push_retry.py
+++ b/tests/unit/test_gitops_push_retry.py
@@ -1,0 +1,36 @@
+"""gitops push (K8s) must retry a commit left unpushed by an earlier failed
+push, not only push when new changes were staged this run."""
+import os
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+PUSHK8S = os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "push_kubernetes.yml")
+
+
+def _read(p):
+    with open(p) as fh:
+        return fh.read()
+
+
+def _tasks():
+    return yaml.safe_load(_read(PUSHK8S))
+
+
+def test_commit_is_gated_on_staged_changes():
+    commit = [t for t in _tasks() if (t.get("name") or "") == "Commit staged changes"]
+    assert commit, "expected a 'Commit staged changes' task"
+    assert "_git_staged.rc != 0" in str(commit[0].get("when"))
+
+
+def test_push_is_gated_on_unpushed_commits_not_staged():
+    c = _read(PUSHK8S)
+    # Unpushed commits are counted against the upstream and drive the push, so
+    # a commit stranded by a prior failed push is retried.
+    assert "git rev-list --count @{u}..HEAD" in c
+    push = [t for t in _tasks() if (t.get("name") or "") == "Push to remote"]
+    assert push, "expected a 'Push to remote' task"
+    when = str(push[0].get("when"))
+    assert "_unpushed" in when and "int) > 0" in when
+    # The push must NOT be gated on freshly-staged changes alone.
+    assert "_git_staged" not in when


### PR DESCRIPTION
Closes #1067.

`gitops push` (Kubernetes) committed and pushed only when `git add -A` produced
staged changes. If a push committed locally but the `git push` then failed —
a transient network drop, an SSH reset, an auth blip — the commit stayed local
and unpushed. On the next `gitops push`, nothing new was staged, the
commit-and-push block was skipped, and the stranded commit was never retried:
the local branch silently stayed ahead of the remote and the config was never
published (the operator just saw "No changes to push").

## Fix

Split the commit from the push:

- Commit stays gated on freshly-staged changes.
- The push now fires whenever the branch is ahead of its upstream
  (`git rev-list --count @{u}..HEAD` > 0), which covers both this run's commit
  and a commit left behind by an earlier failed push.

Adds `tests/unit/test_gitops_push_retry.py`. Surfaced during the multi-host
gitops validation for #1063.
