### PR TITLE
fix: config regenerate no longer takes down a gitops Compose instance

### DIFF
--- a/playbooks/config_regenerate.yml
+++ b/playbooks/config_regenerate.yml
@@ -34,6 +34,18 @@
     {{ canasta_root }}/roles/orchestrator/tasks/render_gitops_config.yml
   when: _regen_gitops_stat.stat.exists | default(false)
 
+# .env is re-rendered verbatim from env.template, which has no
+# COMPOSE_PROFILES line, so the render drops it. Reconcile COMPOSE_PROFILES
+# from the rendered feature flags + DB mode — exactly as gitops pull does
+# (pull_compose.yml Step 7b) — so a subsequent down/up still starts the
+# database and feature containers instead of leaving them unmanaged.
+- name: Reconcile COMPOSE_PROFILES after render
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/sync_compose_profiles.yml
+  when:
+    - _regen_gitops_stat.stat.exists | default(false)
+    - instance_orchestrator | default('compose') == 'compose'
+
 - name: Regenerate orchestrator config (e.g. Caddyfile)
   ansible.builtin.include_role:
     name: orchestrator

--- a/roles/gitops/tasks/render_compose.yml
+++ b/roles/gitops/tasks/render_compose.yml
@@ -74,9 +74,13 @@
         src: "{{ instance_path }}/wikis.yaml.template"
       register: _render_wikis_template_raw
 
-    - name: Render config/wikis.yaml from template
-      ansible.builtin.copy:
-        content: |
+    # Render into a fact first so we can validate it BEFORE it replaces the
+    # live config/wikis.yaml. A missing wiki_url_<id> var renders url empty,
+    # which makes MediaWiki's FarmConfigLoader fatal on every request — refuse
+    # to write that rather than take the wiki down.
+    - name: Render wikis.yaml content from template
+      ansible.builtin.set_fact:
+        _render_wikis_content: |
           {% for line in (_render_wikis_template_raw.content | b64decode).split('\n') %}
           {% if '{{' in line and '}}' in line %}
           {% set before = line.split('{{', 1)[0] %}
@@ -87,6 +91,25 @@
           {{ line }}
           {% endif %}
           {% endfor %}
+
+    - name: Fail if any wiki url rendered empty (missing wiki_url_<id> var)
+      ansible.builtin.fail:
+        msg: >-
+          Refusing to write config/wikis.yaml: the url for wiki(s)
+          {{ _render_empty_url_wikis | join(', ') }} rendered empty because a
+          wiki_url_<id> var is not defined in this host's vars.yaml or
+          hosts/_shared/vars.yaml. Add e.g.
+          'wiki_url_{{ _render_empty_url_wikis[0] }}' to the host vars — a
+          blank url makes MediaWiki fatal on every request.
+      vars:
+        _render_empty_url_wikis: >-
+          {{ (_render_wikis_content | from_yaml).wikis | default([])
+             | rejectattr('url') | map(attribute='id') | list }}
+      when: _render_empty_url_wikis | length > 0
+
+    - name: Write config/wikis.yaml
+      ansible.builtin.copy:
+        content: "{{ _render_wikis_content }}"
         dest: "{{ instance_path }}/config/wikis.yaml"
         mode: "0644"
 


### PR DESCRIPTION
Fixes #1164.

`canasta config regenerate` re-renders rendered files verbatim from templates without the safeguards `gitops pull` applies, which could crash-loop a live wiki. Two distinct defects:

## Defect 1 — blank `wikis.yaml` url → FarmConfigLoader fatal
A missing `wiki_url_<id>` var rendered `config/wikis.yaml`'s `url` empty, and MediaWiki's `FarmConfigLoader` fatals on every request for a blank url (web container crash-loops).

`render_compose.yml` now renders `wikis.yaml` into a fact and **refuses to overwrite** the live file when any wiki `url` came out empty, naming the offending wiki(s) and the var to add — instead of taking the site down.

## Defect 2 — dropped `COMPOSE_PROFILES`
`.env` re-rendered verbatim from `env.template` (which has no `COMPOSE_PROFILES` line) dropped the profile set, so a later `down`/`up` would not start the database or feature containers.

`config_regenerate.yml` now reconciles `COMPOSE_PROFILES` from the rendered flags after the render, exactly as `gitops pull` does (`pull_compose.yml` Step 7b).

## Notes
- The empty-url guard lives in `render_compose.yml`, so `restore`/`join` benefit too.
- `pull_compose.yml` carries the same empty-url render pattern but is a different command; left for a possible follow-up.
- Verified the guard logic with a local ansible repro (path-based urls pass; blank url fails naming the wiki). `make test-unit` (1769 passed), `make lint`, `make validate` all green.