### PR TITLE
ci: static Features job name so skipped PR checks render cleanly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,21 +116,20 @@ jobs:
         timeout-minutes: 20
 
   integration-features:
-    name: "Integration: Features (${{ matrix.leg.name }})"
+    name: "Integration: Features"
     if: github.event_name != 'pull_request'  # See #67
     runs-on: ubuntu-latest
     timeout-minutes: 25
     # Two parallel legs so the suite doesn't approach the step timeout and the
     # whole workflow's long pole is ~halved. Legs are balanced by measured
-    # per-test runtime; keep the two backup tests together on one leg.
+    # per-test runtime; keep the two backup tests together on one leg. The job
+    # name is static (no matrix expression) so GitHub renders the leg suffix
+    # correctly even when the job is skipped on pull_request events; the step
+    # below maps each leg label to its test set.
     strategy:
       fail-fast: false
       matrix:
-        leg:
-          - name: "config & farms"
-            tests: "extension-skin wiki-farm config-side-effects"
-          - name: "backup & ops"
-            tests: "backup backup-advanced sitemap maintenance"
+        leg: ["config & farms", "backup & ops"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -154,9 +153,16 @@ jobs:
           done
           git config --global user.name "CI"
           git config --global user.email "ci@canasta.wiki"
-      - name: Run feature tests
-        run: >-
-          .venv/bin/python tests/integration/run_tests.py ${{ matrix.leg.tests }}
+      - name: Run feature tests (${{ matrix.leg }})
+        env:
+          LEG: ${{ matrix.leg }}
+        run: |
+          case "$LEG" in
+            "config & farms") tests="extension-skin wiki-farm config-side-effects" ;;
+            "backup & ops")   tests="backup backup-advanced sitemap maintenance" ;;
+            *) echo "unknown feature leg: $LEG" >&2; exit 1 ;;
+          esac
+          .venv/bin/python tests/integration/run_tests.py $tests
         timeout-minutes: 20
 
   integration-gitops:


### PR DESCRIPTION
Fixes #1144.

Follow-up to #1142 / #1143.

## Problem

The split `Integration: Features` job named itself `Integration: Features (${{ matrix.leg.name }})`. GitHub does not evaluate a job `name` expression for a matrix job skipped by a job-level `if:`, and the integration jobs carry `if: github.event_name != 'pull_request'`. So on PRs the check appeared with the raw, unexpanded template. Cosmetic (a skipped, non-required check) but confusing.

## Fix

- Job `name` is now static `Integration: Features` (no matrix expression).
- `matrix.leg` reduced to plain strings `["config & farms", "backup & ops"]`.
- The step maps each leg label to its test set via a `case` (value passed through `env: LEG`, with a fail-fast `*)` for an unknown leg).

GitHub now builds the check name from compile-time literals — `Integration: Features (config & farms)` / `(backup & ops)` — which renders correctly whether the job runs (push) or is skipped (PR), like the non-matrix integration jobs already do.

## Validation

- Workflow YAML parses; matrix is two clean strings; the case mapping has a branch per leg and its union is exactly the original 7 tests (none dropped/added); all names exist in `run_tests.py --list`; the `case` block passes `bash -n`.
- No change to `push` behavior: same two legs, same tests, same timeouts.
