### PR TITLE
Block CADDY_AUTO_HTTPS via config set on Kubernetes

### DIFF
--- a/roles/config/tasks/_validate_key.yml
+++ b/roles/config/tasks/_validate_key.yml
@@ -68,6 +68,24 @@
     - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
     - _config_key in ['HTTP_PORT', 'HTTPS_PORT']
 
+# CADDY_AUTO_HTTPS is Compose-only for the same reasons as the ports above.
+# On Kubernetes the Ingress terminates TLS and Caddy always runs behind it in
+# http-only mode (rewrite_caddy.yml forces this), so the value has no effect.
+# And its _side_effects.yml scheme handler carries no orchestrator guard, so on
+# K8s it would rewrite MW_SITE_SERVER to http:// (a scheme nothing serves).
+- name: Block CADDY_AUTO_HTTPS on Kubernetes (Ingress terminates TLS)
+  ansible.builtin.fail:
+    msg: |
+      'CADDY_AUTO_HTTPS' cannot be set via 'canasta config set' on a
+      Kubernetes instance. The Ingress terminates TLS and Caddy always
+      runs behind it in http-only mode, so this value has no effect.
+
+      TLS for a Kubernetes instance is handled by the Ingress and
+      cert-manager, not by Caddy.
+  when:
+    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+    - _config_key == 'CADDY_AUTO_HTTPS'
+
 - name: Check if key is recognized
   ansible.builtin.fail:
     msg: >-

--- a/tests/unit/test_config_set_k8s_blocks.py
+++ b/tests/unit/test_config_set_k8s_blocks.py
@@ -1,0 +1,44 @@
+"""config set blocks Compose-only keys on Kubernetes.
+
+On k8s the Ingress terminates TLS and serves 80/443, and Caddy always runs
+behind it in http-only mode. The Compose scheme/port side-effects in
+_side_effects.yml carry no orchestrator guard, so setting these keys on k8s
+would wrongly rewrite MW_SITE_SERVER to a scheme/port nothing serves. They are
+blocked up front in _validate_key.yml."""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+VALIDATE_KEY = os.path.join(
+    REPO_ROOT, "roles", "config", "tasks", "_validate_key.yml",
+)
+
+
+def _tasks():
+    with open(VALIDATE_KEY) as f:
+        return yaml.safe_load(f)
+
+
+def _k8s_block_for(key_substr):
+    """The fail task that blocks a key on k8s, matched by its `when`."""
+    for t in _tasks():
+        if "ansible.builtin.fail" not in t:
+            continue
+        when = " ".join(str(c) for c in (t.get("when") or []))
+        if "kubernetes" in when and key_substr in when:
+            return t
+    return None
+
+
+def test_caddy_auto_https_blocked_on_k8s():
+    t = _k8s_block_for("CADDY_AUTO_HTTPS")
+    assert t is not None, "config set must block CADDY_AUTO_HTTPS on Kubernetes"
+    msg = t["ansible.builtin.fail"]["msg"]
+    assert "Kubernetes" in msg and "no effect" in msg
+
+
+def test_ports_still_blocked_on_k8s():
+    # The existing guard this one mirrors — keep it wired.
+    assert _k8s_block_for("HTTP_PORT") is not None


### PR DESCRIPTION
Closes #1094

On a Kubernetes instance, `canasta config set CADDY_AUTO_HTTPS=off` rewrote `MW_SITE_SERVER`/wiki URLs to `http://` — because the `CADDY_AUTO_HTTPS` scheme side-effect in `_side_effects.yml` has no orchestrator guard. On k8s the external scheme is https via the Ingress regardless of Caddy, so that's wrong.

`CADDY_AUTO_HTTPS` has no effect on k8s anyway (the Ingress terminates TLS; Caddy always runs http-only behind it — enforced by #1093). So block the key on k8s up front in `_validate_key.yml`, mirroring the existing `HTTP_PORT`/`HTTPS_PORT` block that exists for the identical reason.

Added `tests/unit/test_config_set_k8s_blocks.py` asserting both the new CADDY_AUTO_HTTPS block and the existing port block are present.