### PR TITLE
fix: gitops rm fails on a path that matches no tracked file

### DIFF
--- a/roles/gitops/tasks/rm.yml
+++ b/roles/gitops/tasks/rm.yml
@@ -5,14 +5,39 @@
 - name: Remove specific file
   when: path is defined and path != ''
   block:
+    # Paths are resolved relative to the repo root (chdir below), not the
+    # caller's CWD. Verify the path matches a tracked file BEFORE deleting or
+    # staging: git rm --ignore-unmatch would exit 0 on a non-matching path
+    # (e.g. a bare filename run from a subdirectory), so the command silently
+    # no-ops while reporting success.
+    - name: Check the path matches a tracked file
+      ansible.builtin.command:
+        cmd: "git ls-files --error-unmatch -- {{ path }}"
+        chdir: "{{ instance_path }}"
+      register: _rm_tracked
+      changed_when: false
+      failed_when: false
+
+    - name: Fail if the path matches no tracked file
+      ansible.builtin.fail:
+        msg: >-
+          gitops rm: path '{{ path }}' does not match any tracked file. Paths
+          are relative to the repo root ({{ instance_path }}); pass a
+          repo-root-relative path (e.g.
+          config/settings/global/{{ path | basename }}).
+      when: _rm_tracked.rc != 0
+
     - name: Delete file from disk
       ansible.builtin.file:
         path: "{{ instance_path }}/{{ path }}"
         state: absent
 
+    # No --ignore-unmatch here: the path is confirmed tracked above, so a
+    # non-zero rc now means a real failure worth surfacing. -r allows a
+    # tracked directory path to be removed as well as a single file.
     - name: Stage file deletion
       ansible.builtin.command:
-        cmd: "git rm --cached --ignore-unmatch {{ path }}"
+        cmd: "git rm -r --cached -- {{ path }}"
         chdir: "{{ instance_path }}"
       changed_when: true
 

--- a/tests/unit/test_gitops_rm_scope.py
+++ b/tests/unit/test_gitops_rm_scope.py
@@ -2,10 +2,12 @@
 
 'gitops rm' is the inverse of the well-tested 'gitops add' (see
 test_gitops_add_scope). It must:
-  * untrack a named path with `git rm --cached --ignore-unmatch` — `--cached`
-    so git never touches the working tree (the on-disk delete is a separate,
-    explicit step), and `--ignore-unmatch` so removing an already-untracked
-    path is idempotent rather than a hard failure;
+  * untrack a named path with `git rm --cached` — `--cached` so git never
+    touches the working tree (the on-disk delete is a separate, explicit step);
+  * NOT use `--ignore-unmatch` on the explicit-path rm — that flag exits 0 on
+    a path that matches nothing, which silently no-ops while reporting success
+    (#1163). Instead the path is validated with `git ls-files --error-unmatch`
+    first, so a non-matching path fails loudly with actionable guidance;
   * gate the on-disk delete on an explicit path (never a whole-tree wipe); and
   * stage pending deletions with `git add -u` (deletions only), never a
     whole-tree `git add -A` / `git add .`.
@@ -49,16 +51,25 @@ def _cmd(task):
 
 
 class TestGitopsRmScope:
-    def test_untrack_uses_cached_and_ignore_unmatch(self):
+    def test_untrack_uses_cached_without_ignore_unmatch(self):
         rm_cmds = [_cmd(t) for t, _w in _load_tasks() if "git rm" in _cmd(t)]
         assert rm_cmds, "rm.yml must untrack via a `git rm` command"
         for c in rm_cmds:
             assert "--cached" in c, (
                 "`git rm` must use --cached so it never deletes from the "
                 "working tree (the on-disk delete is a separate step): %r" % c)
-            assert "--ignore-unmatch" in c, (
-                "`git rm` must use --ignore-unmatch so untracking an "
-                "already-untracked path is idempotent: %r" % c)
+            assert "--ignore-unmatch" not in c, (
+                "the explicit-path `git rm` must NOT use --ignore-unmatch — it "
+                "hides a non-matching path as a silent no-op (#1163): %r" % c)
+
+    def test_path_validated_before_removal(self):
+        """A non-matching path must fail loudly, so rm.yml validates the path
+        is tracked (git ls-files --error-unmatch) before deleting/staging."""
+        validators = [_cmd(t) for t, _w in _load_tasks()
+                      if "ls-files" in _cmd(t) and "--error-unmatch" in _cmd(t)]
+        assert validators, (
+            "rm.yml must validate the path with "
+            "`git ls-files --error-unmatch` before removing it (#1163)")
 
     def test_disk_delete_is_path_scoped(self):
         """The on-disk file removal must be guarded by an explicit path so it


### PR DESCRIPTION
Fixes #1163.

`git rm --ignore-unmatch` exits 0 on a path that matches nothing, so `canasta gitops rm <path>` **silently no-opped while reporting success** when the path was not repo-root-relative — most often a bare filename run from a subdirectory. The operator believed a deletion was staged when it was not; `gitops status` then showed the file still unstaged.

## Fix
- Verify the path matches a tracked file (`git ls-files --error-unmatch`) **before** deleting/staging, and fail with an actionable message naming the repo-root requirement.
- Drop `--ignore-unmatch` from the explicit single-path `rm` (a non-zero rc now means a real failure). Keep the no-arg "stage all pending deletions" branch, which legitimately may match nothing.
- Add `-r` so a tracked directory path is removed as well as a single file.

`make lint` / `make validate` green.
