### PR TITLE
Fix gitops reinit leaving a stale Argo CD source block

### DIFF
--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -537,9 +537,14 @@
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/gitops/tasks/_apply_argo_repo_secret.yml"
 
 # --- Register Argo CD Application ---
+# force: replace rather than merge, so switching source type on reinit
+# (e.g. helm -> plugin when enabling --encrypt-secrets) drops the old
+# source block. A plain apply leaves both, and Argo refuses an
+# Application with two source types (ComparisonError, no reconcile).
 - name: Apply Argo CD Application to cluster
   kubernetes.core.k8s:
     state: present
+    force: true
     src: "{{ instance_path }}/argocd/application.yaml"
 
 - name: Report gitops initialized

--- a/roles/gitops/tasks/join_kubernetes.yml
+++ b/roles/gitops/tasks/join_kubernetes.yml
@@ -362,9 +362,13 @@
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_ensure_sops_sidecar.yml"
   when: gitops_sops_secrets | default(false) | bool
 
+# force: replace rather than merge, so a re-join with a changed source
+# type fully overwrites the old source block instead of leaving both
+# (Argo refuses an Application with two source types).
 - name: Apply Argo CD Application to cluster
   kubernetes.core.k8s:
     state: present
+    force: true
     src: "{{ instance_path }}/argocd/application.yaml"
 
 # --- Commit and push ---

--- a/tests/unit/test_gitops_sops_scaffold.py
+++ b/tests/unit/test_gitops_sops_scaffold.py
@@ -7,6 +7,7 @@ import yaml
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 INITK8S = os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "init_kubernetes.yml")
+JOINK8S = os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "join_kubernetes.yml")
 INITSOPS = os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "_init_sops.yml")
 GDEFAULTS = os.path.join(REPO_ROOT, "roles", "gitops", "defaults", "main.yml")
 BOOTSTRAP = os.path.join(REPO_ROOT, "roles", "orchestrator", "tasks",
@@ -43,6 +44,19 @@ def test_argo_app_source_is_gated_plugin_vs_helm():
     # CMP plugin branch (enabled) + native helm branch (default) both present.
     assert "plugin:" in c and "helm-sops" in c
     assert "valueFiles:" in c
+
+
+def test_argo_app_apply_forces_replace():
+    # Switching source type on reinit/re-join (helm <-> plugin) must fully
+    # replace the Application; a merge apply leaves both source blocks and
+    # Argo then refuses to reconcile (multiple application sources defined).
+    for path in (INITK8S, JOINK8S):
+        apply = [t for t in _flatten(yaml.safe_load(_read(path)))
+                 if t.get("name") == "Apply Argo CD Application to cluster"]
+        assert apply, "%s must apply the Argo CD Application" % path
+        k8s = apply[0]["kubernetes.core.k8s"]
+        assert k8s.get("force") is True, \
+            "Application apply in %s must force: true (replace, not merge)" % path
 
 
 def test_init_kubernetes_gates_sops_include():


### PR DESCRIPTION
Closes #1083

Converting an existing Kubernetes gitops instance to `--encrypt-secrets` via reinit switched the Application's `source.helm` to `source.plugin`, but the apply used `kubernetes.core.k8s: state: present` (a merge), which added `plugin` without removing `helm`. Argo refuses an Application with two source types (`ComparisonError: multiple application sources defined: Helm,Plugin`) and stops reconciling.

Apply the Application with `force: true` so the on-disk manifest fully replaces the live object, dropping the old source block on any source-type switch. Applied to both `init_kubernetes.yml` and `join_kubernetes.yml`.

Added a unit test asserting both apply tasks use `force: true`.