### PR TITLE
Make a full k8s restore exactly match the snapshot

### DIFF
--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -145,6 +145,14 @@
               - sh
               - -c
               - |
+                # Full restore: empty the images PVC (mounted at
+                # /currentsnapshot/images) first so it exactly matches the
+                # snapshot. Single-wiki restore must NOT — the PVC is shared
+                # across the farm's wikis and restic's --include already scopes
+                # the write to just this wiki's subdir.
+                {% if wiki is not defined %}
+                rm -rf /currentsnapshot/images/* /currentsnapshot/images/.[!.]* 2>/dev/null || true
+                {% endif %}
                 # Capture restic's rc + output so the controller can tell a
                 # real failure (restic prints "Fatal:") from the benign exit 1
                 # on EBS-backed PVCs whose selinux xattrs the overlay fs
@@ -270,10 +278,17 @@
           '{{ wiki }}' (no db_{{ wiki }}.sql). Nothing to restore.
       when: _restore_k8s_wiki_present.rc != 0
 
+# Clear config/ first so a full restore exactly matches the snapshot: a plain
+# tar-overlay leaves create-seeded files the source deleted (e.g. a removed
+# config/settings/global/*.php) in place, silently drifting config from the
+# source. .env lives outside config/ (restored separately below), and the
+# Caddyfile is regenerated post-restore, so clearing config/ is safe.
 - name: Copy restored config to host
   when: wiki is not defined
   ansible.builtin.shell:
     cmd: >-
+      rm -rf "{{ instance_path }}/config";
+      mkdir -p "{{ instance_path }}/config";
       kubectl exec -n {{ _k8s_namespace }} restic-restore --
       tar cf - -C /currentsnapshot/config . 2>/dev/null |
       tar xf - -C "{{ instance_path }}/config/"
@@ -314,14 +329,20 @@
 # has no host source of truth and is restored straight into its PVC above.)
 # `set -o pipefail` so a broken restic-restore side of the pipe fails loudly;
 # the `test -d` guard skips a dir absent from an older snapshot.
+# Clear each dir first so a full restore exactly matches the snapshot (as the
+# single-wiki public_assets path below already does): a plain overlay leaves
+# create-seeded/source-deleted files behind, and the host->PVC sync then mirrors
+# that drift into the PVC. If the dir is absent from the snapshot, the target
+# ends up empty — the correct exact-match result.
 - name: Restore extensions/skins/public_assets to host
   when: wiki is not defined
   ansible.builtin.shell:
     cmd: >-
       set -o pipefail;
+      rm -rf "{{ instance_path }}/{{ item }}";
+      mkdir -p "{{ instance_path }}/{{ item }}";
       if kubectl exec -n {{ _k8s_namespace }} restic-restore --
       test -d /currentsnapshot/{{ item }}; then
-      mkdir -p "{{ instance_path }}/{{ item }}";
       kubectl exec -n {{ _k8s_namespace }} restic-restore --
       tar cf - -C /currentsnapshot/{{ item }} . |
       tar xf - -C "{{ instance_path }}/{{ item }}/";

--- a/tests/unit/test_restore_exact_snapshot_match.py
+++ b/tests/unit/test_restore_exact_snapshot_match.py
@@ -1,0 +1,57 @@
+"""A full k8s restore must exactly match the snapshot. Each host-source dir
+(config, extensions, skins, public_assets) is cleared before restore so a
+create-seeded file the source deleted doesn't survive, and the shared images
+PVC is cleared before restic — but ONLY on a full restore. A single-wiki
+restore must not clear the shared images PVC or other wikis' dirs."""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+RESTORE_K8S = os.path.join(
+    REPO_ROOT, "roles", "backup", "tasks", "restore_k8s.yml",
+)
+
+
+def _tasks():
+    with open(RESTORE_K8S) as f:
+        return yaml.safe_load(f)
+
+
+def _task(name_substr):
+    for t in _tasks():
+        if name_substr in (t.get("name") or ""):
+            return t
+    raise AssertionError("task %r not found" % name_substr)
+
+
+def _cmd(task):
+    return task["ansible.builtin.shell"]["cmd"]
+
+
+def test_full_config_restore_clears_first():
+    t = _task("Copy restored config to host")
+    assert t["when"] == "wiki is not defined"
+    assert 'rm -rf "{{ instance_path }}/config"' in _cmd(t)
+
+
+def test_full_user_dirs_restore_clears_first():
+    t = _task("Restore extensions/skins/public_assets to host")
+    assert t["when"] == "wiki is not defined"
+    assert 'rm -rf "{{ instance_path }}/{{ item }}"' in _cmd(t)
+    assert t["loop"] == ["extensions", "skins", "public_assets"]
+
+
+def test_images_pvc_cleared_only_on_full_restore():
+    text = open(RESTORE_K8S).read()
+    # The images-PVC clear is gated on a full restore.
+    assert "{% if wiki is not defined %}" in text
+    assert "rm -rf /currentsnapshot/images/" in text
+
+
+def test_single_wiki_still_scoped_not_pruned():
+    # Single-wiki restore keeps restic scoped to just this wiki's paths, so it
+    # never clears/clobbers the shared images PVC or other wikis' data.
+    t = _task("Build restic include filters for single-wiki restore")
+    assert t["when"] == "wiki is defined"


### PR DESCRIPTION
Closes #1096

A full k8s restore tar-overlaid `config/extensions/skins/public_assets` into the host dirs without clearing first, so create-seeded files the source deleted (e.g. `config/settings/global/DefaultSettings.php`) survived and drifted config from the source; the host->PVC sync then mirrored that drift into the PVCs. The shared images PVC was never pruned on a full restore either.

On a full restore (`wiki is not defined`), clear each host-source dir before restoring it, and empty the images PVC before restic — so the target exactly matches the snapshot. Single-wiki restore is unchanged: restic stays scoped to the target wiki (its `--include` filter) and never clears the shared images PVC or other wikis' dirs.

Structural unit tests assert the clears are present and gated to full restore (`tests/unit/test_restore_exact_snapshot_match.py`); the existing single-wiki gating tests still pass.

⚠️ This touches the restore path and is only structurally unit-testable in CI — it needs a live full-restore e2e (which the reporter's Compose->k8s re-restore will provide) before relying on it.