### PR TITLE
Fix wiki-check in published CLI reference (title, menu, coverage test)

### DIFF
--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -110,7 +110,8 @@ def _group_subcommands(group_name):
 CMD_GROUPS = [
     ("System", ["install", "doctor", "host", "storage", "argocd", "uninstall"]),
     ("Instance management", [
-        "create", "delete", "list", "status", "upgrade", "version", "config",
+        "create", "delete", "list", "status", "wiki_check", "upgrade",
+        "version", "config",
     ]),
     ("Wiki management", ["add", "remove", "import", "export"]),
     ("Container lifecycle", [
@@ -156,7 +157,14 @@ def cmd_display_name(internal_name):
     """Convert internal name to display name (preserves hyphenated subcommands)."""
     if internal_name in _DISPLAY_NAMES:
         return _DISPLAY_NAMES[internal_name]
-    return internal_name.replace("_", " ")
+    if internal_name.split("_")[0] in SUBCOMMAND_GROUPS:
+        # Nested-group parent (e.g. 'backup_schedule'): the underscore is
+        # a group separator, so it renders with a space.
+        return internal_name.replace("_", " ")
+    # Top-level command (prefix not a subcommand group): mirror the CLI's
+    # own conversion so a name like 'wiki_check' renders 'wiki-check', not
+    # 'wiki check' (which would imply a nonexistent 'wiki' group).
+    return _canasta.display_name(internal_name)
 
 
 def cmd_page_title(internal_name):

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -200,6 +200,42 @@ def _has_command(name):
     return any(c["name"] == name for c in data["commands"])
 
 
+class TestCmdGroupsCompleteness:
+    """Every top-level command must be listed in exactly one CMD_GROUPS
+    heading, or it silently drops out of both the menu and the root
+    page. This is the reverse of TestRootPageCoverage (CMD_GROUPS ->
+    page); without it a new top-level command (e.g. 'wiki_check') merges
+    undetected and never appears in MediaWiki:Menu-cli-reference."""
+
+    def test_every_top_level_command_is_in_cmd_groups(self):
+        data = wp.load_definitions()
+        listing = [n for _heading, names in wp.CMD_GROUPS for n in names]
+        listed = set(listing)
+
+        missing = []
+        duplicated = []
+        for cmd in data["commands"]:
+            name = cmd["name"]
+            # Commands whose prefix is a subcommand group are reached via
+            # their group key (already in CMD_GROUPS) — mirror canasta.py's
+            # own top-level/grouped split.
+            if name.split("_")[0] in wp.SUBCOMMAND_GROUPS:
+                continue
+            if name not in listed:
+                missing.append(name)
+            elif listing.count(name) != 1:
+                duplicated.append(name)
+
+        assert not missing, (
+            "top-level commands missing from CMD_GROUPS (won't appear in "
+            "menu/root page):\n  " + "\n  ".join(missing)
+        )
+        assert not duplicated, (
+            "commands listed in CMD_GROUPS more than once:\n  "
+            + "\n  ".join(duplicated)
+        )
+
+
 class TestCwdResolutionFootnote:
     """Non-required -i flags get a cwd-resolution footnote in the
     flags table. Required -i (create) does not, because there's no


### PR DESCRIPTION
Fixes #1075. Follow-up to #570, which added the `wiki_check` command but whose auto-published CLI reference was incorrect.

`wiki_check` is the first top-level command with an underscore whose prefix (`wiki`) is not a subcommand group. The publisher assumed every underscore is a group separator, so the command was published as `CLI:Canasta wiki check` and omitted from the menu.

## Changes

- **Page title:** `cmd_display_name()` now mirrors `canasta.py`s `display_name` for top-level commands (`_` -> `-`), so `wiki_check` renders `wiki-check` instead of `wiki check`. Nested-group parents (e.g. `backup_schedule`) still render with a space.
- **Menu / root page:** add `wiki_check` to `CMD_GROUPS` under **Instance management** (alongside `status`/`list`), so it appears in `MediaWiki:Menu-cli-reference` and the root `CLI:canasta` page.
- **Coverage test:** assert every top-level command appears in exactly one `CMD_GROUPS` heading. The existing tests only checked the `CMD_GROUPS` -> page direction, so a top-level command omitted from `CMD_GROUPS` merged undetected — this is what let #570 through. Verified the new test fails without the `CMD_GROUPS` entry.

## Verification

- Full unit suite passes (1719 tests); `make validate` passes.
- Dry-run confirms `CLI:canasta wiki-check` is generated with correct menu and root-page entries.

After merge, the publish workflow re-runs on `main` with `--prune`: it creates `CLI:Canasta wiki-check`, deletes the orphaned `CLI:Canasta wiki check`, and corrects the menu.