### PR TITLE
fix: gitops pull rebases, so a diverged branch has a canasta-only recovery

### DIFF
--- a/roles/gitops/tasks/init_compose.yml
+++ b/roles/gitops/tasks/init_compose.yml
@@ -142,9 +142,11 @@
     chdir: "{{ instance_path }}"
   changed_when: true
 
+# Match what `canasta gitops pull` does (git pull --rebase), so an operator
+# who runs raw git in the instance directory gets the same result.
 - name: Configure git pull strategy
   ansible.builtin.command:
-    cmd: "git config pull.rebase false"
+    cmd: "git config pull.rebase true"
     chdir: "{{ instance_path }}"
   changed_when: true
 

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -399,9 +399,11 @@
     chdir: "{{ instance_path }}"
   changed_when: true
 
+# Match what `canasta gitops pull` does (git pull --rebase), so an operator
+# who runs raw git in the instance directory gets the same result.
 - name: Configure git pull strategy
   ansible.builtin.command:
-    cmd: "git config pull.rebase false"
+    cmd: "git config pull.rebase true"
     chdir: "{{ instance_path }}"
   changed_when: true
 

--- a/roles/gitops/tasks/join.yml
+++ b/roles/gitops/tasks/join.yml
@@ -255,9 +255,11 @@
         canasta gitops join ... --reinit
   when: _join_blocked | length > 0
 
+# Match what `canasta gitops pull` does (git pull --rebase), so an operator
+# who runs raw git in the instance directory gets the same result.
 - name: Configure git pull strategy
   ansible.builtin.command:
-    cmd: "git config pull.rebase false"
+    cmd: "git config pull.rebase true"
     chdir: "{{ instance_path }}"
   changed_when: true
 

--- a/roles/gitops/tasks/join_kubernetes.yml
+++ b/roles/gitops/tasks/join_kubernetes.yml
@@ -229,9 +229,11 @@
         canasta gitops join ... --reinit
   when: _join_blocked | length > 0
 
+# Match what `canasta gitops pull` does (git pull --rebase), so an operator
+# who runs raw git in the instance directory gets the same result.
 - name: Configure git pull strategy
   ansible.builtin.command:
-    cmd: "git config pull.rebase false"
+    cmd: "git config pull.rebase true"
     chdir: "{{ instance_path }}"
   changed_when: true
 

--- a/roles/gitops/tasks/pull_compose.yml
+++ b/roles/gitops/tasks/pull_compose.yml
@@ -49,13 +49,46 @@
   ignore_errors: true  # OK if wikis.yaml doesn't exist yet
 
 # --- Step 3: Pull and update submodules ---
+# Rebase, not merge or fast-forward-only. Hosts contribute small config commits
+# to one shared branch, so replaying this host's commits on top of the remote is
+# the right semantic — and it is the only one that resolves the diverged state
+# 'gitops push' sends the operator here to fix. A plain 'git pull' honors the
+# host's ambient pull.rebase / pull.ff config, so it could abort on divergence
+# with nothing but git's own hints; --rebase is explicit and always applies.
 - name: Pull from remote
   ansible.builtin.command:
-    cmd: "git pull"
+    cmd: "git -c commit.gpgsign=false pull --rebase"
     chdir: "{{ instance_path }}"
   environment: "{{ gitops_git_env }}"
   register: _pull_result
   changed_when: "'Already up to date' not in _pull_result.stdout"
+  failed_when: false
+
+# A conflicting replay stops mid-rebase, which strands the instance in a state
+# no canasta command understands. Roll back to exactly where the pull started —
+# local commits intact — so the operator has one clear problem to solve.
+- name: Abort an incomplete rebase
+  ansible.builtin.command:
+    cmd: "git rebase --abort"
+    chdir: "{{ instance_path }}"
+  register: _pull_abort
+  changed_when: _pull_abort.rc == 0
+  failed_when: false
+  when: _pull_result.rc != 0
+
+- name: Fail if the pull could not be replayed
+  ansible.builtin.fail:
+    msg: >-
+      Cannot pull: this host's local commit(s) conflict with the remote
+      changes, so they could not be replayed on top. The rebase was rolled
+      back — the instance is exactly as it was and the local commit(s) are
+      intact. Resolve the conflict in the file(s) named below, either by
+      re-applying this host's change on top of the remote version, or by
+      discarding the local commit(s) with
+      'git reset --hard origin/main' (this throws them away).
+      git said: {{ (_pull_result.stdout | default('') ~ ' '
+                    ~ _pull_result.stderr | default('')) | trim }}
+  when: _pull_result.rc != 0
 
 - name: Update submodules
   ansible.builtin.command:

--- a/roles/gitops/tasks/pull_kubernetes.yml
+++ b/roles/gitops/tasks/pull_kubernetes.yml
@@ -4,12 +4,40 @@
 # Use 'gitops push' to commit and push any rendered changes.
 # Requires: instance_path, instance_id (set by dispatcher)
 
+# Rebase, not merge or fast-forward-only — see pull_compose.yml. --rebase is
+# explicit so the outcome does not depend on the host's ambient pull config.
 - name: Pull values repo
   ansible.builtin.command:
-    cmd: "git pull"
+    cmd: "git -c commit.gpgsign=false pull --rebase"
     chdir: "{{ instance_path }}"
   register: _git_pull
   changed_when: "'Already up to date' not in _git_pull.stdout"
+  failed_when: false
+
+# Never leave the repo mid-rebase: roll back to where the pull started so the
+# operator has one clear problem to solve, with local commits intact.
+- name: Abort an incomplete rebase
+  ansible.builtin.command:
+    cmd: "git rebase --abort"
+    chdir: "{{ instance_path }}"
+  register: _git_pull_abort
+  changed_when: _git_pull_abort.rc == 0
+  failed_when: false
+  when: _git_pull.rc != 0
+
+- name: Fail if the pull could not be replayed
+  ansible.builtin.fail:
+    msg: >-
+      Cannot pull: this host's local commit(s) conflict with the remote
+      changes, so they could not be replayed on top. The rebase was rolled
+      back — the instance is exactly as it was and the local commit(s) are
+      intact. Resolve the conflict in the file(s) named below, either by
+      re-applying this host's change on top of the remote version, or by
+      discarding the local commit(s) with
+      'git reset --hard origin/main' (this throws them away).
+      git said: {{ (_git_pull.stdout | default('') ~ ' '
+                    ~ _git_pull.stderr | default('')) | trim }}
+  when: _git_pull.rc != 0
 
 # Keep extensions/skins submodules in sync with the pulled pointers.
 - name: Update submodules

--- a/tests/unit/test_gitops_pull_rebase.py
+++ b/tests/unit/test_gitops_pull_rebase.py
@@ -1,0 +1,102 @@
+"""`canasta gitops pull` must be able to resolve a diverged branch.
+
+Hosts contribute small config commits to one shared branch, so divergence is
+routine: another host pushes while this one has a local commit. A plain
+`git pull` honors the host's ambient pull.rebase / pull.ff config and could
+abort with git's own hints, leaving no canasta command that resolves the
+state — `gitops push` tells the operator to run `gitops pull`, and `gitops
+pull` failed on exactly that. Pull with an explicit --rebase, and never leave
+the repository mid-rebase.
+"""
+
+import glob
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+TASKS = os.path.join(REPO_ROOT, "roles", "gitops", "tasks")
+PULLS = ("pull_compose.yml", "pull_kubernetes.yml")
+
+
+def _tasks(name):
+    with open(os.path.join(TASKS, name)) as fh:
+        return yaml.safe_load(fh)
+
+
+def _cmds(tasks):
+    out = []
+    for t in tasks:
+        c = t.get("ansible.builtin.command") or t.get("command") or {}
+        if isinstance(c, dict) and c.get("cmd"):
+            out.append((t, c["cmd"]))
+    return out
+
+
+def _pull_task(name):
+    for task, cmd in _cmds(_tasks(name)):
+        if "git" in cmd and " pull" in cmd:
+            return task, cmd
+    return None, None
+
+
+def test_pull_rebases_explicitly():
+    for name in PULLS:
+        task, cmd = _pull_task(name)
+        assert task is not None, "%s: expected a git pull task" % name
+        assert "--rebase" in cmd, (
+            "%s: pull must pass --rebase explicitly so a diverged branch is "
+            "resolved regardless of the host's ambient git config" % name
+        )
+        # Replayed commits must not depend on the user's signing setup (#668).
+        assert "commit.gpgsign=false" in cmd, name
+
+
+def test_a_failed_replay_is_rolled_back_and_explained():
+    for name in PULLS:
+        tasks = _tasks(name)
+        pull_task, _ = _pull_task(name)
+        # The pull must not hard-fail, or the rollback below never runs.
+        assert pull_task.get("failed_when") is False, (
+            "%s: the pull must be caught so a stuck rebase can be aborted" % name
+        )
+
+        abort = next(
+            (t for t, c in _cmds(tasks) if "rebase --abort" in c), None
+        )
+        assert abort is not None, (
+            "%s: a conflicting replay must be rolled back, not left mid-rebase"
+            % name
+        )
+        assert abort.get("failed_when") is False, (
+            "%s: 'no rebase in progress' must not itself fail the play" % name
+        )
+
+        fail = next(
+            (t for t in tasks if "ansible.builtin.fail" in t
+             and "could not be replayed" in str(t["ansible.builtin.fail"]["msg"])),
+            None,
+        )
+        assert fail is not None, "%s: expected an explanatory failure" % name
+        msg = " ".join(str(fail["ansible.builtin.fail"]["msg"]).split())
+        assert "rolled back" in msg and "intact" in msg, (
+            "%s: the message must say the local commits survived" % name
+        )
+
+
+def test_init_and_join_configure_rebase_to_match():
+    # The ambient config an operator hits running raw git must agree with what
+    # `canasta gitops pull` does.
+    configured = []
+    for path in sorted(glob.glob(os.path.join(TASKS, "*.yml"))):
+        with open(path) as fh:
+            for _, cmd in _cmds(yaml.safe_load(fh) or []):
+                if "pull.rebase" in cmd:
+                    configured.append((os.path.basename(path), cmd))
+    assert configured, "expected init/join to configure a pull strategy"
+    wrong = [(f, c) for f, c in configured if "pull.rebase true" not in c]
+    assert not wrong, (
+        "these set a pull strategy that contradicts `gitops pull --rebase`:\n"
+        + "\n".join("  %s: %s" % (f, c) for f, c in wrong)
+    )


### PR DESCRIPTION
Fixes #1209

`canasta gitops pull` ran a bare `git pull`. On a diverged branch that could abort with nothing but git's own hint text, and no canasta command could resolve the resulting state — `gitops push` explicitly tells the operator to run `gitops pull`, and `gitops pull` then failed on exactly the state the push had produced. The only way out was raw git.

## Why a bare `git pull` was the wrong call

Its behavior depends entirely on the host's ambient git config. `init`/`join` set `pull.rebase false`, but the reported failure was `fatal: Not possible to fast-forward, aborting` — a global `pull.ff = only` overriding it. Whatever the CLI writes at init time, a bare `git pull` inherits whatever the operator's `~/.gitconfig` says.

Rebase is also the semantically correct operation here: hosts contribute small config commits to one shared branch, so replaying this host's commits on top of the remote is what the workflow means. It keeps the history linear and resolves divergence, which fast-forward-only cannot.

## Change

- `git -c commit.gpgsign=false pull --rebase` in both `pull_compose.yml` and `pull_kubernetes.yml`. Passing `--rebase` on the command line makes the outcome independent of the host's config. Signing is disabled for the replayed commits for the same reason every other internal commit does it (#668).
- Flip the `pull.rebase` written at init/join from `false` to `true`, so an operator who runs raw git in the instance directory gets the same result the CLI does rather than a contradictory one.
- **A conflicting replay is rolled back.** The pull is caught, `git rebase --abort` restores the pre-pull state, and the failure message says the local commits are intact and names the two real options (re-apply on top of the remote, or `git reset --hard origin/main` to discard). Without this the fix would trade a blocked pull for a repo stuck mid-rebase — strictly worse for an operator who does not know git.

A genuine content conflict between two hosts' edits to the same file still needs a human decision; what changes is that the instance is left in a state that is understandable and recoverable, instead of half-rebased.

## Tests

`tests/unit/test_gitops_pull_rebase.py` — pins the explicit `--rebase`, that the pull is caught so the rollback can run, that the abort exists and cannot itself fail the play, that the message says the commits survived, and that no init/join path configures a strategy contradicting the pull.

`make test-unit`, `make lint`, `make validate` pass.

## Note

Merges cleanly with #1210 in either order — both touch `pull_compose.yml`, in disjoint hunks.
