### PR TITLE
Always render Caddy http-only on Kubernetes (behind-proxy)

### DIFF
--- a/roles/orchestrator/tasks/rewrite_caddy.yml
+++ b/roles/orchestrator/tasks/rewrite_caddy.yml
@@ -16,7 +16,15 @@
 
 - name: Determine Caddyfile parameters
   ansible.builtin.set_fact:
-    _http_only: "{{ _env_caddy.variables.CADDY_AUTO_HTTPS | default('on') | lower == 'off' }}"
+    # On K8s the ingress (Traefik) terminates TLS and forwards plain HTTP to
+    # Caddy, so Caddy must serve HTTP-only with no HTTP->HTTPS redirect — else
+    # it loops behind the ingress (sees HTTP, redirects to HTTPS, ingress
+    # terminates, forwards HTTP, ...). Force http-only on K8s regardless of
+    # CADDY_AUTO_HTTPS, which a cross-orchestrator restore can leave unset/on.
+    # Compose (where Caddy is the TLS edge) keeps the .env-driven behavior.
+    _http_only: >-
+      {{ (instance_orchestrator | default('compose') in ['kubernetes', 'k8s'])
+         or (_env_caddy.variables.CADDY_AUTO_HTTPS | default('on') | lower == 'off') }}
     _observable: "{{ _env_caddy.variables.CANASTA_ENABLE_OBSERVABILITY | default('false') | lower == 'true' }}"
     _varnish_enabled: "{{ _env_caddy.variables.CANASTA_ENABLE_VARNISH | default('true') | lower == 'true' }}"
     _staging_certs: "{{ _env_caddy.variables.CANASTA_STAGING_CERTS | default('false') | lower == 'true' }}"

--- a/tests/unit/test_k8s_caddy_http_only.py
+++ b/tests/unit/test_k8s_caddy_http_only.py
@@ -1,0 +1,61 @@
+"""On Kubernetes, Caddy sits behind the ingress (Traefik terminates TLS and
+forwards plain HTTP), so the generated Caddyfile must always be http-only — no
+HTTP->HTTPS redirect — or it loops behind the ingress. rewrite_caddy.yml must
+therefore force _http_only on K8s regardless of the CADDY_AUTO_HTTPS value a
+cross-orchestrator restore may leave in .env. On Compose (Caddy is the TLS
+edge) CADDY_AUTO_HTTPS still drives it."""
+
+import os
+
+import jinja2
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+REWRITE_CADDY = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "rewrite_caddy.yml",
+)
+
+
+def _http_only_expr():
+    """The actual _http_only Jinja expression from rewrite_caddy.yml."""
+    with open(REWRITE_CADDY) as f:
+        tasks = yaml.safe_load(f)
+    for t in tasks:
+        sf = t.get("ansible.builtin.set_fact") or {}
+        if "_http_only" in sf:
+            return sf["_http_only"]
+    raise AssertionError("_http_only set_fact not found in rewrite_caddy.yml")
+
+
+def _eval(orchestrator, caddy_auto_https):
+    variables = {}
+    if caddy_auto_https is not None:
+        variables["CADDY_AUTO_HTTPS"] = caddy_auto_https
+    env = jinja2.Environment(undefined=jinja2.StrictUndefined)
+    out = env.from_string(_http_only_expr()).render(
+        instance_orchestrator=orchestrator,
+        _env_caddy={"variables": variables},
+    ).strip()
+    return out == "True"
+
+
+def test_k8s_forces_http_only_even_without_caddy_auto_https():
+    # The exact cross-orchestrator-restore case: k8s instance, .env has no
+    # CADDY_AUTO_HTTPS (the Compose backup's .env clobbered the create default).
+    assert _eval("kubernetes", None) is True
+    assert _eval("k8s", None) is True
+
+
+def test_k8s_forces_http_only_even_when_auto_https_on():
+    assert _eval("kubernetes", "on") is True
+
+
+def test_compose_still_driven_by_caddy_auto_https():
+    assert _eval("compose", "off") is True     # http-only
+    assert _eval("compose", "on") is False      # Caddy is the TLS edge
+    assert _eval("compose", None) is False      # default 'on'
+
+
+def test_expression_references_the_orchestrator():
+    # Guard against the k8s clause being dropped in a future refactor.
+    assert "instance_orchestrator" in _http_only_expr()


### PR DESCRIPTION
Closes #1092

On Kubernetes the ingress (Traefik) terminates TLS and forwards plain HTTP to Caddy, so Caddy must serve HTTP-only with no HTTP->HTTPS redirect. `rewrite_caddy.yml` derived `_http_only` solely from `CADDY_AUTO_HTTPS`, so any path that leaves that key unset or `on` on a k8s instance — notably a cross-orchestrator restore overwriting `.env` with a Compose backup's — made Caddy redirect and loop behind the ingress (endless `308`).

Force `_http_only` on Kubernetes regardless of `CADDY_AUTO_HTTPS`; Compose (Caddy as the TLS edge) keeps the `.env`-driven behavior. This is the robust fix — no `.env` value can put a k8s instance into the loop.

Added `tests/unit/test_k8s_caddy_http_only.py` evaluating the real `_http_only` expression: k8s forces http-only even with `CADDY_AUTO_HTTPS` unset or `on`; Compose still honors the value.