### PR TITLE
fix: upgrade stages the gitops image pin it writes

### DIFF
--- a/roles/orchestrator/tasks/upgrade_image_tag.yml
+++ b/roles/orchestrator/tasks/upgrade_image_tag.yml
@@ -69,6 +69,26 @@
         state: present
       when: _upgrade_k8s_gitops_stat.stat.exists | default(false)
 
+    # Leaving the edit unstaged blocks the next 'canasta gitops pull' (which
+    # refuses to run on a dirty tree) and hides the bump from 'canasta gitops
+    # push' (which only commits what is staged). Stage it, as the config role
+    # does for its own gitops edits.
+    - name: Stage the bumped image_tag
+      ansible.builtin.command:
+        cmd: >-
+          git add hosts/{{ _upgrade_k8s_host.content | b64decode | trim }}/vars.yaml
+        chdir: "{{ instance_path }}"
+      changed_when: true
+      when: _upgrade_k8s_gitops_stat.stat.exists | default(false)
+
+    - name: Report the pending gitops push
+      ansible.builtin.debug:
+        msg: >-
+          Staged the new image tag in hosts/{{ _upgrade_k8s_host.content
+          | b64decode | trim }}/vars.yaml. Run 'canasta gitops push' to share
+          it with the other hosts.
+      when: _upgrade_k8s_gitops_stat.stat.exists | default(false)
+
 # --- Update Compose CANASTA_IMAGE tag ---
 # Bump the tag if it's the default ghcr.io image,
 # leave it alone if user set a custom/local-build image.
@@ -106,4 +126,23 @@
         regexp: "^CANASTA_IMAGE="
         line: "CANASTA_IMAGE={{ canasta_default_image }}"
         state: present
+      when: _upgrade_image_gitops_stat.stat.exists | default(false)
+
+    # Leaving the edit unstaged blocks the next 'canasta gitops pull' (which
+    # refuses to run on a dirty tree) and hides the bump from 'canasta gitops
+    # push' (which only commits what is staged). Stage it, as the config role
+    # does for its own env.template edits.
+    - name: Stage the bumped env.template
+      ansible.builtin.command:
+        cmd: "git add env.template"
+        chdir: "{{ instance_path }}"
+      changed_when: true
+      when: _upgrade_image_gitops_stat.stat.exists | default(false)
+
+    - name: Report the pending gitops push
+      ansible.builtin.debug:
+        msg: >-
+          Staged CANASTA_IMAGE={{ canasta_default_image }} in env.template.
+          Run 'canasta gitops push' to share the new image pin with the other
+          hosts.
       when: _upgrade_image_gitops_stat.stat.exists | default(false)

--- a/tests/unit/test_upgrade_stages_gitops_pin.py
+++ b/tests/unit/test_upgrade_stages_gitops_pin.py
@@ -1,0 +1,69 @@
+"""`canasta upgrade` must stage the gitops files it edits.
+
+The image bump is persisted to env.template (Compose) / hosts/<host>/vars.yaml
+(K8s) so it survives the next render. Left unstaged, that edit blocks the next
+`canasta gitops pull` (which refuses a dirty tree) and is invisible to
+`canasta gitops push` (which only commits what is staged) — so the pin never
+reaches the other hosts. Guard that both branches stage their edit.
+"""
+
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+UPGRADE_IMAGE_TAG = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "upgrade_image_tag.yml"
+)
+
+
+def _blocks():
+    """Map top-level task name -> its inner task list."""
+    with open(UPGRADE_IMAGE_TAG) as fh:
+        tasks = yaml.safe_load(fh)
+    return {t.get("name"): t.get("block") or [] for t in tasks}
+
+
+def _cmd(task):
+    c = task.get("ansible.builtin.command") or task.get("command") or {}
+    return c.get("cmd", "") if isinstance(c, dict) else str(c)
+
+
+def _index(block, name):
+    return next((i for i, t in enumerate(block) if t.get("name") == name), None)
+
+
+def test_compose_stages_env_template_after_writing_it():
+    block = _blocks()["Update Compose image tag"]
+    write = _index(block, "Persist CANASTA_IMAGE to env.template (durable across pulls)")
+    stage = _index(block, "Stage the bumped env.template")
+    assert write is not None, "expected the env.template persist task"
+    assert stage is not None, "upgrade must stage env.template on a gitops instance"
+    assert stage > write, "staging must follow the write"
+    assert "git add env.template" in _cmd(block[stage])
+    # Off gitops there is no repo to stage into.
+    assert "_upgrade_image_gitops_stat" in str(block[stage].get("when"))
+
+
+def test_kubernetes_stages_host_vars_after_writing_it():
+    block = _blocks()["Update Kubernetes image tag in values.yaml"]
+    write = _index(block, "Persist image_tag to gitops vars.yaml (durable across pulls)")
+    stage = _index(block, "Stage the bumped image_tag")
+    assert write is not None, "expected the vars.yaml persist task"
+    assert stage is not None, "upgrade must stage hosts/<host>/vars.yaml on gitops"
+    assert stage > write, "staging must follow the write"
+    assert "git add hosts/" in _cmd(block[stage])
+    assert "_upgrade_k8s_gitops_stat" in str(block[stage].get("when"))
+
+
+def test_each_branch_reports_the_pending_push():
+    for name in (
+        "Update Compose image tag",
+        "Update Kubernetes image tag in values.yaml",
+    ):
+        block = _blocks()[name]
+        report = _index(block, "Report the pending gitops push")
+        assert report is not None, f"{name} must tell the operator a push is pending"
+        msg = str(block[report].get("ansible.builtin.debug", {}).get("msg", ""))
+        assert "canasta gitops push" in msg


### PR DESCRIPTION
Fixes #1208

`canasta upgrade` persists the bumped image into the gitops repo so the pin survives the next render — `env.template` on Compose, `hosts/<host>/vars.yaml` on Kubernetes — but never staged the edit.

On Compose that arms a trap that fires later: the working tree is left dirty, and the next `canasta gitops pull` refuses to run on a dirty tree, usually for someone who has forgotten the upgrade happened.

On Kubernetes it fails more quietly. `gitops push` only commits what is already staged, so the unstaged `image_tag` bump is invisible to it and the new pin never reaches the repo at all.

## Change

Stage the file right after writing it, mirroring what the config role already does for its own `env.template` edits (`roles/config/tasks/_remove_gitops_var.yml`), and report that a `canasta gitops push` is pending so the pin actually reaches the other hosts.

Both orchestrator branches are fixed — the issue reports the Compose symptom, but the K8s branch has the same defect a few lines up in the same file.

Staging rather than committing keeps the gitops model intact: `gitops push` commits what is staged, and operators stage explicitly with `canasta gitops add`.

## Tests

`tests/unit/test_upgrade_stages_gitops_pin.py` — structural guard that each branch stages after it writes, gates the staging on the gitops marker, and names `canasta gitops push` in its report.

`make test-unit`, `make lint`, `make validate` pass.
