### PR TITLE
fix: surface DB import failures instead of silent success

### DIFF
--- a/playbooks/add.yml
+++ b/playbooks/add.yml
@@ -176,7 +176,6 @@
       vars:
         import_wiki_id: "{{ wiki }}"
         import_database_path: "{{ database }}"
-        import_db_password: "{{ _add_dbpass.value }}"
 
 # --skip-install: the external database already holds this wiki's schema,
 # so register it in the farm without running install.php. Still wait for

--- a/playbooks/import.yml
+++ b/playbooks/import.yml
@@ -4,14 +4,6 @@
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
-- name: Read DB password from .env
-  canasta_env:
-    path: "{{ instance_path }}/.env"
-    state: read
-    key: MYSQL_PASSWORD
-  register: _import_dbpass
-  no_log: true
-
 - name: Wait for database
   ansible.builtin.include_role:
     name: mediawiki
@@ -24,7 +16,6 @@
   vars:
     import_wiki_id: "{{ wiki }}"
     import_database_path: "{{ database }}"
-    import_db_password: "{{ _import_dbpass.value }}"
 
 - name: Copy per-wiki Settings.php if provided
   ansible.builtin.copy:

--- a/roles/create/tasks/_database.yml
+++ b/roles/create/tasks/_database.yml
@@ -35,7 +35,6 @@
       vars:
         import_wiki_id: "{{ wiki }}"
         import_database_path: "{{ database }}"
-        import_db_password: "{{ _rootdbpass }}"
 
     - name: Generate and save MW_SECRET_KEY
       ansible.builtin.include_role:

--- a/roles/mediawiki/tasks/import_database.yml
+++ b/roles/mediawiki/tasks/import_database.yml
@@ -1,7 +1,12 @@
 ---
 # Import a SQL dump into a wiki database.
 # Input: instance_path, instance_orchestrator, instance_id,
-#        import_wiki_id, import_database_path, import_db_password
+#        import_wiki_id, import_database_path
+#
+# The mariadb client reads the root password from the db container's own
+# MYSQL_PWD/$MYSQL_ROOT_PASSWORD env, so the secret never enters the command
+# line. That keeps these execs off no_log, so a load failure surfaces the
+# actual mariadb stderr (the SQL error) instead of a redacted message.
 
 - name: Check if database file is gzipped
   ansible.builtin.set_fact:
@@ -12,8 +17,7 @@
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
   vars:
     exec_service: db
-    exec_command: "mariadb -u root -p'{{ import_db_password }}' -e 'CREATE DATABASE IF NOT EXISTS `{{ import_wiki_id }}`'"
-    exec_no_log: true
+    exec_command: "MYSQL_PWD=\"$MYSQL_ROOT_PASSWORD\" mariadb -u root -e 'CREATE DATABASE IF NOT EXISTS `{{ import_wiki_id }}`'"
 
 # Transfer the dump file from the controller to the target host if remote.
 # For localhost this is a no-op (same filesystem). For remote hosts, ansible
@@ -45,8 +49,7 @@
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
   vars:
     exec_service: db
-    exec_command: "gunzip -c /tmp/import.sql.gz | mariadb -u root -p'{{ import_db_password }}' '{{ import_wiki_id }}'"
-    exec_no_log: true
+    exec_command: "gunzip -c /tmp/import.sql.gz | MYSQL_PWD=\"$MYSQL_ROOT_PASSWORD\" mariadb -u root '{{ import_wiki_id }}'"
     exec_long: true
   when: _is_gzipped | bool
 
@@ -54,8 +57,7 @@
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
   vars:
     exec_service: db
-    exec_command: "mariadb -u root -p'{{ import_db_password }}' '{{ import_wiki_id }}' < /tmp/import.sql"
-    exec_no_log: true
+    exec_command: "MYSQL_PWD=\"$MYSQL_ROOT_PASSWORD\" mariadb -u root '{{ import_wiki_id }}' < /tmp/import.sql"
     exec_long: true
   when: not (_is_gzipped | bool)
 

--- a/roles/orchestrator/tasks/resilient_exec.yml
+++ b/roles/orchestrator/tasks/resilient_exec.yml
@@ -61,6 +61,13 @@
   # until-loop simply retries — transient resets during the wait don't
   # abort the operation, which keeps running on the target.
   ignore_unreachable: true
+  # A completed job with a non-zero rc makes async_status return the wrapped
+  # failure, which would abort this poll (and, on older ansible, retry the
+  # deterministic failure until retries drain) before "Report failure" runs.
+  # Keep the rc decision in "Report failure" so the loop only waits for the
+  # job to finish, deterministic failures stop immediately, and rx_fail is
+  # honored.
+  failed_when: false
   # async_status returns the wrapped job's result, including its `cmd`, so
   # honor rx_no_log here too — otherwise a secret in rx_cmd (e.g. the k3s
   # join token) surfaces in this task's output under -v.

--- a/tests/unit/test_import_failure_surfaced.py
+++ b/tests/unit/test_import_failure_surfaced.py
@@ -1,0 +1,99 @@
+"""Regression guard for #1150: a failed DB import must fail loudly with the
+real mariadb error, never a silent success that leaves an empty database.
+
+Two structural invariants keep the fix in place:
+
+  * resilient_exec.yml (the launch-then-poll used by every `exec_long` command,
+    including the import load) must set `failed_when: false` on the completion
+    poll. Otherwise async_status aborts the poll on a completed job's non-zero
+    rc — before "Report failure" runs — and on older ansible retries the
+    deterministic failure until the retries drain. failed_when: false keeps the
+    rc decision in "Report failure", so the load fails fast with the stderr and
+    `rx_fail` is honored.
+
+  * import_database.yml must source the DB root password from the db
+    container's own $MYSQL_ROOT_PASSWORD env, not inline it on the command
+    line. Inlining forces `exec_no_log`, which redacts "Report failure" — so
+    the operator sees a censored message instead of the SQL error.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+RESILIENT_EXEC = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "resilient_exec.yml")
+IMPORT_DB = os.path.join(
+    REPO_ROOT, "roles", "mediawiki", "tasks", "import_database.yml")
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f) or []
+
+
+class TestResilientExecFailsFast:
+    def test_completion_poll_does_not_fail_on_nonzero_rc(self):
+        tasks = _load(RESILIENT_EXEC)
+        waits = [
+            t for t in tasks
+            if isinstance(t, dict)
+            and ("ansible.builtin.async_status" in t or "async_status" in t)
+            and "until" in t
+        ]
+        assert waits, (
+            "resilient_exec.yml must poll completion with async_status + until")
+        for t in waits:
+            assert t.get("failed_when") is False, (
+                "the completion poll must set `failed_when: false` so a "
+                "completed job's non-zero rc reaches 'Report failure' instead "
+                "of aborting the poll / retrying a deterministic failure "
+                "(#1150): %r" % t.get("name"))
+
+    def test_report_failure_task_present(self):
+        tasks = _load(RESILIENT_EXEC)
+        fails = [t for t in tasks if isinstance(t, dict)
+                 and ("ansible.builtin.fail" in t or "fail" in t)]
+        assert fails, (
+            "resilient_exec.yml must keep a 'Report failure' task that surfaces "
+            "the job's rc/stderr")
+
+
+class TestImportSurfacesError:
+    def _load_commands(self):
+        """(task, exec_command) for every include of exec.yml that runs a
+        mariadb command in import_database.yml."""
+        out = []
+        for t in _load(IMPORT_DB):
+            if not isinstance(t, dict):
+                continue
+            v = t.get("vars") or {}
+            cmd = v.get("exec_command", "")
+            if "mariadb" in cmd:
+                out.append((t, v, cmd))
+        return out
+
+    def test_password_not_inlined_on_command_line(self):
+        cmds = self._load_commands()
+        assert cmds, "import_database.yml must run mariadb commands"
+        for t, _v, cmd in cmds:
+            assert "import_db_password" not in cmd, (
+                "the DB load must not inline import_db_password on the command "
+                "line (forces no_log, which redacts the SQL error) (#1150): %r"
+                % cmd)
+            assert "-p'" not in cmd and "-p{{" not in cmd, (
+                "the DB load must not pass -p<password> on the command line "
+                "(#1150): %r" % cmd)
+
+    def test_password_sourced_from_container_env(self):
+        for _t, _v, cmd in self._load_commands():
+            assert "MYSQL_ROOT_PASSWORD" in cmd, (
+                "the DB load must source the password from the db container's "
+                "$MYSQL_ROOT_PASSWORD env: %r" % cmd)
+
+    def test_load_execs_not_no_log(self):
+        for t, v, _cmd in self._load_commands():
+            assert not v.get("exec_no_log"), (
+                "the DB load must not set exec_no_log, so the mariadb stderr "
+                "(the SQL error) surfaces on failure (#1150): %r" % t.get("name"))


### PR DESCRIPTION
Fixes #1150.

`canasta import` (and `create`/`add --database`) could leave a wiki's database **empty while reporting success**: a non-zero `mariadb` load was not surfaced as an import failure, and on older ansible the deterministic failure was retried ~180× as if it were a transient connection reset.

## Changes

**`resilient_exec.yml`** — add `failed_when: false` to the completion poll so `async_status` no longer aborts (or retries) on a completed job's non-zero rc before "Report failure" runs. The rc decision stays in "Report failure", so a deterministic failure stops immediately and `rx_fail` is honored (the current behavior aborts the poll regardless of `rx_fail`, e.g. `helm_uninstall`).

**`import_database.yml`** — source the root password from the db container's own `$MYSQL_ROOT_PASSWORD` env instead of inlining it, so the load execs no longer need `no_log` and the actual `mariadb` stderr (the SQL error) reaches the operator. Drops the now-unused `import_db_password` plumbing from `import`/`add`/`create`.

## Notes
- The Python `retry_on_reset` path was already correct (retries only on ssh-255), so it is unchanged.
- Verified with local ansible repros: a completed job with non-zero rc now reaches "Report failure" with the stderr, does not retry, and `rx_fail: false` completes cleanly.
- `make test-unit` (1769 passed), `make lint`, `make validate` all green.