### PR TITLE
Point untracked wikis.yaml.template advisory at config/wikis.yaml

### DIFF
--- a/direct_commands/gitops.py
+++ b/direct_commands/gitops.py
@@ -136,9 +136,20 @@ def _working_tree_advisory_lines(staged, unstaged, untracked, wikis_drift):
     if untracked:
         lines.append("Untracked files (%d):" % len(untracked))
         lines.extend("  %s" % f for f in untracked)
-        lines.append(
-            "  capture with 'canasta gitops add <file>' (or add to .gitignore)."
-        )
+        # wikis.yaml.template is captured by reconciling the live
+        # config/wikis.yaml, not a plain 'gitops add' of the template — the
+        # latter skips the reconcile and can stage a stale template, dropping
+        # an uncaptured config/wikis.yaml edit. Point at the right command.
+        if "wikis.yaml.template" in untracked:
+            lines.append(
+                "  for wikis.yaml.template, run "
+                "'canasta gitops add config/wikis.yaml'."
+            )
+        if any(f != "wikis.yaml.template" for f in untracked):
+            lines.append(
+                "  capture with 'canasta gitops add <file>' "
+                "(or add to .gitignore)."
+            )
         lines.append("")
     if wikis_drift:
         lines.append("Uncaptured config/wikis.yaml edits (e.g. wiki display name):")

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2218,6 +2218,22 @@ class TestParseGitopsStatus:
         # Untracked files mean there ARE changes — must not claim otherwise.
         assert "No changes." not in result
 
+    def test_untracked_wikis_template_points_at_config(self):
+        # A plain 'gitops add wikis.yaml.template' skips the reconcile; the
+        # advisory must route to 'gitops add config/wikis.yaml' instead.
+        out = self._make_output(untracked="?? wikis.yaml.template")
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "canasta gitops add config/wikis.yaml" in result
+        assert "gitops add <file>" not in result
+
+    def test_untracked_mixed_shows_both_hints(self):
+        out = self._make_output(
+            untracked="?? wikis.yaml.template\n?? hosts/hosts.yaml",
+        )
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "canasta gitops add config/wikis.yaml" in result
+        assert "gitops add <file>" in result  # generic hint for hosts.yaml
+
     def test_untracked_does_not_break_clean_status(self):
         out = self._make_output(untracked="")
         result = direct_commands._parse_gitops_status(out, "mysite")
@@ -2557,7 +2573,9 @@ class TestParseGitopsStatusK8s:
         result = direct_commands._parse_gitops_status_k8s(out, "mysite", argocd)
         assert "Untracked files (1):" in result
         assert "wikis.yaml.template" in result
-        assert "canasta gitops add" in result
+        # Must point at the reconcile command, not a plain add of the template.
+        assert "canasta gitops add config/wikis.yaml" in result
+        assert "gitops add <file>" not in result
         # Advisory must not shadow the Argo section.
         assert "Sync status:    Synced" in result
 


### PR DESCRIPTION
Closes #1088

The untracked-files advisory in `canasta gitops status` told users to `canasta gitops add <file>`. For `wikis.yaml.template` that resolves to `gitops add wikis.yaml.template` — a plain `git add` that **skips the reconcile**. `gitops add config/wikis.yaml` is the correct path: it regenerates the template from the live config (placeholdering URLs, capturing display names) and stages it. The generic hint stages the template as-is, and if `config/wikis.yaml` was edited it drops that edit — also contradicting the existing wikis-drift advisory.

Special-case `wikis.yaml.template` in the untracked advisory to recommend `canasta gitops add config/wikis.yaml`; other untracked files keep the generic `gitops add <file>` hint. Both hints appear when a mix is untracked.

Added unit tests: the wikis template routes to config/wikis.yaml (and not the generic hint), and a mixed untracked set shows both hints. Follow-up to #1087.