### PR TITLE
gitops: track k8s source-of-truth dirs (extensions/skins/public_assets, per-wiki settings)

### DIFF
--- a/roles/gitops/tasks/diff_kubernetes.yml
+++ b/roles/gitops/tasks/diff_kubernetes.yml
@@ -54,6 +54,15 @@
   changed_when: false
   ignore_errors: true  # OK if no upstream configured
 
+# --- Submodule changes ---
+- name: Check submodule status
+  ansible.builtin.command:
+    cmd: git submodule status
+    chdir: "{{ instance_path }}"
+  register: _kdiff_submodules
+  changed_when: false
+  ignore_errors: true  # OK if no submodules configured
+
 # --- Argo CD live diff ---
 - name: Render Helm template to temp file
   ansible.builtin.command:
@@ -97,6 +106,13 @@
 
       Remote changes (would be applied on pull): {{ _kdiff_remote_names.stdout_lines | default([]) | length }} file(s)
       {{ _kdiff_remote.stdout | default('') }}
+      {% set subs = _kdiff_submodules.stdout_lines | default([]) | select('match', '^[+]') | list %}
+      {% if subs | length > 0 %}
+      Submodules with changes:
+      {% for s in subs %}
+        {{ s.split()[1] | default(s) }}
+      {% endfor %}
+      {% endif %}
       {% if _kdiff_cluster is defined and _kdiff_cluster.stdout | default('') | trim | length > 0 %}
 
       Live cluster diff (desired vs current):

--- a/roles/gitops/tasks/fix_submodules.yml
+++ b/roles/gitops/tasks/fix_submodules.yml
@@ -2,16 +2,10 @@
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
-# Input validation rejecting an operation that does not apply on K8s
-# (extensions are image-bundled, not git submodules) — no Compose-
-# equivalent action to dispatch to. Kept in place by design.
-- name: Not applicable for Kubernetes
-  ansible.builtin.fail:
-    msg: >-
-      'canasta gitops fix-submodules' is not applicable for the kubernetes
-      orchestrator. Extensions are bundled in the Canasta image rather than
-      managed as git submodules.
-  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+# Applies to both orchestrators. extensions/ and skins/ are tracked in the
+# gitops repo on Compose and on K8s (where they are also the source of truth
+# for the user-extensions / user-skins PVCs), so loose git checkouts must be
+# promoted to submodules on either.
 
 # --- Step 1: Convert any loose git repos in extensions/ and skins/ to submodules ---
 # This mirrors the logic gitops init runs, so extensions added after init

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -409,10 +409,6 @@
       scripts/
       values-configdata.yaml
       values-sidecars.yaml
-      extensions/
-      skins/
-      public_assets/
-      wikis/
     dest: "{{ instance_path }}/.gitignore"
     mode: "0644"
 
@@ -501,6 +497,44 @@
     content: "{{ host_name }}"
     dest: "{{ instance_path }}/.gitops-host"
     mode: "0644"
+
+# --- Convert extensions/skins git repos to submodules ---
+# extensions/ and skins/ are the source of truth for the user-extensions
+# and user-skins PVCs (roles/orchestrator/tasks/k8s_sync_user_dirs.yml),
+# so they must be tracked. A loose git checkout under them is promoted to a
+# proper submodule (pinned to its current commit) — otherwise `git add -A`
+# below would record it as a bare gitlink whose files never get tracked.
+- name: Find git repos in extensions
+  ansible.builtin.find:
+    paths: "{{ instance_path }}/extensions"
+    patterns: ".git"
+    file_type: directory
+    hidden: true
+    recurse: false
+    depth: 2
+  register: _ext_git_repos
+
+- name: Convert extension git repos to submodules
+  ansible.builtin.include_tasks: _convert_submodule.yml
+  loop: "{{ _ext_git_repos.files | map(attribute='path') | map('dirname') | list }}"
+  loop_control:
+    loop_var: _repo_path
+
+- name: Find git repos in skins
+  ansible.builtin.find:
+    paths: "{{ instance_path }}/skins"
+    patterns: ".git"
+    file_type: directory
+    hidden: true
+    recurse: false
+    depth: 2
+  register: _skin_git_repos
+
+- name: Convert skin git repos to submodules
+  ansible.builtin.include_tasks: _convert_submodule.yml
+  loop: "{{ _skin_git_repos.files | map(attribute='path') | map('dirname') | list }}"
+  loop_control:
+    loop_var: _repo_path
 
 # --- Initial commit and push ---
 - name: Stage all files

--- a/roles/gitops/tasks/join_kubernetes.yml
+++ b/roles/gitops/tasks/join_kubernetes.yml
@@ -235,6 +235,15 @@
     chdir: "{{ instance_path }}"
   changed_when: true
 
+# Materialize extensions/skins submodules so this host has the source of
+# truth on disk for the user-extensions / user-skins PVC sync.
+- name: Update submodules
+  ansible.builtin.command:
+    cmd: "git submodule update --init --recursive"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+  ignore_errors: true  # OK if no submodules configured
+
 # --- Extract per-host vars from current values.yaml ---
 - name: Read current values.yaml
   ansible.builtin.slurp:

--- a/roles/gitops/tasks/pull_kubernetes.yml
+++ b/roles/gitops/tasks/pull_kubernetes.yml
@@ -11,6 +11,14 @@
   register: _git_pull
   changed_when: "'Already up to date' not in _git_pull.stdout"
 
+# Keep extensions/skins submodules in sync with the pulled pointers.
+- name: Update submodules
+  ansible.builtin.command:
+    cmd: "git submodule update --init --recursive"
+    chdir: "{{ instance_path }}"
+  changed_when: _git_pull.changed
+  ignore_errors: true  # OK if no submodules configured
+
 - name: Check for multi-env structure
   ansible.builtin.stat:
     path: "{{ instance_path }}/values.template.yaml"

--- a/roles/gitops/tasks/refresh_gitignore.yml
+++ b/roles/gitops/tasks/refresh_gitignore.yml
@@ -38,3 +38,20 @@
         line: "{{ item }}"
         state: present
       loop: "{{ _gi_shipped_rules }}"
+
+    # Remove obsolete K8s ignore lines that wrongly excluded source-of-truth
+    # dirs from the gitops repo (extensions/, skins/, public_assets/ feed the
+    # PVCs; the unanchored `wikis/` also matched config/settings/wikis/). Older
+    # K8s repos carry these; drop them so the next `gitops push` tracks the
+    # files. No-op on Compose, which never wrote them. The base default still
+    # ignores public_assets/*/sitemap/, so generated sitemaps stay excluded.
+    - name: Remove obsolete K8s source-dir ignore lines
+      ansible.builtin.lineinfile:
+        path: "{{ instance_path }}/.gitignore"
+        regexp: "^{{ item }}/$"
+        state: absent
+      loop:
+        - extensions
+        - skins
+        - public_assets
+        - wikis

--- a/tests/unit/test_k8s_gitops_source_dirs.py
+++ b/tests/unit/test_k8s_gitops_source_dirs.py
@@ -1,0 +1,113 @@
+"""Regression guards: the K8s gitops repo must track its source-of-truth dirs.
+
+extensions/, skins/, and public_assets/ are the source of truth for the
+user-extensions / user-skins / public-assets PVCs
+(roles/orchestrator/tasks/k8s_sync_user_dirs.yml), and
+config/settings/wikis/<id>/Settings.php is the source of truth for per-wiki
+config. An earlier K8s .gitignore appended bare `extensions/`, `skins/`,
+`public_assets/`, and `wikis/` lines; the unanchored `wikis/` also matched
+config/settings/wikis/, so per-wiki settings and the PVC source dirs were
+silently excluded from the gitops repo (data-loss on a fresh clone / join /
+DR host). These tests lock in the fix.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+INIT_K8S = os.path.join(
+    REPO_ROOT, "roles", "gitops", "tasks", "init_kubernetes.yml",
+)
+REFRESH_GITIGNORE = os.path.join(
+    REPO_ROOT, "roles", "gitops", "tasks", "refresh_gitignore.yml",
+)
+FIX_SUBMODULES = os.path.join(
+    REPO_ROOT, "roles", "gitops", "tasks", "fix_submodules.yml",
+)
+
+# Directories that must never be gitignored on K8s — they are the source of
+# truth the repo exists to version-control.
+SOURCE_DIRS = ("extensions", "skins", "public_assets", "wikis")
+
+
+def _walk_tasks(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk_tasks(t[nested])
+
+
+def _k8s_gitignore_content():
+    with open(INIT_K8S) as f:
+        tasks = yaml.safe_load(f)
+    for task in _walk_tasks(tasks):
+        copy = task.get("ansible.builtin.copy") or task.get("copy")
+        if not isinstance(copy, dict):
+            continue
+        if copy.get("dest", "").endswith("/.gitignore"):
+            return copy["content"]
+    raise AssertionError("init_kubernetes.yml has no .gitignore-writing task")
+
+
+class TestK8sGitignoreDoesNotExcludeSourceDirs:
+    def test_source_dirs_not_ignored(self):
+        """The written .gitignore must not carry a bare `<dir>/` line for any
+        source-of-truth directory."""
+        lines = [ln.strip() for ln in _k8s_gitignore_content().splitlines()]
+        for d in SOURCE_DIRS:
+            assert f"{d}/" not in lines, (
+                f"init_kubernetes.yml's .gitignore ignores {d}/ — that "
+                "directory is the K8s source of truth and must be tracked."
+            )
+
+
+class TestK8sInitConvertsSubmodules:
+    def test_init_converts_extensions_and_skins(self):
+        """extensions/skins loose git checkouts must be promoted to submodules
+        before the initial `git add -A`, else they land as bare gitlinks."""
+        with open(INIT_K8S) as f:
+            tasks = yaml.safe_load(f)
+        includes = [
+            t.get("ansible.builtin.include_tasks") or t.get("include_tasks")
+            for t in _walk_tasks(tasks)
+        ]
+        assert includes.count("_convert_submodule.yml") >= 2, (
+            "init_kubernetes.yml must convert both extensions/ and skins/ "
+            "git repos to submodules (two _convert_submodule.yml includes)."
+        )
+
+
+class TestRefreshGitignoreRemovesObsoleteLines:
+    def test_refresh_removes_source_dir_ignores(self):
+        """refresh_gitignore.yml (run on every upgrade) must strip the obsolete
+        source-dir ignore lines so existing K8s repos self-heal."""
+        with open(REFRESH_GITIGNORE) as f:
+            tasks = yaml.safe_load(f)
+        removed = []
+        for task in _walk_tasks(tasks):
+            li = task.get("ansible.builtin.lineinfile") or task.get("lineinfile")
+            if not isinstance(li, dict) or li.get("state") != "absent":
+                continue
+            loop = task.get("loop") or []
+            if isinstance(loop, list):
+                removed.extend(loop)
+        for d in SOURCE_DIRS:
+            assert d in removed, (
+                f"refresh_gitignore.yml does not remove the obsolete {d}/ "
+                "ignore line — existing K8s repos would stay broken on upgrade."
+            )
+
+
+class TestFixSubmodulesRunsOnK8s:
+    def test_no_kubernetes_refusal(self):
+        """fix-submodules must no longer hard-refuse on K8s."""
+        with open(FIX_SUBMODULES) as f:
+            content = f.read()
+        assert "not applicable for the kubernetes" not in content, (
+            "fix_submodules.yml still refuses to run on K8s — extensions/skins "
+            "are now tracked as submodules on both orchestrators."
+        )


### PR DESCRIPTION
Fixes #1112.

The k8s gitops `.gitignore` was appending bare `extensions/`, `skins/`, `public_assets/`, and `wikis/` lines, excluding the very directories the gitops repo exists to version-control. `extensions/`/`skins/`/`public_assets/` are the source of truth for their PVCs (`k8s_sync_user_dirs.yml`), and the unanchored `wikis/` also matched `config/settings/wikis/`, dropping per-wiki `Settings.php`. On a fresh clone / `join` / DR host these dirs came up empty and the next start pruned the PVCs (and Argo could prune per-wiki config).

## Changes
- **`init_kubernetes.yml`** — drop the four ignore lines; convert loose `extensions/`/`skins/` git checkouts to submodules before the initial `git add -A` (mirrors `init_compose.yml`), so they track as content rather than bare gitlinks.
- **`fix_submodules.yml`** — remove the k8s hard-refuse guard; `canasta gitops fix-submodules` now works on both orchestrators.
- **`join_kubernetes.yml` / `pull_kubernetes.yml`** — `git submodule update --init --recursive` so DR/pull materialize extension/skin content on disk.
- **`diff_kubernetes.yml`** — surface submodule changes (parity with `diff_compose.yml`).
- **`refresh_gitignore.yml`** — remove the four obsolete lines on `upgrade` (no-op on Compose). The base default still ignores `public_assets/*/sitemap/`.
- **`tests/unit/test_k8s_gitops_source_dirs.py`** — regression guards for all of the above.

## Existing-repo backfill
After upgrading, on each k8s controller:

```
canasta gitops fix-submodules -i <id>   # promote extensions/skins to submodules
canasta gitops push -i <id>             # commit newly-tracked config/settings/wikis + public_assets
```

## Testing
`make test-unit` (1747 passed), `make validate`, `make lint` all green.