### PR TITLE
feat: host-local settings overrides on gitops Compose instances

### DIFF
--- a/instance_template/config/settings/global/README
+++ b/instance_template/config/settings/global/README
@@ -43,6 +43,28 @@ For wiki-specific settings, add files to:
 
 Per-wiki settings are loaded AFTER global settings and can override them.
 
+## Host-Local Overrides (GitOps, Docker Compose)
+
+On a GitOps-managed instance every file here is shared with the other hosts in
+the repo. For settings that must apply on THIS host only — a staging clone
+pointing at a local mail catcher, a debug flag, a captcha turned off for
+testing — name the file with a .local.php suffix:
+
+    zz-mail.local.php
+    zz-debug.local.php
+
+Files matching *.local.php are ignored by git, so they stay on this host, are
+never pushed to the other hosts, and never block a `canasta gitops pull`.
+
+Loading is still lexicographic, and the suffix alone does not sort last
+(Extensions.local.php loads BEFORE Extensions.php). To override a setting from
+a shared file, give the local file a name that sorts after it — the zz- prefix
+above is the simplest way.
+
+On Kubernetes this whole directory is delivered to the pods through the shared
+repo, so a *.local.php file there is not host-local — use it on Docker Compose
+instances only.
+
 ## Notes
 
 - All .php files in this directory are loaded automatically

--- a/instance_template/config/settings/wikis/README
+++ b/instance_template/config/settings/wikis/README
@@ -41,6 +41,20 @@ For settings that apply to ALL wikis, add files to:
 
     config/settings/global/
 
+## Host-Local Overrides (GitOps, Docker Compose)
+
+On a GitOps-managed instance every file here is shared with the other hosts in
+the repo. For settings that must apply on THIS host only, name the file with a
+.local.php suffix:
+
+    zz-debug.local.php
+
+Files matching *.local.php are ignored by git, so they stay on this host, are
+never pushed to the other hosts, and never block a `canasta gitops pull`.
+Loading is still lexicographic and the suffix alone does not sort last, so give
+a local override a name that sorts after the shared file it overrides. See
+config/settings/global/README for the full convention (Docker Compose only).
+
 ## Notes
 
 - All .php files in this directory are loaded automatically

--- a/roles/gitops/files/gitignore.default
+++ b/roles/gitops/files/gitignore.default
@@ -41,3 +41,7 @@ config/persistent/
 .gitops-applied
 .gitops-host
 .gitops-deploy-key
+
+# Host-local settings overrides — apply on this host only, never shared
+config/settings/global/*.local.php
+config/settings/wikis/*/*.local.php

--- a/tests/unit/test_gitops_local_settings_override.py
+++ b/tests/unit/test_gitops_local_settings_override.py
@@ -1,0 +1,57 @@
+"""A gitops instance needs a place for host-local settings.
+
+config/settings/{global,wikis/<id>}/ is auto-loaded, so it is the only place a
+host-local override can live — but on a gitops instance every file there is
+shared, and an untracked one used to block `canasta gitops pull` outright.
+A *.local.php suffix is the sanctioned escape hatch: ignored by git, so it
+stays on the host it was written on.
+"""
+
+import os
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+GITIGNORE = os.path.join(
+    REPO_ROOT, "roles", "gitops", "files", "gitignore.default"
+)
+READMES = (
+    os.path.join(REPO_ROOT, "instance_template", "config", "settings", "global", "README"),
+    os.path.join(REPO_ROOT, "instance_template", "config", "settings", "wikis", "README"),
+)
+
+
+def _rules():
+    with open(GITIGNORE) as fh:
+        return [ln.strip() for ln in fh
+                if ln.strip() and not ln.strip().startswith("#")]
+
+
+def test_local_settings_overrides_are_ignored():
+    rules = _rules()
+    for pattern in (
+        "config/settings/global/*.local.php",
+        "config/settings/wikis/*/*.local.php",
+    ):
+        assert pattern in rules, (
+            "gitignore.default must ignore %s so a host-local override neither "
+            "leaks to the other hosts nor blocks `canasta gitops pull`" % pattern
+        )
+
+
+def test_the_convention_is_documented_where_operators_will_look():
+    # The READMEs ship into every instance's settings directories, which is
+    # where an operator writing an override is already looking.
+    for path in READMES:
+        with open(path) as fh:
+            text = fh.read()
+        assert ".local.php" in text, "%s must document the convention" % path
+        # The suffix does not sort last on its own (Foo.local.php < Foo.php),
+        # so the docs must not imply it overrides by name alone.
+        assert "lexicographic" in text and "sort" in text, (
+            "%s must state the load-order caveat" % path
+        )
+        # Kubernetes delivers this directory through the shared repo, so the
+        # convention is Compose-only until that has a design.
+        assert "Compose" in text, (
+            "%s must scope the convention to Docker Compose" % path
+        )


### PR DESCRIPTION
Fixes #1211

`config/settings/global/` and `config/settings/wikis/<id>/` are auto-loaded, so they are the only place a settings override can live. On a gitops instance every file there is shared with the other hosts, and an untracked one blocked `canasta gitops pull` outright (#1210) — so there was no supported way to keep a setting that applies to one host only: a staging clone pointing at a local mail catcher instead of the customer's real relay, a captcha disabled so the account-request flow can be exercised, a temporary debug flag.

## Change

- Ignore `config/settings/global/*.local.php` and `config/settings/wikis/*/*.local.php` in the shipped `.gitignore`.
- Document the convention in the settings READMEs, which ship into every instance — that is where an operator writing an override is already looking.

Existing gitops repos pick the rules up through `refresh_gitignore.yml` on the next `canasta upgrade`.

## Two corrections to the convention as proposed in the issue

**The suffix does not sort last.** The issue suggests `.local.php` "sorts late enough to override earlier files in most cases". It does not — loading is lexicographic, and `Foo.local.php` sorts *before* `Foo.php` (`.` < `p` at the first differing byte). So the suffix marks a file as local but does not make it win. The READMEs state this and tell operators to prefix with `zz-` when the point is to override a shared file.

**This does not apply to Kubernetes.** The issue says it "applies equally to Kubernetes"; it does not. On Compose the settings tree is bind-mounted from the instance directory, so a git-ignored file is still loaded while staying out of the repo. On Kubernetes settings never reach the pods from disk, and two properties close off both halves of the Compose approach:

- `push_kubernetes.yml:15` runs `k8s_sync_config.yml`, which scans every file under `config/settings/` into `configData.web`. That lands in `values-configdata.yaml`, which is itself gitignored — but push then merges its contents into `values.yaml` and **`values.template.yaml`** (`push_kubernetes.yml:99-115`) and commits with `git add -A`. The template is shared, so an ignored file is still published to the other hosts. The ignore rule buys nothing.
- Excluding it from the scan instead would mean it never loads — and the Argo Application is created with `selfHeal: true, prune: true` (`init_kubernetes.yml:485-488`), so a ConfigMap applied out of band gets reverted.

Filed as #1212 with the mechanism and a fix direction — `hosts/<host>/rendered-values.yaml` is already a per-host layer, it just doesn't carry configData. The READMEs scope the convention to Docker Compose so nobody reaches for it on a cluster and quietly ships a local override to production.

## Tests

`tests/unit/test_gitops_local_settings_override.py` — pins both ignore patterns, and asserts each README documents the convention, states the load-order caveat, and scopes itself to Compose.

`make test-unit`, `make lint`, `make validate` pass.

## Follow-up

The GitOps help page on canasta.wiki should carry this convention alongside the in-instance READMEs — not done here.

