### PR TITLE
fix: gitops join reconciles COMPOSE_PROFILES after rendering .env

### DIFF
--- a/roles/gitops/tasks/join.yml
+++ b/roles/gitops/tasks/join.yml
@@ -387,6 +387,13 @@
     name: gitops
     tasks_from: render_compose.yml
 
+# env.template carries no COMPOSE_PROFILES literal — the reconcile materializes
+# it from the feature flags and DB mode. Without it a joined .env has no
+# COMPOSE_PROFILES until the next start/reconcile. Mirrors pull_compose.yml.
+- name: Reconcile COMPOSE_PROFILES after render
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/sync_compose_profiles.yml
+
 - name: Regenerate orchestrator config (Caddyfile)
   ansible.builtin.include_role:
     name: orchestrator

--- a/tests/unit/test_gitops_join_profiles.py
+++ b/tests/unit/test_gitops_join_profiles.py
@@ -1,0 +1,75 @@
+"""Guard: gitops join must reconcile COMPOSE_PROFILES after rendering .env.
+
+join renders .env verbatim from env.template + host vars, which carry no
+COMPOSE_PROFILES literal; the reconcile (sync_compose_profiles) is what
+materializes it from the feature flags and DB mode. Without it a freshly
+joined instance's .env has no COMPOSE_PROFILES, leaving profile-gated services
+unmanaged on a raw `docker compose up`. pull_compose.yml already does this;
+join must match so both gitops entry points leave .env in the same state.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+JOIN = os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "join.yml")
+PULL = os.path.join(REPO_ROOT, "roles", "gitops", "tasks", "pull_compose.yml")
+
+RENDER = "render_compose.yml"
+SYNC = "sync_compose_profiles.yml"
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f) or []
+
+
+def _walk(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk(t[nested])
+
+
+def _includes(tasks):
+    """Ordered list of file basenames pulled in via include_tasks/role."""
+    out = []
+    for t in _walk(tasks):
+        inc = t.get("ansible.builtin.include_tasks") or t.get("include_tasks")
+        if isinstance(inc, dict):
+            inc = inc.get("file", "")
+        if inc:
+            out.append(os.path.basename(str(inc).strip()))
+        role = (t.get("ansible.builtin.include_role")
+                or t.get("include_role"))
+        if isinstance(role, dict) and role.get("tasks_from"):
+            out.append(os.path.basename(str(role["tasks_from"]).strip()))
+    return out
+
+
+class TestJoinReconcilesProfiles:
+    def test_join_syncs_compose_profiles(self):
+        assert SYNC in _includes(_load(JOIN)), (
+            "gitops join must reconcile COMPOSE_PROFILES (include "
+            "sync_compose_profiles.yml) after rendering .env, or a joined "
+            "instance's .env is left without COMPOSE_PROFILES"
+        )
+
+    def test_join_syncs_after_render(self):
+        incs = _includes(_load(JOIN))
+        assert RENDER in incs and SYNC in incs
+        assert incs.index(SYNC) > incs.index(RENDER), (
+            "the profile reconcile must run after render_compose so it "
+            "materializes COMPOSE_PROFILES on the freshly rendered .env"
+        )
+
+    def test_matches_pull_which_already_reconciles(self):
+        # Parity: both gitops entry points that render .env must reconcile it.
+        assert SYNC in _includes(_load(PULL)), (
+            "pull_compose.yml is the reference pattern and must reconcile "
+            "COMPOSE_PROFILES; join is expected to mirror it"
+        )


### PR DESCRIPTION
Fixes #1202.

On Compose, `canasta gitops join` rendered `.env` from `env.template` + host vars but did **not** reconcile `COMPOSE_PROFILES` afterward, so a freshly joined instance's `.env` was left with the key **absent**.

## Root cause
- `roles/gitops/tasks/join.yml` (Step 9) includes `render_compose.yml` — which writes `.env` verbatim and has no `COMPOSE_PROFILES` logic — then proceeds to the Caddyfile regen and commit.
- Its sibling `roles/gitops/tasks/pull_compose.yml` (Step 7b) does the same render **and then** calls `roles/orchestrator/tasks/sync_compose_profiles.yml` to recompute `COMPOSE_PROFILES` from the feature flags / DB mode.
- `env.template` carries no `COMPOSE_PROFILES` literal, so the reconcile is what materializes it. Without that step join's `.env` has the key missing.

## Impact
Low but real. `start.yml` runs `sync_compose_profiles` before `docker compose up`, so any `canasta start`/`restart`/`reconcile`/`restore`/`gitops pull` self-heals the value before it matters. The exposure is a raw `docker compose up` issued after a join and before any canasta op — profile-gated services (internal `db`, `varnish`, …) would sit unmanaged. join and pull also left `.env` in inconsistent states for the same repo.

## Change
- Add the same `sync_compose_profiles` step used by pull, immediately after the render in `join.yml`.
- `tests/unit/test_gitops_join_profiles.py` — guards that join reconciles profiles, does so after the render, and stays in parity with the pull path.

## Testing
- New guards pass; full suite 1843 pass; `make lint` + `make validate` clean.
- Found while validating the gitops-managed restore journey (create → gitops join → restore): immediately after join, `.env` had no `COMPOSE_PROFILES`; the subsequent restore's re-render restored it. The underlying `sync_compose_profiles` task is the same one that ran successfully in that restore.