### PR TITLE
fix: gitops init fails early on an unreachable/unauthorized remote

### DIFF
--- a/roles/gitops/tasks/init_compose.yml
+++ b/roles/gitops/tasks/init_compose.yml
@@ -90,14 +90,32 @@
 # The fetch module handles overwriting if the file already exists.
 
 # --- Step 4: Validate remote is empty (unless --force) ---
-- name: Check remote is empty
+# Runs under the deploy-key env, so it authenticates exactly like the eventual
+# push. Inspect the rc ourselves rather than letting ignore_errors swallow it:
+# an unreachable/unauthorized remote (rc != 0, empty stdout) must not look the
+# same as a reachable empty remote, or init would do all the local work
+# (submodule conversion, git init, commit) and only discover the problem at the
+# final push — leaving a committed .git that forces a --reinit.
+- name: Check remote is reachable and empty
   ansible.builtin.command:
     cmd: "git ls-remote {{ repo }}"
   environment: "{{ gitops_git_env }}"
   register: _remote_check
   changed_when: false
-  ignore_errors: true  # OK if remote unreachable
+  failed_when: false
   when: not (force | default(false) | bool)
+
+- name: Fail early if the remote is unreachable or unauthorized
+  ansible.builtin.fail:
+    msg: >-
+      Cannot access remote '{{ repo }}' (git ls-remote failed:
+      {{ _remote_check.stderr | default('') | trim }}). Check the deploy key
+      and that it has push permission to the repo, then retry. init stops
+      here, before the local git repository is created.
+  when:
+    - not (force | default(false) | bool)
+    - _remote_check is defined
+    - _remote_check.rc | default(1) != 0
 
 - name: Fail if remote is not empty
   ansible.builtin.fail:

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -240,7 +240,11 @@
     - not (_deploy_key_authorized | bool)
     - not (non_interactive | default(false) | bool)
 
-- name: Check remote is empty
+# Inspect the rc ourselves rather than letting ignore_errors swallow it: an
+# unreachable/unauthorized remote must not look the same as a reachable empty
+# remote, or init would do all the local work (git init, submodule conversion,
+# commit at lines below) and only discover the problem at the final push.
+- name: Check remote is reachable and empty
   ansible.builtin.command:
     cmd: "git ls-remote {{ repo }}"
   environment:
@@ -250,7 +254,16 @@
       -o UserKnownHostsFile=~/.ssh/known_hosts
   register: _gitops_remote
   changed_when: false
-  ignore_errors: true
+  failed_when: false
+
+- name: Fail early if the remote is unreachable or unauthorized
+  ansible.builtin.fail:
+    msg: >-
+      Cannot access remote '{{ repo }}' (git ls-remote failed:
+      {{ _gitops_remote.stderr | default('') | trim }}). Check the deploy key
+      and that it has push permission to the repo, then retry. init stops here,
+      before the local git repository is created.
+  when: _gitops_remote.rc | default(1) != 0
 
 - name: Fail if remote is not empty
   ansible.builtin.fail:

--- a/tests/unit/test_init_fail_early_remote.py
+++ b/tests/unit/test_init_fail_early_remote.py
@@ -52,23 +52,27 @@ class TestInitFailsEarlyOnUnreachableRemote:
     def test_each_init_path_fails_on_unreachable_remote(self):
         for path in INIT_FILES:
             tasks = list(_walk(_load(path)))
-            checks = [t for t in tasks if "ls-remote" in _cmd_text(t)]
+            # An init file may run more than one `git ls-remote` (e.g. a
+            # deploy-key authorization probe that legitimately uses
+            # ignore_errors). We only require that the *empty/reachability*
+            # check — the one whose registered rc a fail task keys on — inspects
+            # rc via failed_when: false and hard-fails when it is non-zero.
+            checks = [t for t in tasks
+                      if "ls-remote" in _cmd_text(t) and t.get("register")]
             assert checks, (
-                "%s must probe the remote with git ls-remote" % path)
-            reg = checks[0].get("register")
-            assert reg, "%s: the ls-remote check must register its result" % path
-
-            # The rc must be inspectable (not aborted mid-play): the check uses
-            # failed_when: false rather than plain success.
-            assert checks[0].get("failed_when") is False, (
-                "%s: the ls-remote check must use `failed_when: false` so its "
-                "rc can be inspected instead of aborting (#1157)" % path)
-
+                "%s must probe the remote with a registered git ls-remote"
+                % path)
             fails = [t for t in tasks
                      if "ansible.builtin.fail" in t or "fail" in t]
-            rc_guard = [t for t in fails
-                        if reg in _when_text(t) and "rc" in _when_text(t)]
-            assert rc_guard, (
-                "%s must fail early when the remote is unreachable — a fail "
-                "task keyed on %s.rc != 0, before any local mutation (#1157)"
-                % (path, reg))
+
+            reachability = [
+                c for c in checks
+                if c.get("failed_when") is False
+                and any(c["register"] in _when_text(f) and "rc" in _when_text(f)
+                        for f in fails)
+            ]
+            assert reachability, (
+                "%s must fail early when the remote is unreachable — an "
+                "ls-remote check with `failed_when: false` plus a fail task "
+                "keyed on its rc != 0, before any local mutation (#1157)"
+                % path)

--- a/tests/unit/test_init_fail_early_remote.py
+++ b/tests/unit/test_init_fail_early_remote.py
@@ -1,0 +1,74 @@
+"""Regression guard for #1157: `gitops init` must fail early on an
+unreachable/unauthorized remote, before any local mutation.
+
+The Step 4 `git ls-remote` must not swallow access failures — a permission /
+network failure (non-zero rc) must be distinguishable from a reachable empty
+remote, and a fail task keyed on that rc must stop init before it converts
+submodules / inits the repo / commits (which would leave a committed .git that
+forces a --reinit). Applies to both the Compose and Kubernetes init paths.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+INIT_FILES = [
+    os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "init_compose.yml"),
+    os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "init_kubernetes.yml"),
+]
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f) or []
+
+
+def _walk(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk(t[nested])
+
+
+def _cmd_text(t):
+    c = t.get("ansible.builtin.command") or t.get("command") or {}
+    if not isinstance(c, dict):
+        return str(c)
+    return c.get("cmd", "")
+
+
+def _when_text(t):
+    w = t.get("when")
+    if not w:
+        return ""
+    return " ".join(w) if isinstance(w, list) else str(w)
+
+
+class TestInitFailsEarlyOnUnreachableRemote:
+    def test_each_init_path_fails_on_unreachable_remote(self):
+        for path in INIT_FILES:
+            tasks = list(_walk(_load(path)))
+            checks = [t for t in tasks if "ls-remote" in _cmd_text(t)]
+            assert checks, (
+                "%s must probe the remote with git ls-remote" % path)
+            reg = checks[0].get("register")
+            assert reg, "%s: the ls-remote check must register its result" % path
+
+            # The rc must be inspectable (not aborted mid-play): the check uses
+            # failed_when: false rather than plain success.
+            assert checks[0].get("failed_when") is False, (
+                "%s: the ls-remote check must use `failed_when: false` so its "
+                "rc can be inspected instead of aborting (#1157)" % path)
+
+            fails = [t for t in tasks
+                     if "ansible.builtin.fail" in t or "fail" in t]
+            rc_guard = [t for t in fails
+                        if reg in _when_text(t) and "rc" in _when_text(t)]
+            assert rc_guard, (
+                "%s must fail early when the remote is unreachable — a fail "
+                "task keyed on %s.rc != 0, before any local mutation (#1157)"
+                % (path, reg))


### PR DESCRIPTION
Fixes #1157.

`gitops init` did not fail early when the remote was unreachable/unauthorized. The Step 4 `git ls-remote` ran under `ignore_errors`, so a permission/network failure (non-zero rc, empty stdout) was indistinguishable from a reachable empty remote. init then did all the local work — submodule conversion, `git init`, commit — and only discovered the problem at the final push, leaving a committed `.git` that forces a `--reinit` (which trips the broken-submodule bug #1155). A missing deploy key thus cascaded into a corrupted submodule set.

## Fix
Inspect the `ls-remote` rc directly (`failed_when: false`) and hard-fail **before any local mutation** when the remote is unreachable/unauthorized, with an actionable message pointing at the deploy key / push permission. Only a genuinely reachable, non-empty remote still requires `--force`.

Applied to both the Compose (`init_compose.yml`) and Kubernetes (`init_kubernetes.yml`) init paths — same command, same swallow. `make lint` / `make validate` green.
