### PR TITLE
Auto-derive k8s ingress domains from the farm's wiki URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ htmlcov/
 *.env
 admin-password_*
 values-configdata.yaml
+values-domains.yaml
 inventory/hosts.yml
 .DS_Store
 

--- a/roles/gitops/tasks/push_kubernetes.yml
+++ b/roles/gitops/tasks/push_kubernetes.yml
@@ -59,19 +59,42 @@
     src: "{{ instance_path }}/values-sidecars.yaml"
   register: _push_sidecars
 
-# values-configdata.yaml (configData, appSecretEnv) and values-sidecars.yaml
-# (sidecars) are complete, freshly-rebuilt snapshots that fully own those
-# keys. Merge them NON-recursively so each one REPLACES the copy already baked
-# into values.yaml by the previous push. A recursive merge would union the
-# configData maps instead, so a settings/caddy/crowdsec file deleted from the
-# instance dir would keep its stale ConfigMap key in the committed values.yaml
-# — and Argo CD would keep rendering it into the running config — forever.
-- name: Merge fresh configData + sidecars over the persisted values
+# Derive the ingress domains from the farm's wiki URLs (union extraDomains) so
+# the committed rendered values route exactly the wikis' hostnames — the same
+# derivation helm_deploy.yml applies on a direct deploy, done here so a
+# GitOps-managed instance (deployed by Argo from rendered-values.yaml) stays in
+# sync. Falls back to the persisted domains when wikis.yaml is absent/empty.
+- name: Read wikis.yaml for ingress-domain derivation
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/config/wikis.yaml"
+  register: _push_wikis_raw
+  failed_when: false
+
+- name: Derive ingress domains from wiki URLs
+  ansible.builtin.set_fact:
+    _push_wiki_hosts: >-
+      {{ ((_push_wikis_raw.content | default('') | b64decode | from_yaml)
+          | default({}, true)).wikis | default([])
+         | map(attribute='url')
+         | map('regex_replace', '/.*$', '')
+         | map('regex_replace', ':[0-9]+$', '')
+         | select | list }}
+    _push_base_values: "{{ _push_values.content | b64decode | from_yaml }}"
+
+# configData + sidecars are complete, freshly-rebuilt snapshots that fully own
+# their keys — merge NON-recursively so each REPLACES the copy already in
+# values.yaml (a recursive merge would keep stale keys from deleted files
+# forever). The derived domains list likewise replaces the persisted one.
+- name: Merge fresh configData + sidecars + derived domains over the values
   ansible.builtin.set_fact:
     _push_merged_values: >-
-      {{ _push_values.content | b64decode | from_yaml
+      {{ _push_base_values
          | combine(_push_configdata.content | b64decode | from_yaml)
-         | combine(_push_sidecars.content | b64decode | from_yaml) }}
+         | combine(_push_sidecars.content | b64decode | from_yaml)
+         | combine({'domains': (_push_wiki_hosts
+                                + (_push_base_values.extraDomains | default([])))
+                               | unique}
+                   if (_push_wiki_hosts | length) > 0 else {}) }}
 
 - name: Merge configData + sidecars into values.yaml for git
   ansible.builtin.copy:

--- a/roles/orchestrator/tasks/helm_deploy.yml
+++ b/roles/orchestrator/tasks/helm_deploy.yml
@@ -11,6 +11,58 @@
     dest: "{{ instance_path }}/_chart/"
     mode: preserve
 
+# Auto-derive the ingress domains from the farm's wiki URLs so the Ingress
+# always routes exactly the wikis' hostnames — no manual values.yaml upkeep
+# (adding a wiki, or restoring a farm, updates the Ingress automatically). The
+# result is written as a -f override applied AFTER values.yaml below, so it
+# replaces the domains list (helm is last-wins for lists) on every deploy.
+# An operator escape hatch, extraDomains in values.yaml, is unioned in for any
+# non-wiki hostname. Falls back to the existing values.yaml domains when
+# wikis.yaml is absent/empty, so a bare instance is unaffected.
+- name: Read wikis.yaml for ingress-domain derivation
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/config/wikis.yaml"
+  register: _hd_wikis_raw
+  failed_when: false
+
+- name: Read values.yaml for extraDomains + existing domains
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/values.yaml"
+  register: _hd_values_raw
+  failed_when: false
+
+- name: Derive ingress domains from wiki URLs + extraDomains
+  ansible.builtin.set_fact:
+    _hd_wiki_hosts: >-
+      {{ ((_hd_wikis_raw.content | default('') | b64decode | from_yaml)
+          | default({}, true)).wikis | default([])
+         | map(attribute='url')
+         | map('regex_replace', '/.*$', '')
+         | map('regex_replace', ':[0-9]+$', '')
+         | select | list }}
+    _hd_values: >-
+      {{ (_hd_values_raw.content | default('') | b64decode | from_yaml)
+         | default({}, true) }}
+
+- name: Compute final ingress domains
+  ansible.builtin.set_fact:
+    _hd_domains: >-
+      {{ ((_hd_wiki_hosts + (_hd_values.extraDomains | default([]))) | unique)
+         if (_hd_wiki_hosts | length) > 0
+         else (_hd_values.domains | default([])) }}
+
+- name: Write derived ingress-domains override
+  ansible.builtin.copy:
+    content: "{{ {'domains': _hd_domains} | to_nice_yaml(indent=2) }}"
+    dest: "{{ instance_path }}/values-domains.yaml"
+    mode: "0644"
+  when: _hd_domains | length > 0
+
+- name: Check for derived domains file
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/values-domains.yaml"
+  register: _domains_file
+
 - name: Check for configData values file
   ansible.builtin.stat:
     path: "{{ instance_path }}/values-configdata.yaml"
@@ -39,6 +91,8 @@
          | ternary('-f ' ~ instance_path ~ '/values-configdata.yaml', '') }}
       {{ (_sidecars_file.stat.exists | default(false))
          | ternary('-f ' ~ instance_path ~ '/values-sidecars.yaml', '') }}
+      {{ (_domains_file.stat.exists | default(false))
+         | ternary('-f ' ~ instance_path ~ '/values-domains.yaml', '') }}
       {{ (helm_reset_values | default(true) | bool)
          | ternary('--reset-values', '') }}
       {{ (helm_wait | default(true) | bool)

--- a/tests/unit/test_gitops_config_prune.py
+++ b/tests/unit/test_gitops_config_prune.py
@@ -33,7 +33,7 @@ def _tasks():
 def _merge_task():
     task = next(
         t for t in _tasks()
-        if t.get("name") == "Merge fresh configData + sidecars over the persisted values"
+        if "Merge fresh configData" in (t.get("name") or "")
     )
     return task["ansible.builtin.set_fact"]["_push_merged_values"]
 
@@ -41,15 +41,16 @@ def _merge_task():
 def test_merge_is_not_recursive():
     # A recursive combine unions the configData maps and never drops a key, so
     # a deleted settings file lingers in the committed values.yaml. Guard
-    # against recursive=True creeping back into either combine.
+    # against recursive=True creeping back into any combine.
     expr = _merge_task()
     assert "recursive=True" not in expr and "recursive = True" not in expr, (
         "the configData/sidecars merge must be non-recursive so the fresh "
         "values-configdata.yaml replaces (not unions) the persisted configData"
     )
-    assert expr.count("combine(") == 2, (
-        "expected the merge to combine both values-configdata and "
-        "values-sidecars over the persisted values"
+    # configData + sidecars + derived domains, each replacing non-recursively.
+    assert expr.count("combine(") == 3, (
+        "expected the merge to combine values-configdata, values-sidecars, "
+        "and the derived domains over the persisted values"
     )
 
 

--- a/tests/unit/test_k8s_ingress_domains_derived.py
+++ b/tests/unit/test_k8s_ingress_domains_derived.py
@@ -1,0 +1,67 @@
+"""On Kubernetes the Ingress 'domains' are auto-derived from the farm's wiki
+URLs at deploy time (helm_deploy.yml), so the Ingress always routes exactly the
+wikis' hostnames — no manual values.yaml upkeep. An operator escape hatch
+(extraDomains) is unioned in, and the result is applied as a -f override AFTER
+values.yaml so the derived list wins (helm is last-wins for lists)."""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+HELM_DEPLOY = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "helm_deploy.yml",
+)
+
+
+def _tasks():
+    with open(HELM_DEPLOY) as f:
+        return yaml.safe_load(f)
+
+
+def _task(name_substr):
+    for t in _tasks():
+        if name_substr in (t.get("name") or ""):
+            return t
+    raise AssertionError("task %r not found" % name_substr)
+
+
+def test_derives_hostnames_from_wiki_urls():
+    expr = str(_task("Derive ingress domains from wiki URLs")
+               ["ansible.builtin.set_fact"])
+    assert "wikis" in expr and "url" in expr
+    # bare hostname: scheme/path and :port stripped
+    assert "/.*$" in expr and ":[0-9]+$" in expr
+
+
+def test_unions_extra_domains_dedupes_and_falls_back():
+    expr = str(_task("Compute final ingress domains")
+               ["ansible.builtin.set_fact"])
+    assert "extraDomains" in expr          # operator escape hatch
+    assert "unique" in expr                # de-dup shared hostnames
+    assert "domains" in expr               # else branch: keep existing when no wikis
+
+
+def test_override_written_and_wired_after_values_yaml():
+    write = _task("Write derived ingress-domains override")
+    assert "values-domains.yaml" in write["ansible.builtin.copy"]["dest"]
+    cmd = _task("Deploy Canasta Helm release")["vars"]["rx_cmd"]
+    assert "values.yaml" in cmd and "values-domains.yaml" in cmd
+    # the override must come after the base values so its domains list wins
+    assert cmd.index("values.yaml") < cmd.index("values-domains.yaml")
+
+
+def test_gitops_push_also_derives_domains():
+    # A GitOps-managed instance deploys from rendered-values.yaml via Argo, so
+    # the push must apply the same derivation into the committed values.
+    push = os.path.join(REPO_ROOT, "roles", "gitops", "tasks",
+                        "push_kubernetes.yml")
+    with open(push) as f:
+        tasks = yaml.safe_load(f)
+    text = open(push).read()
+    assert "Derive ingress domains from wiki URLs" in text
+    assert "extraDomains" in text
+    merge = [t for t in tasks
+             if "Merge fresh configData" in (t.get("name") or "")]
+    assert merge, "gitops push must merge derived domains into the values"
+    assert "domains" in str(merge[0]["ansible.builtin.set_fact"])


### PR DESCRIPTION
Closes #1098

The k8s Ingress rendered its hosts from a hand-maintained `values.yaml` `domains:` list, so adding a wiki or restoring a farm required hand-editing `domains` to route the new hostname — and `config set` of the primary wiki overwrote the whole list (`_side_effects.yml:388`), dropping other wikis' domains.

Derive `domains` from the wiki URLs in `wikis.yaml` (bare hostname: scheme/port/path stripped), union an `extraDomains` escape hatch for non-wiki hostnames, and apply it on **both** deploy paths:
- `helm_deploy.yml` writes a `-f values-domains.yaml` override applied after `values.yaml` (last-wins for lists) — the direct create/start/reconcile path;
- `push_kubernetes.yml` folds the derived domains into the committed values so GitOps-managed instances (Argo from `rendered-values.yaml`) stay in sync.

Falls back to the existing `domains` when `wikis.yaml` is absent/empty, so bare instances are unaffected. The Ingress now always routes exactly the farm's wiki hostnames with no manual upkeep.

Unit tests: `tests/unit/test_k8s_ingress_domains_derived.py` (derive strips to bare hostnames, unions extraDomains, dedupes, falls back, override applied after values.yaml, and the gitops push derives too); updated `test_gitops_config_prune.py` for the added non-recursive combine.

⚠️ Touches the k8s deploy/render pipeline — needs a live migration e2e (create farm -> restore -> reconcile, and a gitops push) before relying on it.