### PR TITLE
Point a STOPPED Kubernetes instance at canasta start

### DIFF
--- a/direct_commands/info.py
+++ b/direct_commands/info.py
@@ -380,6 +380,16 @@ def cmd_status(args):
     if orchestrator in ("kubernetes", "k8s"):
         running = _helpers._check_running_k8s(inst_id, host)
         print("Status:       %s" % ("RUNNING" if running else "STOPPED"))
+        if not running:
+            # A restart runs stop (scale to zero) then start; if it is
+            # interrupted in between, the instance is stranded at zero
+            # replicas and reads as STOPPED. That end-state is identical
+            # to a deliberate stop, so point either way at the recovery.
+            print(
+                "              (workloads are scaled to zero; run "
+                "`canasta start --id %s` to bring it up. An interrupted "
+                "restart can leave an instance in this state.)" % inst_id
+            )
         ns = "canasta-%s" % inst_id
         sections = [
             ("Pods", "pods -o wide"),

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -3111,6 +3111,49 @@ class TestCanastaStatus:
         ]:
             assert piece in joined
 
+    def test_k8s_stopped_hints_at_start(self, monkeypatch, capsys):
+        monkeypatch.setattr(direct_commands._helpers, "_read_registry",
+            lambda p: {
+                "mysite": {
+                    "id": "mysite", "orchestrator": "kubernetes",
+                    "host": "node1", "path": "/home/admin/canasta-instances/mysite",
+                },
+            },
+        )
+        monkeypatch.setattr(direct_commands._helpers, "_check_running_k8s",
+            lambda inst, host: False,
+        )
+        monkeypatch.setattr(direct_commands._helpers, "_ssh_run",
+            lambda host, cmd: (0, "stub-output"),
+        )
+        rc = direct_commands.cmd_status(self._args(id="mysite"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "STOPPED" in out
+        assert "canasta start --id mysite" in out
+        assert "interrupted restart" in out
+
+    def test_k8s_running_omits_start_hint(self, monkeypatch, capsys):
+        monkeypatch.setattr(direct_commands._helpers, "_read_registry",
+            lambda p: {
+                "mysite": {
+                    "id": "mysite", "orchestrator": "kubernetes",
+                    "host": "node1", "path": "/home/admin/canasta-instances/mysite",
+                },
+            },
+        )
+        monkeypatch.setattr(direct_commands._helpers, "_check_running_k8s",
+            lambda inst, host: True,
+        )
+        monkeypatch.setattr(direct_commands._helpers, "_ssh_run",
+            lambda host, cmd: (0, "stub-output"),
+        )
+        rc = direct_commands.cmd_status(self._args(id="mysite"))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "RUNNING" in out
+        assert "canasta start" not in out
+
     def test_compose_uses_docker_compose_ps_locally(self, monkeypatch, capsys, tmp_path):
         path = str(tmp_path)
         monkeypatch.setattr(direct_commands._helpers, "_read_registry",


### PR DESCRIPTION
Closes #1051.

A Kubernetes restart runs stop (scale all workloads to zero) then start. An SSH reset or other interruption between the two strands the instance at zero replicas, where it reads as STOPPED. Recovery is simply `canasta start`, but nothing told the operator that.

That stranded end-state is byte-for-byte identical to a deliberate `canasta stop` at the cluster level (all workloads at zero, Argo CD auto-sync suspended), so there is no way to single out "stranded restart" without false-positiving on every intentional stop. Instead, `canasta status` now notes the recovery — `canasta start` — whenever a Kubernetes instance reads STOPPED, and flags that an interrupted restart can leave it that way.

Adds unit coverage for the hint appearing when STOPPED and being absent when RUNNING.