### PR TITLE
fix: fix-submodules writes clean .gitmodules stanzas

### DIFF
--- a/roles/gitops/tasks/fix_submodules.yml
+++ b/roles/gitops/tasks/fix_submodules.yml
@@ -137,15 +137,37 @@
       loop_control:
         label: "{{ item.item }}"
 
-    - name: Append recovered entries to .gitmodules
-      ansible.builtin.blockinfile:
-        path: "{{ instance_path }}/.gitmodules"
-        create: true
-        marker: "# {mark} ANSIBLE MANAGED BLOCK (fix-submodules {{ item.item }})"
-        block: |
-          [submodule "{{ item.item }}"]
-          	path = {{ item.item }}
-          	url = {{ item.stdout | trim }}
+    # Write clean [submodule] stanzas with git's own config writer rather than
+    # blockinfile, which would wrap every entry in
+    # "# BEGIN/END ANSIBLE MANAGED BLOCK" comments — noise in a machine-read,
+    # git-managed file. git config creates .gitmodules if absent and updates
+    # the entry in place on a re-run.
+    - name: Register recovered submodule path in .gitmodules
+      ansible.builtin.command:
+        argv:
+          - git
+          - config
+          - -f
+          - .gitmodules
+          - "submodule.{{ item.item }}.path"
+          - "{{ item.item }}"
+        chdir: "{{ instance_path }}"
+      changed_when: true
+      loop: "{{ _orphan_urls.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    - name: Register recovered submodule url in .gitmodules
+      ansible.builtin.command:
+        argv:
+          - git
+          - config
+          - -f
+          - .gitmodules
+          - "submodule.{{ item.item }}.url"
+          - "{{ item.stdout | trim }}"
+        chdir: "{{ instance_path }}"
+      changed_when: true
       loop: "{{ _orphan_urls.results }}"
       loop_control:
         label: "{{ item.item }}"

--- a/tests/unit/test_fix_submodules_gitmodules.py
+++ b/tests/unit/test_fix_submodules_gitmodules.py
@@ -1,0 +1,59 @@
+"""Regression guard for #1156: `gitops fix-submodules` must write clean
+.gitmodules stanzas, not blockinfile with "ANSIBLE MANAGED BLOCK" comments.
+
+.gitmodules is a machine-read, git-managed file; the wrapper comments are noise
+that obscures any legitimate annotation. Recovered entries must be written with
+git's own config writer (git config -f .gitmodules).
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+FIX_SUBMODULES = os.path.join(
+    REPO_ROOT, "roles", "gitops", "tasks", "fix_submodules.yml")
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f) or []
+
+
+def _walk(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk(t[nested])
+
+
+def _cmd_text(t):
+    c = t.get("ansible.builtin.command") or t.get("command") or {}
+    if not isinstance(c, dict):
+        return str(c)
+    if c.get("argv"):
+        return " ".join(str(a) for a in c["argv"])
+    return c.get("cmd", "")
+
+
+class TestFixSubmodulesGitmodules:
+    def test_no_blockinfile_on_gitmodules(self):
+        for t in _walk(_load(FIX_SUBMODULES)):
+            bi = t.get("ansible.builtin.blockinfile") or t.get("blockinfile")
+            if isinstance(bi, dict) and ".gitmodules" in bi.get("path", ""):
+                raise AssertionError(
+                    "fix-submodules must not write .gitmodules with blockinfile "
+                    "— it injects '# ANSIBLE MANAGED BLOCK' comments (#1156): %r"
+                    % t.get("name"))
+
+    def test_writes_gitmodules_with_git_config(self):
+        writers = [
+            t for t in _walk(_load(FIX_SUBMODULES))
+            if "config" in _cmd_text(t) and ".gitmodules" in _cmd_text(t)
+        ]
+        assert writers, (
+            "fix-submodules must write .gitmodules entries with "
+            "`git config -f .gitmodules submodule.<name>.path/.url` (#1156)")


### PR DESCRIPTION
Fixes #1156.

`gitops fix-submodules` built `.gitmodules` with `blockinfile`, wrapping every recovered entry in `# BEGIN/END ANSIBLE MANAGED BLOCK (...)` comments — noise in a machine-read, git-managed file that obscures any legitimate annotation.

## Fix
Write the entries with git's own config writer (`git config -f .gitmodules submodule.<name>.path/.url`) instead, producing clean `[submodule]` stanzas. `git config` creates the file if absent and updates entries in place on a re-run. The `argv` form passes the URL as a single literal argument, robust against special characters.

Verified the output is byte-for-byte git-canonical and round-trips via `git config --get`. `make lint` / `make validate` green.
