### PR TITLE
fix: gitops push gives canasta-native guidance on a non-fast-forward rejection

### DIFF
--- a/roles/gitops/tasks/push_compose.yml
+++ b/roles/gitops/tasks/push_compose.yml
@@ -216,12 +216,35 @@
       changed_when: true
       when: _push_has_staged
 
+    # The commit above is already made, so on a rejection the operator's work
+    # is safe locally. Catch the push failure and translate git's raw
+    # non-fast-forward hint (which points at raw `git pull`) into canasta-native
+    # guidance; surface any other failure verbatim.
     - name: Push to main
       ansible.builtin.command:
         cmd: "git push origin main"
         chdir: "{{ instance_path }}"
       environment: "{{ gitops_git_env }}"
+      register: _push_result
       changed_when: true
+      failed_when: false
+
+    - name: Explain a non-fast-forward rejection in canasta terms
+      ansible.builtin.fail:
+        msg: >-
+          The remote has changes this host does not have yet, so the push was
+          rejected. Your local commit is safe. Run 'canasta gitops pull' to
+          integrate the remote changes, then 'canasta gitops push' again.
+      when:
+        - _push_result.rc != 0
+        - >-
+          'non-fast-forward' in (_push_result.stderr | default(''))
+          or 'rejected' in (_push_result.stderr | default(''))
+
+    - name: Fail if the push failed for another reason
+      ansible.builtin.fail:
+        msg: "git push failed: {{ _push_result.stderr | default('') | trim }}"
+      when: _push_result.rc != 0
 
     - name: Report pushed
       ansible.builtin.debug:

--- a/roles/gitops/tasks/push_kubernetes.yml
+++ b/roles/gitops/tasks/push_kubernetes.yml
@@ -167,7 +167,32 @@
       ssh -i {{ ssh_key | default(instance_path + '/.gitops-deploy-key', true) }}
       -o StrictHostKeyChecking=accept-new
       -o UserKnownHostsFile=~/.ssh/known_hosts
+  register: _push_result
   changed_when: true
+  failed_when: false
+
+# The commit is already in place, so on a rejection the operator's work is safe
+# locally. Translate git's raw non-fast-forward hint into canasta-native
+# guidance; surface any other failure verbatim.
+- name: Explain a non-fast-forward rejection in canasta terms
+  ansible.builtin.fail:
+    msg: >-
+      The remote has changes this host does not have yet, so the push was
+      rejected. Your local commit is safe. Run 'canasta gitops pull' to
+      integrate the remote changes, then 'canasta gitops push' again.
+  when:
+    - _push_result is defined
+    - _push_result.rc | default(0) != 0
+    - >-
+      'non-fast-forward' in (_push_result.stderr | default(''))
+      or 'rejected' in (_push_result.stderr | default(''))
+
+- name: Fail if the push failed for another reason
+  ansible.builtin.fail:
+    msg: "git push failed: {{ _push_result.stderr | default('') | trim }}"
+  when:
+    - _push_result is defined
+    - _push_result.rc | default(0) != 0
 
 - name: Report result
   ansible.builtin.debug:

--- a/tests/unit/test_push_nonff_guidance.py
+++ b/tests/unit/test_push_nonff_guidance.py
@@ -1,0 +1,79 @@
+"""Regression guard for #1166: `gitops push` must translate git's raw
+non-fast-forward rejection into canasta-native guidance, not leak the raw
+`hint: use 'git pull'`.
+
+Each push path must: register the push result and not abort on it
+(failed_when: false), then, on a 'non-fast-forward'/'rejected' stderr, fail
+with guidance that points at `canasta gitops pull` (never raw git). Applies to
+both the Compose and Kubernetes push paths.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+PUSH_FILES = [
+    os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "push_compose.yml"),
+    os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "push_kubernetes.yml"),
+]
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f) or []
+
+
+def _walk(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk(t[nested])
+
+
+def _cmd_text(t):
+    c = t.get("ansible.builtin.command") or t.get("command") or {}
+    if not isinstance(c, dict):
+        return str(c)
+    return c.get("cmd", "")
+
+
+def _fail_msg(t):
+    f = t.get("ansible.builtin.fail") or t.get("fail") or {}
+    return f.get("msg", "") if isinstance(f, dict) else ""
+
+
+class TestPushNonFastForwardGuidance:
+    def test_each_push_path_gives_canasta_guidance(self):
+        for path in PUSH_FILES:
+            tasks = list(_walk(_load(path)))
+            pushes = [t for t in tasks
+                      if _cmd_text(t).strip().startswith("git push")]
+            assert pushes, "%s must run git push" % path
+            # The push must be catchable (not abort the play on rejection).
+            assert any(p.get("failed_when") is False and p.get("register")
+                       for p in pushes), (
+                "%s: the push must register its result and use "
+                "`failed_when: false` so a rejection can be translated (#1166)"
+                % path)
+
+            guidance = [
+                t for t in tasks
+                if ("ansible.builtin.fail" in t or "fail" in t)
+                and "non-fast-forward" in _when_text(t)
+                and "canasta gitops pull" in _fail_msg(t)
+            ]
+            assert guidance, (
+                "%s must, on a non-fast-forward rejection, fail with "
+                "canasta-native guidance pointing at `canasta gitops pull` "
+                "(#1166)" % path)
+
+
+def _when_text(t):
+    w = t.get("when")
+    if not w:
+        return ""
+    return " ".join(w) if isinstance(w, list) else str(w)


### PR DESCRIPTION
Fixes #1166.

When the local branch was behind the remote, `canasta gitops push` surfaced git's raw non-fast-forward error, whose hint tells the operator to run raw `git pull` — pointing the (non-git) target audience at the exact tooling the canasta layer exists to hide, with no canasta-native way forward.

## Fix
Catch the push failure (the commit is already made, so the operator's work is safe locally) and, on a non-fast-forward rejection, fail with canasta-native guidance:

> The remote has changes this host does not have yet, so the push was rejected. Your local commit is safe. Run `canasta gitops pull` to integrate the remote changes, then `canasta gitops push` again.

Any other push failure is surfaced verbatim. Applied to both the Compose and Kubernetes push paths. Verified the non-fast-forward / other-error / success branching via an ansible repro. `make lint` / `make validate` green.
