### PR TITLE
Add --purge to canasta upgrade to reclaim superseded images

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -900,11 +900,18 @@ commands:
       on its own. Pass --allow-major to move to the latest release overall,
       including a new major version (which may include breaking changes).
       Pass --dev to track the development branch (head of main) instead.
+
+      Pass --purge to reclaim disk after the upgrade: each upgraded host has
+      the Canasta images the upgrade superseded removed (only those no
+      container or pod still references), dangling sidecar-rebuild layers
+      pruned, and — on Kubernetes — the in-cluster registry garbage-collected.
+      Volumes are never touched.
     examples:
       - "canasta upgrade"
       - "canasta upgrade --allow-major"
       - "canasta upgrade --dev"
       - "canasta upgrade --dry-run"
+      - "canasta upgrade --purge"
     playbook: upgrade.yml
     parameters:
       - name: dry_run
@@ -919,6 +926,10 @@ commands:
         type: bool
         default: false
         description: "Allow upgrading across a major version boundary to the latest release overall (may include breaking changes)"
+      - name: purge
+        type: bool
+        default: false
+        description: "After upgrading, reclaim disk by removing images the upgrade superseded (never removes in-use images or volumes)"
 
   # ---------------------------------------------------------------------------
   # Wiki management

--- a/playbooks/_purge_host.yml
+++ b/playbooks/_purge_host.yml
@@ -1,0 +1,119 @@
+---
+# Reclaim images an upgrade superseded on a single host. Called once per
+# distinct host from upgrade.yml when --purge is passed, after every instance
+# on that host has finished upgrading.
+# Input: _purge_host_name (registry host string: 'localhost' or 'user@host')
+#
+# Deliberately narrow — never touches volumes and never blanket-removes images
+# still in use:
+#   * Compose/Docker: remove superseded ghcr.io/canastawiki/canasta tags that
+#     no container references (Docker refuses to remove an in-use image, so a
+#     tag still run by another instance is skipped), then prune dangling layers
+#     left by sidecar rebuilds.
+#   * Kubernetes: prune containerd images no pod references, then garbage-
+#     collect the in-cluster registry.
+
+- name: "Purging superseded images on host '{{ _purge_host_name }}'"
+  ansible.builtin.debug:
+    msg: "Reclaiming images superseded by the upgrade on {{ _purge_host_name }}..."
+
+- name: Point the connection at the host
+  ansible.builtin.set_fact:
+    _instance_host: "{{ _purge_host_name }}"
+
+- name: Switch connection to the host
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/switch_connection.yml"
+
+# --- Docker / Compose reclaim ---
+- name: Probe for a working Docker daemon
+  ansible.builtin.command:
+    cmd: docker info --format '{% raw %}{{.ServerVersion}}{% endraw %}'
+  register: _purge_docker
+  changed_when: false
+  failed_when: false
+
+- name: Reclaim superseded Canasta images (Docker)
+  when: _purge_docker.rc == 0
+  block:
+    - name: List Canasta base images on the host
+      ansible.builtin.command:
+        cmd: >-
+          docker images ghcr.io/canastawiki/canasta
+          --format {% raw %}'{{.Repository}}:{{.Tag}}'{% endraw %}
+      register: _purge_images
+      changed_when: false
+
+    # No --force: Docker refuses to remove an image any container (running or
+    # stopped) still references, so a tag another instance on this host is
+    # pinned to is skipped rather than yanked out from under it. Only tags left
+    # dangling by the upgrade actually get removed.
+    - name: Remove superseded Canasta image tags no container references
+      ansible.builtin.command:
+        cmd: "docker image rm {{ _purge_image_ref }}"
+      loop: >-
+        {{ _purge_images.stdout_lines
+           | reject('search', ':<none>')
+           | reject('equalto', '')
+           | list }}
+      loop_control:
+        loop_var: _purge_image_ref
+      register: _purge_removed
+      changed_when: "'Untagged' in stdout or 'Deleted' in stdout"
+      failed_when: false
+
+    # Dangling (<none>) layers orphaned by rebuilding `build:` sidecars under
+    # the same tag, plus intermediate build layers. Referenced by nothing, so
+    # this cannot affect a stopped instance or any volume.
+    - name: Prune dangling images (sidecar rebuild orphans)
+      ansible.builtin.command:
+        cmd: docker image prune -f
+      register: _purge_dangling
+      changed_when: "'Total reclaimed space: 0B' not in _purge_dangling.stdout"
+
+    - name: Report Docker reclaim
+      ansible.builtin.debug:
+        msg: >-
+          Docker: removed
+          {{ _purge_removed.results | default([])
+             | selectattr('stdout', 'search', 'Untagged|Deleted')
+             | list | length }}
+          superseded Canasta tag(s);
+          {{ ((_purge_dangling.stdout_lines | default([])
+               | select('search', 'Total reclaimed space')
+               | list) or ['no dangling layers']) | first }}
+
+# --- Kubernetes reclaim ---
+- name: Probe for a Kubernetes cluster on the host
+  ansible.builtin.command:
+    cmd: kubectl get nodes -o name
+  register: _purge_k8s
+  changed_when: false
+  failed_when: false
+
+- name: Reclaim superseded images (Kubernetes)
+  when: _purge_k8s.rc == 0
+  block:
+    # crictl rmi --prune removes only images no pod references, so pods running
+    # the just-upgraded tag keep their image while the superseded one goes.
+    - name: Prune containerd images no pod references
+      ansible.builtin.shell:
+        cmd: >-
+          if command -v crictl >/dev/null 2>&1; then crictl rmi --prune;
+          elif command -v k3s >/dev/null 2>&1; then k3s crictl rmi --prune;
+          else echo 'no crictl on host'; fi
+      register: _purge_crictl
+      changed_when: "'Deleted' in _purge_crictl.stdout"
+      failed_when: false
+
+    - name: Report containerd reclaim
+      ansible.builtin.debug:
+        msg: >-
+          containerd:
+          {{ (_purge_crictl.stdout_lines | default([])
+              | select('search', 'Deleted')
+              | list | length) }}
+          image(s) removed.
+
+    - name: Garbage-collect the in-cluster registry
+      ansible.builtin.include_tasks: >-
+        {{ canasta_root }}/roles/orchestrator/tasks/registry_gc.yml

--- a/playbooks/image_prune.yml
+++ b/playbooks/image_prune.yml
@@ -1,12 +1,10 @@
 ---
 # canasta image prune - Garbage-collect the in-cluster image registry.
 #
-# Repeated pushes of the same tag (the :local tags used by --build-from,
-# build: sidecars, and image push) orphan the previous push's layers, and
-# nothing else ever garbage-collects them. This runs the registry's own
-# garbage collector (--delete-untagged) inside the registry pod, then
-# restarts the deployment so its in-memory blob cache matches the pruned
-# store.
+# The garbage-collection itself lives in the shared registry_gc.yml task so
+# `canasta upgrade --purge` can reuse it. This command wraps it with a hard
+# failure when the host has no Kubernetes cluster, since running it there is
+# always an operator mistake.
 
 - name: Probe for a Kubernetes cluster on the host
   ansible.builtin.command:
@@ -22,61 +20,6 @@
       host, and no cluster was found here.
   when: _prune_k8s.rc != 0
 
-- name: Check the in-cluster registry is deployed
-  ansible.builtin.command:
-    cmd: kubectl -n canasta-registry get deploy/registry -o name
-  register: _prune_reg
-  changed_when: false
-  failed_when: false
-
-- name: Report when there is no registry to prune
-  ansible.builtin.debug:
-    msg: >-
-      No in-cluster registry is deployed on this cluster; nothing to
-      prune. (It is created by k8s-cp install, create --build-from, or
-      image push.)
-  when: _prune_reg.rc != 0
-
-# Re-apply the registry manifests before pruning so a registry deployed
-# by an older CLI picks up spec fixes (e.g. the Recreate strategy the
-# restart below depends on) instead of deadlocking its rollout.
-- name: Ensure the registry manifests are current
+- name: Garbage-collect the in-cluster registry
   ansible.builtin.include_tasks: >-
-    {{ canasta_root }}/roles/orchestrator/tasks/k8s_ensure_registry.yml
-  when: _prune_reg.rc == 0
-
-- name: Garbage-collect manifests no tag references, and their layers
-  ansible.builtin.command:
-    cmd: >-
-      kubectl -n canasta-registry exec deploy/registry --
-      registry garbage-collect --delete-untagged
-      /etc/docker/registry/config.yml
-  register: _prune_gc
-  changed_when: true
-  when: _prune_reg.rc == 0
-
-# The running registry caches blob existence in memory; after an
-# on-disk GC it can serve stale metadata and reject re-pushes of
-# deleted blobs. A restart re-reads the pruned store.
-- name: Restart the registry
-  ansible.builtin.command:
-    cmd: kubectl -n canasta-registry rollout restart deploy/registry
-  changed_when: true
-  when: _prune_reg.rc == 0
-
-- name: Wait for the registry to come back
-  ansible.builtin.command:
-    cmd: >-
-      kubectl -n canasta-registry rollout status deploy/registry
-      --timeout=180s
-  changed_when: false
-  when: _prune_reg.rc == 0
-
-- name: Report the prune result
-  ansible.builtin.debug:
-    msg: >-
-      {{ (_prune_gc.stdout_lines | default([])
-          | select('search', 'eligible for deletion|blobs marked')
-          | list)
-         or ['Garbage collection completed.'] }}
-  when: _prune_reg.rc == 0
+    {{ canasta_root }}/roles/orchestrator/tasks/registry_gc.yml

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -18,12 +18,23 @@
   register: _upgrade_instances
 
 - name: Report dry run
-  ansible.builtin.debug:
-    msg: >-
-      Dry run - would upgrade
-      {{ _upgrade_instances.instances | length }} instance(s):
-      {{ _upgrade_instances.instances.keys() | list | join(', ') }}
   when: dry_run | default(false) | bool
+  block:
+    - name: Report instances that would upgrade
+      ansible.builtin.debug:
+        msg: >-
+          Dry run - would upgrade
+          {{ _upgrade_instances.instances | length }} instance(s):
+          {{ _upgrade_instances.instances.keys() | list | join(', ') }}
+
+    - name: Report purge that would run
+      ansible.builtin.debug:
+        msg: >-
+          Dry run - would then purge images superseded by the upgrade on:
+          {{ _upgrade_instances.instances.values()
+             | map(attribute='host') | map('default', 'localhost')
+             | unique | list | join(', ') }}
+      when: purge | default(false) | bool
 
 - name: Upgrade each instance
   when: not (dry_run | default(false) | bool)
@@ -38,3 +49,16 @@
     - name: Report upgrade complete
       ansible.builtin.debug:
         msg: "Upgraded {{ _upgrade_instances.instances | length }} instance(s)."
+
+    # --- Purge superseded images (--purge) ---
+    # Runs once per distinct host after all its instances have upgraded, so
+    # the per-host prune / registry restart happens once, not per instance.
+    - name: Purge superseded images
+      ansible.builtin.include_tasks: _purge_host.yml
+      loop: >-
+        {{ _upgrade_instances.instances.values()
+           | map(attribute='host') | map('default', 'localhost')
+           | unique | list }}
+      loop_control:
+        loop_var: _purge_host_name
+      when: purge | default(false) | bool

--- a/roles/orchestrator/tasks/registry_gc.yml
+++ b/roles/orchestrator/tasks/registry_gc.yml
@@ -1,0 +1,73 @@
+---
+# Garbage-collect the in-cluster image registry (Kubernetes).
+#
+# Repeated pushes of the same tag (the :local tags used by --build-from,
+# build: sidecars, and image push) orphan the previous push's layers, and
+# nothing else ever garbage-collects them. This runs the registry's own
+# garbage collector (--delete-untagged) inside the registry pod, then
+# restarts the deployment so its in-memory blob cache matches the pruned
+# store.
+#
+# Assumes the caller has already confirmed a Kubernetes cluster is present
+# on the host. Skips cleanly when no registry is deployed, so it is safe to
+# call unconditionally on any cluster. Shared by `canasta image prune` and
+# `canasta upgrade --purge`.
+
+- name: Check the in-cluster registry is deployed
+  ansible.builtin.command:
+    cmd: kubectl -n canasta-registry get deploy/registry -o name
+  register: _prune_reg
+  changed_when: false
+  failed_when: false
+
+- name: Report when there is no registry to prune
+  ansible.builtin.debug:
+    msg: >-
+      No in-cluster registry is deployed on this cluster; nothing to
+      prune. (It is created by k8s-cp install, create --build-from, or
+      image push.)
+  when: _prune_reg.rc != 0
+
+# Re-apply the registry manifests before pruning so a registry deployed
+# by an older CLI picks up spec fixes (e.g. the Recreate strategy the
+# restart below depends on) instead of deadlocking its rollout.
+- name: Ensure the registry manifests are current
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/k8s_ensure_registry.yml
+  when: _prune_reg.rc == 0
+
+- name: Garbage-collect manifests no tag references, and their layers
+  ansible.builtin.command:
+    cmd: >-
+      kubectl -n canasta-registry exec deploy/registry --
+      registry garbage-collect --delete-untagged
+      /etc/docker/registry/config.yml
+  register: _prune_gc
+  changed_when: true
+  when: _prune_reg.rc == 0
+
+# The running registry caches blob existence in memory; after an
+# on-disk GC it can serve stale metadata and reject re-pushes of
+# deleted blobs. A restart re-reads the pruned store.
+- name: Restart the registry
+  ansible.builtin.command:
+    cmd: kubectl -n canasta-registry rollout restart deploy/registry
+  changed_when: true
+  when: _prune_reg.rc == 0
+
+- name: Wait for the registry to come back
+  ansible.builtin.command:
+    cmd: >-
+      kubectl -n canasta-registry rollout status deploy/registry
+      --timeout=180s
+  changed_when: false
+  when: _prune_reg.rc == 0
+
+- name: Report the prune result
+  ansible.builtin.debug:
+    msg: >-
+      {{ (_prune_gc.stdout_lines | default([])
+          | select('search', 'eligible for deletion|blobs marked')
+          | list)
+         or ['Garbage collection completed.'] }}
+  when: _prune_reg.rc == 0


### PR DESCRIPTION
Closes #1080.

## What

Adds an opt-in `--purge` flag to `canasta upgrade`. After the upgrade completes, it reclaims the disk the upgrade would otherwise leak — old images and orphaned layers that accumulate until a host runs out of space mid-upgrade.

Default behavior is unchanged; cleanup only happens when `--purge` is passed.

## How

Runs once per distinct upgraded host (not per instance, so a K8s registry restart/prune happens once), composed of three deliberately narrow mechanisms:

- **Docker/Compose** — remove superseded `ghcr.io/canastawiki/canasta` tags with `docker image rm` (no `--force`, so a tag another instance still runs is skipped rather than yanked), then `docker image prune -f` for dangling layers left by rebuilding `build:` sidecars.
- **Kubernetes** — `crictl rmi --prune` for containerd images no pod references, then garbage-collect the in-cluster registry (the sidecar-push orphans).

Volumes are never touched, and `-a`-style blanket removal is never used, so a stopped instance never loses its image.

The registry-GC body is extracted from `image_prune.yml` into `roles/orchestrator/tasks/registry_gc.yml` and shared by both `canasta image prune` and `upgrade --purge`.

## Testing

- `make lint`, `make validate`, `make test-unit` (1720 passed), `make docs` — all green
- `ansible-playbook --syntax-check` on the dispatcher for `upgrade` and `image`
- End-to-end `upgrade --dry-run --purge` against an isolated empty registry
- Verified against a live Docker daemon that no-force `docker image rm` refuses a sole-tagged in-use image (`conflict: ... must be forced`), which is swallowed so the image is kept