### PR TITLE
fix: gitops pull refuses to write a blank wikis.yaml url

### DIFF
--- a/roles/gitops/tasks/pull_compose.yml
+++ b/roles/gitops/tasks/pull_compose.yml
@@ -149,9 +149,14 @@
         src: "{{ instance_path }}/wikis.yaml.template"
       register: _pull_wikis_template_raw
 
-    - name: Render config/wikis.yaml from template
-      ansible.builtin.copy:
-        content: |
+    # Render into a fact first so we can validate it BEFORE it replaces the
+    # live config/wikis.yaml. A wiki whose wiki_url_<id> var is absent on this
+    # host renders url empty, which makes MediaWiki's FarmConfigLoader fatal on
+    # every request — refuse to write that rather than crash-loop the site.
+    # (Mirrors render_compose.yml; see #1164 / #1177.)
+    - name: Render wikis.yaml content from template
+      ansible.builtin.set_fact:
+        _pull_wikis_content: |
           {% for line in (_pull_wikis_template_raw.content | b64decode).split('\n') %}
           {% if '{{' in line and '}}' in line %}
           {% set before = line.split('{{', 1)[0] %}
@@ -162,6 +167,26 @@
           {{ line }}
           {% endif %}
           {% endfor %}
+
+    - name: Fail if any wiki url rendered empty (missing wiki_url_<id> var)
+      ansible.builtin.fail:
+        msg: >-
+          Refusing to write config/wikis.yaml on pull: the url for wiki(s)
+          {{ _pull_empty_url_wikis | join(', ') }} rendered empty because a
+          wiki_url_<id> var is not defined in this host's vars.yaml or
+          hosts/_shared/vars.yaml. A wiki added on another host needs its url
+          set for this host too — add e.g.
+          'wiki_url_{{ _pull_empty_url_wikis[0] }}' to the host vars (a blank
+          url makes MediaWiki fatal on every request).
+      vars:
+        _pull_empty_url_wikis: >-
+          {{ (_pull_wikis_content | from_yaml).wikis | default([])
+             | rejectattr('url') | map(attribute='id') | list }}
+      when: _pull_empty_url_wikis | length > 0
+
+    - name: Write config/wikis.yaml
+      ansible.builtin.copy:
+        content: "{{ _pull_wikis_content }}"
         dest: "{{ instance_path }}/config/wikis.yaml"
         mode: "0644"
 

--- a/tests/unit/test_pull_empty_url_guard.py
+++ b/tests/unit/test_pull_empty_url_guard.py
@@ -1,0 +1,52 @@
+"""Regression guard for #1177: `gitops pull` must not overwrite config/wikis.yaml
+with a blank url.
+
+pull_compose.yml renders wikis.yaml from wikis.yaml.template with the same
+`{{wiki_url_<id>}} | default('')` pattern as render_compose.yml. If a wiki's
+wiki_url_<id> var is absent on the pulling host, the url renders empty and
+MediaWiki's FarmConfigLoader fatals on every request. pull must render into a
+fact and refuse to write when any url came out empty (sibling of #1164).
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+PULL_COMPOSE = os.path.join(
+    REPO_ROOT, "roles", "gitops", "tasks", "pull_compose.yml")
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f) or []
+
+
+def _walk(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk(t[nested])
+
+
+class TestPullRefusesEmptyUrl:
+    def test_fail_task_guards_empty_url(self):
+        guards = [
+            t for t in _walk(_load(PULL_COMPOSE))
+            if ("ansible.builtin.fail" in t or "fail" in t)
+            and "rejectattr('url')" in yaml.safe_dump(t)
+        ]
+        assert guards, (
+            "pull_compose.yml must fail (before writing config/wikis.yaml) when "
+            "a wiki url rendered empty — rejectattr('url') on the rendered "
+            "wikis list (#1177)")
+
+    def test_wikis_yaml_written_from_validated_fact(self):
+        text = open(PULL_COMPOSE).read()
+        assert "_pull_wikis_content" in text, (
+            "pull_compose.yml must render wikis.yaml into a fact "
+            "(_pull_wikis_content) so it can be validated before it replaces "
+            "the live file (#1177)")


### PR DESCRIPTION
Fixes #1177.

`pull_compose.yml` rendered `config/wikis.yaml` from `wikis.yaml.template` with the same unguarded `{{wiki_url_<id>}} | default('')` pattern that #1164 fixed for `config regenerate` / `render_compose.yml`. When a wiki's `wiki_url_<id>` var is absent on the pulling host — common in multi-host setups, where a wiki added on another host has no url set locally yet — the url renders empty and MediaWiki's `FarmConfigLoader` fatals on every request.

## Fix
Render `wikis.yaml` into a fact and refuse to overwrite the live file when any url came out empty, naming the offending wiki(s) and the `wiki_url_<id>` var to add on this host — mirroring `render_compose.yml`. Adds a regression guard (`test_pull_empty_url_guard.py`).

Surfaced during the direct-vs-Ansible / duplicate-render drift audit of #1164. `make test-unit` / `make lint` / `make validate` green.
