### PR TITLE
create: distinct exit code for an already-existing instance ID (#1124)

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -23,6 +23,12 @@ DEFINITIONS_PATH = os.path.join(SCRIPT_DIR, "meta", "command_definitions.yml")
 CANASTA_YML = os.path.join(SCRIPT_DIR, "canasta.yml")
 ANSIBLE_CFG = os.path.join(SCRIPT_DIR, "ansible.cfg")
 
+# Exit codes a wrapping script can branch on. 0 success; 1 unexpected
+# error; 2 usage error (argparse). 3 flags an expected precondition
+# refusal — the target already exists — so CI can special-case it
+# instead of treating it like a crash.
+EXIT_ALREADY_EXISTS = 3
+
 # Registry-location and lookup helpers are shared with the
 # canasta_registry Ansible module (which reads/writes conf.json), so the
 # CLI and the module never disagree about where the registry lives. The
@@ -864,6 +870,41 @@ def resolve_instance(instance_id=None):
     sys.exit(1)
 
 
+def check_create_precondition(args):
+    """For `create`, refuse a duplicate instance ID before Ansible runs.
+
+    Mirrors the `_validate_inputs.yml` registry check so an existing ID
+    fails in milliseconds with exit code 3 (EXIT_ALREADY_EXISTS) — a
+    distinct, expected refusal a wrapping script can branch on, rather
+    than the generic Ansible task-failure code. The playbook's own
+    `fail:` stays as the backstop. Returns without acting when the
+    registry is absent or the ID is free.
+    """
+    instance_id = getattr(args, "id", None)
+    if not instance_id:
+        return
+    conf_file = get_config_file_path()
+    if not os.path.isfile(conf_file):
+        return
+    instances = canasta_config.read_config(get_config_dir()).get("Instances", {})
+    existing = instances.get(instance_id)
+    if existing is None:
+        return
+    print(
+        "Error: Instance '%s' already exists in the registry "
+        "(path: %s, host: %s). "
+        "Run 'canasta delete --id %s' to remove it first."
+        % (
+            instance_id,
+            existing.get("path", "unknown"),
+            existing.get("host", "localhost"),
+            instance_id,
+        ),
+        file=sys.stderr,
+    )
+    sys.exit(EXIT_ALREADY_EXISTS)
+
+
 def _redirect_stdin_from_file(path):
     """Point fd 0 at `path` so the about-to-be-exec'd command reads it as
     stdin. Used by `maintenance exec --stdin-file`. No-op when path is unset.
@@ -1628,6 +1669,13 @@ def main():
     for code, message in collect_cli_param_errors(cmd_def, args):
         print(message, file=sys.stderr)
         sys.exit(code)
+
+    # Pre-flight: a duplicate instance ID is an expected refusal, not a
+    # crash. Catch it here so it exits with EXIT_ALREADY_EXISTS instead
+    # of the opaque Ansible task-failure code (the playbook still checks
+    # as a backstop).
+    if command_name == "create":
+        check_create_precondition(args)
 
     # Interactive exec: bypass Ansible for TTY support.
     if command_name == "maintenance_exec":

--- a/tests/unit/test_create_already_exists.py
+++ b/tests/unit/test_create_already_exists.py
@@ -1,0 +1,75 @@
+"""Tests for the `create` duplicate-ID pre-flight in canasta.py.
+
+`canasta create` refuses an ID that already exists in the registry. The
+refusal is caught in the CLI layer before Ansible runs so it exits with a
+distinct code (EXIT_ALREADY_EXISTS = 3) a wrapping script can branch on,
+rather than the opaque Ansible task-failure code. The playbook's own
+`fail:` in _validate_inputs.yml stays as the backstop.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+sys.path.insert(0, REPO_ROOT)
+
+import canasta  # noqa: E402
+
+
+def _seed_registry(config_dir, instances):
+    with open(os.path.join(config_dir, "conf.json"), "w") as f:
+        json.dump({"Instances": instances}, f)
+
+
+def _args(instance_id):
+    return argparse.Namespace(id=instance_id)
+
+
+class TestCreatePrecondition:
+    def test_duplicate_id_exits_already_exists(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("CANASTA_CONFIG_DIR", str(tmp_path))
+        _seed_registry(str(tmp_path), {
+            "icannwiki": {"path": "/opt/canasta/icannwiki", "host": "localhost"},
+        })
+        with pytest.raises(SystemExit) as exc:
+            canasta.check_create_precondition(_args("icannwiki"))
+        assert exc.value.code == canasta.EXIT_ALREADY_EXISTS
+        err = capsys.readouterr().err
+        assert "already exists in the registry" in err
+        assert "/opt/canasta/icannwiki" in err
+        assert "canasta delete --id icannwiki" in err
+
+    def test_message_uses_registered_host(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("CANASTA_CONFIG_DIR", str(tmp_path))
+        _seed_registry(str(tmp_path), {
+            "prodwiki": {"path": "/srv/prodwiki", "host": "prod1.example.com"},
+        })
+        with pytest.raises(SystemExit):
+            canasta.check_create_precondition(_args("prodwiki"))
+        assert "host: prod1.example.com" in capsys.readouterr().err
+
+    def test_host_defaults_to_localhost_when_absent(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("CANASTA_CONFIG_DIR", str(tmp_path))
+        _seed_registry(str(tmp_path), {"local": {"path": "/opt/canasta/local"}})
+        with pytest.raises(SystemExit):
+            canasta.check_create_precondition(_args("local"))
+        assert "host: localhost" in capsys.readouterr().err
+
+    def test_fresh_id_returns_without_exit(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CANASTA_CONFIG_DIR", str(tmp_path))
+        _seed_registry(str(tmp_path), {"other": {"path": "/opt/canasta/other"}})
+        # Must not raise: a free ID falls through to the normal create path.
+        assert canasta.check_create_precondition(_args("brandnew")) is None
+
+    def test_no_registry_file_returns_without_exit(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CANASTA_CONFIG_DIR", str(tmp_path))
+        assert canasta.check_create_precondition(_args("anything")) is None
+
+    def test_missing_id_returns_without_exit(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CANASTA_CONFIG_DIR", str(tmp_path))
+        _seed_registry(str(tmp_path), {"x": {"path": "/opt/canasta/x"}})
+        assert canasta.check_create_precondition(_args(None)) is None


### PR DESCRIPTION
## Summary

`canasta create` against an ID that already exists is an expected refusal,
but it exited with ansible-playbook's generic code `2` — the same code
argparse uses for usage errors and that any failed playbook task produces.
A wrapping CI script (e.g. a create-if-not-exists flow with `set -e`) had
no way to tell "already exists — carry on" from "something actually broke".

This adds a small documented exit-code contract and catches the
already-exists case in the CLI layer so it exits with a dedicated code.

| Code | Meaning |
|------|---------|
| 0 | success |
| 1 | unexpected/internal error (the "file an issue" case) |
| 2 | usage error (argparse) |
| **3** | **expected precondition refusal — instance already exists** |

## What changed

- `EXIT_ALREADY_EXISTS = 3` constant in `canasta.py`, documenting the scheme.
- `check_create_precondition(args)` reads the registry and, on a duplicate
  ID, prints the same message as the playbook and exits `3`. It returns
  silently when the registry is absent, the ID is free, or no `--id` is given.
- Wired into `main()` right after the existing CLI-layer parameter
  validation, gated on `create`.

Because `create` ends by `execvp`-ing into `ansible-playbook`, its exit code
can't be remapped after the fact — the check has to run before Ansible. This
mirrors the existing `collect_cli_param_errors` pattern (fast CLI-layer
validation, playbook re-validates as a backstop). The `fail:` in
`roles/create/tasks/_validate_inputs.yml` is unchanged and still catches the
case if the pre-flight is ever bypassed; the message text is identical
between the two layers.

## Scope

Deliberately narrow to the already-exists refusal. The other precondition
failures (non-empty target dir, invalid ID, port conflicts) stay hard
errors, and this does not make `create` idempotent — it does not reconcile
config against the existing instance, it just reports the refusal with a
code a script can branch on.

## Testing

- `tests/unit/test_create_already_exists.py` — 6 cases (duplicate ID,
  registered host in message, host default, fresh ID passthrough, no
  registry, missing `--id`).
- `make test-unit` — 1769 passed.
- `make validate` — passed.
- Manually: duplicate ID → clean message + exit 3; fresh ID → proceeds
  into the normal create flow.

Closes #1124
