### PR TITLE
fix: gitops pull no longer blocks on untracked files

### DIFF
--- a/roles/gitops/tasks/pull_compose.yml
+++ b/roles/gitops/tasks/pull_compose.yml
@@ -13,9 +13,15 @@
   ansible.builtin.include_tasks: "_detect_gitcrypt_lock.yml"
 
 # --- Step 1: Check for uncommitted changes ---
-- name: Check for uncommitted changes
+# Only tracked files are a hazard: a pull can overwrite a locally modified
+# tracked file. Untracked files cannot be clobbered unless an incoming commit
+# adds the same path, which git itself refuses with a clear message — so
+# --untracked-files=no keeps a host-local settings override or a scratch file
+# from blocking every pull. (It also kept the old advice from being a dead
+# end: plain `git stash` does not stash untracked files.)
+- name: Check for uncommitted changes to tracked files
   ansible.builtin.command:
-    cmd: "git status --porcelain"
+    cmd: "git status --porcelain --untracked-files=no"
     chdir: "{{ instance_path }}"
   register: _pull_uncommitted
   changed_when: false
@@ -23,8 +29,10 @@
 - name: Fail if uncommitted changes exist
   ansible.builtin.fail:
     msg: >-
-      Cannot pull: there are uncommitted changes in the instance
-      directory. Commit or stash them first, then retry.
+      Cannot pull: the instance directory has local changes to tracked
+      files that a pull could overwrite. Share them with
+      'canasta gitops add <file>' then 'canasta gitops push', or discard
+      them with 'git checkout -- <file>', then retry.
       Changed files: {{ _pull_uncommitted.stdout }}
   when: _pull_uncommitted.stdout | trim | length > 0
 

--- a/tests/unit/test_gitops_pull_untracked_files.py
+++ b/tests/unit/test_gitops_pull_untracked_files.py
@@ -1,0 +1,57 @@
+"""`canasta gitops pull` must not block on untracked files.
+
+The dirty-tree guard exists so a pull cannot overwrite a locally modified
+tracked file. Untracked files carry no such hazard — git refuses a genuine
+collision on its own — and blocking on them made the pull unrunnable on any
+host carrying a local settings override or scratch file. The old advice was
+also a dead end: plain `git stash` does not stash untracked files, so
+following it changed nothing and the operator looped.
+"""
+
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+PULL_COMPOSE = os.path.join(
+    REPO_ROOT, "roles", "gitops", "tasks", "pull_compose.yml"
+)
+
+
+def _tasks():
+    with open(PULL_COMPOSE) as fh:
+        return yaml.safe_load(fh)
+
+
+def _guard():
+    for t in _tasks():
+        cmd = (t.get("ansible.builtin.command") or {}).get("cmd", "")
+        if cmd.startswith("git status --porcelain"):
+            return t
+    return None
+
+
+def test_dirty_tree_guard_ignores_untracked_files():
+    guard = _guard()
+    assert guard is not None, "expected the pre-pull dirty-tree check"
+    cmd = guard["ansible.builtin.command"]["cmd"]
+    assert "--untracked-files=no" in cmd, (
+        "the pull guard must ignore untracked files; bare "
+        "`git status --porcelain` reports '??' entries and blocks the pull"
+    )
+
+
+def test_failure_message_names_a_command_that_resolves_the_state():
+    fail = next(
+        (t for t in _tasks() if "ansible.builtin.fail" in t
+         and "Cannot pull" in str(t["ansible.builtin.fail"].get("msg", ""))),
+        None,
+    )
+    assert fail is not None, "expected the dirty-tree failure task"
+    msg = " ".join(str(fail["ansible.builtin.fail"]["msg"]).split())
+    assert "canasta gitops add" in msg and "canasta gitops push" in msg, (
+        "the message must point at the canasta commands that share the change"
+    )
+    # `git stash` is a no-op on the state the old message reported.
+    assert "stash" not in msg


### PR DESCRIPTION
Fixes #1210

The pre-pull dirty-tree guard ran `git status --porcelain`, whose output includes `??` untracked entries, so **any** untracked file in the instance directory blocked `canasta gitops pull` outright.

The guard is sound for modified *tracked* files — a pull could overwrite them. Untracked files carry no such hazard: a pull can only collide with one if an incoming commit adds the same path, and git detects that itself and refuses with a clear message. Blocking on all of them was stricter than git needs to be.

The advice it gave could also not resolve the state it reported:

```
Error: Cannot pull: there are uncommitted changes in the instance directory.
Commit or stash them first, then retry. Changed files: ?? config/settings/global/zz_test.php

$ git stash
No local changes to save
```

`git stash` does not stash untracked files, so following the message changed nothing and the operator looped.

## Change

- Gate on tracked files only: `git status --porcelain --untracked-files=no`.
- Rewrite the message to name the canasta commands that actually resolve the state it now reports — `canasta gitops add <file>` then `canasta gitops push` to share the change, or `git checkout -- <file>` to discard it.

## Tests

`tests/unit/test_gitops_pull_untracked_files.py` — pins `--untracked-files=no` on the guard, and asserts the failure message points at the canasta commands rather than at `stash`.

`make test-unit`, `make lint`, `make validate` pass.

## Note

Merges cleanly with #1209 in either order — both touch `pull_compose.yml`, in disjoint hunks (the guard at the top vs. the pull itself).
