### PR TITLE
Don't print the gitops init failure message twice

### DIFF
--- a/roles/gitops/tasks/init.yml
+++ b/roles/gitops/tasks/init.yml
@@ -89,10 +89,13 @@
         - _init_existing_git.stat.exists | default(false)
       changed_when: true
 
+    # Re-raise so the play exits non-zero (a rescue otherwise "recovers" to
+    # success). The failed task already printed its own error, so reference it
+    # rather than embedding ansible_failed_result.msg — repeating it here is
+    # what printed the message twice.
     - name: Re-raise the init failure
       ansible.builtin.fail:
         msg: >-
-          gitops init failed:
-          {{ ansible_failed_result.msg | default('see the error above') }}{{
+          gitops init failed (see the error above).{{
           (reinit | default(false) | bool and _init_existing_git.stat.exists | default(false))
-          | ternary(' (the previous .git was restored, so the instance gitops link is unchanged)', '') }}
+          | ternary(' The previous .git was restored, so the instance gitops link is unchanged.', '') }}

--- a/tests/unit/test_gitops_init_error.py
+++ b/tests/unit/test_gitops_init_error.py
@@ -1,0 +1,38 @@
+"""Guard: gitops init doesn't print its failure message twice.
+
+init.yml wraps init in a block/rescue and re-raises so the play exits non-zero.
+Ansible already prints the failed task's error, so the re-raise must NOT embed
+`ansible_failed_result.msg` — doing so printed the same error a second time.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+INIT = os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "init.yml")
+
+
+def _flatten(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for key in ("block", "rescue", "always"):
+            if key in t:
+                yield from _flatten(t[key])
+
+
+def _reraise_msg():
+    with open(INIT) as f:
+        tasks = list(_flatten(yaml.safe_load(f)))
+    t = next(t for t in tasks if t.get("name") == "Re-raise the init failure")
+    return t["ansible.builtin.fail"]["msg"]
+
+
+def test_reraise_does_not_repeat_the_original_message():
+    msg = _reraise_msg()
+    assert "ansible_failed_result.msg" not in msg, (
+        "re-raise must not embed the failed task's message (it's already "
+        "printed) — that is what caused the duplicate error output")
+    assert "see the error above" in msg


### PR DESCRIPTION
## Summary

When `canasta gitops init` fails (e.g. git-crypt not installed on the target host), the same error printed twice — once for the failed task, once from the rescue's re-raise:

```
Error: git-crypt is not installed on the gitops target host. Install it with: ...
Error: gitops init failed: git-crypt is not installed on the gitops target host. Install it with: ...
```

Closes #1071.

## Fix

`roles/gitops/tasks/init.yml` wraps init in a `block/rescue` and re-raises so the play exits non-zero (a rescue otherwise recovers to success). The re-raise embedded `ansible_failed_result.msg`, repeating the message Ansible already printed. It now says `gitops init failed (see the error above).` plus the reinit `.git`-restored note, without repeating the message.

## Tests

New `test_gitops_init_error.py` (asserts the re-raise doesn't embed `ansible_failed_result.msg`). Full unit suite (1714) + lint + validate green.