### PR TITLE
fix: gitops status reports unknown instead of false in-sync when the remote check fails

### DIFF
--- a/direct_commands/__init__.py
+++ b/direct_commands/__init__.py
@@ -135,6 +135,7 @@ from .gitops import (  # noqa: F401
     _parse_gitops_diff,
     _parse_gitops_status,
     _parse_gitops_status_k8s,
+    _parse_remote_sync,
     _wikis_uncaptured_edit,
 )
 from .extension_skin import cmd_extension_list, cmd_skin_list  # noqa: F401

--- a/direct_commands/gitops.py
+++ b/direct_commands/gitops.py
@@ -12,20 +12,29 @@ from ._helpers import register
 
 
 def _git_ssh_env_prefix(ssh_key):
-    """Shell `export GIT_SSH_COMMAND=...; ` prefix for a given SSH key.
+    """Shell `export GIT_SSH_COMMAND=...; ` prefix that authenticates read-side
+    git operations (fetch/ls-remote) the same way push/pull do.
 
-    Mirrors the Ansible gitops_git_env convention (accept-new host keys,
-    explicit known_hosts). Returns an empty string when no key is given,
-    leaving git's ambient SSH config (agent forwarding / deploy key)
-    untouched.
+    Always applies the Ansible gitops_git_env host-key convention (accept-new,
+    explicit known_hosts) — even without an explicit key — so a status `git
+    fetch` doesn't fail host-key verification on a host that has never talked
+    to the forge, which push (running under gitops_git_env) survives.
+
+    Key precedence mirrors the Ansible flows: an explicit --ssh-key, else the
+    instance's staged .gitops-deploy-key (Kubernetes), else ambient ssh (the
+    operator's forwarded agent on Compose). The .gitops-deploy-key fallback is
+    a relative path, so callers must have cd'd into the instance path first.
     """
-    if not ssh_key:
-        return ""
+    opts = ("-o StrictHostKeyChecking=accept-new "
+            "-o UserKnownHostsFile=~/.ssh/known_hosts")
+    if ssh_key:
+        return ('export GIT_SSH_COMMAND="ssh -i %s %s"; '
+                % (_helpers._shell_quote(ssh_key), opts))
     return (
-        'export GIT_SSH_COMMAND="ssh -i %s '
-        '-o StrictHostKeyChecking=accept-new '
-        '-o UserKnownHostsFile=~/.ssh/known_hosts"; '
-        % _helpers._shell_quote(ssh_key)
+        'if [ -f .gitops-deploy-key ]; then '
+        'export GIT_SSH_COMMAND="ssh -i .gitops-deploy-key %(o)s"; '
+        'else export GIT_SSH_COMMAND="ssh %(o)s"; fi; '
+        % {"o": opts}
     )
 
 
@@ -48,8 +57,11 @@ def _gitops_status_script(path, ssh_key=None):
         "echo '%(d)s'; "
         "git diff --name-status 2>/dev/null; "
         "echo '%(d)s'; "
-        "git fetch 2>/dev/null; "
-        "git rev-list --left-right --count HEAD...@{upstream} 2>/dev/null || echo '0\t0'; "
+        # Report fetch and rev-list outcomes distinctly instead of collapsing
+        # any failure into '0\t0' — a failed fetch or an unresolved @{upstream}
+        # must not read as "in sync". The parser keys on these markers.
+        "git fetch 2>/dev/null && echo 'FETCH:ok' || echo 'FETCH:fail'; "
+        "git rev-list --left-right --count HEAD...@{upstream} 2>/dev/null || echo 'REVLIST:fail'; "
         "echo '%(d)s'; "
         "cat config/wikis.yaml 2>/dev/null; "
         "echo '%(d)s'; "
@@ -205,6 +217,41 @@ def _working_tree_advisory_lines(staged, unstaged, untracked, wikis_drift):
     return lines
 
 
+def _parse_remote_sync(section):
+    """Parse the fetch-status + rev-list section into (ahead, behind, state).
+
+    state is one of:
+      'ok'           - fetch succeeded and @{upstream} resolved; ahead/behind
+                       are meaningful.
+      'fetch_failed' - `git fetch` did not reach the remote; any ahead/behind
+                       would be against a stale ref, so it is not reported.
+      'no_upstream'  - fetch was fine but @{upstream} does not resolve (no
+                       tracking ref / detached HEAD).
+    ahead/behind are 0 unless state == 'ok'.
+    """
+    fetch_ok = False
+    revline = None
+    for ln in (section or "").split("\n"):
+        s = ln.strip()
+        if not s:
+            continue
+        if s == "FETCH:ok":
+            fetch_ok = True
+        elif s == "FETCH:fail":
+            fetch_ok = False
+        else:
+            revline = s
+    if not fetch_ok:
+        return 0, 0, "fetch_failed"
+    if revline is None or revline == "REVLIST:fail":
+        return 0, 0, "no_upstream"
+    try:
+        fields = revline.split("\t")
+        return int(fields[0]), int(fields[1]), "ok"
+    except (ValueError, IndexError):
+        return 0, 0, "no_upstream"
+
+
 def _parse_gitops_status(stdout, instance_id):
     """Parse the batched gitops status output into a formatted string."""
     parts = stdout.split(_helpers._SENTINEL + "\n")
@@ -227,16 +274,11 @@ def _parse_gitops_status(stdout, instance_id):
 
     commit = parts[2].strip() if len(parts) > 2 else "none"
     applied = parts[3].strip() if len(parts) > 3 else "none"
-    revcount_raw = parts[6].strip() if len(parts) > 6 else "0\t0"
 
     staged, unstaged, untracked, wikis_drift = _parse_working_tree_changes(parts)
 
-    try:
-        revcount_parts = revcount_raw.split("\t")
-        ahead = int(revcount_parts[0])
-        behind = int(revcount_parts[1]) if len(revcount_parts) > 1 else 0
-    except (ValueError, IndexError):
-        ahead, behind = 0, 0
+    ahead, behind, remote_state = _parse_remote_sync(
+        parts[6] if len(parts) > 6 else "")
 
     # No .gitops-host marker and no git repository means the instance is simply
     # not under GitOps management. Reporting "No changes / Up to date with
@@ -270,7 +312,12 @@ def _parse_gitops_status(stdout, instance_id):
         lines.append("No changes.")
         lines.append("")
 
-    if ahead > 0:
+    if remote_state == "fetch_failed":
+        lines.append("Remote status unknown (could not fetch from the remote — "
+                     "check the deploy key / network).")
+    elif remote_state == "no_upstream":
+        lines.append("Remote status unknown (no upstream tracking configured).")
+    elif ahead > 0:
         lines.append("Ahead of remote by %d commit(s)." % ahead)
     elif behind > 0:
         lines.append("Behind remote by %d commit(s)." % behind)
@@ -372,13 +419,8 @@ def _parse_gitops_status_k8s(stdout, instance_id, argocd):
     if hostname == "MISSING":
         hostname = "unknown"
     commit = parts[2].strip() if len(parts) > 2 else "none"
-    revcount_raw = parts[6].strip() if len(parts) > 6 else "0\t0"
-    try:
-        revcount_parts = revcount_raw.split("\t")
-        ahead = int(revcount_parts[0])
-        behind = int(revcount_parts[1]) if len(revcount_parts) > 1 else 0
-    except (ValueError, IndexError):
-        ahead, behind = 0, 0
+    ahead, behind, remote_state = _parse_remote_sync(
+        parts[6] if len(parts) > 6 else "")
 
     sync_status, health, last_sync, revision = argocd[:4]
     sops_hint = argocd[4] if len(argocd) > 4 else None
@@ -392,10 +434,16 @@ def _parse_gitops_status_k8s(stdout, instance_id, argocd):
         "Host:             %s" % hostname,
         "Canasta ID:       %s" % instance_id,
         "Current commit:   %s" % commit,
-        "Ahead of remote:  %d" % ahead,
-        "Behind remote:    %d" % behind,
-        "",
     ]
+    if remote_state == "ok":
+        lines.append("Ahead of remote:  %d" % ahead)
+        lines.append("Behind remote:    %d" % behind)
+    else:
+        reason = ("could not fetch from the remote"
+                  if remote_state == "fetch_failed"
+                  else "no upstream tracking configured")
+        lines.append("Remote status:    unknown (%s)" % reason)
+    lines.append("")
     lines.extend(
         _working_tree_advisory_lines(staged, unstaged, untracked, wikis_drift)
     )

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2151,12 +2151,35 @@ class TestHostRemove:
 # Gitops status tests
 # ---------------------------------------------------------------------------
 
+class TestParseRemoteSync:
+    def test_in_sync(self):
+        assert direct_commands._parse_remote_sync("FETCH:ok\n0\t0") == (0, 0, "ok")
+
+    def test_ahead_behind(self):
+        assert direct_commands._parse_remote_sync("FETCH:ok\n3\t2") == (3, 2, "ok")
+
+    def test_fetch_failed_even_with_zero_revcount(self):
+        # rev-list against a stale ref can print 0\t0; a failed fetch still wins.
+        assert direct_commands._parse_remote_sync("FETCH:fail\n0\t0") == (
+            0, 0, "fetch_failed")
+
+    def test_no_upstream(self):
+        assert direct_commands._parse_remote_sync("FETCH:ok\nREVLIST:fail") == (
+            0, 0, "no_upstream")
+
+    def test_missing_markers_treated_as_fetch_failed(self):
+        # Defensive: an old/garbled section with no FETCH marker is not in-sync.
+        assert direct_commands._parse_remote_sync("0\t0")[2] == "fetch_failed"
+
+
 class TestParseGitopsStatus:
     def _make_output(self, hostname="myhost", hosts_yaml="MISSING",
                      commit="abc1234", applied="abc1234",
-                     staged="", unstaged="", revcount="0\t0",
+                     staged="", unstaged="", revcount="0\t0", fetch="ok",
                      wikis=None, template=None, untracked=None):
         d = direct_commands._SENTINEL
+        # parts[6] is the fetch-status marker followed by the rev-list line.
+        remote = "FETCH:%s\n%s" % (fetch, revcount)
         out = (
             hostname + "\n" + d + "\n"
             + hosts_yaml + "\n" + d + "\n"
@@ -2164,7 +2187,7 @@ class TestParseGitopsStatus:
             + applied + "\n" + d + "\n"
             + staged + "\n" + d + "\n"
             + unstaged + "\n" + d + "\n"
-            + revcount + "\n"
+            + remote + "\n"
         )
         if wikis is not None or template is not None or untracked is not None:
             out += (
@@ -2288,6 +2311,26 @@ class TestParseGitopsStatus:
         result = direct_commands._parse_gitops_status(out, "mysite")
         assert "Behind remote by 2 commit(s)." in result
 
+    def test_fetch_failed_reports_unknown_not_in_sync(self):
+        # A failed fetch left origin stale; rev-list may still print 0\t0
+        # against the stale ref. Must NOT read as in-sync (issue #1161).
+        out = self._make_output(fetch="fail", revcount="0\t0")
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "Remote status unknown" in result
+        assert "Up to date with remote." not in result
+
+    def test_no_upstream_reports_unknown(self):
+        out = self._make_output(fetch="ok", revcount="REVLIST:fail")
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "Remote status unknown" in result
+        assert "no upstream tracking" in result
+        assert "Up to date with remote." not in result
+
+    def test_in_sync_only_when_fetch_ok_and_zero(self):
+        out = self._make_output(fetch="ok", revcount="0\t0")
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "Up to date with remote." in result
+
     def test_with_hosts_yaml(self):
         hosts_yaml = "hosts:\n  - role: production\n    pull_requests: true"
         out = self._make_output(hosts_yaml=hosts_yaml)
@@ -2364,9 +2407,15 @@ class TestCmdGitopsStatus:
 class TestGitopsSshKey:
     """--ssh-key builds GIT_SSH_COMMAND for the status fetch."""
 
-    def test_prefix_empty_without_key(self):
-        assert direct_commands._git_ssh_env_prefix(None) == ""
-        assert direct_commands._git_ssh_env_prefix("") == ""
+    def test_prefix_without_key_still_sets_host_key_convention(self):
+        # Even without an explicit key the prefix must apply the gitops
+        # host-key convention (accept-new) and fall back to a staged
+        # .gitops-deploy-key, so a status fetch authenticates like push (#1161).
+        for prefix in (direct_commands._git_ssh_env_prefix(None),
+                       direct_commands._git_ssh_env_prefix("")):
+            assert "GIT_SSH_COMMAND" in prefix
+            assert "StrictHostKeyChecking=accept-new" in prefix
+            assert ".gitops-deploy-key" in prefix
 
     def test_prefix_sets_git_ssh_command(self):
         prefix = direct_commands._git_ssh_env_prefix("/home/u/.ssh/id_ed25519")
@@ -2379,9 +2428,13 @@ class TestGitopsSshKey:
         prefix = direct_commands._git_ssh_env_prefix("/tmp/my key")
         assert "'/tmp/my key'" in prefix
 
-    def test_status_script_omits_prefix_without_key(self):
+    def test_status_script_sets_ssh_env_without_key(self):
+        # Without --ssh-key the fetch still runs under the host-key convention
+        # (accept-new) with a .gitops-deploy-key fallback, so it authenticates
+        # wherever push does (#1161).
         script = direct_commands._gitops_status_script("/srv/mysite")
-        assert "GIT_SSH_COMMAND" not in script
+        assert "GIT_SSH_COMMAND" in script
+        assert ".gitops-deploy-key" in script
         assert "git fetch" in script
 
     def test_status_script_includes_prefix_with_key(self):
@@ -2420,7 +2473,7 @@ class TestDirectCommandRegistry:
             + "abc1234\n" + d + "\n"
             + "\n" + d + "\n"
             + "\n" + d + "\n"
-            + "0\t0\n"
+            + "FETCH:ok\n0\t0\n"
         )
         monkeypatch.setattr(direct_commands._helpers, "_resolve_instance",
             lambda args: ("mysite", {
@@ -2581,12 +2634,13 @@ class TestGitopsArgocdStatus:
 
 class TestParseGitopsStatusK8s:
     def _make_output(self, hostname="myhost", commit="abc1234", revcount="0\t0",
-                     staged="", unstaged="", wikis=None, template=None,
-                     untracked=None):
+                     fetch="ok", staged="", unstaged="", wikis=None,
+                     template=None, untracked=None):
         d = direct_commands._SENTINEL
         # Parts: hostname (0), hosts.yaml (1), commit (2), applied (3),
-        # staged (4), unstaged (5), revcount (6), then optionally
+        # staged (4), unstaged (5), fetch-status + rev-list (6), then optionally
         # wikis (7), template (8), git-status porcelain (9).
+        remote = "FETCH:%s\n%s" % (fetch, revcount)
         out = (
             hostname + "\n" + d + "\n"
             + "\n" + d + "\n"
@@ -2594,7 +2648,7 @@ class TestParseGitopsStatusK8s:
             + "\n" + d + "\n"
             + staged + "\n" + d + "\n"
             + unstaged + "\n" + d + "\n"
-            + revcount + "\n"
+            + remote + "\n"
         )
         if wikis is not None or template is not None or untracked is not None:
             out += (
@@ -2637,6 +2691,14 @@ class TestParseGitopsStatusK8s:
         result = direct_commands._parse_gitops_status_k8s(out, "mysite", argocd)
         assert "Ahead of remote:  3" in result
         assert "Behind remote:    2" in result
+
+    def test_fetch_failed_shows_unknown(self):
+        # A failed fetch must not print "Ahead/Behind: 0" as if in sync.
+        out = self._make_output(fetch="fail", revcount="0\t0")
+        argocd = ("Synced", "Healthy", "never", "unknown")
+        result = direct_commands._parse_gitops_status_k8s(out, "mysite", argocd)
+        assert "Remote status:    unknown" in result
+        assert "Ahead of remote:" not in result
 
     def test_untracked_files_surfaced(self):
         # A K8s instance with an uncaptured file (e.g. wikis.yaml.template


### PR DESCRIPTION
Fixes #1161.

`gitops status` collapsed any failure of the fetch / rev-list into "0 ahead, 0 behind" (`2>/dev/null || echo '0\t0'`), which the reporter printed as **"Up to date with remote."** — so a checkout that was actually behind read as in sync, and a later push was rejected non-fast-forward. Two compounding causes:

## 1. Failure masked as in-sync
The fetch and rev-list outcomes are now reported distinctly (`FETCH:ok`/`FETCH:fail`, `REVLIST:fail`). A new `_parse_remote_sync` helper prints "Up to date" only on a **successful fetch AND a genuine 0/0**, otherwise an explicit **"Remote status unknown (fetch failed / no upstream)."**

## 2. The status fetch didn't authenticate like push
`_git_ssh_env_prefix` now always applies the gitops host-key convention (`accept-new` + explicit `known_hosts`) and falls back to the instance's staged `.gitops-deploy-key`, so the fetch succeeds wherever push/pull do instead of failing host-key verification and leaving `origin` stale.

Applied to both the Compose and K8s status parsers. Adds 9 unit tests covering `_parse_remote_sync` and the unknown-state reporting. Full suite (1778) + lint + validate green.
