### PR TITLE
Stop canasta version reporting a running instance as stopped

### DIFF
--- a/direct_commands/info.py
+++ b/direct_commands/info.py
@@ -177,12 +177,29 @@ def cmd_list(args):
     _helpers._print_table(details)
     return 0
 
+def _describe_unread_version(inst_id, inst, path, orchestrator, host):
+    """Why the running version could not be read.
+
+    Asks the orchestrator the same question `canasta list` asks, so the
+    two commands cannot disagree about whether an instance is up. A
+    container that is running but did not answer is unavailable, not
+    stopped — the version file is written at startup, so a healthy
+    instance can still miss the read.
+    """
+    docker_host = inst.get("dockerHost")
+    if _helpers._check_running(inst_id, path, orchestrator, host, docker_host):
+        return "(unavailable)"
+    return "(not running)"
+
+
 def _read_instance_image(inst_id, inst):
     """Return 'CANASTA_IMAGE (running: X)' for a single instance entry.
 
-    'running' comes from /tmp/canasta-version inside the web container;
-    absent when the container isn't up or the command fails for any
-    reason. Never raises.
+    'running' comes from /tmp/canasta-version inside the web container.
+    When that read fails the orchestrator decides which of three answers
+    to give — the instance is down, it is up but the version could not be
+    read, or its host could not be reached — so a failed read is never
+    reported as a stopped instance. Never raises.
     """
     host = inst.get("host") or "localhost"
     path = inst.get("path", "")
@@ -190,10 +207,9 @@ def _read_instance_image(inst_id, inst):
     image = env_vars.get("CANASTA_IMAGE", "(unset)")
 
     # Running Canasta version — line 2 of /tmp/canasta-version inside the web
-    # container/pod. Best effort; falls back silently to "(not running)".
-    # The probe depends on the orchestrator: Compose execs the web service, K8s
-    # execs the Running web pod (mirroring the dispatch in `canasta exec`).
-    running = "(not running)"
+    # container/pod. The probe depends on the orchestrator: Compose execs the
+    # web service, K8s execs the Running web pod (mirroring `canasta exec`).
+    running = None
     orchestrator = (inst.get("orchestrator") or "compose").lower()
     if orchestrator in ("kubernetes", "k8s"):
         ns = "canasta-%s" % inst_id
@@ -227,6 +243,13 @@ def _read_instance_image(inst_id, inst):
         rc, stdout = _helpers._ssh_run(host, probe_cmd)
         if rc == 0 and stdout.strip():
             running = stdout.strip()
+        elif rc == 255:
+            # OpenSSH's own transport failure — the container was never
+            # asked, so nothing is known about the instance.
+            return image, "(host unreachable)"
+
+    if running is None:
+        running = _describe_unread_version(inst_id, inst, path, orchestrator, host)
 
     return image, running
 

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1201,6 +1201,72 @@ class TestCmdVersionInstanceModes:
         # is intentionally skipped for the fast default.
         assert "running:" not in out
 
+    def test_running_container_that_cannot_answer_is_unavailable(
+        self, tmp_path, monkeypatch
+    ):
+        """A failed version read on a running instance is not 'not running'.
+
+        The version file is written at startup, so a healthy instance can
+        still miss the read; reporting that as stopped contradicts what
+        `canasta list` says about the same instance.
+        """
+        inst = {"path": str(tmp_path), "host": "localhost"}
+        monkeypatch.setattr(
+            direct_commands._helpers, "_read_env_file",
+            lambda path, host: {"CANASTA_IMAGE": "canasta:3.6.3"},
+        )
+        monkeypatch.setattr(
+            direct_commands.info.subprocess, "run",
+            lambda *a, **k: type("R", (), {"returncode": 1, "stdout": ""})(),
+        )
+        monkeypatch.setattr(
+            direct_commands._helpers, "_check_running",
+            lambda *a, **k: True,
+        )
+        image, running = direct_commands.info._read_instance_image("site", inst)
+        assert image == "canasta:3.6.3"
+        assert running == "(unavailable)"
+
+    def test_stopped_instance_still_reports_not_running(
+        self, tmp_path, monkeypatch
+    ):
+        inst = {"path": str(tmp_path), "host": "localhost"}
+        monkeypatch.setattr(
+            direct_commands._helpers, "_read_env_file",
+            lambda path, host: {"CANASTA_IMAGE": "canasta:3.6.3"},
+        )
+        monkeypatch.setattr(
+            direct_commands.info.subprocess, "run",
+            lambda *a, **k: type("R", (), {"returncode": 1, "stdout": ""})(),
+        )
+        monkeypatch.setattr(
+            direct_commands._helpers, "_check_running",
+            lambda *a, **k: False,
+        )
+        _, running = direct_commands.info._read_instance_image("site", inst)
+        assert running == "(not running)"
+
+    def test_unreachable_host_is_not_reported_as_stopped(
+        self, tmp_path, monkeypatch
+    ):
+        """SSH rc 255 is a transport failure: the container was never asked."""
+        inst = {"path": "/srv/site", "host": "prod1"}
+        monkeypatch.setattr(
+            direct_commands._helpers, "_read_env_file",
+            lambda path, host: {"CANASTA_IMAGE": "canasta:3.6.3"},
+        )
+        monkeypatch.setattr(
+            direct_commands._helpers, "_ssh_run",
+            lambda host, cmd: (255, ""),
+        )
+
+        def fail(*a, **k):
+            raise AssertionError("must not ask the orchestrator over a dead link")
+
+        monkeypatch.setattr(direct_commands._helpers, "_check_running", fail)
+        _, running = direct_commands.info._read_instance_image("site", inst)
+        assert running == "(host unreachable)"
+
     def test_inside_instance_dir_shows_current_full(
         self, tmp_path, monkeypatch, capsys
     ):


### PR DESCRIPTION
Closes item 4 of #1206. Follow-up to #1217, which consolidated the wiki liveness probe; this applies the same principle to `canasta version`.

## Problem

`_read_instance_image` reads the running Canasta version from `/tmp/canasta-version` inside the web container and initialized its result to `"(not running)"`, overwriting it only on a successful read. Every failure mode therefore printed the same definite negative claim:

- the container is up but has not yet written the file (it is written at startup)
- the exec hits the 10-second timeout
- `_ssh_run` returns 255 because SSH itself failed — DNS, connection refused, auth, host key

In each case `canasta version -i <id>` prints `(running: (not running))` for an instance that `canasta list` reports as `RUNNING` at the same moment. The docstring described the read as "best effort", but the output states the instance is stopped.

The SSH case is the worst of the three: an unreachable host says nothing about whether the instance is running, and reporting it as stopped is the same defect #1217 fixed in the wiki probe — absence of evidence rendered as evidence of absence.

## Change

When the version read fails, ask the orchestrator the same question `canasta list` asks (`_helpers._check_running`) before answering, and distinguish three outcomes:

| Result | Meaning |
| --- | --- |
| `3.5.17` | version read succeeded |
| `(unavailable)` | workload is up, but did not answer |
| `(not running)` | orchestrator confirms the workload is down |
| `(host unreachable)` | SSH transport failure; nothing was learned |

`(host unreachable)` returns early without consulting the orchestrator, since that call would fail over the same dead link. A test asserts `_check_running` is never reached on that path.

Because both commands now consult `_check_running`, `list` and `version` cannot disagree about whether an instance is up.

## Cost

The extra orchestrator call happens only when the version read has already failed. The common case — a healthy instance answering the probe — is unchanged.

## Compatibility

`(unavailable)` and `(host unreachable)` are new strings in `canasta version` output. Nothing in the repo parses that output. Scripts keying on `(not running)` would no longer match these two cases, which is the intent: they were previously mislabeled.

## Testing

- `make test-unit` — 1873 passed
- `make lint`, `make validate` — clean
- New tests cover all three failure outcomes, including that the orchestrator is not consulted after an SSH transport failure
- `canasta version -i dev` verified unchanged against a running Compose instance
