### PR TITLE
fix: K8s backup chowns a local-path restic repo back to the operator

### DIFF
--- a/roles/orchestrator/tasks/k8s_run_backup.yml
+++ b/roles/orchestrator/tasks/k8s_run_backup.yml
@@ -34,6 +34,16 @@
   ansible.builtin.set_fact:
     _restic_local_repo: "{{ _restic_repo is match('^/') }}"
 
+# restic runs as root (to read every backup source), so a local-path repo it
+# writes is root-owned and the operator can't remove it without sudo. Record
+# the repo's parent-dir owner (the user who created it) so the Job can chown
+# the repo back to them afterward.
+- name: Stat the local repo's parent directory for its owner
+  ansible.builtin.stat:
+    path: "{{ _restic_repo | dirname }}"
+  register: _restic_repo_parent
+  when: _restic_local_repo | bool
+
 # The backup snapshots the instance's on-disk config/ and .env from the
 # control-plane node via hostPath (parity with Compose, which stages the
 # host config dir), so every backup must land on the cp node where those
@@ -231,6 +241,24 @@
 - name: Apply backup-env Secret before the backup Job
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_apply_backup_env_secret.yml"
 
+- name: Build the restic container command
+  ansible.builtin.set_fact:
+    _restic_command: "restic --cache-dir /tmp/restic-cache {{ backup_args | join(' ') }}"
+
+# chown the local-path repo back to its parent-dir owner after restic runs, so
+# the operator (not root) owns it and can remove it without sudo. Runs for any
+# repo-touching op (init writes lock/config files too), tolerates a missing
+# chown, and preserves restic's exit code so a failure still surfaces.
+- name: Reclaim local-path repo ownership after the op
+  ansible.builtin.set_fact:
+    _restic_command: >-
+      {{ _restic_command }}; _rc=$?; chown -R
+      {{ _restic_repo_parent.stat.uid }}:{{ _restic_repo_parent.stat.gid }}
+      {{ _restic_repo | quote }} 2>/dev/null || true; exit "$_rc"
+  when:
+    - _restic_local_repo | bool
+    - _restic_repo_parent.stat.exists | default(false)
+
 - name: Create restic Job
   kubernetes.core.k8s:
     state: present
@@ -261,7 +289,7 @@
                 command:
                   - sh
                   - -c
-                  - "restic --cache-dir /tmp/restic-cache {{ backup_args | join(' ') }}"
+                  - "{{ _restic_command }}"
                 # canasta-<id>-backup-env carries RESTIC_*, AWS_*,
                 # B2_*, AZURE_*, GOOGLE_*, OS_*, ST_* — every cloud-
                 # backend credential restic might need (#497). Mirrors

--- a/tests/unit/test_k8s_backup_repo_ownership.py
+++ b/tests/unit/test_k8s_backup_repo_ownership.py
@@ -1,0 +1,72 @@
+"""Guard: a K8s local-path restic repo must end up owned by the operator.
+
+restic runs as root in the backup Job (so it can read every backup source), so
+a local hostPath repo it writes is root-owned and the operator can't remove it
+without sudo. The Job must chown the repo back to its parent directory's owner
+after the op, gated on a local-path repo, and preserve restic's exit code so a
+failure still surfaces.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+JOB = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "k8s_run_backup.yml")
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f) or []
+
+
+def _tasks(path):
+    return _load(path)
+
+
+def _set_facts(tasks):
+    out = []
+    for t in tasks:
+        sf = t.get("ansible.builtin.set_fact") or t.get("set_fact")
+        if isinstance(sf, dict):
+            out.append((t, sf))
+    return out
+
+
+class TestLocalRepoOwnershipReclaim:
+    def test_stats_parent_for_owner(self):
+        tasks = _tasks(JOB)
+        stat = next(
+            (t for t in tasks
+             if (t.get("ansible.builtin.stat") or t.get("stat"))
+             and "dirname" in str(t.get("ansible.builtin.stat")
+                                   or t.get("stat"))),
+            None,
+        )
+        assert stat is not None, (
+            "must stat the local repo's parent dir to learn its owner")
+        assert "_restic_local_repo" in str(stat.get("when", "")), (
+            "the parent stat must be gated on a local-path repo")
+
+    def test_command_chowns_repo_to_parent_owner(self):
+        chown = [
+            (t, sf) for (t, sf) in _set_facts(_tasks(JOB))
+            if "_restic_command" in sf and "chown" in str(sf["_restic_command"])
+        ]
+        assert chown, "the restic command must chown a local-path repo"
+        task, sf = chown[0]
+        cmd = str(sf["_restic_command"])
+        assert "_restic_repo_parent.stat.uid" in cmd, (
+            "chown must target the parent dir's uid (the operator)")
+        assert "exit" in cmd and "_rc" in cmd, (
+            "the chown must preserve restic's exit code so a failure surfaces")
+        assert "_restic_local_repo" in str(task.get("when", "")), (
+            "the chown must only run for a local-path repo")
+
+    def test_job_uses_built_command_variable(self):
+        # The Job container command must reference the built _restic_command,
+        # not a hardcoded restic invocation that would skip the chown.
+        text = open(JOB).read()
+        assert '- "{{ _restic_command }}"' in text, (
+            "the restic container command must use the built _restic_command")


### PR DESCRIPTION
Fixes #1204.

On Kubernetes, the backup Job runs `restic` as root (so it can read every backup source), so a local-path (`hostPath`) `RESTIC_REPOSITORY` it writes was left owned by `root:root`. The operator who ran `canasta` then could not remove the repo — or reclaim its disk — without `sudo`, unlike every other artifact `canasta` creates.

## Change
`roles/orchestrator/tasks/k8s_run_backup.yml`:
- Stat the repo's parent directory on the cp host to learn its owner (the user who created it).
- After `restic` runs, `chown -R <uid>:<gid>` the repo back to that owner. Gated on a local-path repo, tolerant of a missing `chown` (`2>/dev/null || true`), and preserves restic's exit code (`exit "$_rc"`) so a failure still surfaces. Cloud/remote repos are unaffected.

restic still runs as root — only the repo ownership is reclaimed afterward, so backup sources are still fully readable.

## Testing
- `tests/unit/test_k8s_backup_repo_ownership.py` — guards that the Job stats the parent for its owner, chowns the local repo to that uid while preserving the exit code, and that the container command uses the built variable.
- Full suite 1851 pass; `make lint` + `make validate` clean.
- Live-validated on a real 2-node cluster: confirmed `restic/restic:latest` provides `chown`, that chowning the `hostPath` to the cp host's operator uid makes the repo operator-owned, and that the operator can then remove it without `sudo`. The target uid must come from the cp host (where the hostPath lives), which is where the fix stats it.

Found during a hands-on multi-node e2e of released CLI 4.13.0.