### PR TITLE
fix: canasta add announces the database import phase

### DIFF
--- a/playbooks/add.yml
+++ b/playbooks/add.yml
@@ -159,6 +159,13 @@
         name: mediawiki
         tasks_from: wait_for_db.yml
 
+    # A large dump import runs detached and polled, producing no incremental
+    # output, so announce the phase up front — otherwise `canasta add` sits
+    # silently for the whole import and reads as hung (mirrors create). (#1152)
+    - name: Report importing database
+      ansible.builtin.debug:
+        msg: "Importing database (this can take a while for a large dump)..."
+
     - name: Create empty wiki database
       ansible.builtin.include_tasks: >-
         {{ canasta_root }}/roles/orchestrator/tasks/exec.yml


### PR DESCRIPTION
Fixes #1152.

`canasta add` with `--database` printed a couple of lines up front and then sat silently for the entire dump import before printing the final "added" line — for a large dump, a long output-free wait that reads as hung.

The import runs detached and polled (via `exec_long`), so it produces no incremental output. Add an "Importing database..." banner before the import phase, mirroring what `canasta create` already does in `_database.yml`. `make lint` / `make test-unit` green.