### PR TITLE
Run the Kubernetes jobrunner job loop as www-data

### DIFF
--- a/roles/orchestrator/files/helm/canasta/templates/deployment-jobrunner.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/deployment-jobrunner.yaml
@@ -59,8 +59,14 @@ spec:
               # symlink.
               mkdir -p /mediawiki/cache
               chown www-data:www-data /mediawiki/cache
+              # Run the job loop as www-data so files jobs write to the
+              # shared images/ PVC (thumbnails, uploads-adjacent output)
+              # are owned by the same user the web pod serves as. Running
+              # as root would leave root-owned files the web tier can't
+              # later regenerate or delete. runuser mirrors the drop the
+              # image entrypoint does for the web pod.
               while true; do
-                php maintenance/runJobs.php --wait --maxjobs=10
+                runuser -u www-data -- php maintenance/runJobs.php --wait --maxjobs=10
                 sleep 5
               done
           # See deployment-web.yaml for the full explanation of the


### PR DESCRIPTION
Closes #1052.

The Kubernetes jobrunner ran `runJobs.php` as root, so files jobs wrote to the shared `images/` PVC (thumbnails and other uploads-adjacent output) landed root-owned. The web pod accesses that PVC as `www-data` and could not later regenerate or delete those files.

Drop to `www-data` with `runuser` for the job loop, mirroring the privilege drop the image entrypoint gives the web pod. The `mkdir`/`chown` of the localisation cache dir stays as root, as before.