### PR TITLE
fix: gitops init recovers orphan gitlinks so extensions/skins aren't lost

### DIFF
--- a/roles/gitops/tasks/init_compose.yml
+++ b/roles/gitops/tasks/init_compose.yml
@@ -349,6 +349,104 @@
     chdir: "{{ instance_path }}"
   changed_when: true
 
+# An extension/skin whose Step-13 conversion didn't run — its .git is a gitlink
+# file the directory-only find missed, or it is a loose clone with no origin
+# remote — is now staged as a bare gitlink (mode 160000) with no .gitmodules
+# entry. Committing that loses the extension: a later clone / pull leaves the
+# directory empty. Recover a .gitmodules entry for each such orphan from its
+# clone's origin URL before committing, or fail loudly when the URL is
+# unavailable — never commit a broken submodule (#1155). (This mirrors
+# fix_submodules.yml's orphan recovery; a follow-up can DRY them into one task.)
+- name: List staged gitlinks
+  ansible.builtin.shell:
+    cmd: "git ls-files --stage | awk '$1 == \"160000\" {print $4}'"
+    chdir: "{{ instance_path }}"
+  register: _init_gitlinks
+  changed_when: false
+
+- name: Read .gitmodules registered paths (may not exist)
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/.gitmodules"
+  register: _init_gitmodules_raw
+  failed_when: false
+
+- name: Identify orphan gitlinks (staged 160000 not in .gitmodules)
+  ansible.builtin.set_fact:
+    _init_orphan_gitlinks: >-
+      {{ _init_gitlinks.stdout_lines
+         | reject('in',
+             (_init_gitmodules_raw.content | default('') | b64decode).splitlines()
+             | select('match', '^\s*path\s*=')
+             | map('regex_replace', '^\s*path\s*=\s*', '') | map('trim') | list)
+         | list }}
+
+- name: Recover .gitmodules for orphan gitlinks
+  when: _init_orphan_gitlinks | length > 0
+  block:
+    - name: Get origin URL from each orphan's clone
+      ansible.builtin.command:
+        cmd: "git -C {{ instance_path }}/{{ item }} config --get remote.origin.url"
+        chdir: "{{ instance_path }}"
+      register: _init_orphan_urls
+      changed_when: false
+      failed_when: false
+      loop: "{{ _init_orphan_gitlinks }}"
+
+    - name: Fail if any orphan has no recoverable URL
+      ansible.builtin.fail:
+        msg: >-
+          Cannot register submodule '{{ item.item }}' in .gitmodules — its
+          directory has no remote.origin.url, so committing it would lose the
+          extension/skin on the next clone. Ensure extensions/skins are clones
+          with an 'origin' remote, then re-run with --reinit.
+      when: item.rc != 0 or (item.stdout | default('') | trim | length == 0)
+      loop: "{{ _init_orphan_urls.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    - name: Register orphan submodule path in .gitmodules
+      ansible.builtin.command:
+        argv:
+          - git
+          - config
+          - -f
+          - .gitmodules
+          - "submodule.{{ item.item }}.path"
+          - "{{ item.item }}"
+        chdir: "{{ instance_path }}"
+      changed_when: true
+      loop: "{{ _init_orphan_urls.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    - name: Register orphan submodule url in .gitmodules
+      ansible.builtin.command:
+        argv:
+          - git
+          - config
+          - -f
+          - .gitmodules
+          - "submodule.{{ item.item }}.url"
+          - "{{ item.stdout | trim }}"
+        chdir: "{{ instance_path }}"
+      changed_when: true
+      loop: "{{ _init_orphan_urls.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    - name: Sync recovered submodules into git config
+      ansible.builtin.command:
+        cmd: "git submodule sync -- {{ item.item }}"
+        chdir: "{{ instance_path }}"
+      changed_when: true
+      loop: "{{ _init_orphan_gitlinks }}"
+
+    - name: Stage the recovered .gitmodules
+      ansible.builtin.command:
+        cmd: "git add .gitmodules"
+        chdir: "{{ instance_path }}"
+      changed_when: true
+
 - name: Initial commit
   ansible.builtin.command:
     cmd: "git -c commit.gpgsign=false commit -m 'Initial gitops configuration'"

--- a/tests/unit/test_init_orphan_gitlinks.py
+++ b/tests/unit/test_init_orphan_gitlinks.py
@@ -1,0 +1,89 @@
+"""Regression guard for #1155: `gitops init` must never commit an orphan
+gitlink (a staged mode-160000 submodule with no .gitmodules entry), which
+silently loses the extension/skin on the next clone.
+
+After `git add -A`, init must recover a .gitmodules entry for each orphan
+gitlink from its clone's origin URL — or fail loudly when the URL is
+unavailable — before the initial commit.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+INIT = os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "init_compose.yml")
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f) or []
+
+
+def _walk(tasks):
+    """Flatten tasks, preserving order (a block's children follow the block)."""
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk(t[nested])
+
+
+def _text(t):
+    for key in ("ansible.builtin.command", "command",
+                "ansible.builtin.shell", "shell"):
+        c = t.get(key)
+        if isinstance(c, dict):
+            if c.get("argv"):
+                return " ".join(str(a) for a in c["argv"])
+            return c.get("cmd", "")
+        if isinstance(c, str):
+            return c
+    return ""
+
+
+def _fail_msg(t):
+    f = t.get("ansible.builtin.fail") or t.get("fail") or {}
+    return f.get("msg", "") if isinstance(f, dict) else ""
+
+
+class TestInitRecoversOrphanGitlinks:
+    def setup_method(self):
+        self.tasks = list(_walk(_load(INIT)))
+
+    def _index(self, predicate):
+        for i, t in enumerate(self.tasks):
+            if predicate(t):
+                return i
+        return -1
+
+    def test_lists_staged_gitlinks(self):
+        assert any("160000" in _text(t) for t in self.tasks), (
+            "init_compose.yml must inspect staged gitlinks (mode 160000) so it "
+            "can catch unconverted extensions/skins (#1155)")
+
+    def test_writes_gitmodules_for_orphans(self):
+        assert any("config" in _text(t) and ".gitmodules" in _text(t)
+                   for t in self.tasks), (
+            "init must register recovered orphans in .gitmodules via "
+            "`git config -f .gitmodules` (#1155)")
+
+    def test_fails_loudly_when_url_unrecoverable(self):
+        guards = [t for t in self.tasks
+                  if ("ansible.builtin.fail" in t or "fail" in t)
+                  and ".gitmodules" in _fail_msg(t)]
+        assert guards, (
+            "init must fail loudly when an orphan gitlink has no recoverable "
+            "URL, rather than commit a broken submodule (#1155)")
+
+    def test_recovery_runs_before_initial_commit(self):
+        gitmodules_i = self._index(
+            lambda t: "config" in _text(t) and ".gitmodules" in _text(t))
+        commit_i = self._index(
+            lambda t: "commit" in _text(t) and "Initial gitops" in _text(t))
+        assert gitmodules_i >= 0 and commit_i >= 0
+        assert gitmodules_i < commit_i, (
+            "the orphan-gitlink recovery must run before the initial commit, "
+            "so the commit records proper submodules (#1155)")


### PR DESCRIPTION
Fixes #1155.

`gitops init` could commit an extension/skin as a bare gitlink (mode `160000`) with **no `.gitmodules` entry**, so a later clone / `gitops pull` left the directory empty and the extension was lost.

## Root cause (confirmed via isolated git repros)
It happens when Step 13's submodule conversion is skipped or a no-op, then `git add -A` embeds the directory as an orphan gitlink. Two triggers:
1. **Gitlink-file `.git`** — in a real Canasta checkout, extensions are submodules of the Canasta repo, so `<Name>/.git` is a *file*. Step 13's `find` uses `file_type: directory`, so it doesn't match → conversion is skipped.
2. **Loose clone with no `origin` remote** — `find` matches, but `_convert_submodule.yml`'s guard `when: _sub_url.rc == 0 and stdout != ''` is false → the block silently skips.

(Ruled out: "no initial commit" — `git submodule add` works fine before the first commit and writes `.gitmodules`.)

## Fix
After `git add -A`, detect staged gitlinks not registered in `.gitmodules` and recover each from its clone's `remote.origin.url` (`git config -f .gitmodules submodule.<p>.path/.url`), sync, and stage — **before** the initial commit. If any orphan has no recoverable URL, fail loudly rather than commit a broken submodule (the issue's "produces proper submodules, or fails loudly").

Verified end-to-end: an orphan gitlink is recovered, and a fresh clone + `git submodule update --init` restores the extension.

## Scope
Self-contained in `init_compose.yml` (mirrors `fix_submodules.yml`'s orphan recovery). Kept separate to avoid conflicting with #1170, which is currently editing that recovery; a follow-up can DRY them into one shared task once #1170 lands. Adds a regression guard (`test_init_orphan_gitlinks.py`).

`make test-unit` / `make lint` / `make validate` green.
