### PR TITLE
fix: maintenance exec preserves quoted multi-word passthrough args

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -1552,6 +1552,21 @@ def should_prompt_confirmation(cmd_def, yes_passed):
     return has_yes_param and not yes_passed
 
 
+def split_passthrough(remaining):
+    """Split argv at the first ``--``.
+
+    Returns ``(args_before, passthrough_tokens)``. The passthrough tokens are
+    kept as a list so a quoted argument containing spaces (a SQL string via
+    ``-e``, a ``--summary``, a page title) stays a single argv element; joining
+    them into one string here would lose the boundaries a later shell-split
+    cannot recover.
+    """
+    if "--" in remaining:
+        idx = remaining.index("--")
+        return remaining[:idx], remaining[idx + 1:]
+    return remaining, []
+
+
 def main():
     data = load_definitions()
     parser = build_parser(data)
@@ -1603,12 +1618,10 @@ def main():
     # Recombine: unused pre-command args + all post-command args
     remaining = pre_remaining + post_cmd
 
-    # Handle -- separator for pass-through args
-    passthrough = ""
-    if "--" in remaining:
-        idx = remaining.index("--")
-        passthrough = " ".join(remaining[idx + 1:])
-        remaining = remaining[:idx]
+    # Handle -- separator for pass-through args. Consumers already accept a list
+    # (the exec handler uses it directly; the Ansible path space-joins it to the
+    # same string a string passthrough would have produced).
+    remaining, passthrough = split_passthrough(remaining)
 
     # Parse with the full parser (subcommands + flags)
     args = parser.parse_args(remaining)

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -517,6 +517,27 @@ class TestRemainderArgs:
         assert args.exec_args == []
 
 
+class TestSplitPassthrough:
+    """Args after `--` must keep their word boundaries, so a quoted argument
+    with spaces stays one argv element instead of being shredded."""
+
+    def test_quoted_arg_stays_one_token(self):
+        before, passthrough = canasta_cli.split_passthrough(
+            ["-s", "db", "--", "mariadb", "-e", "CREATE DATABASE foo; GRANT x;"])
+        assert before == ["-s", "db"]
+        assert passthrough == ["mariadb", "-e", "CREATE DATABASE foo; GRANT x;"]
+
+    def test_no_separator(self):
+        assert canasta_cli.split_passthrough(["a", "b"]) == (["a", "b"], [])
+
+    def test_separator_at_end(self):
+        assert canasta_cli.split_passthrough(["a", "--"]) == (["a"], [])
+
+    def test_only_first_separator_splits(self):
+        _, passthrough = canasta_cli.split_passthrough(["--", "sh", "-c", "a -- b"])
+        assert passthrough == ["sh", "-c", "a -- b"]
+
+
 class TestRemainderFlagHoisting:
     """Canasta flags trapped inside script_args/exec_args by REMAINDER
     should be lifted back out (#279)."""


### PR DESCRIPTION
Fixes #1153.

A quoted argument containing spaces, passed after `--` to `canasta maintenance exec`, was broken into multiple arguments before it reached the container:

```
canasta maintenance exec -i wikifarm -s db -- mariadb -e "CREATE DATABASE foo; GRANT ALL ON foo.* TO 'u'@'%';"
```

`mariadb` received `-e CREATE` followed by `DATABASE`, `foo;`, … as separate positionals and printed its usage instead of running the statement.

## Root cause
`main()` collected the post-`--` tokens by joining them into one space-delimited string (`" ".join(remaining[idx+1:])`); the exec handler then re-split that string with `shlex.split`. By the time it re-split, the original quoting was gone — a single quoted element cannot be recovered from `mariadb -e CREATE DATABASE foo; …`.

## Fix
Keep the passthrough tokens as a **list** rather than join-then-resplit. `handle_interactive_exec` already uses a list directly (each token stays one argv element), and the Ansible-vars path space-joins a list to the same string a string passthrough would have produced — so that path is unchanged. Extracted the `--` split into a `split_passthrough()` helper with unit tests (a multi-word quoted arg stays one token; no separator; separator at end; only the first `--` splits).

`make test-unit` / `make lint` / `make validate` green.
