### PR TITLE
feat: canasta extension set-version to pin a user extension's submodule

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -91,7 +91,7 @@ _ensure_ca_bundle()
 # Commands that have subcommands (e.g., "config get" -> "config_get")
 SUBCOMMAND_GROUPS = {
     "config": ["get", "set", "unset", "regenerate", "refresh-template"],
-    "extension": ["list", "enable", "disable"],
+    "extension": ["list", "enable", "disable", "set-version"],
     "skin": ["list", "enable", "disable"],
     "maintenance": ["update", "script", "extension", "exec"],
     "crowdsec": [

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1337,6 +1337,36 @@ commands:
         required: true
         description: "Comma-separated extension names"
 
+  - name: extension_set_version
+    description: "Pin a user extension to a specific version"
+    long_description: |
+      Move a gitops-managed user extension's submodule to a specific
+      version (branch, tag, or commit) and stage the change, ready for
+      `canasta gitops push` to distribute it to every host. This replaces
+      the raw `git checkout` inside the submodule that changing an
+      extension's version otherwise requires.
+
+      Pass the release branch matching your MediaWiki version (e.g.
+      `REL1_43`) rather than a development branch like `master`, which is
+      the common cause of version-mismatch regressions.
+    examples:
+      - "canasta extension set-version UserPageEditProtection --ref REL1_43"
+    playbook: extension_set_version.yml
+    parameters:
+      - name: id
+        short: i
+        type: string
+        description: "Canasta instance ID"
+      - name: name
+        type: string
+        positional: true
+        required: true
+        description: "Extension name (the extensions/<name> submodule)"
+      - name: ref
+        type: string
+        required: true
+        description: "Version to pin to: a branch, tag, or commit SHA"
+
   # ---------------------------------------------------------------------------
   # Skins
   # ---------------------------------------------------------------------------

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1350,11 +1350,12 @@ commands:
       `REL1_43`) rather than a development branch like `master`, which is
       the common cause of version-mismatch regressions.
       Only user extensions (vendored as submodules) can be pinned. A
-      bundled extension's version is fixed by the Canasta image, so this
-      refuses one with a clear message. Pass `--run-update` to apply any
-      database schema changes for the new version immediately; otherwise
-      run `canasta maintenance update` afterward if the version touches
-      the schema.
+      bundled extension has no per-instance submodule, so this refuses it —
+      to use a different version, add it to your extensions/ directory,
+      where a user copy overrides the bundled one. Pass `--run-update` to
+      apply any database schema changes for the new version immediately;
+      otherwise run `canasta maintenance update` afterward if the version
+      touches the schema.
     examples:
       - "canasta extension set-version UserPageEditProtection --ref REL1_43"
     playbook: extension_set_version.yml

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1349,6 +1349,12 @@ commands:
       Pass the release branch matching your MediaWiki version (e.g.
       `REL1_43`) rather than a development branch like `master`, which is
       the common cause of version-mismatch regressions.
+      Only user extensions (vendored as submodules) can be pinned. A
+      bundled extension's version is fixed by the Canasta image, so this
+      refuses one with a clear message. Pass `--run-update` to apply any
+      database schema changes for the new version immediately; otherwise
+      run `canasta maintenance update` afterward if the version touches
+      the schema.
     examples:
       - "canasta extension set-version UserPageEditProtection --ref REL1_43"
     playbook: extension_set_version.yml
@@ -1366,6 +1372,10 @@ commands:
         type: string
         required: true
         description: "Version to pin to: a branch, tag, or commit SHA"
+      - name: run_update
+        type: bool
+        default: false
+        description: "Run update.php after pinning to apply DB schema changes"
 
   # ---------------------------------------------------------------------------
   # Skins

--- a/playbooks/extension_set_version.yml
+++ b/playbooks/extension_set_version.yml
@@ -1,0 +1,7 @@
+---
+# canasta extension set-version - Pin a user extension submodule to a ref.
+
+- name: Set extension version
+  ansible.builtin.include_role:
+    name: extensions_skins
+    tasks_from: set_version.yml

--- a/roles/extensions_skins/tasks/set_version.yml
+++ b/roles/extensions_skins/tasks/set_version.yml
@@ -115,27 +115,63 @@
   register: _ext_new
   changed_when: false
 
-# Apply DB schema changes for the new version when asked. Runs update.php for
-# every wiki in the farm (the version change is instance-wide), mirroring
-# canasta maintenance update.
+# Apply DB schema changes for the new version when asked — but skip update.php
+# when the pinned version clearly needs no schema update, i.e. its extension.json
+# registers no LoadExtensionSchemaUpdates hook. If extension.json is absent (an
+# older PHP-registered extension) or does register the hook, run update.php
+# (idempotent) to be safe. Runs for every wiki in the farm (the version change
+# is instance-wide), mirroring canasta maintenance update.
 - name: Apply schema changes with update.php
   when: run_update | default(false) | bool
   block:
-    - name: Read wikis for update.php
-      canasta_wikis_yaml:
-        instance_path: "{{ instance_path }}"
-        state: read
-      register: _ext_wikis
+    - name: Stat the new version's extension.json
+      ansible.builtin.stat:
+        path: "{{ instance_path }}/{{ _ext_path }}/extension.json"
+      register: _ext_json
+
+    - name: Check whether the new version registers schema updates
+      ansible.builtin.command:
+        cmd: >-
+          grep -q LoadExtensionSchemaUpdates
+          {{ (instance_path ~ '/' ~ _ext_path ~ '/extension.json') | quote }}
+      register: _ext_schema
+      changed_when: false
+      failed_when: false
+      when: _ext_json.stat.exists
+
+    # Skip only when we're confident: extension.json exists and doesn't
+    # register the schema-update hook (grep rc 1). Otherwise run update.php.
+    - name: Decide whether update.php is needed
+      ansible.builtin.set_fact:
+        _ext_run_update: >-
+          {{ (not _ext_json.stat.exists)
+             or ((_ext_schema.rc | default(0)) != 1) }}
 
     - name: Run update.php for each wiki
-      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
-      vars:
-        exec_service: web
-        exec_command: "php maintenance/update.php --wiki={{ item.id | quote }}"
-        exec_long: true
-      loop: "{{ _ext_wikis.wikis | default([]) }}"
-      loop_control:
-        label: "{{ item.id }}"
+      when: _ext_run_update | bool
+      block:
+        - name: Read wikis for update.php
+          canasta_wikis_yaml:
+            instance_path: "{{ instance_path }}"
+            state: read
+          register: _ext_wikis
+
+        - name: Run update.php for each wiki
+          ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+          vars:
+            exec_service: web
+            exec_command: "php maintenance/update.php --wiki={{ item.id | quote }}"
+            exec_long: true
+          loop: "{{ _ext_wikis.wikis | default([]) }}"
+          loop_control:
+            label: "{{ item.id }}"
+
+    - name: Report that update.php was skipped (no schema updates)
+      ansible.builtin.debug:
+        msg: >-
+          '{{ name }}' registers no schema updates in extension.json, so
+          update.php was skipped.
+      when: not (_ext_run_update | bool)
 
 - name: Report the version change
   ansible.builtin.debug:

--- a/roles/extensions_skins/tasks/set_version.yml
+++ b/roles/extensions_skins/tasks/set_version.yml
@@ -3,7 +3,8 @@
 # 'canasta gitops push'. Fills the "choose the version" gap between gitops add
 # (capture) and gitops pull (distribute), so version pinning is CLI-driven
 # rather than raw `git checkout` inside the submodule.
-# Input: id (via resolve), name (extension), ref (branch|tag|sha)
+# Input: id (via resolve), name (extension), ref (branch|tag|sha),
+#        run_update (bool)
 
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
@@ -29,14 +30,52 @@
   changed_when: false
   failed_when: false
 
-- name: Fail if the extension is not a registered submodule
-  ansible.builtin.fail:
-    msg: >-
-      '{{ name }}' is not a registered extension submodule in this instance
-      ({{ _ext_path }} is not in .gitmodules). Version pinning applies to
-      gitops-managed user extensions; check the name, or run
-      'canasta gitops fix-submodules' if the submodule registration is missing.
+# When it's not a host submodule, distinguish a bundled (in-image) extension
+# from a typo/missing registration so the error is actionable. Bundled
+# extensions are real directories in the container's extensions dir; user
+# extensions are symlinks into ../user-extensions. The probe needs the
+# container, so tolerate a stopped one and fall back to the generic message.
+- name: Diagnose a non-submodule extension name
   when: _ext_submodule.rc != 0
+  block:
+    - name: Probe whether the name is a bundled (in-image) extension
+      block:
+        - name: Check the container's bundled extensions directory
+          ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+          vars:
+            exec_service: web
+            exec_command: >-
+              if [ -d /var/www/mediawiki/w/extensions/{{ name | quote }} ] &&
+              [ ! -L /var/www/mediawiki/w/extensions/{{ name | quote }} ]; then
+              echo bundled; else echo other; fi
+        - name: Record the probe result
+          ansible.builtin.set_fact:
+            _ext_bundled: "{{ (exec_result.stdout | default('') | trim) == 'bundled' }}"
+      rescue:
+        - name: Treat an unreachable container as inconclusive
+          ansible.builtin.set_fact:
+            _ext_bundled: false
+
+    - name: Fail — a bundled extension cannot be version-pinned per instance
+      ansible.builtin.fail:
+        msg: >-
+          '{{ name }}' is a bundled Canasta extension (shipped inside the image
+          at /var/www/mediawiki/w/extensions), not a per-instance user
+          extension. Its version is fixed by the Canasta image and can't be
+          pinned here — build/use a custom Canasta image, or vendor it as a
+          user extension, to change its version.
+      when: _ext_bundled | bool
+
+    - name: Fail — not a user-extension submodule
+      ansible.builtin.fail:
+        msg: >-
+          '{{ name }}' is not a gitops-managed user-extension submodule
+          (extensions/{{ name }} is not in .gitmodules). Version pinning applies
+          to user extensions vendored as submodules. Check the name; if it is a
+          bundled Canasta extension its version is set by the image (not
+          pinnable here); or run 'canasta gitops fix-submodules' if the
+          submodule registration is missing.
+      when: not (_ext_bundled | bool)
 
 - name: Record the current ref
   ansible.builtin.command:
@@ -76,6 +115,28 @@
   register: _ext_new
   changed_when: false
 
+# Apply DB schema changes for the new version when asked. Runs update.php for
+# every wiki in the farm (the version change is instance-wide), mirroring
+# canasta maintenance update.
+- name: Apply schema changes with update.php
+  when: run_update | default(false) | bool
+  block:
+    - name: Read wikis for update.php
+      canasta_wikis_yaml:
+        instance_path: "{{ instance_path }}"
+        state: read
+      register: _ext_wikis
+
+    - name: Run update.php for each wiki
+      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
+      vars:
+        exec_service: web
+        exec_command: "php maintenance/update.php --wiki={{ item.id | quote }}"
+        exec_long: true
+      loop: "{{ _ext_wikis.wikis | default([]) }}"
+      loop_control:
+        label: "{{ item.id }}"
+
 - name: Report the version change
   ansible.builtin.debug:
     msg: >-
@@ -83,3 +144,7 @@
       ({{ _ext_current.stdout | default('') | trim | default('unknown', true) }}
       -> {{ _ext_new.stdout | trim }}). Staged — run 'canasta gitops push' to
       distribute it to other hosts.
+      {{ '' if (run_update | default(false) | bool)
+         else "If this version changes the database schema, apply it with
+         'canasta maintenance update -i " ~ instance_id ~ "' (or re-run with
+         --run-update)." }}

--- a/roles/extensions_skins/tasks/set_version.yml
+++ b/roles/extensions_skins/tasks/set_version.yml
@@ -56,14 +56,14 @@
           ansible.builtin.set_fact:
             _ext_bundled: false
 
-    - name: Fail — a bundled extension cannot be version-pinned per instance
+    - name: Fail — a bundled extension has no per-instance submodule to pin
       ansible.builtin.fail:
         msg: >-
-          '{{ name }}' is a bundled Canasta extension (shipped inside the image
-          at /var/www/mediawiki/w/extensions), not a per-instance user
-          extension. Its version is fixed by the Canasta image and can't be
-          pinned here — build/use a custom Canasta image, or vendor it as a
-          user extension, to change its version.
+          '{{ name }}' is a bundled Canasta extension (shipped in the image),
+          not a per-instance user-extension submodule, so there is no submodule
+          to pin here. To use a different version, add that version to this
+          instance's extensions/ directory — a user copy there overrides the
+          bundled one — and manage its version from there.
       when: _ext_bundled | bool
 
     - name: Fail — not a user-extension submodule

--- a/roles/extensions_skins/tasks/set_version.yml
+++ b/roles/extensions_skins/tasks/set_version.yml
@@ -1,0 +1,85 @@
+---
+# Pin a user extension's submodule to a specific ref and stage the gitlink for
+# 'canasta gitops push'. Fills the "choose the version" gap between gitops add
+# (capture) and gitops pull (distribute), so version pinning is CLI-driven
+# rather than raw `git checkout` inside the submodule.
+# Input: id (via resolve), name (extension), ref (branch|tag|sha)
+
+- name: Resolve instance
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
+
+# Reject a name that could escape the extensions dir or name a sub-path — this
+# pins the top-level extension submodule (extensions/<name>).
+- name: Validate the extension name
+  ansible.builtin.fail:
+    msg: >-
+      Invalid extension name '{{ name }}': use a plain extension directory
+      name (letters, digits, '.', '_', '-').
+  when: name is not match('^[A-Za-z0-9][A-Za-z0-9_.-]*$')
+
+- name: Set the extension submodule path
+  ansible.builtin.set_fact:
+    _ext_path: "extensions/{{ name }}"
+
+- name: Verify the extension is a registered submodule
+  ansible.builtin.command:
+    cmd: "git submodule status {{ _ext_path | quote }}"
+    chdir: "{{ instance_path }}"
+  register: _ext_submodule
+  changed_when: false
+  failed_when: false
+
+- name: Fail if the extension is not a registered submodule
+  ansible.builtin.fail:
+    msg: >-
+      '{{ name }}' is not a registered extension submodule in this instance
+      ({{ _ext_path }} is not in .gitmodules). Version pinning applies to
+      gitops-managed user extensions; check the name, or run
+      'canasta gitops fix-submodules' if the submodule registration is missing.
+  when: _ext_submodule.rc != 0
+
+- name: Record the current ref
+  ansible.builtin.command:
+    cmd: "git -C {{ _ext_path | quote }} rev-parse --short HEAD"
+    chdir: "{{ instance_path }}"
+  register: _ext_current
+  changed_when: false
+  failed_when: false
+
+# Fetch branches and tags so the requested ref is available locally, then check
+# it out. git records the resulting commit in the gitlink regardless of whether
+# the ref is a branch (tracking), tag, or SHA (detached).
+- name: Fetch the extension's remote
+  ansible.builtin.command:
+    cmd: "git -C {{ _ext_path | quote }} fetch --tags origin"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+
+- name: Check out the requested ref
+  ansible.builtin.command:
+    cmd: "git -C {{ _ext_path | quote }} checkout {{ ref | quote }}"
+    chdir: "{{ instance_path }}"
+  register: _ext_checkout
+  changed_when: true
+  failed_when: _ext_checkout.rc != 0
+
+- name: Stage the updated gitlink
+  ansible.builtin.command:
+    cmd: "git add -- {{ _ext_path | quote }}"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+
+- name: Record the new ref
+  ansible.builtin.command:
+    cmd: "git -C {{ _ext_path | quote }} rev-parse --short HEAD"
+    chdir: "{{ instance_path }}"
+  register: _ext_new
+  changed_when: false
+
+- name: Report the version change
+  ansible.builtin.debug:
+    msg: >-
+      Extension '{{ name }}' set to '{{ ref }}'
+      ({{ _ext_current.stdout | default('') | trim | default('unknown', true) }}
+      -> {{ _ext_new.stdout | trim }}). Staged — run 'canasta gitops push' to
+      distribute it to other hosts.

--- a/tests/unit/test_extension_set_version.py
+++ b/tests/unit/test_extension_set_version.py
@@ -98,6 +98,18 @@ class TestExtensionSetVersion:
         assert any("update.php" in c for c in _exec_commands(_load(TASK))), (
             "--run-update must run update.php to apply schema changes")
 
+    def test_consults_extension_json_for_schema_updates(self):
+        cmds = [_cmd(t) for t in _walk(_load(TASK))]
+        assert any("LoadExtensionSchemaUpdates" in c for c in cmds), (
+            "--run-update must consult the new version's extension.json for "
+            "LoadExtensionSchemaUpdates to decide whether update.php is needed")
+
+    def test_can_skip_update_when_no_schema_change(self):
+        text = open(TASK).read()
+        assert "_ext_run_update" in text, (
+            "--run-update must be able to skip update.php when the pinned "
+            "version registers no schema updates")
+
 
 class TestCommandRegistered:
     def test_command_defined(self):

--- a/tests/unit/test_extension_set_version.py
+++ b/tests/unit/test_extension_set_version.py
@@ -33,6 +33,21 @@ def _cmd(t):
     return c.get("cmd", "") if isinstance(c, dict) else str(c)
 
 
+def _exec_commands(tasks):
+    # exec_command values passed to included exec.yml tasks.
+    return [(t.get("vars") or {}).get("exec_command", "")
+            for t in _walk(tasks) if (t.get("vars") or {}).get("exec_command")]
+
+
+def _fail_msgs(tasks):
+    out = []
+    for t in _walk(tasks):
+        f = t.get("ansible.builtin.fail") or t.get("fail") or {}
+        if isinstance(f, dict) and f.get("msg"):
+            out.append(f["msg"])
+    return out
+
+
 class TestExtensionSetVersion:
     def setup_method(self):
         self.cmds = [_cmd(t) for t in _walk(_load(TASK)) if _cmd(t)]
@@ -61,6 +76,27 @@ class TestExtensionSetVersion:
             t.get("when") if isinstance(t.get("when"), list) else [str(t.get("when"))])
             for t in fails if t.get("when")), (
             "set-version must validate the extension name (reject path escapes)")
+
+    def test_probes_container_for_bundled_extension(self):
+        tasks = _load(TASK)
+        assert any("/var/www/mediawiki/w/extensions" in c
+                   for c in _exec_commands(tasks)), (
+            "set-version must probe the container's bundled extensions dir to "
+            "distinguish a bundled extension from a typo")
+
+    def test_has_bundled_specific_error(self):
+        assert any("bundled" in m.lower() for m in _fail_msgs(_load(TASK))), (
+            "set-version must give a bundled-specific error message")
+
+    def test_probe_tolerates_stopped_container(self):
+        # A block/rescue guards the container probe so a stopped instance
+        # doesn't abort with an opaque error.
+        assert any("rescue" in t for t in _walk(_load(TASK))), (
+            "the bundled probe must have a rescue for a stopped container")
+
+    def test_run_update_runs_update_php(self):
+        assert any("update.php" in c for c in _exec_commands(_load(TASK))), (
+            "--run-update must run update.php to apply schema changes")
 
 
 class TestCommandRegistered:

--- a/tests/unit/test_extension_set_version.py
+++ b/tests/unit/test_extension_set_version.py
@@ -1,0 +1,71 @@
+"""Guard for `canasta extension set-version`: it must move a user extension's
+submodule to the requested ref and stage the gitlink for `gitops push`, and
+refuse a name that isn't a registered submodule.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+TASK = os.path.join(
+    REPO_ROOT, "roles", "extensions_skins", "tasks", "set_version.yml")
+DEFS = os.path.join(REPO_ROOT, "meta", "command_definitions.yml")
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f) or []
+
+
+def _walk(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk(t[nested])
+
+
+def _cmd(t):
+    c = t.get("ansible.builtin.command") or t.get("command") or {}
+    return c.get("cmd", "") if isinstance(c, dict) else str(c)
+
+
+class TestExtensionSetVersion:
+    def setup_method(self):
+        self.cmds = [_cmd(t) for t in _walk(_load(TASK)) if _cmd(t)]
+
+    def test_verifies_submodule_registration(self):
+        assert any("submodule status" in c for c in self.cmds), (
+            "set-version must verify the extension is a registered submodule")
+
+    def test_fetches_before_checkout(self):
+        assert any("fetch" in c and "origin" in c for c in self.cmds), (
+            "set-version must fetch the extension's remote")
+
+    def test_checks_out_the_requested_ref(self):
+        assert any("checkout" in c and "{{ ref" in c for c in self.cmds), (
+            "set-version must check out the requested ref")
+
+    def test_stages_the_gitlink(self):
+        assert any("git add" in c and "_ext_path" in c for c in self.cmds), (
+            "set-version must stage the gitlink (git add -- <ext path>) "
+            "for gitops push")
+
+    def test_rejects_invalid_name(self):
+        fails = [t for t in _walk(_load(TASK))
+                 if "ansible.builtin.fail" in t or "fail" in t]
+        assert any("is not match" in " ".join(
+            t.get("when") if isinstance(t.get("when"), list) else [str(t.get("when"))])
+            for t in fails if t.get("when")), (
+            "set-version must validate the extension name (reject path escapes)")
+
+
+class TestCommandRegistered:
+    def test_command_defined(self):
+        data = yaml.safe_load(open(DEFS))
+        names = {c["name"] for c in data["commands"]}
+        assert "extension_set_version" in names, (
+            "extension_set_version must be defined in command_definitions.yml")


### PR DESCRIPTION
Fixes #1165.

Changing which version of a user extension is vendored (its submodule ref) required raw `git` inside the submodule, which is error-prone and breaks the otherwise CLI-driven gitops flow. `gitops add` (capture), `gitops pull` (distribute), and `gitops fix-submodules` (repair) already exist; this fills the missing **"choose the version"** step.

## Command
`canasta extension set-version <name> --ref <branch|tag|sha> [--run-update]`:
1. Resolves the `extensions/<name>` submodule.
2. Fetches the submodule's remote (branches + tags).
3. Checks out `<ref>` — git records the resulting commit in the gitlink (branch/tag/SHA).
4. Stages the gitlink, ready for `canasta gitops push`.
5. Reports the old → new commit.

Solves the issue's real case: pin `UserPageEditProtection` to `REL1_43` instead of a `master`-dev snapshot that carried a regression.

## Bundled vs user extensions
Only **user extensions** (vendored as submodules) can be pinned. A **bundled** extension lives inside the Canasta image (`/var/www/mediawiki/w/extensions/<name>` as a real dir; user extensions are symlinks into `../user-extensions`), so there's no per-instance submodule to pin. When the name isn't a host submodule, the command probes the container to tell a bundled extension apart from a typo and gives a **bundled-specific error** that points to the real fix — vendor the version you want in your `extensions/` directory, where a user copy overrides the bundled one — rather than the generic one. The probe is `block`/`rescue`-guarded so a stopped instance falls back gracefully.

## update.php interaction
`--run-update` applies DB schema changes for the new version, **for every wiki in the farm** (mirroring `canasta maintenance update`). It's opt-in (not on by default like `enable`) because `set-version` is a gitops-staging operation and shouldn't require a running container/DB.

It's **schema-aware**: it consults the pinned version's own `extension.json` for a `LoadExtensionSchemaUpdates` hook and **skips `update.php`** when the version registers none (reporting the skip). If `extension.json` is absent (older PHP-registered extension) or does register the hook, it runs `update.php` (idempotent) to be safe. Checking the extension's own `extension.json` is version-accurate for the specific user version being pinned — unlike the bundled `RecommendedRevisions` manifest, which only covers bundled extensions at their recommended revision. Without `--run-update`, the report advises running `canasta maintenance update` if the version touches the schema.

## Design note: why not `--ref` on `extension enable`?
Deliberately kept separate. `enable` accepts both bundled and user extensions (its check follows the container symlink), but `--ref` only applies to user-extension submodules — a flag valid for only a subset of `enable`'s inputs. It also conflates "does it load" with "which version is vendored," and duplicates `set-version`. Clean composition is `set-version --ref X` then `enable X`.

## Verification
End-to-end on scratch submodules: a `master` regression → `REL1_43` staged the correct gitlink; the bundled probe correctly classifies a real dir (bundled) vs a symlink (user) vs a missing name (typo); a non-submodule name is rejected. Adds regression guards. `make test-unit` / `make lint` / `make validate` (87 commands) green.

## Not included
`--rel-branch` (derive `REL1_XX` from the instance's MediaWiki version) left as a follow-up; pass the release branch explicitly via `--ref`.
