### PR TITLE
Deduplicate backup schedule crontab entries on set

### DIFF
--- a/roles/orchestrator/tasks/backup_schedule_apply.yml
+++ b/roles/orchestrator/tasks/backup_schedule_apply.yml
@@ -95,6 +95,38 @@
   ansible.builtin.set_fact:
     _cron_cmd: "{{ (_cron_base + ' ' + _cron_purge + ' ' + _cron_log) | regex_replace('\\s+', ' ') | trim }}"
 
+# The write below only replaces an entry with THIS code path's marker
+# (#Ansible: for the cron module, # BEGIN/END for blockinfile). An entry left
+# by an older Canasta version, the other CLI flavor (canasta vs canasta-docker),
+# or a different install path carries a different marker/format, so it would
+# survive — duplicating the crontab (the instance backs up twice) and letting
+# 'schedule list' report the stale one. Remove EVERY prior entry for this
+# instance first: the ' backup create -i <id> ' job line (the same fragment
+# 'schedule list' matches, with a trailing space so 'foo' != 'foo2') and any
+# Canasta backup marker comment. The write below then leaves exactly one entry.
+- name: Remove any prior backup schedule entries for this instance (live crontab)
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: >-
+      set -o pipefail;
+      kept="$(crontab -l 2>/dev/null
+      | grep -vE '( backup create -i {{ instance_id }} | canasta-backup-{{ instance_id }}( |$))' || true)";
+      printf '%s\n' "$kept" | crontab -
+  when: not _sched_use_file
+  changed_when: true
+
+- name: Remove any prior backup schedule entries for this instance (host crontab file)
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: >-
+      set -o pipefail;
+      f={{ _host_crontab_file | quote }};
+      [ -f "$f" ] || exit 0;
+      kept="$(grep -vE '( backup create -i {{ instance_id }} | canasta-backup-{{ instance_id }}( |$))' "$f" || true)";
+      printf '%s\n' "$kept" > "$f"
+  when: _sched_use_file
+  changed_when: true
+
 # Native / remote: edit the live crontab via the cron module.
 - name: Set cron schedule
   ansible.builtin.cron:

--- a/roles/orchestrator/tasks/backup_schedule_list.yml
+++ b/roles/orchestrator/tasks/backup_schedule_list.yml
@@ -67,6 +67,21 @@
     msg: "No backup schedule found for instance '{{ instance_id }}'."
   when: _schedule_lines | length == 0
 
+# More than one entry means a duplicate schedule (e.g. one left by an older
+# Canasta version alongside a newly-set one) — the instance backs up more than
+# once, and the single-entry display below would silently report only the first.
+# Surface all of them so the duplicate is visible.
+- name: Warn about duplicate schedule entries
+  ansible.builtin.debug:
+    msg: >-
+      Warning: found {{ _schedule_lines | length }} backup schedule entries in
+      the crontab for instance '{{ instance_id }}' (there should be one) — the
+      instance may be backing up more than once. Schedules:
+      {{ _schedule_lines
+         | map('regex_replace', '^(\S+\s+\S+\s+\S+\s+\S+\s+\S+).*$', '\1')
+         | join('; ') }}. Re-run 'canasta backup schedule set' to consolidate.
+  when: _schedule_lines | length > 1
+
 - name: Parse and display schedule
   when: _schedule_lines | length > 0
   block:

--- a/tests/unit/test_backup_schedule_dedupe.py
+++ b/tests/unit/test_backup_schedule_dedupe.py
@@ -1,0 +1,66 @@
+"""Guards for backup-schedule crontab de-duplication.
+
+Re-scheduling an instance that was previously scheduled by a different Canasta
+version / CLI flavor left the old crontab entry in place (different marker), so
+the instance backed up twice and `schedule list` reported only the first
+(stale) entry. `apply` must now sweep every prior entry for the instance before
+writing the new one, and `list` must warn when duplicates exist.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+APPLY = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "backup_schedule_apply.yml")
+LIST = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "backup_schedule_list.yml")
+
+
+def _tasks(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _names(path):
+    return [t.get("name") for t in _tasks(path) if isinstance(t, dict)]
+
+
+def _by_name(path, name):
+    return next((t for t in _tasks(path) if t.get("name") == name), None)
+
+
+LIVE = "Remove any prior backup schedule entries for this instance (live crontab)"
+FILE = "Remove any prior backup schedule entries for this instance (host crontab file)"
+
+
+def test_apply_sweeps_both_crontab_paths():
+    for name in (LIVE, FILE):
+        t = _by_name(APPLY, name)
+        assert t is not None, "missing sweep task: %s" % name
+        cmd = t["ansible.builtin.shell"]["cmd"]
+        # Matches the same job fragment `list` uses (trailing space so
+        # 'foo' != 'foo2') plus the Canasta marker comments.
+        assert "backup create -i {{ instance_id }}" in cmd
+        assert "canasta-backup-{{ instance_id }}" in cmd
+
+
+def test_sweep_runs_before_the_write():
+    names = _names(APPLY)
+    assert names.index(LIVE) < names.index("Set cron schedule"), (
+        "live-crontab sweep must run before the cron-module write")
+    assert names.index(FILE) < names.index("Set cron schedule in the host crontab file"), (
+        "file sweep must run before the blockinfile write")
+
+
+def test_sweeps_are_gated_to_their_path():
+    # live-crontab sweep on the module path; file sweep on the mounted-file path
+    assert "not _sched_use_file" in str(_by_name(APPLY, LIVE).get("when"))
+    assert _by_name(APPLY, FILE).get("when") == "_sched_use_file"
+
+
+def test_list_warns_on_duplicate_entries():
+    t = _by_name(LIST, "Warn about duplicate schedule entries")
+    assert t is not None, "list must warn when multiple schedule entries exist"
+    assert "_schedule_lines | length > 1" in str(t.get("when"))


### PR DESCRIPTION
## Summary

Re-running `canasta backup schedule set` on an instance previously scheduled by a different Canasta version, CLI flavor (`canasta` vs `canasta-docker`), or install path **added a second crontab entry instead of replacing the first** — the instance backed up twice, and `backup schedule list` reported a stale schedule.

Closes #1069.

## Root cause

`backup_schedule_apply.yml` writes via the `cron` module (marker `#Ansible: canasta-backup-<id>`) or `blockinfile` (`# BEGIN/END canasta-backup-<id>`); each only replaces an entry with **its own** marker. An entry with a different marker/format survived, and `backup_schedule_list.yml` reported only `_schedule_lines[0]` (the first match) with no duplicate warning.

Observed on a real host (from a migrated, long-lived instance): an old daily `--older-than` entry from `/usr/local/bin/canasta` masked a freshly-set weekly `--keep-within` entry from the current CLI — `list` showed the daily one and `Auto-purge: not configured`.

## Fix

- **`apply`**: before writing, sweep **every** prior entry for the instance — the ` backup create -i <id> ` job line (the same fragment `list` matches; trailing-space-anchored so `foo` ≠ `foo2`) and any Canasta marker comment — on both the live-crontab and mounted-file paths. Exactly one entry remains regardless of who wrote the old one.
- **`list`**: warn (and show all cron expressions) when more than one entry is found.

## Tests

New `test_backup_schedule_dedupe.py` (sweep tasks exist on both paths, run before the write, are path-gated; `list` warns on duplicates). The sweep regex was also validated against the real duplicated crontab — it strips all of the instance's entries and every marker style while preserving unrelated jobs and a different instance (`wikifarm2`). Full unit suite (1713) + lint + validate green.

**Live e2e deferred** (needs a host): re-scheduling an instance with a pre-existing foreign entry should leave exactly one crontab entry.