### PR TITLE
Surface working-tree changes in gitops status on Kubernetes

### DIFF
--- a/direct_commands/gitops.py
+++ b/direct_commands/gitops.py
@@ -74,8 +74,9 @@ def _wikis_uncaptured_edit(live_raw, tmpl_raw):
     invisible to git status until 'gitops add' reconciles it. Compare the
     two per wiki id, ignoring the host-specific url (a {{placeholder}} in
     the template), so the advisory fires only on a genuine uncaptured edit.
-    Returns False when either file is absent or unparseable (e.g. non-gitops
-    or K8s gitops, which has no wikis.yaml.template).
+    Returns False when either file is absent or unparseable (e.g. a
+    non-gitops instance, or one whose wikis.yaml.template has not been
+    created/backfilled yet). Applies to both Compose and K8s gitops.
     """
     if not (live_raw or "").strip() or not (tmpl_raw or "").strip():
         return False
@@ -100,6 +101,55 @@ def _wikis_uncaptured_edit(live_raw, tmpl_raw):
     return _by_id(live) != _by_id(tmpl)
 
 
+def _parse_working_tree_changes(parts):
+    """Extract (staged, unstaged, untracked, wikis_drift) from the shared
+    status-probe output (see _gitops_status_script). Used by both the Compose
+    and K8s formatters so their working-tree advisories can't diverge."""
+    staged_raw = parts[4].strip() if len(parts) > 4 else ""
+    unstaged_raw = parts[5].strip() if len(parts) > 5 else ""
+    staged = staged_raw.split("\n") if staged_raw else []
+    unstaged = unstaged_raw.split("\n") if unstaged_raw else []
+
+    live_wikis_raw = parts[7] if len(parts) > 7 else ""
+    tmpl_wikis_raw = parts[8] if len(parts) > 8 else ""
+    wikis_drift = _wikis_uncaptured_edit(live_wikis_raw, tmpl_wikis_raw)
+
+    # parts[9] is `git status --porcelain`; untracked entries are the
+    # '?? <path>' lines (staged/modified come from the git diff sections).
+    status_raw = parts[9].strip() if len(parts) > 9 else ""
+    untracked = [ln[3:] for ln in status_raw.split("\n") if ln.startswith("?? ")]
+    return staged, unstaged, untracked, wikis_drift
+
+
+def _working_tree_advisory_lines(staged, unstaged, untracked, wikis_drift):
+    """Advisory lines for uncommitted / untracked / uncaptured working-tree
+    changes. Empty list when the tree is clean."""
+    lines = []
+    if staged:
+        lines.append("Staged for push (%d files):" % len(staged))
+        lines.extend("  %s" % f for f in staged)
+        lines.append("")
+    if unstaged:
+        lines.append("Unstaged changes (%d files):" % len(unstaged))
+        lines.extend("  %s" % f for f in unstaged)
+        lines.append("")
+    if untracked:
+        lines.append("Untracked files (%d):" % len(untracked))
+        lines.extend("  %s" % f for f in untracked)
+        lines.append(
+            "  capture with 'canasta gitops add <file>' (or add to .gitignore)."
+        )
+        lines.append("")
+    if wikis_drift:
+        lines.append("Uncaptured config/wikis.yaml edits (e.g. wiki display name):")
+        lines.append(
+            "  run 'canasta gitops add config/wikis.yaml' to capture and "
+            "stage them."
+        )
+        lines.append("")
+    return lines
+
+
 def _parse_gitops_status(stdout, instance_id):
     """Parse the batched gitops status output into a formatted string."""
     parts = stdout.split(_helpers._SENTINEL + "\n")
@@ -122,24 +172,9 @@ def _parse_gitops_status(stdout, instance_id):
 
     commit = parts[2].strip() if len(parts) > 2 else "none"
     applied = parts[3].strip() if len(parts) > 3 else "none"
-    staged_raw = parts[4].strip() if len(parts) > 4 else ""
-    unstaged_raw = parts[5].strip() if len(parts) > 5 else ""
     revcount_raw = parts[6].strip() if len(parts) > 6 else "0\t0"
 
-    staged = staged_raw.split("\n") if staged_raw else []
-    unstaged = unstaged_raw.split("\n") if unstaged_raw else []
-
-    live_wikis_raw = parts[7] if len(parts) > 7 else ""
-    tmpl_wikis_raw = parts[8] if len(parts) > 8 else ""
-    wikis_drift = _wikis_uncaptured_edit(live_wikis_raw, tmpl_wikis_raw)
-
-    # parts[9] is `git status --porcelain`; untracked entries are the
-    # '?? <path>' lines (staged/modified come from git diff above).
-    status_raw = parts[9].strip() if len(parts) > 9 else ""
-    untracked = [
-        ln[3:] for ln in status_raw.split("\n")
-        if ln.startswith("?? ")
-    ]
+    staged, unstaged, untracked, wikis_drift = _parse_working_tree_changes(parts)
 
     try:
         revcount_parts = revcount_raw.split("\t")
@@ -173,36 +208,10 @@ def _parse_gitops_status(stdout, instance_id):
         "",
     ]
 
-    if staged:
-        lines.append("Staged for push (%d files):" % len(staged))
-        for f in staged:
-            lines.append("  %s" % f)
-        lines.append("")
-
-    if unstaged:
-        lines.append("Unstaged changes (%d files):" % len(unstaged))
-        for f in unstaged:
-            lines.append("  %s" % f)
-        lines.append("")
-
-    if untracked:
-        lines.append("Untracked files (%d):" % len(untracked))
-        for f in untracked:
-            lines.append("  %s" % f)
-        lines.append(
-            "  capture with 'canasta gitops add <file>' (or add to .gitignore)."
-        )
-        lines.append("")
-
-    if wikis_drift:
-        lines.append("Uncaptured config/wikis.yaml edits (e.g. wiki display name):")
-        lines.append(
-            "  run 'canasta gitops add config/wikis.yaml' to capture and "
-            "stage them."
-        )
-        lines.append("")
-
-    if not staged and not unstaged and not untracked and not wikis_drift:
+    changes = _working_tree_advisory_lines(staged, unstaged, untracked, wikis_drift)
+    if changes:
+        lines.extend(changes)
+    else:
         lines.append("No changes.")
         lines.append("")
 
@@ -281,6 +290,11 @@ def _parse_gitops_status_k8s(stdout, instance_id, argocd):
 
     sync_status, health, last_sync, revision = argocd
 
+    # Uncommitted/untracked working-tree changes and uncaptured config/wikis.yaml
+    # edits apply to K8s gitops too (e.g. an upgrade backfilling
+    # wikis.yaml.template), so surface the same advisories as the Compose path.
+    staged, unstaged, untracked, wikis_drift = _parse_working_tree_changes(parts)
+
     lines = [
         "Host:             %s" % hostname,
         "Canasta ID:       %s" % instance_id,
@@ -288,12 +302,17 @@ def _parse_gitops_status_k8s(stdout, instance_id, argocd):
         "Ahead of remote:  %d" % ahead,
         "Behind remote:    %d" % behind,
         "",
+    ]
+    lines.extend(
+        _working_tree_advisory_lines(staged, unstaged, untracked, wikis_drift)
+    )
+    lines.extend([
         "Argo CD:",
         "  Sync status:    %s" % sync_status,
         "  Health status:  %s" % health,
         "  Last sync:      %s" % last_sync,
         "  Applied rev:    %s" % revision,
-    ]
+    ])
     if sync_status == "OutOfSync":
         lines.append("")
         lines.append("Note: Run 'canasta gitops sync' to apply pending changes immediately.")

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2491,19 +2491,29 @@ class TestGitopsArgocdStatus:
 
 
 class TestParseGitopsStatusK8s:
-    def _make_output(self, hostname="myhost", commit="abc1234", revcount="0\t0"):
+    def _make_output(self, hostname="myhost", commit="abc1234", revcount="0\t0",
+                     staged="", unstaged="", wikis=None, template=None,
+                     untracked=None):
         d = direct_commands._SENTINEL
-        # K8s parser only reads hostname (0), commit (2), revcount (6).
-        # Fill the unread slots with empty strings for the split to align.
-        return (
+        # Parts: hostname (0), hosts.yaml (1), commit (2), applied (3),
+        # staged (4), unstaged (5), revcount (6), then optionally
+        # wikis (7), template (8), git-status porcelain (9).
+        out = (
             hostname + "\n" + d + "\n"
             + "\n" + d + "\n"
             + commit + "\n" + d + "\n"
             + "\n" + d + "\n"
-            + "\n" + d + "\n"
-            + "\n" + d + "\n"
+            + staged + "\n" + d + "\n"
+            + unstaged + "\n" + d + "\n"
             + revcount + "\n"
         )
+        if wikis is not None or template is not None or untracked is not None:
+            out += (
+                d + "\n" + (wikis or "") + "\n"
+                + d + "\n" + (template or "") + "\n"
+                + d + "\n" + (untracked or "")
+            )
+        return out
 
     def test_synced_healthy(self):
         out = self._make_output()
@@ -2538,6 +2548,36 @@ class TestParseGitopsStatusK8s:
         result = direct_commands._parse_gitops_status_k8s(out, "mysite", argocd)
         assert "Ahead of remote:  3" in result
         assert "Behind remote:    2" in result
+
+    def test_untracked_files_surfaced(self):
+        # A K8s instance with an uncaptured file (e.g. wikis.yaml.template
+        # backfilled by an upgrade) must flag it, not just report Ahead: 0.
+        out = self._make_output(untracked="?? wikis.yaml.template")
+        argocd = ("Synced", "Healthy", "never", "unknown")
+        result = direct_commands._parse_gitops_status_k8s(out, "mysite", argocd)
+        assert "Untracked files (1):" in result
+        assert "wikis.yaml.template" in result
+        assert "canasta gitops add" in result
+        # Advisory must not shadow the Argo section.
+        assert "Sync status:    Synced" in result
+
+    def test_uncaptured_wikis_edit_surfaced(self):
+        live = "wikis:\n- id: main\n  url: rs.example.com\n  name: New Name\n"
+        tmpl = "wikis:\n  - id: main\n    url: {{wiki_url_main}}\n    name: \"main\"\n"
+        out = self._make_output(wikis=live, template=tmpl)
+        argocd = ("Synced", "Healthy", "never", "unknown")
+        result = direct_commands._parse_gitops_status_k8s(out, "mysite", argocd)
+        assert "Uncaptured config/wikis.yaml edits" in result
+
+    def test_clean_tree_shows_no_advisory(self):
+        # No working-tree changes: the Argo section renders as before, with
+        # none of the advisory headers.
+        out = self._make_output(untracked="")
+        argocd = ("Synced", "Healthy", "never", "unknown")
+        result = direct_commands._parse_gitops_status_k8s(out, "mysite", argocd)
+        assert "Untracked files" not in result
+        assert "Uncaptured config/wikis.yaml edits" not in result
+        assert "Argo CD:" in result
 
 
 class TestCmdGitopsStatusK8s:


### PR DESCRIPTION
Closes #1086

`canasta gitops status` on a Kubernetes instance reported only commit / ahead-behind / Argo status, dropping the untracked-files and uncaptured `config/wikis.yaml` advisories that the Compose path shows — even though the status probe already gathers that data. So when `canasta upgrade` backfills `wikis.yaml.template` (leaving `config/wikis.yaml` to be captured with `gitops add`/`push`), `gitops status` gave no reminder: it showed `Ahead of remote: 0` because the pending item is an uncommitted working-tree file, not a commit.

Extract the working-tree parsing (`_parse_working_tree_changes`) and advisory formatting (`_working_tree_advisory_lines`) into shared helpers used by **both** the Compose and K8s formatters, and wire them into the K8s path. Compose output is unchanged (same helpers, refactored). Also corrects the stale `_wikis_uncaptured_edit` docstring that assumed K8s gitops has no `wikis.yaml.template`.

Added unit tests for the K8s path: untracked file surfaced, uncaptured wikis.yaml edit surfaced, and a clean tree still renders the Argo section with no advisory.