### PR TITLE
gitops: ignore legacy config/.smw.json orphan

### DIFF
--- a/roles/gitops/files/gitignore.default
+++ b/roles/gitops/files/gitignore.default
@@ -33,6 +33,10 @@ images/
 # Runtime state (e.g. Semantic MediaWiki rebuild status)
 config/persistent/
 
+# Legacy SMW state location (pre-CanastaBase 1.2.1, before .smw.json moved
+# to config/persistent/); ignore any orphan left on migrated instances
+config/.smw.json
+
 # Editor / tooling backup files
 *.bak
 *.bak.*


### PR DESCRIPTION
`.smw.json` is Semantic MediaWiki runtime state. Since CanastaBase 1.2.1 it is written to `config/persistent/.smw.json`, already covered by the `config/persistent/` rule in `gitignore.default`. Instances first initialized under an older image carry an orphan `config/.smw.json` at the config root — a path no ignore rule covered — so `gitops init`'s `git add -A` tracked it and it shows as permanent churn in `gitops status`.

This ignores the legacy path too.

Operators with an existing orphan also need a one-time `git rm --cached config/.smw.json` (SMW recreates it under `config/persistent/` on demand).

Fixes #1102
