### PR TITLE
Share the wiki liveness probe and surface it in canasta list

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -8,8 +8,11 @@ import json
 import os
 import re
 import shlex
+import ssl
 import subprocess
 import sys
+import urllib.parse
+import urllib.request
 
 import yaml
 
@@ -1034,6 +1037,138 @@ def _check_running_k8s(instance_id, host):
     return rc == 0 and stdout.strip() not in ("", "0")
 
 
+# --- wiki liveness probe (shared by wiki-check and list) ---
+#
+# The orchestrator checks above answer "is the workload up"; this one
+# answers "is the wiki actually serving MediaWiki", which is what a
+# reader experiences. A container can be up while MediaWiki 500s.
+
+WIKI_REACHABLE = "reachable"
+WIKI_UNREACHABLE = "unreachable"
+# The probe could not be run at all — nothing was learned about the wiki.
+WIKI_INDETERMINATE = "indeterminate"
+
+_WIKI_PROTOCOLS = ("https", "http")
+_WIKI_LOCAL_DOMAINS = {"localhost", "127.0.0.1"}
+_SITEINFO_QUERY = "/w/api.php?action=query&meta=siteinfo&format=json"
+
+
+def _wiki_probe_urls(wiki_url):
+    """Candidate siteinfo URLs for a wikis.yaml url, most likely first.
+
+    A url with no scheme is tried over https then http.
+    """
+    base = wiki_url.rstrip("/")
+    if base.startswith("http://") or base.startswith("https://"):
+        return [base + _SITEINFO_QUERY]
+
+    parsed = urllib.parse.urlsplit("http://" + base)
+    host = parsed.netloc
+    path = parsed.path.rstrip("/")
+    if path:
+        host = host + path
+
+    return ["%s://%s%s" % (p, host, _SITEINFO_QUERY) for p in _WIKI_PROTOCOLS]
+
+
+def _is_mediawiki_response(body):
+    """True if body is a MediaWiki API reply.
+
+    A wiki with a private read API answers `readapidenied`, which still
+    proves MediaWiki is serving.
+    """
+    if not body:
+        return False
+    try:
+        if isinstance(body, bytes):
+            body = body.decode("utf-8", errors="ignore")
+        data = json.loads(body)
+        if "query" in data or "batchcomplete" in data:
+            return True
+        if (
+            "error" in data
+            and isinstance(data["error"], dict)
+            and data["error"].get("code") == "readapidenied"
+        ):
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _fetch_is_mediawiki(url, host_header, scheme):
+    req = urllib.request.Request(url)
+    if host_header:
+        req.add_header("Host", host_header)
+    context = ssl._create_unverified_context() if scheme == "https" else None
+    try:
+        with urllib.request.urlopen(req, timeout=15, context=context) as resp:
+            return _is_mediawiki_response(resp.read())
+    except Exception:
+        return False
+
+
+def _probe_wiki_local(url, instance_path):
+    """True if the wiki answers from this machine.
+
+    An instance published on a non-default port is reached through that
+    port on localhost, carrying the configured domain in the Host header
+    — the instance's own domain need not resolve here.
+    """
+    parsed = urllib.parse.urlsplit(url)
+    scheme = parsed.scheme
+    domain = parsed.netloc
+    url_path = parsed.path or "/"
+
+    # Already a localhost URL with an explicit port: use it as-is.
+    if domain.split(":")[0] in _WIKI_LOCAL_DOMAINS and ":" in domain:
+        return _fetch_is_mediawiki(url, None, scheme)
+
+    env = _read_env_file(instance_path, "localhost") if instance_path else {}
+    port = (
+        env.get("HTTPS_PORT", "") if scheme == "https" else env.get("HTTP_PORT", "")
+    )
+
+    if port:
+        query = "?%s" % parsed.query if parsed.query else ""
+        check_url = "%s://localhost:%s%s%s" % (scheme, port, url_path, query)
+    else:
+        check_url = url
+
+    return _fetch_is_mediawiki(check_url, domain, scheme)
+
+
+def _probe_wiki(wiki_url, host, instance_path=""):
+    """Liveness verdict for one wiki: does it answer the MediaWiki API?
+
+    Returns WIKI_REACHABLE, WIKI_UNREACHABLE or WIKI_INDETERMINATE.
+    INDETERMINATE covers an SSH transport failure reaching the instance's
+    host, where nothing was learned about the wiki — callers must not
+    report that as down.
+    """
+    if not (wiki_url or "").strip():
+        return WIKI_INDETERMINATE
+
+    if _is_localhost(host):
+        for url in _wiki_probe_urls(wiki_url):
+            if _probe_wiki_local(url, instance_path):
+                return WIKI_REACHABLE
+        return WIKI_UNREACHABLE
+
+    transport_failed = False
+    for url in _wiki_probe_urls(wiki_url):
+        rc, stdout = _ssh_run(host, "curl -sSLk " + _shell_quote(url))
+        # OpenSSH reserves 255 for its own transport failures; any other
+        # non-zero rc means curl ran and failed on its own terms.
+        if rc == 255:
+            transport_failed = True
+            continue
+        if rc == 0 and _is_mediawiki_response(stdout):
+            return WIKI_REACHABLE
+
+    return WIKI_INDETERMINATE if transport_failed else WIKI_UNREACHABLE
+
+
 _SENTINEL = "---CANASTA_DELIM---"
 
 
@@ -1135,6 +1270,13 @@ def _make_detail(inst_id, host, path, orchestrator, status, wikis):
     }
 
 
+_LIVENESS_LABELS = {
+    WIKI_REACHABLE: "REACHABLE",
+    WIKI_UNREACHABLE: "NOT REACHABLE",
+    WIKI_INDETERMINATE: "UNKNOWN",
+}
+
+
 def _print_table(details):
     host_lengths = [len(d["host"]) for d in details] + [16]
     hw = max(host_lengths) + 2
@@ -1154,6 +1296,11 @@ def _print_table(details):
                 url = w.get("url") or ""
                 if "/" not in url:
                     url = url + "/"
+                liveness = w.get("liveness")
+                if liveness:
+                    url = "%s  [%s]" % (
+                        url, _LIVENESS_LABELS.get(liveness, liveness)
+                    )
                 print("  %-14s%s" % (w.get("id", "?"), url))
         else:
             print("  (no wikis)")

--- a/direct_commands/info.py
+++ b/direct_commands/info.py
@@ -70,6 +70,39 @@ def _classify_for_cleanup(inst_id, inst):
     return "missing"
 
 
+def _annotate_wiki_liveness(details, instances):
+    """Record a liveness verdict on each wiki of every RUNNING instance.
+
+    Only RUNNING instances are probed: for anything else the orchestrator
+    has already given a definitive answer, and probing a stopped instance
+    just waits out connection timeouts.
+    """
+    targets = []
+    for detail in details:
+        if detail["status"] != "RUNNING":
+            continue
+        inst = instances.get(detail["id"], {})
+        for wiki in detail["wikis"]:
+            targets.append((wiki, detail["host"], inst.get("path", "")))
+
+    if not targets:
+        return
+
+    with ThreadPoolExecutor(max_workers=min(len(targets), 16)) as pool:
+        futures = {
+            pool.submit(
+                _helpers._probe_wiki, (wiki.get("url") or "").strip(), host, path
+            ): wiki
+            for wiki, host, path in targets
+        }
+        for future in as_completed(futures):
+            wiki = futures[future]
+            try:
+                wiki["liveness"] = future.result()
+            except Exception:
+                wiki["liveness"] = _helpers.WIKI_INDETERMINATE
+
+
 @register("list")
 def cmd_list(args):
     config_dir = _helpers._get_config_dir()
@@ -137,6 +170,9 @@ def cmd_list(args):
         return 0
 
     details = _gather_all_instances(instances)
+
+    if getattr(args, "check_wikis", False):
+        _annotate_wiki_liveness(details, instances)
 
     _helpers._print_table(details)
     return 0

--- a/direct_commands/wiki_check.py
+++ b/direct_commands/wiki_check.py
@@ -1,108 +1,9 @@
 #!/usr/bin/env python3
 """wiki-check command — verify MediaWiki instances are accessible."""
 
-import json
-import ssl
 import sys
-import urllib.parse
-import urllib.request
 from . import _helpers
 from ._helpers import register
-
-
-_PROTOCOLS = ("https", "http")
-_LOCAL_DOMAINS = {"localhost", "127.0.0.1"}
-
-
-def _build_urls(wiki_url):
-    base = wiki_url.rstrip("/")
-    suffix = "/w/api.php?action=query&meta=siteinfo&format=json"
-    if base.startswith("http://") or base.startswith("https://"):
-        return [base + suffix]
-
-    parsed = urllib.parse.urlsplit("http://" + base)
-    host = parsed.netloc
-    path = parsed.path.rstrip("/")
-    if path:
-        host = host + path
-
-    return [f"{protocol}://{host}{suffix}" for protocol in _PROTOCOLS]
-
-
-def _is_mediawiki_response(body):
-    if not body:
-        return False
-    try:
-        if isinstance(body, bytes):
-            body = body.decode("utf-8", errors="ignore")
-        data = json.loads(body)
-        if "query" in data or "batchcomplete" in data:
-            return True
-        if "error" in data and isinstance(data["error"], dict) and data["error"].get("code") == "readapidenied":
-            return True
-    except Exception:
-        pass
-    return False
-
-
-def _localhost_probe(url, instance_path):
-    parsed = urllib.parse.urlsplit(url)
-    scheme = parsed.scheme
-    domain = parsed.netloc
-    url_path = parsed.path or "/"
-
-    bare_hostname = domain.split(":")[0]
-
-    if bare_hostname in _LOCAL_DOMAINS and ":" in domain:
-        req = urllib.request.Request(url)
-        context = ssl._create_unverified_context() if scheme == "https" else None
-        try:
-            with urllib.request.urlopen(req, timeout=15, context=context) as resp:
-                return _is_mediawiki_response(resp.read())
-        except Exception:
-            return False
-
-    env = _helpers._read_env_file(instance_path, "localhost") if instance_path else {}
-    if scheme == "https":
-        port = env.get("HTTPS_PORT", "")
-    else:
-        port = env.get("HTTP_PORT", "")
-
-    if port:
-        query_suffix = f"?{parsed.query}" if parsed.query else ""
-        check_url = f"{scheme}://localhost:{port}{url_path}{query_suffix}"
-    else:
-        check_url = url
-
-    req = urllib.request.Request(check_url)
-    req.add_header("Host", domain)
-
-    if scheme == "https":
-        context = ssl._create_unverified_context()
-    else:
-        context = None
-
-    try:
-        with urllib.request.urlopen(req, timeout=15, context=context) as resp:
-            return _is_mediawiki_response(resp.read())
-    except Exception:
-        return False
-
-
-def _check_url(wiki_url, host, instance_path=""):
-    for url in _build_urls(wiki_url):
-        if _helpers._is_localhost(host):
-            if _localhost_probe(url, instance_path):
-                return True
-        else:
-            cmd = (
-                "curl -sSLk "
-                + _helpers._shell_quote(url)
-            )
-            rc, stdout = _helpers._ssh_run(host, cmd)
-            if rc == 0 and _is_mediawiki_response(stdout):
-                return True
-    return False
 
 
 @register("wiki_check")
@@ -133,8 +34,15 @@ def cmd_wiki_check(args):
             all_ok = False
             continue
 
-        if _check_url(wiki_url, host, instance_path=path):
+        verdict = _helpers._probe_wiki(wiki_url, host, instance_path=path)
+        if verdict == _helpers.WIKI_REACHABLE:
             print("Wiki '%s' is reachable at %s." % (wiki_id, wiki_url))
+        elif verdict == _helpers.WIKI_INDETERMINATE:
+            print(
+                "Wiki '%s' could not be checked at %s: host '%s' is unreachable."
+                % (wiki_id, wiki_url, host)
+            )
+            all_ok = False
         else:
             print("Wiki '%s' could not be reached at %s." % (wiki_id, wiki_url))
             all_ok = False

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -620,8 +620,17 @@ commands:
       a transient network problem shouldn't cause entries to be
       silently dropped. Pass --force to remove unreachable entries
       too, or --dry-run to preview without removing anything.
+
+      The STATUS column reports what the orchestrator says about the
+      web container, which can read RUNNING while MediaWiki itself is
+      failing. With --check-wikis, each wiki of every running instance
+      is also probed over HTTP and annotated REACHABLE, NOT REACHABLE
+      or UNKNOWN — the last meaning the instance's host could not be
+      reached, so the wiki's state is unknown rather than known-bad.
+      This costs one request per wiki, so it is off by default.
     examples:
       - "canasta list"
+      - "canasta list --check-wikis"
       - "canasta list --cleanup"
       - "canasta list --cleanup --dry-run"
       - "canasta list --cleanup --force"
@@ -631,6 +640,10 @@ commands:
         short: H
         type: string
         description: "Filter output by host (default: all hosts)"
+      - name: check_wikis
+        type: bool
+        default: false
+        description: "Probe each wiki over HTTP and report whether it responds"
       - name: cleanup
         type: bool
         default: false

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -190,39 +190,135 @@ class TestReadWikis:
 
 class TestBuildUrls:
     def test_url_with_https_protocol(self):
-        urls = direct_commands.wiki_check._build_urls("https://example-wiki.com")
+        urls = direct_commands._helpers._wiki_probe_urls("https://example-wiki.com")
         assert urls == ["https://example-wiki.com/w/api.php?action=query&meta=siteinfo&format=json"]
 
     def test_url_with_http_protocol(self):
-        urls = direct_commands.wiki_check._build_urls("http://example-wiki.com")
+        urls = direct_commands._helpers._wiki_probe_urls("http://example-wiki.com")
         assert urls == ["http://example-wiki.com/w/api.php?action=query&meta=siteinfo&format=json"]
 
     def test_url_without_protocol(self):
-        urls = direct_commands.wiki_check._build_urls("example-wiki.com")
+        urls = direct_commands._helpers._wiki_probe_urls("example-wiki.com")
         assert urls == [
             "https://example-wiki.com/w/api.php?action=query&meta=siteinfo&format=json",
             "http://example-wiki.com/w/api.php?action=query&meta=siteinfo&format=json"
         ]
 
     def test_url_without_protocol_with_path(self):
-        urls = direct_commands.wiki_check._build_urls("example-wiki.com/wiki")
+        urls = direct_commands._helpers._wiki_probe_urls("example-wiki.com/wiki")
         assert urls == [
             "https://example-wiki.com/wiki/w/api.php?action=query&meta=siteinfo&format=json",
             "http://example-wiki.com/wiki/w/api.php?action=query&meta=siteinfo&format=json"
         ]
 
     def test_url_without_protocol_with_port(self):
-        urls = direct_commands.wiki_check._build_urls("example-wiki.com:8080")
+        urls = direct_commands._helpers._wiki_probe_urls("example-wiki.com:8080")
         assert urls == [
             "https://example-wiki.com:8080/w/api.php?action=query&meta=siteinfo&format=json",
             "http://example-wiki.com:8080/w/api.php?action=query&meta=siteinfo&format=json"
         ]
 
 
+class TestProbeWiki:
+    """_probe_wiki's three-way verdict (shared by wiki-check and list)."""
+
+    def test_localhost_reachable(self, monkeypatch):
+        monkeypatch.setattr(
+            direct_commands._helpers, "_probe_wiki_local",
+            lambda url, path: True,
+        )
+        assert direct_commands._helpers._probe_wiki(
+            "example-wiki.com", "localhost"
+        ) == direct_commands._helpers.WIKI_REACHABLE
+
+    def test_localhost_unreachable(self, monkeypatch):
+        monkeypatch.setattr(
+            direct_commands._helpers, "_probe_wiki_local",
+            lambda url, path: False,
+        )
+        assert direct_commands._helpers._probe_wiki(
+            "example-wiki.com", "localhost"
+        ) == direct_commands._helpers.WIKI_UNREACHABLE
+
+    def test_empty_url_is_indeterminate(self):
+        assert direct_commands._helpers._probe_wiki(
+            "", "localhost"
+        ) == direct_commands._helpers.WIKI_INDETERMINATE
+
+    def test_ssh_transport_failure_is_indeterminate(self, monkeypatch):
+        # rc=255 is OpenSSH's own transport failure: the wiki was never
+        # reached, so it must not be reported as down.
+        monkeypatch.setattr(
+            direct_commands._helpers, "_ssh_run",
+            lambda host, cmd: (255, ""),
+        )
+        assert direct_commands._helpers._probe_wiki(
+            "example-wiki.com", "prod1"
+        ) == direct_commands._helpers.WIKI_INDETERMINATE
+
+    def test_remote_curl_failure_is_unreachable(self, monkeypatch):
+        # curl ran and failed on its own terms — a real answer.
+        monkeypatch.setattr(
+            direct_commands._helpers, "_ssh_run",
+            lambda host, cmd: (7, ""),
+        )
+        assert direct_commands._helpers._probe_wiki(
+            "example-wiki.com", "prod1"
+        ) == direct_commands._helpers.WIKI_UNREACHABLE
+
+    def test_remote_reachable(self, monkeypatch):
+        monkeypatch.setattr(
+            direct_commands._helpers, "_ssh_run",
+            lambda host, cmd: (0, '{"batchcomplete":""}'),
+        )
+        assert direct_commands._helpers._probe_wiki(
+            "example-wiki.com", "prod1"
+        ) == direct_commands._helpers.WIKI_REACHABLE
+
+    def test_readapidenied_counts_as_reachable(self):
+        body = '{"error":{"code":"readapidenied","info":"denied"}}'
+        assert direct_commands._helpers._is_mediawiki_response(body) is True
+
+
+class TestListCheckWikis:
+    def test_probes_only_running_instances(self, monkeypatch):
+        details = [
+            {"id": "up", "host": "localhost", "status": "RUNNING",
+             "wikis": [{"id": "main", "url": "up.example.com"}]},
+            {"id": "down", "host": "localhost", "status": "STOPPED",
+             "wikis": [{"id": "main", "url": "down.example.com"}]},
+        ]
+        instances = {"up": {"path": "/srv/up"}, "down": {"path": "/srv/down"}}
+
+        probed = []
+
+        def fake_probe(url, host, instance_path=""):
+            probed.append(url)
+            return direct_commands._helpers.WIKI_REACHABLE
+
+        monkeypatch.setattr(direct_commands._helpers, "_probe_wiki", fake_probe)
+        direct_commands.info._annotate_wiki_liveness(details, instances)
+
+        assert probed == ["up.example.com"]
+        assert details[0]["wikis"][0]["liveness"] == "reachable"
+        assert "liveness" not in details[1]["wikis"][0]
+
+    def test_table_shows_verdict(self, capsys):
+        direct_commands._helpers._print_table([{
+            "id": "mysite", "host": "localhost", "path": "/srv/mysite",
+            "orchestrator": "COMPOSE", "status": "RUNNING",
+            "wikis": [{
+                "id": "main", "url": "mysite.example.com/",
+                "liveness": direct_commands._helpers.WIKI_UNREACHABLE,
+            }],
+        }])
+        assert "NOT REACHABLE" in capsys.readouterr().out
+
+
 class TestCmdWikiCheckNullUrl:
     def test_null_url_reports_missing_not_crash(self, monkeypatch, capsys):
         # A present-but-null url must reach the missing-url guard, not crash on
-        # None.strip() before it. No _check_url call, so no network.
+        # None.strip() before it. No probe call, so no network.
         monkeypatch.setattr(
             direct_commands._helpers, "_resolve_instance",
             lambda args: ("mysite", {"path": "/srv/mysite", "host": "localhost"}),


### PR DESCRIPTION
Implements items 1-3 of #1206.

## Problem

The reachability probe was private to `wiki_check.py`, so `canasta list` had no access to it and derived STATUS from the orchestrator alone — `docker compose ps -q web` or a ready replica count. That reports RUNNING whenever the web container exists, including when MediaWiki is returning 500s, misconfigured, or serving an installer page.

## Changes

**A shared probe.** `_build_urls`, `_is_mediawiki_response` and the localhost port-remapping logic move from `wiki_check.py` into `_helpers.py` as `_wiki_probe_urls`, `_is_mediawiki_response`, `_probe_wiki_local` and `_probe_wiki`. `wiki_check.py` drops from 143 lines to 50 and now contains only the command. Probe behavior is unchanged — same URL candidates, same Host-header remapping, same `readapidenied`-counts-as-alive rule.

**A three-way verdict.** `_probe_wiki` returns `WIKI_REACHABLE`, `WIKI_UNREACHABLE` or `WIKI_INDETERMINATE`. Indeterminate covers an SSH transport failure (OpenSSH rc 255) reaching the instance's host: the wiki was never contacted, so its state is unknown rather than known-bad. This mirrors the distinction `_classify_for_cleanup` already makes for `--cleanup`, where a transient network problem must not look like a confirmed absence.

**`canasta list --check-wikis`.** Probes each wiki of every RUNNING instance in parallel and annotates it `[REACHABLE]`, `[NOT REACHABLE]` or `[UNKNOWN]`. Off by default, since it costs one HTTP request per wiki. Only RUNNING instances are probed — for anything else the orchestrator has already answered definitively, and probing a stopped instance only waits out connection timeouts.

```
$ canasta list --check-wikis
Canasta ID      Host              Instance Path
  Orchestrator  Status
  Wiki ID       Wiki URL
──────────────────────────────────────────────────────
dev             localhost         /Users/me/instances/dev
  COMPOSE       RUNNING
  dev           localhost/  [REACHABLE]
```

`wiki-check` keeps its existing output, gaining a distinct message for the indeterminate case rather than reporting an unreachable host as an unreachable wiki.

## Not included

Two items from #1206 are left for separate PRs, to keep this diff scoped:

- Reconciling the `list` STATUS column with the `(running: X)` line — that line comes from `_read_instance_image`, which belongs to `canasta version`, a different command.
- Folding `_classify_for_cleanup`'s tri-state into the shared model. It already behaves correctly; changing it would be refactoring for symmetry alone.

## Note

This rewrites `wiki_check.py`, which #1123 also modifies substantially. Whichever merges second will need a rebase.

## Testing

- `make test-unit` — 1860 passed
- `make validate`, `make lint` — clean
- New tests cover all three verdicts, the SSH-255 indeterminate path, that only RUNNING instances are probed, and the table rendering
- Exercised against a live Compose instance: `canasta list`, `canasta list --check-wikis`, `canasta wiki-check -i dev`
