### PR TITLE
chore: remove issue-number references from code comments

### DIFF
--- a/roles/gitops/tasks/init_compose.yml
+++ b/roles/gitops/tasks/init_compose.yml
@@ -373,7 +373,7 @@
 # entry. Committing that loses the extension: a later clone / pull leaves the
 # directory empty. Recover a .gitmodules entry for each such orphan from its
 # clone's origin URL before committing, or fail loudly when the URL is
-# unavailable — never commit a broken submodule (#1155). (This mirrors
+# unavailable — never commit a broken submodule. (This mirrors
 # fix_submodules.yml's orphan recovery; a follow-up can DRY them into one task.)
 - name: List staged gitlinks
   ansible.builtin.shell:

--- a/roles/gitops/tasks/pull_compose.yml
+++ b/roles/gitops/tasks/pull_compose.yml
@@ -153,7 +153,7 @@
     # live config/wikis.yaml. A wiki whose wiki_url_<id> var is absent on this
     # host renders url empty, which makes MediaWiki's FarmConfigLoader fatal on
     # every request — refuse to write that rather than crash-loop the site.
-    # (Mirrors render_compose.yml; see #1164 / #1177.)
+    # (Mirrors render_compose.yml)
     - name: Render wikis.yaml content from template
       ansible.builtin.set_fact:
         _pull_wikis_content: |

--- a/tests/unit/test_config_regenerate_safety.py
+++ b/tests/unit/test_config_regenerate_safety.py
@@ -1,4 +1,4 @@
-"""Regression guard for #1164: `canasta config regenerate` must not take down a
+"""Regression guard: `canasta config regenerate` must not take down a
 gitops Compose instance.
 
 Two structural invariants:
@@ -58,7 +58,7 @@ class TestConfigRegenerateProfiles:
         assert sync_i > render_i, (
             "config_regenerate.yml must reconcile COMPOSE_PROFILES "
             "(sync_compose_profiles) AFTER the render, like gitops pull, or the "
-            "render drops the profile set (#1164)")
+            "render drops the profile set")
 
 
 class TestRenderRefusesEmptyUrl:
@@ -71,7 +71,7 @@ class TestRenderRefusesEmptyUrl:
         assert guards, (
             "render_compose.yml must fail (before writing config/wikis.yaml) "
             "when a wiki url rendered empty — rejectattr('url') on the rendered "
-            "wikis list (#1164)")
+            "wikis list")
 
     def test_wikis_yaml_written_from_validated_fact(self):
         # The render must go through a fact it can validate, not copy the
@@ -80,4 +80,4 @@ class TestRenderRefusesEmptyUrl:
         assert "_render_wikis_content" in text, (
             "render_compose.yml must render wikis.yaml into a fact "
             "(_render_wikis_content) so it can be validated before it replaces "
-            "the live file (#1164)")
+            "the live file")

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -2331,7 +2331,7 @@ class TestParseGitopsStatus:
 
     def test_fetch_failed_reports_unknown_not_in_sync(self):
         # A failed fetch left origin stale; rev-list may still print 0\t0
-        # against the stale ref. Must NOT read as in-sync (issue #1161).
+        # against the stale ref. Must NOT read as in-sync.
         out = self._make_output(fetch="fail", revcount="0\t0")
         result = direct_commands._parse_gitops_status(out, "mysite")
         assert "Remote status unknown" in result
@@ -2428,7 +2428,7 @@ class TestGitopsSshKey:
     def test_prefix_without_key_still_sets_host_key_convention(self):
         # Even without an explicit key the prefix must apply the gitops
         # host-key convention (accept-new) and fall back to a staged
-        # .gitops-deploy-key, so a status fetch authenticates like push (#1161).
+        # .gitops-deploy-key, so a status fetch authenticates like push.
         for prefix in (direct_commands._git_ssh_env_prefix(None),
                        direct_commands._git_ssh_env_prefix("")):
             assert "GIT_SSH_COMMAND" in prefix
@@ -2449,7 +2449,7 @@ class TestGitopsSshKey:
     def test_status_script_sets_ssh_env_without_key(self):
         # Without --ssh-key the fetch still runs under the host-key convention
         # (accept-new) with a .gitops-deploy-key fallback, so it authenticates
-        # wherever push does (#1161).
+        # wherever push does.
         script = direct_commands._gitops_status_script("/srv/mysite")
         assert "GIT_SSH_COMMAND" in script
         assert ".gitops-deploy-key" in script

--- a/tests/unit/test_fix_submodules_gitmodules.py
+++ b/tests/unit/test_fix_submodules_gitmodules.py
@@ -1,4 +1,4 @@
-"""Regression guard for #1156: `gitops fix-submodules` must write clean
+"""Regression guard: `gitops fix-submodules` must write clean
 .gitmodules stanzas, not blockinfile with "ANSIBLE MANAGED BLOCK" comments.
 
 .gitmodules is a machine-read, git-managed file; the wrapper comments are noise
@@ -46,7 +46,7 @@ class TestFixSubmodulesGitmodules:
             if isinstance(bi, dict) and ".gitmodules" in bi.get("path", ""):
                 raise AssertionError(
                     "fix-submodules must not write .gitmodules with blockinfile "
-                    "— it injects '# ANSIBLE MANAGED BLOCK' comments (#1156): %r"
+                    "— it injects '# ANSIBLE MANAGED BLOCK' comments: %r"
                     % t.get("name"))
 
     def test_writes_gitmodules_with_git_config(self):
@@ -56,4 +56,4 @@ class TestFixSubmodulesGitmodules:
         ]
         assert writers, (
             "fix-submodules must write .gitmodules entries with "
-            "`git config -f .gitmodules submodule.<name>.path/.url` (#1156)")
+            "`git config -f .gitmodules submodule.<name>.path/.url`")

--- a/tests/unit/test_gitops_rm_scope.py
+++ b/tests/unit/test_gitops_rm_scope.py
@@ -5,8 +5,8 @@ test_gitops_add_scope). It must:
   * untrack a named path with `git rm --cached` — `--cached` so git never
     touches the working tree (the on-disk delete is a separate, explicit step);
   * NOT use `--ignore-unmatch` on the explicit-path rm — that flag exits 0 on
-    a path that matches nothing, which silently no-ops while reporting success
-    (#1163). Instead the path is validated with `git ls-files --error-unmatch`
+    a path that matches nothing, which silently no-ops while reporting success.
+    Instead the path is validated with `git ls-files --error-unmatch`
     first, so a non-matching path fails loudly with actionable guidance;
   * gate the on-disk delete on an explicit path (never a whole-tree wipe); and
   * stage pending deletions with `git add -u` (deletions only), never a
@@ -60,7 +60,7 @@ class TestGitopsRmScope:
                 "working tree (the on-disk delete is a separate step): %r" % c)
             assert "--ignore-unmatch" not in c, (
                 "the explicit-path `git rm` must NOT use --ignore-unmatch — it "
-                "hides a non-matching path as a silent no-op (#1163): %r" % c)
+                "hides a non-matching path as a silent no-op: %r" % c)
 
     def test_path_validated_before_removal(self):
         """A non-matching path must fail loudly, so rm.yml validates the path
@@ -69,7 +69,7 @@ class TestGitopsRmScope:
                       if "ls-files" in _cmd(t) and "--error-unmatch" in _cmd(t)]
         assert validators, (
             "rm.yml must validate the path with "
-            "`git ls-files --error-unmatch` before removing it (#1163)")
+            "`git ls-files --error-unmatch` before removing it")
 
     def test_disk_delete_is_path_scoped(self):
         """The on-disk file removal must be guarded by an explicit path so it

--- a/tests/unit/test_import_failure_surfaced.py
+++ b/tests/unit/test_import_failure_surfaced.py
@@ -1,4 +1,4 @@
-"""Regression guard for #1150: a failed DB import must fail loudly with the
+"""Regression guard: a failed DB import must fail loudly with the
 real mariadb error, never a silent success that leaves an empty database.
 
 Two structural invariants keep the fix in place:
@@ -49,7 +49,7 @@ class TestResilientExecFailsFast:
                 "the completion poll must set `failed_when: false` so a "
                 "completed job's non-zero rc reaches 'Report failure' instead "
                 "of aborting the poll / retrying a deterministic failure "
-                "(#1150): %r" % t.get("name"))
+                ": %r" % t.get("name"))
 
     def test_report_failure_task_present(self):
         tasks = _load(RESILIENT_EXEC)
@@ -80,11 +80,11 @@ class TestImportSurfacesError:
         for t, _v, cmd in cmds:
             assert "import_db_password" not in cmd, (
                 "the DB load must not inline import_db_password on the command "
-                "line (forces no_log, which redacts the SQL error) (#1150): %r"
+                "line (forces no_log, which redacts the SQL error): %r"
                 % cmd)
             assert "-p'" not in cmd and "-p{{" not in cmd, (
                 "the DB load must not pass -p<password> on the command line "
-                "(#1150): %r" % cmd)
+                ": %r" % cmd)
 
     def test_password_sourced_from_container_env(self):
         for _t, _v, cmd in self._load_commands():
@@ -96,4 +96,4 @@ class TestImportSurfacesError:
         for t, v, _cmd in self._load_commands():
             assert not v.get("exec_no_log"), (
                 "the DB load must not set exec_no_log, so the mariadb stderr "
-                "(the SQL error) surfaces on failure (#1150): %r" % t.get("name"))
+                "(the SQL error) surfaces on failure: %r" % t.get("name"))

--- a/tests/unit/test_init_fail_early_remote.py
+++ b/tests/unit/test_init_fail_early_remote.py
@@ -1,4 +1,4 @@
-"""Regression guard for #1157: `gitops init` must fail early on an
+"""Regression guard: `gitops init` must fail early on an
 unreachable/unauthorized remote, before any local mutation.
 
 The Step 4 `git ls-remote` must not swallow access failures — a permission /
@@ -74,5 +74,5 @@ class TestInitFailsEarlyOnUnreachableRemote:
             assert reachability, (
                 "%s must fail early when the remote is unreachable — an "
                 "ls-remote check with `failed_when: false` plus a fail task "
-                "keyed on its rc != 0, before any local mutation (#1157)"
+                "keyed on its rc != 0, before any local mutation"
                 % path)

--- a/tests/unit/test_init_orphan_gitlinks.py
+++ b/tests/unit/test_init_orphan_gitlinks.py
@@ -1,4 +1,4 @@
-"""Regression guard for #1155: `gitops init` must never commit an orphan
+"""Regression guard: `gitops init` must never commit an orphan
 gitlink (a staged mode-160000 submodule with no .gitmodules entry), which
 silently loses the extension/skin on the next clone.
 
@@ -62,13 +62,13 @@ class TestInitRecoversOrphanGitlinks:
     def test_lists_staged_gitlinks(self):
         assert any("160000" in _text(t) for t in self.tasks), (
             "init_compose.yml must inspect staged gitlinks (mode 160000) so it "
-            "can catch unconverted extensions/skins (#1155)")
+            "can catch unconverted extensions/skins")
 
     def test_writes_gitmodules_for_orphans(self):
         assert any("config" in _text(t) and ".gitmodules" in _text(t)
                    for t in self.tasks), (
             "init must register recovered orphans in .gitmodules via "
-            "`git config -f .gitmodules` (#1155)")
+            "`git config -f .gitmodules`")
 
     def test_fails_loudly_when_url_unrecoverable(self):
         guards = [t for t in self.tasks
@@ -76,7 +76,7 @@ class TestInitRecoversOrphanGitlinks:
                   and ".gitmodules" in _fail_msg(t)]
         assert guards, (
             "init must fail loudly when an orphan gitlink has no recoverable "
-            "URL, rather than commit a broken submodule (#1155)")
+            "URL, rather than commit a broken submodule")
 
     def test_recovery_runs_before_initial_commit(self):
         gitmodules_i = self._index(
@@ -86,4 +86,4 @@ class TestInitRecoversOrphanGitlinks:
         assert gitmodules_i >= 0 and commit_i >= 0
         assert gitmodules_i < commit_i, (
             "the orphan-gitlink recovery must run before the initial commit, "
-            "so the commit records proper submodules (#1155)")
+            "so the commit records proper submodules")

--- a/tests/unit/test_join_scope.py
+++ b/tests/unit/test_join_scope.py
@@ -1,4 +1,4 @@
-"""Regression guard for #1162: `gitops join` (Compose) must not push the fresh
+"""Regression guard: `gitops join` (Compose) must not push the fresh
 instance's create-time default settings back into the shared repo.
 
 A fresh `canasta create` generates Canasta's default config/settings/global/*.php
@@ -50,7 +50,7 @@ class TestJoinStagingScope:
         assert not offenders, (
             "gitops join must not `git add -A` — it sweeps the fresh instance's "
             "untracked create-time default settings into the shared repo "
-            "(#1162): %r" % offenders)
+            ": %r" % offenders)
 
     def test_stages_only_host_registration_and_vars(self):
         adds = [_cmd_text(t) for t in _walk(_load(JOIN))

--- a/tests/unit/test_memory_floor.py
+++ b/tests/unit/test_memory_floor.py
@@ -1,4 +1,4 @@
-"""Regression guard for #1147: the host memory floor is profile-aware and
+"""Regression guard: the host memory floor is profile-aware and
 enforced in both `create` and `config set`.
 
 Elasticsearch and the observability stack each raise the requirement, so the
@@ -59,7 +59,7 @@ class TestCheckHostMemory:
         for mib in ("7000", "3500", "1600"):
             assert mib in text, (
                 "check_host_memory.yml must encode the %s MiB floor "
-                "(~2/4/8 GiB by profile) (#1147)" % mib)
+                "(~2/4/8 GiB by profile)" % mib)
 
     def test_has_a_fail_gated_on_measured_memory(self):
         fails = [t for t in _walk(_load(CHECK))
@@ -67,19 +67,19 @@ class TestCheckHostMemory:
                  and "_mem_floor_mib" in _when_text(t)]
         assert fails, (
             "check_host_memory.yml must fail when measured memory is below the "
-            "required floor (#1147)")
+            "required floor")
 
 
 class TestWiredIntoCreateAndConfigSet:
     def test_create_enforces_floor(self):
         assert any("check_host_memory.yml" in inc for inc in _includes(ENV_UPDATE)), (
             "create (_env_update.yml) must include check_host_memory.yml once "
-            ".env is finalized (#1147)")
+            ".env is finalized")
 
     def test_config_set_enforces_on_enable(self):
         assert any("check_host_memory.yml" in inc for inc in _includes(SIDE_EFFECTS)), (
             "config set (_side_effects.yml) must include check_host_memory.yml "
-            "when enabling a profile (#1147)")
+            "when enabling a profile")
         # The include must be reachable only when enabling ES/observability.
         text = open(SIDE_EFFECTS).read()
         assert "CANASTA_ENABLE_ELASTICSEARCH" in text
@@ -91,4 +91,4 @@ class TestOldFlatFloorRemoved:
         text = open(PREFLIGHT).read()
         assert "3500" not in text, (
             "the old flat 3500 MiB preflight floor must be removed — the "
-            "profile-aware check replaces it (#1147)")
+            "profile-aware check replaces it")

--- a/tests/unit/test_pull_empty_url_guard.py
+++ b/tests/unit/test_pull_empty_url_guard.py
@@ -1,11 +1,11 @@
-"""Regression guard for #1177: `gitops pull` must not overwrite config/wikis.yaml
+"""Regression guard: `gitops pull` must not overwrite config/wikis.yaml
 with a blank url.
 
 pull_compose.yml renders wikis.yaml from wikis.yaml.template with the same
 `{{wiki_url_<id>}} | default('')` pattern as render_compose.yml. If a wiki's
 wiki_url_<id> var is absent on the pulling host, the url renders empty and
 MediaWiki's FarmConfigLoader fatals on every request. pull must render into a
-fact and refuse to write when any url came out empty (sibling of #1164).
+fact and refuse to write when any url came out empty.
 """
 
 import os
@@ -42,11 +42,11 @@ class TestPullRefusesEmptyUrl:
         assert guards, (
             "pull_compose.yml must fail (before writing config/wikis.yaml) when "
             "a wiki url rendered empty — rejectattr('url') on the rendered "
-            "wikis list (#1177)")
+            "wikis list")
 
     def test_wikis_yaml_written_from_validated_fact(self):
         text = open(PULL_COMPOSE).read()
         assert "_pull_wikis_content" in text, (
             "pull_compose.yml must render wikis.yaml into a fact "
             "(_pull_wikis_content) so it can be validated before it replaces "
-            "the live file (#1177)")
+            "the live file")


### PR DESCRIPTION
Follow-up hygiene cleanup: removes the issue-number references that were left in **code comments** and test docstrings/assertion messages across the recent batch of merged fixes (the correctness + gitops + memory-floor work). Issue numbers belong in commit messages and PR descriptions, not in source comments — they're noise and go stale.

- Scoped to the 12 files touched in that batch, and only the issue numbers introduced by it; pre-existing legacy references elsewhere in the codebase are intentionally left untouched.
- Comment/docstring text only — no behavior change. `make test-unit` / `make lint` / `make validate` green.
