### PR TITLE
fix: extension enable accepts sub-module sub-paths

### DIFF
--- a/roles/extensions_skins/library/canasta_settings_yaml.py
+++ b/roles/extensions_skins/library/canasta_settings_yaml.py
@@ -49,7 +49,11 @@ import yaml
 from ansible.module_utils.basic import AnsibleModule
 
 
-VALID_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.\-]*$")
+# Allows an optional single sub-path segment (e.g. ConfirmEdit/ReCaptchaNoCaptcha)
+# for extensions that expose sub-modules loaded by sub-path, which the settings
+# loader accepts.
+VALID_NAME_PATTERN = re.compile(
+    r"^[a-zA-Z0-9][a-zA-Z0-9_.\-]*(/[a-zA-Z0-9][a-zA-Z0-9_.\-]*)?$")
 HEADER = "# Canasta will add and remove lines from this file as extensions and skins are enabled and disabled.\n"
 
 

--- a/roles/extensions_skins/tasks/enable.yml
+++ b/roles/extensions_skins/tasks/enable.yml
@@ -7,18 +7,26 @@
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
-# Check each item is actually installed in the container
-- name: "List available {{ _item_type }} in container"
+# Check each item is actually installed in the container. Test each name's
+# directory directly rather than matching a top-level listing, so a sub-module
+# sub-path (e.g. ConfirmEdit/ReCaptchaNoCaptcha, which the settings loader
+# accepts) is verified too. Echo any name whose directory is missing.
+- name: "Verify {{ _item_type }} are installed"
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
   vars:
     exec_service: web
-    exec_command: "cd /var/www/mediawiki/w/{{ _item_type }} && find -L * -maxdepth 0 -type d 2>/dev/null || true"
+    exec_command: >-
+      cd /var/www/mediawiki/w/{{ _item_type }} &&
+      for n in {{ _names.split(',') | map('trim') | map('quote') | join(' ') }}; do
+      [ -d "$n" ] || echo "$n"; done
 
-- name: "Verify {{ _item_type }} are installed"
+- name: "Fail if any {{ _item_type }} are not installed"
   ansible.builtin.fail:
-    msg: "{{ _item_type | capitalize }} '{{ item }}' is not installed in the container."
-  when: item not in (exec_result.stdout | default('') | split('\n') | map('trim') | list)
-  loop: "{{ _names.split(',') | map('trim') | list }}"
+    msg: >-
+      {{ _item_type | capitalize }} not installed in the container:
+      {{ exec_result.stdout | default('') | split('\n') | map('trim')
+         | reject('equalto', '') | join(', ') }}.
+  when: exec_result.stdout | default('') | trim | length > 0
 
 - name: "Enable {{ _item_type }}"
   canasta_settings_yaml:

--- a/tests/unit/test_canasta_settings_yaml.py
+++ b/tests/unit/test_canasta_settings_yaml.py
@@ -21,7 +21,7 @@ class TestValidateName:
         assert canasta_settings_yaml.validate_name("VisualEditor") is None
 
     def test_valid_submodule_subpath(self):
-        # A single sub-path segment for extensions with sub-modules (#1151).
+        # A single sub-path segment for extensions with sub-modules.
         assert canasta_settings_yaml.validate_name(
             "ConfirmEdit/ReCaptchaNoCaptcha") is None
 

--- a/tests/unit/test_canasta_settings_yaml.py
+++ b/tests/unit/test_canasta_settings_yaml.py
@@ -20,11 +20,25 @@ class TestValidateName:
     def test_valid(self):
         assert canasta_settings_yaml.validate_name("VisualEditor") is None
 
+    def test_valid_submodule_subpath(self):
+        # A single sub-path segment for extensions with sub-modules (#1151).
+        assert canasta_settings_yaml.validate_name(
+            "ConfirmEdit/ReCaptchaNoCaptcha") is None
+
     def test_empty(self):
         assert canasta_settings_yaml.validate_name("") is not None
 
     def test_invalid_start(self):
         assert canasta_settings_yaml.validate_name(".bad") is not None
+
+    def test_invalid_double_slash(self):
+        assert canasta_settings_yaml.validate_name("A/B/C") is not None
+
+    def test_invalid_trailing_slash(self):
+        assert canasta_settings_yaml.validate_name("ConfirmEdit/") is not None
+
+    def test_invalid_subpath_bad_start(self):
+        assert canasta_settings_yaml.validate_name("ConfirmEdit/.bad") is not None
 
 
 class TestReadWriteConfig:


### PR DESCRIPTION
Fixes #1151.

`canasta extension enable ConfirmEdit/ReCaptchaNoCaptcha` failed with "not installed in the container", even though the image's `settings.yaml` loader accepts the sub-path and loads it correctly. Two places rejected it:

1. **Presence check** (`enable.yml`) listed only top-level directories (`find -L * -maxdepth 0 -type d`), so a nested `ConfirmEdit/ReCaptchaNoCaptcha` never appeared. Now it tests each name's directory directly (`[ -d "$n" ]`), which handles both a top-level extension and a sub-module sub-path, and reports any that are missing.
2. **Name validator** (`canasta_settings_yaml.py`) forbade `/`. Now allows one optional sub-path segment: `^[A-Za-z0-9][A-Za-z0-9_.\-]*(/[A-Za-z0-9][A-Za-z0-9_.\-]*)?$`.

Bundled captcha/auth sub-modules (ReCaptchaNoCaptcha, hCaptcha, Turnstile, QuestyCaptcha, …) can now be enabled through the CLI instead of hand-editing `settings.yaml`. The shared validator also covers `disable`/`list` by symmetry (`disable` has no presence check). Adds validator tests (valid sub-path; rejects double-slash / trailing-slash / bad sub-path start). `make test-unit` / `make lint` / `make validate` green.
