### PR TITLE
Implement write checks for wiki-check command

### DIFF
--- a/direct_commands/_mediawiki_api.py
+++ b/direct_commands/_mediawiki_api.py
@@ -1,0 +1,131 @@
+import http.cookiejar
+import json
+import secrets
+import ssl
+import urllib.parse
+import urllib.request
+
+
+class MediaWikiClient:
+    def __init__(self, api_url, host_header=None):
+        self.api_url = api_url
+        self.host_header = host_header
+        cj = http.cookiejar.CookieJar()
+        handlers = [urllib.request.HTTPCookieProcessor(cj)]
+        if api_url.startswith("https"):
+            context = ssl._create_unverified_context()
+            handlers.append(urllib.request.HTTPSHandler(context=context))
+        self.opener = urllib.request.build_opener(*handlers)
+
+    def _request(self, params=None, files=None):
+        headers = {}
+        if self.host_header:
+            headers["Host"] = self.host_header
+
+        if files:
+            content_type, body = self._encode_multipart(params or {}, files)
+            headers["Content-Type"] = content_type
+            req = urllib.request.Request(self.api_url, data=body, headers=headers)
+        else:
+            data = urllib.parse.urlencode(params or {}).encode("utf-8")
+            req = urllib.request.Request(self.api_url, data=data, headers=headers)
+
+        with self.opener.open(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8", errors="ignore"))
+
+    def _encode_multipart(self, fields, files):
+        boundary = secrets.token_hex(16)
+        parts = []
+        for name, value in fields.items():
+            parts.append(f'--{boundary}')
+            parts.append(f'Content-Disposition: form-data; name="{name}"')
+            parts.append('')
+            parts.append(str(value))
+        for name, (filename, content, mimetype) in files.items():
+            parts.append(f'--{boundary}')
+            parts.append(f'Content-Disposition: form-data; name="{name}"; filename="{filename}"')
+            parts.append(f'Content-Type: {mimetype}')
+            parts.append('')
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+            parts.append(content)
+        parts.append(f'--{boundary}--')
+        parts.append(b'')
+
+        body = b""
+        for part in parts:
+            if isinstance(part, str):
+                body += part.encode("utf-8") + b"\r\n"
+            else:
+                body += part + b"\r\n"
+        
+        content_type = f"multipart/form-data; boundary={boundary}"
+        return content_type, body
+
+    def login(self, username, password):
+        res = self._request({"action": "query", "meta": "tokens", "type": "login", "format": "json"})
+        login_token = res.get("query", {}).get("tokens", {}).get("logintoken")
+        if not login_token:
+            raise RuntimeError("Could not retrieve login token")
+
+        res = self._request({
+            "action": "login",
+            "lgname": username,
+            "lgpassword": password,
+            "lgtoken": login_token,
+            "format": "json"
+        })
+        if res.get("login", {}).get("result") != "Success":
+            raise RuntimeError(f"Login failed: {res.get('login', {}).get('result')}")
+
+    def get_csrf_token(self):
+        res = self._request({"action": "query", "meta": "tokens", "type": "csrf", "format": "json"})
+        csrf_token = res.get("query", {}).get("tokens", {}).get("csrftoken")
+        if not csrf_token:
+            raise RuntimeError("Could not retrieve CSRF token")
+        return csrf_token
+
+    def edit_page(self, title, text, summary, token):
+        res = self._request({
+            "action": "edit",
+            "title": title,
+            "text": text,
+            "summary": summary,
+            "token": token,
+            "format": "json"
+        })
+        if "error" in res:
+            raise RuntimeError(f"Edit failed: {res['error'].get('info')}")
+        if res.get("edit", {}).get("result") != "Success":
+            raise RuntimeError("Edit failed")
+
+    def upload_file(self, filename, file_content, token):
+        res = self._request(
+            params={
+                "action": "upload",
+                "filename": filename,
+                "ignorewarnings": "1",
+                "token": token,
+                "format": "json"
+            },
+            files={
+                "file": (filename, file_content, "image/gif")
+            }
+        )
+        if "error" in res:
+            raise RuntimeError(f"Upload failed: {res['error'].get('info')}")
+        if res.get("upload", {}).get("result") != "Success":
+            raise RuntimeError("Upload failed")
+
+    def delete_page(self, title, reason, token):
+        res = self._request({
+            "action": "delete",
+            "title": title,
+            "reason": reason,
+            "token": token,
+            "format": "json"
+        })
+        if "error" in res:
+            if res["error"].get("code") in ("cantdelete", "missingtitle"):
+                return
+            raise RuntimeError(f"Delete failed: {res['error'].get('info')}")

--- a/direct_commands/wiki_check.py
+++ b/direct_commands/wiki_check.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import random
 import secrets
 import ssl
 import sys
@@ -173,8 +174,31 @@ def _run_write_check(api_url, host_header, username, password):
     client.login(f"{username}@canasta-cli", password)
     token = client.get_csrf_token()
     
-    temp_page = "Canasta-Wiki-Check-Temp-Page"
-    temp_file = "File:Canasta-Wiki-Check-Temp-File.gif"
+    # Find a unique page and file name with a random 3-digit suffix
+    while True:
+        num = random.randint(100, 999)
+        test_page = f"Canasta-Wiki-Check-Temp-Page-{num}"
+        test_filename = f"Canasta-Wiki-Check-Temp-File-{num}.gif"
+        test_file = f"File:{test_filename}"
+        
+        # Check if they already exist
+        res = client._request({
+            "action": "query",
+            "titles": f"{test_page}|{test_file}",
+            "format": "json"
+        })
+        pages = res.get("query", {}).get("pages", {})
+        exists = False
+        for page_id, page_info in pages.items():
+            if "missing" not in page_info:
+                exists = True
+                break
+        
+        if not exists:
+            temp_page = test_page
+            temp_file = test_file
+            temp_filename = test_filename
+            break
     
     # 1x1 pixel transparent GIF
     gif_data = bytes.fromhex("47494638396101000100800000000000ffffff21f90401000000002c00000000010001000002024401003b")
@@ -196,7 +220,7 @@ def _run_write_check(api_url, host_header, username, password):
         )
         # Upload
         client.upload_file(
-            filename="Canasta-Wiki-Check-Temp-File.gif",
+            filename=temp_filename,
             file_content=gif_data,
             token=token
         )

--- a/direct_commands/wiki_check.py
+++ b/direct_commands/wiki_check.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """wiki-check command — verify MediaWiki instances are accessible."""
 
-import http.cookiejar
 import json
 import os
 import secrets
@@ -11,6 +10,7 @@ import urllib.parse
 import urllib.request
 from . import _helpers
 from ._helpers import register
+from ._mediawiki_api import MediaWikiClient
 
 
 _PROTOCOLS = ("https", "http")
@@ -166,131 +166,6 @@ def _get_or_create_bot_password(instance_id, instance, wiki_id, host):
             return username, password
             
     return None, None
-
-
-class MediaWikiClient:
-    def __init__(self, api_url, host_header=None):
-        self.api_url = api_url
-        self.host_header = host_header
-        cj = http.cookiejar.CookieJar()
-        handlers = [urllib.request.HTTPCookieProcessor(cj)]
-        if api_url.startswith("https"):
-            context = ssl._create_unverified_context()
-            handlers.append(urllib.request.HTTPSHandler(context=context))
-        self.opener = urllib.request.build_opener(*handlers)
-
-    def _request(self, params=None, files=None):
-        headers = {}
-        if self.host_header:
-            headers["Host"] = self.host_header
-
-        if files:
-            content_type, body = self._encode_multipart(params or {}, files)
-            headers["Content-Type"] = content_type
-            req = urllib.request.Request(self.api_url, data=body, headers=headers)
-        else:
-            data = urllib.parse.urlencode(params or {}).encode("utf-8")
-            req = urllib.request.Request(self.api_url, data=data, headers=headers)
-
-        with self.opener.open(req, timeout=30) as resp:
-            return json.loads(resp.read().decode("utf-8", errors="ignore"))
-
-    def _encode_multipart(self, fields, files):
-        boundary = secrets.token_hex(16)
-        parts = []
-        for name, value in fields.items():
-            parts.append(f'--{boundary}')
-            parts.append(f'Content-Disposition: form-data; name="{name}"')
-            parts.append('')
-            parts.append(str(value))
-        for name, (filename, content, mimetype) in files.items():
-            parts.append(f'--{boundary}')
-            parts.append(f'Content-Disposition: form-data; name="{name}"; filename="{filename}"')
-            parts.append(f'Content-Type: {mimetype}')
-            parts.append('')
-            if isinstance(content, str):
-                content = content.encode("utf-8")
-            parts.append(content)
-        parts.append(f'--{boundary}--')
-        parts.append(b'')
-
-        body = b""
-        for part in parts:
-            if isinstance(part, str):
-                body += part.encode("utf-8") + b"\r\n"
-            else:
-                body += part + b"\r\n"
-        
-        content_type = f"multipart/form-data; boundary={boundary}"
-        return content_type, body
-
-    def login(self, username, password):
-        res = self._request({"action": "query", "meta": "tokens", "type": "login", "format": "json"})
-        login_token = res.get("query", {}).get("tokens", {}).get("logintoken")
-        if not login_token:
-            raise RuntimeError("Could not retrieve login token")
-
-        res = self._request({
-            "action": "login",
-            "lgname": username,
-            "lgpassword": password,
-            "lgtoken": login_token,
-            "format": "json"
-        })
-        if res.get("login", {}).get("result") != "Success":
-            raise RuntimeError(f"Login failed: {res.get('login', {}).get('result')}")
-
-    def get_csrf_token(self):
-        res = self._request({"action": "query", "meta": "tokens", "type": "csrf", "format": "json"})
-        csrf_token = res.get("query", {}).get("tokens", {}).get("csrftoken")
-        if not csrf_token:
-            raise RuntimeError("Could not retrieve CSRF token")
-        return csrf_token
-
-    def edit_page(self, title, text, summary, token):
-        res = self._request({
-            "action": "edit",
-            "title": title,
-            "text": text,
-            "summary": summary,
-            "token": token,
-            "format": "json"
-        })
-        if "error" in res:
-            raise RuntimeError(f"Edit failed: {res['error'].get('info')}")
-        if res.get("edit", {}).get("result") != "Success":
-            raise RuntimeError("Edit failed")
-
-    def upload_file(self, filename, file_content, token):
-        res = self._request(
-            params={
-                "action": "upload",
-                "filename": filename,
-                "ignorewarnings": "1",
-                "token": token,
-                "format": "json"
-            },
-            files={
-                "file": (filename, file_content, "image/gif")
-            }
-        )
-        if "error" in res:
-            raise RuntimeError(f"Upload failed: {res['error'].get('info')}")
-        if res.get("upload", {}).get("result") != "Success":
-            raise RuntimeError("Upload failed")
-
-    def delete_page(self, title, reason, token):
-        res = self._request({
-            "action": "delete",
-            "title": title,
-            "reason": reason,
-            "token": token,
-            "format": "json"
-        })
-        if "error" in res:
-            if res["error"].get("code") in ("cantdelete", "missingtitle"):
-                return
-            raise RuntimeError(f"Delete failed: {res['error'].get('info')}")
 
 
 def _run_write_check(api_url, host_header, username, password):

--- a/direct_commands/wiki_check.py
+++ b/direct_commands/wiki_check.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 """wiki-check command — verify MediaWiki instances are accessible."""
 
+import http.cookiejar
 import json
+import os
+import secrets
 import ssl
 import sys
 import urllib.parse
@@ -49,7 +52,7 @@ def _localhost_probe(url, instance_path):
     parsed = urllib.parse.urlsplit(url)
     scheme = parsed.scheme
     domain = parsed.netloc
-    url_path = parsed.path or "/"
+    url_path = parsed.path or "/w/api.php"
 
     bare_hostname = domain.split(":")[0]
 
@@ -58,9 +61,10 @@ def _localhost_probe(url, instance_path):
         context = ssl._create_unverified_context() if scheme == "https" else None
         try:
             with urllib.request.urlopen(req, timeout=15, context=context) as resp:
-                return _is_mediawiki_response(resp.read())
+                ok = _is_mediawiki_response(resp.read())
+                return ok, url.split("?")[0], None
         except Exception:
-            return False
+            return False, None, None
 
     env = _helpers._read_env_file(instance_path, "localhost") if instance_path else {}
     if scheme == "https":
@@ -71,11 +75,14 @@ def _localhost_probe(url, instance_path):
     if port:
         query_suffix = f"?{parsed.query}" if parsed.query else ""
         check_url = f"{scheme}://localhost:{port}{url_path}{query_suffix}"
+        api_base = f"{scheme}://localhost:{port}{url_path}"
     else:
         check_url = url
+        api_base = url.split("?")[0]
 
     req = urllib.request.Request(check_url)
-    req.add_header("Host", domain)
+    if port:
+        req.add_header("Host", domain)
 
     if scheme == "https":
         context = ssl._create_unverified_context()
@@ -84,25 +91,249 @@ def _localhost_probe(url, instance_path):
 
     try:
         with urllib.request.urlopen(req, timeout=15, context=context) as resp:
-            return _is_mediawiki_response(resp.read())
+            ok = _is_mediawiki_response(resp.read())
+            return ok, api_base, (domain if port else None)
     except Exception:
-        return False
+        return False, None, None
 
 
 def _check_url(wiki_url, host, instance_path=""):
     for url in _build_urls(wiki_url):
         if _helpers._is_localhost(host):
-            if _localhost_probe(url, instance_path):
-                return True
+            ok, api_url, host_header = _localhost_probe(url, instance_path)
+            if ok:
+                return True, api_url, host_header
         else:
-            cmd = (
-                "curl -sSLk "
-                + _helpers._shell_quote(url)
-            )
+            cmd = "curl -sSLk " + _helpers._shell_quote(url)
             rc, stdout = _helpers._ssh_run(host, cmd)
             if rc == 0 and _is_mediawiki_response(stdout):
-                return True
-    return False
+                return True, url.split("?")[0], None
+    return False, None, None
+
+
+def _get_admin_username(instance_id, instance, wiki_id):
+    cmd = "echo 'echo User::newFromId(1)->getName();' | php maintenance/run.php eval --wiki=%s" % _helpers._shell_quote(wiki_id)
+    rc, stdout = _helpers._exec_in_container(instance_id, instance, cmd)
+    if rc == 0 and stdout.strip():
+        lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+        if lines:
+            username = lines[-1]
+            if username and not username.startswith("Error"):
+                return username
+
+    return "WikiSysop"
+
+
+def _provision_bot_password(instance_id, instance, wiki_id, username, password):
+    cmd = (
+        "php maintenance/run.php createBotPassword --wiki=%s --appid=canasta-cli --grants=basic,createeditmovepage,delete,uploadfile %s %s"
+        % (
+            _helpers._shell_quote(wiki_id),
+            _helpers._shell_quote(username),
+            _helpers._shell_quote(password),
+        )
+    )
+    rc, stdout = _helpers._exec_in_container(instance_id, instance, cmd)
+    return rc == 0
+
+
+def _get_or_create_bot_password(instance_id, instance, wiki_id, host):
+    path = instance.get("path", "")
+    bot_password_file = os.path.join(path, f"admin-bot-password_{wiki_id}")
+    
+    # Read existing bot password
+    content = _helpers._read_remote_or_local_file(bot_password_file, host)
+    if content:
+        content = content.strip()
+        if ":" in content:
+            username, password = content.split(":", 1)
+            return username.strip(), password.strip()
+            
+    # Generate new one if not found
+    username = _get_admin_username(instance_id, instance, wiki_id)
+    password = secrets.token_hex(16)
+    
+    if _provision_bot_password(instance_id, instance, wiki_id, username, password):
+        file_content = f"{username}:{password}\n"
+        if _helpers._write_remote_or_local_file(bot_password_file, host, file_content):
+            if _helpers._is_localhost(host):
+                try:
+                    os.chmod(bot_password_file, 0o600)
+                except OSError:
+                    pass
+            else:
+                _helpers._ssh_run(host, "chmod 0600 %s" % _helpers._shell_quote(bot_password_file))
+            return username, password
+            
+    return None, None
+
+
+class MediaWikiClient:
+    def __init__(self, api_url, host_header=None):
+        self.api_url = api_url
+        self.host_header = host_header
+        cj = http.cookiejar.CookieJar()
+        handlers = [urllib.request.HTTPCookieProcessor(cj)]
+        if api_url.startswith("https"):
+            context = ssl._create_unverified_context()
+            handlers.append(urllib.request.HTTPSHandler(context=context))
+        self.opener = urllib.request.build_opener(*handlers)
+
+    def _request(self, params=None, files=None):
+        headers = {}
+        if self.host_header:
+            headers["Host"] = self.host_header
+
+        if files:
+            content_type, body = self._encode_multipart(params or {}, files)
+            headers["Content-Type"] = content_type
+            req = urllib.request.Request(self.api_url, data=body, headers=headers)
+        else:
+            data = urllib.parse.urlencode(params or {}).encode("utf-8")
+            req = urllib.request.Request(self.api_url, data=data, headers=headers)
+
+        with self.opener.open(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8", errors="ignore"))
+
+    def _encode_multipart(self, fields, files):
+        boundary = secrets.token_hex(16)
+        parts = []
+        for name, value in fields.items():
+            parts.append(f'--{boundary}')
+            parts.append(f'Content-Disposition: form-data; name="{name}"')
+            parts.append('')
+            parts.append(str(value))
+        for name, (filename, content, mimetype) in files.items():
+            parts.append(f'--{boundary}')
+            parts.append(f'Content-Disposition: form-data; name="{name}"; filename="{filename}"')
+            parts.append(f'Content-Type: {mimetype}')
+            parts.append('')
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+            parts.append(content)
+        parts.append(f'--{boundary}--')
+        parts.append(b'')
+
+        body = b""
+        for part in parts:
+            if isinstance(part, str):
+                body += part.encode("utf-8") + b"\r\n"
+            else:
+                body += part + b"\r\n"
+        
+        content_type = f"multipart/form-data; boundary={boundary}"
+        return content_type, body
+
+    def login(self, username, password):
+        res = self._request({"action": "query", "meta": "tokens", "type": "login", "format": "json"})
+        login_token = res.get("query", {}).get("tokens", {}).get("logintoken")
+        if not login_token:
+            raise RuntimeError("Could not retrieve login token")
+
+        res = self._request({
+            "action": "login",
+            "lgname": username,
+            "lgpassword": password,
+            "lgtoken": login_token,
+            "format": "json"
+        })
+        if res.get("login", {}).get("result") != "Success":
+            raise RuntimeError(f"Login failed: {res.get('login', {}).get('result')}")
+
+    def get_csrf_token(self):
+        res = self._request({"action": "query", "meta": "tokens", "type": "csrf", "format": "json"})
+        csrf_token = res.get("query", {}).get("tokens", {}).get("csrftoken")
+        if not csrf_token:
+            raise RuntimeError("Could not retrieve CSRF token")
+        return csrf_token
+
+    def edit_page(self, title, text, summary, token):
+        res = self._request({
+            "action": "edit",
+            "title": title,
+            "text": text,
+            "summary": summary,
+            "token": token,
+            "format": "json"
+        })
+        if "error" in res:
+            raise RuntimeError(f"Edit failed: {res['error'].get('info')}")
+        if res.get("edit", {}).get("result") != "Success":
+            raise RuntimeError("Edit failed")
+
+    def upload_file(self, filename, file_content, token):
+        res = self._request(
+            params={
+                "action": "upload",
+                "filename": filename,
+                "ignorewarnings": "1",
+                "token": token,
+                "format": "json"
+            },
+            files={
+                "file": (filename, file_content, "image/gif")
+            }
+        )
+        if "error" in res:
+            raise RuntimeError(f"Upload failed: {res['error'].get('info')}")
+        if res.get("upload", {}).get("result") != "Success":
+            raise RuntimeError("Upload failed")
+
+    def delete_page(self, title, reason, token):
+        res = self._request({
+            "action": "delete",
+            "title": title,
+            "reason": reason,
+            "token": token,
+            "format": "json"
+        })
+        if "error" in res:
+            if res["error"].get("code") in ("cantdelete", "missingtitle"):
+                return
+            raise RuntimeError(f"Delete failed: {res['error'].get('info')}")
+
+
+def _run_write_check(api_url, host_header, username, password):
+    client = MediaWikiClient(api_url, host_header)
+    client.login(f"{username}@canasta-cli", password)
+    token = client.get_csrf_token()
+    
+    temp_page = "Canasta-Wiki-Check-Temp-Page"
+    temp_file = "File:Canasta-Wiki-Check-Temp-File.gif"
+    
+    # 1x1 pixel transparent GIF
+    gif_data = bytes.fromhex("47494638396101000100800000000000ffffff21f90401000000002c00000000010001000002024401003b")
+    
+    try:
+        # Create
+        client.edit_page(
+            title=temp_page,
+            text="This is a temporary page created by the Canasta CLI wiki-check write test.",
+            summary="Canasta CLI write check",
+            token=token
+        )
+        # Edit
+        client.edit_page(
+            title=temp_page,
+            text="This is an updated temporary page created by the Canasta CLI wiki-check write test.",
+            summary="Canasta CLI write check update",
+            token=token
+        )
+        # Upload
+        client.upload_file(
+            filename="Canasta-Wiki-Check-Temp-File.gif",
+            file_content=gif_data,
+            token=token
+        )
+    finally:
+        try:
+            client.delete_page(temp_file, "Canasta CLI write check cleanup", token)
+        except Exception as e:
+            print(f"Warning: Failed to delete temporary file {temp_file}: {e}", file=sys.stderr)
+        try:
+            client.delete_page(temp_page, "Canasta CLI write check cleanup", token)
+        except Exception as e:
+            print(f"Warning: Failed to delete temporary page {temp_page}: {e}", file=sys.stderr)
 
 
 @register("wiki_check")
@@ -111,6 +342,7 @@ def cmd_wiki_check(args):
     host = getattr(args, "host", None) or instance.get("host") or "localhost"
     path = instance.get("path", "")
     wikis = _helpers._read_wikis(path, host)
+    do_write = getattr(args, "write", False)
 
     if not wikis:
         print(
@@ -130,8 +362,21 @@ def cmd_wiki_check(args):
             all_ok = False
             continue
 
-        if _check_url(wiki_url, host, instance_path=path):
+        is_reachable, api_url, host_header = _check_url(wiki_url, host, instance_path=path)
+
+        if is_reachable:
             print("Wiki '%s' is reachable at %s." % (wiki_id, wiki_url))
+            if do_write:
+                print("Performing write checks for '%s'..." % wiki_id)
+                try:
+                    username, password = _get_or_create_bot_password(instance_id, instance, wiki_id, host)
+                    if not username or not password:
+                        raise RuntimeError("Failed to retrieve or create bot password credentials")
+                    _run_write_check(api_url, host_header, username, password)
+                    print("Wiki '%s' write checks passed." % wiki_id)
+                except Exception as e:
+                    print("Wiki '%s' write checks failed: %s" % (wiki_id, e), file=sys.stderr)
+                    all_ok = False
         else:
             print("Wiki '%s' could not be reached at %s." % (wiki_id, wiki_url))
             all_ok = False

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -738,6 +738,10 @@ commands:
           Canasta instance ID — check the host where this instance is
           registered. Mutually exclusive with --host; --host wins if
           both are given.
+      - name: write
+        type: bool
+        default: false
+        description: "Perform write checks (create, edit, delete, upload) and clean up"
 
   - name: install
     description: "Install dependencies on the target host"

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -4534,3 +4534,146 @@ class TestRemoteK8sStreamAndExec:
         rc, out = direct_commands._helpers._exec_in_container("rsdev", inst, "true")
         assert rc == 0
         assert fake_run.argv[0] == "kubectl"
+
+
+class TestWikiCheckWrite:
+    def test_wiki_check_write_success(self, monkeypatch):
+        inst = {"id": "siteA", "host": "localhost", "path": "/tmp/i"}
+        monkeypatch.setattr(direct_commands.wiki_check._helpers, "_resolve_instance", lambda args: ("siteA", inst))
+        monkeypatch.setattr(direct_commands.wiki_check._helpers, "_read_wikis", lambda path, host: [{"id": "main", "url": "http://localhost:8080"}])
+        
+        monkeypatch.setattr(direct_commands.wiki_check._helpers, "_read_remote_or_local_file", lambda path, host: None)
+        monkeypatch.setattr(direct_commands.wiki_check._helpers, "_write_remote_or_local_file", lambda path, host, content: True)
+        
+        execs = []
+        def fake_exec_in_container(inst_id, instance, command, service="web"):
+            execs.append(command)
+            if "User::newFromId(1)->getName()" in command:
+                return 0, "WikiSysop\n"
+            if "createBotPassword" in command:
+                return 0, "success\n"
+            return 0, ""
+        monkeypatch.setattr(direct_commands.wiki_check._helpers, "_exec_in_container", fake_exec_in_container)
+        
+        urls_visited = []
+        
+        class FakeResponse:
+            def __init__(self, data):
+                self.data = data
+            def read(self):
+                return self.data
+            def __enter__(self):
+                return self
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+        def fake_open(opener_self, req, *args, **kwargs):
+            if isinstance(req, str):
+                url = req
+                data = None
+            else:
+                url = req.full_url
+                data = req.data
+            
+            urls_visited.append((url, data))
+            
+            data_str = ""
+            if data:
+                if isinstance(data, bytes):
+                    data_str = data.decode("utf-8", errors="ignore")
+                else:
+                    data_str = str(data)
+
+            def has_param(param):
+                if "=" in param:
+                    k, v = param.split("=", 1)
+                    if f"{k}={v}" in url or f"{k}={v}" in data_str:
+                        return True
+                    if f'name="{k}"' in data_str and v in data_str:
+                        return True
+                    return False
+                return param in url or param in data_str
+
+            if has_param("action=query") and has_param("meta=siteinfo"):
+                return FakeResponse(b'{"query": {"namespaces": {}}}')
+            elif has_param("action=query") and has_param("meta=tokens") and has_param("type=login"):
+                return FakeResponse(b'{"query": {"tokens": {"logintoken": "mock_login_token"}}}')
+            elif has_param("action=login"):
+                return FakeResponse(b'{"login": {"result": "Success"}}')
+            elif has_param("action=query") and has_param("meta=tokens") and has_param("type=csrf"):
+                return FakeResponse(b'{"query": {"tokens": {"csrftoken": "mock_csrf_token"}}}')
+            elif has_param("action=edit"):
+                return FakeResponse(b'{"edit": {"result": "Success"}}')
+            elif has_param("action=upload"):
+                return FakeResponse(b'{"upload": {"result": "Success"}}')
+            elif has_param("action=delete"):
+                return FakeResponse(b'{"delete": {"result": "Success"}}')
+            
+            return FakeResponse(b'{}')
+
+        monkeypatch.setattr(direct_commands.wiki_check.urllib.request.OpenerDirector, "open", fake_open)
+        
+        class Args:
+            id = "siteA"
+            host = None
+            write = True
+            
+        rc = direct_commands.wiki_check.cmd_wiki_check(Args())
+        assert rc == 0
+        
+        assert any("User::newFromId(1)->getName()" in cmd for cmd in execs)
+        assert any("createBotPassword" in cmd for cmd in execs)
+        
+        def has_visited(param):
+            for url, data in urls_visited:
+                data_str = data.decode("utf-8", errors="ignore") if isinstance(data, bytes) else str(data or "")
+                if param in url or param in data_str:
+                    return True
+                # also handle multipart fields (e.g. action and upload separated)
+                if "=" in param:
+                    k, v = param.split("=", 1)
+                    if f'name="{k}"' in data_str and v in data_str:
+                        return True
+            return False
+
+        assert has_visited("action=query") and has_visited("type=login")
+        assert has_visited("action=login")
+        assert has_visited("action=query") and has_visited("type=csrf")
+        assert has_visited("action=edit")
+        assert has_visited("action=upload")
+        
+        # Verify both deletes were sent (temporary page and temporary file)
+        assert len([data for _, data in urls_visited if data and (b"action=delete" in data or b'name="action"\r\n\r\ndelete' in data or b"delete" in data)]) == 2
+
+    def test_wiki_check_read_only_success(self, monkeypatch):
+        inst = {"id": "siteA", "host": "localhost", "path": "/tmp/i"}
+        monkeypatch.setattr(direct_commands.wiki_check._helpers, "_resolve_instance", lambda args: ("siteA", inst))
+        monkeypatch.setattr(direct_commands.wiki_check._helpers, "_read_wikis", lambda path, host: [{"id": "main", "url": "http://localhost:8080"}])
+        
+        urls_visited = []
+        
+        class FakeResponse:
+            def __init__(self, data):
+                self.data = data
+            def read(self):
+                return self.data
+            def __enter__(self):
+                return self
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+        def fake_open(opener_self, req, *args, **kwargs):
+            url = req if isinstance(req, str) else req.full_url
+            urls_visited.append(url)
+            return FakeResponse(b'{"query": {"namespaces": {}}}')
+
+        monkeypatch.setattr(direct_commands.wiki_check.urllib.request.OpenerDirector, "open", fake_open)
+        
+        class Args:
+            id = "siteA"
+            host = None
+            write = False
+            
+        rc = direct_commands.wiki_check.cmd_wiki_check(Args())
+        assert rc == 0
+        assert len(urls_visited) > 0


### PR DESCRIPTION
Implements #1077.

This PR implements the new `--write` flag for the `wiki-check` command. It enables full end-to-end mutation and write verification (page creation/editing and file uploading) for MediaWiki instances, ensuring write accessibility is operational.