### PR TITLE
refactor: parameterize the container runtime as compose_command/inspect_command

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -36,7 +36,7 @@ EXIT_ALREADY_EXISTS = 3
 # so `import canasta_config` resolves the same file Ansible ships.
 sys.path.append(os.path.join(SCRIPT_DIR, "roles", "common", "module_utils"))
 import canasta_config  # noqa: E402
-from direct_commands import _helpers  # noqa: E402
+from direct_commands._helpers import _read_env, _resolve_compose_cmd  # noqa: E402
 
 # Ensure Ansible uses the repo's config regardless of working directory
 os.environ.setdefault("ANSIBLE_CONFIG", ANSIBLE_CFG)
@@ -1045,7 +1045,7 @@ def handle_interactive_exec(args):
         # payload reaches the command: `docker compose exec -T` (no TTY).
         # Without it, omit -T to preserve the interactive shell behavior.
         stdin_file = getattr(args, "stdin_file", None)
-        docker_cmd = _helpers._resolve_compose_cmd(inst) + ["exec"]
+        docker_cmd = _resolve_compose_cmd(inst) + ["exec"]
         if stdin_file:
             docker_cmd.append("-T")
         docker_cmd += [service] + command
@@ -1462,10 +1462,10 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
             ) if os.path.isfile(get_config_file_path()) else {}
             path = inst.get("path", "")
             if path:
-                env_val = _helpers._read_env(path, "compose_command")
+                env_val = _read_env(path, "compose_command")
                 if env_val:
                     extra_vars["compose_command"] = env_val
-                env_val = _helpers._read_env(path, "inspect_command")
+                env_val = _read_env(path, "inspect_command")
                 if env_val:
                     extra_vars["inspect_command"] = env_val
         except SystemExit:

--- a/canasta.py
+++ b/canasta.py
@@ -833,27 +833,6 @@ def get_config_file_path():
     return canasta_config.config_path(get_config_dir())
 
 
-def _read_env_file_value(path, key):
-    """Read a single value from an instance's .env file.
-
-    Parses KEY=VALUE lines. Returns the value string or None.
-    """
-    env_file = os.path.join(path, ".env")
-    try:
-        with open(env_file, "r") as f:
-            for line in f:
-                line = line.strip()
-                if not line or line.startswith("#"):
-                    continue
-                if "=" in line:
-                    k, v = line.split("=", 1)
-                    if k.strip() == key:
-                        return v.strip()
-    except (OSError, IOError):
-        pass
-    return None
-
-
 def resolve_instance(instance_id=None):
     """Resolve an instance from the registry by ID or working directory.
 
@@ -1482,15 +1461,15 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
             ) if os.path.isfile(get_config_file_path()) else {}
             path = inst.get("path", "")
             if path:
-                env_val = _read_env_file_value(path, "compose_command")
+                env_val = _helpers._read_env(path, "compose_command")
                 if env_val:
                     extra_vars["compose_command"] = env_val
-                env_val = _read_env_file_value(path, "inspect_command")
+                env_val = _helpers._read_env(path, "inspect_command")
                 if env_val:
                     extra_vars["inspect_command"] = env_val
         except SystemExit:
             pass
-        except Exception:
+        except (OSError, IOError, KeyError):
             pass
 
     # Always set a value, even the default one: the variables are

--- a/canasta.py
+++ b/canasta.py
@@ -36,6 +36,7 @@ EXIT_ALREADY_EXISTS = 3
 # so `import canasta_config` resolves the same file Ansible ships.
 sys.path.append(os.path.join(SCRIPT_DIR, "roles", "common", "module_utils"))
 import canasta_config  # noqa: E402
+from direct_commands import _helpers  # noqa: E402
 
 # Ensure Ansible uses the repo's config regardless of working directory
 os.environ.setdefault("ANSIBLE_CONFIG", ANSIBLE_CFG)
@@ -1044,7 +1045,7 @@ def handle_interactive_exec(args):
         # payload reaches the command: `docker compose exec -T` (no TTY).
         # Without it, omit -T to preserve the interactive shell behavior.
         stdin_file = getattr(args, "stdin_file", None)
-        docker_cmd = ["docker", "compose", "exec"]
+        docker_cmd = _helpers._resolve_compose_cmd(inst) + ["exec"]
         if stdin_file:
             docker_cmd.append("-T")
         docker_cmd += [service] + command

--- a/canasta.py
+++ b/canasta.py
@@ -833,6 +833,27 @@ def get_config_file_path():
     return canasta_config.config_path(get_config_dir())
 
 
+def _read_env_file_value(path, key):
+    """Read a single value from an instance's .env file.
+
+    Parses KEY=VALUE lines. Returns the value string or None.
+    """
+    env_file = os.path.join(path, ".env")
+    try:
+        with open(env_file, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" in line:
+                    k, v = line.split("=", 1)
+                    if k.strip() == key:
+                        return v.strip()
+    except (OSError, IOError):
+        pass
+    return None
+
+
 def resolve_instance(instance_id=None):
     """Resolve an instance from the registry by ID or working directory.
 
@@ -1450,6 +1471,35 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
     # delete=False because ansible-playbook needs to read it after
     # execvp replaces this process. Stale files are cleaned up by
     # _cleanup_stale_vars_files() at the start of each invocation.
+
+    # When the registry lacks composeCommand/inspectCommand (e.g.
+    # instances created before Podman support), fall back to reading
+    # from the instance's .env file so Ansible gets the values.
+    if "compose_command" not in extra_vars:
+        try:
+            inst = resolve_instance(
+                getattr(args, "id", None)
+            ) if os.path.isfile(get_config_file_path()) else {}
+            path = inst.get("path", "")
+            if path:
+                env_val = _read_env_file_value(path, "compose_command")
+                if env_val:
+                    extra_vars["compose_command"] = env_val
+                env_val = _read_env_file_value(path, "inspect_command")
+                if env_val:
+                    extra_vars["inspect_command"] = env_val
+        except SystemExit:
+            pass
+        except Exception:
+            pass
+
+    # Always set a value, even the default one: the variables are
+    # declared in the orchestrator role's defaults, so tasks in other
+    # roles (crowdsec, devmode, upgrade) that reference them are out of
+    # that scope and would otherwise see them undefined.
+    if "compose_command" not in extra_vars:
+        extra_vars["compose_command"] = "docker compose"
+        extra_vars["inspect_command"] = "docker"
     vars_file = tempfile.NamedTemporaryFile(
         mode="w", suffix=".json", prefix="canasta-vars-",
         delete=False,

--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -346,7 +346,7 @@ def _compose_file_args(path, host, devmode=False, include_sidecars=False):
 
 
 def _run_compose(inst_id, inst, action_args, include_sidecars=False):
-    """Run a docker compose command for an instance. Returns exit code.
+    """Run a compose command for an instance. Returns exit code.
 
     Output streams to the terminal and there is NO timeout: the actions
     routed here (`up -d` with image pulls, `down`, `build` from rebuild)
@@ -359,9 +359,10 @@ def _run_compose(inst_id, inst, action_args, include_sidecars=False):
     path = inst.get("path", "")
     devmode = inst.get("devMode", False)
     file_args = _compose_file_args(path, host, devmode, include_sidecars)
+    compose_cmd = _resolve_compose_cmd(inst)
 
     if _is_localhost(host):
-        cmd = ["docker", "compose"] + file_args + action_args
+        cmd = compose_cmd + file_args + action_args
         try:
             return subprocess.call(cmd, cwd=path)
         except OSError as e:
@@ -370,8 +371,9 @@ def _run_compose(inst_id, inst, action_args, include_sidecars=False):
 
     file_str = " ".join(file_args)
     action_str = " ".join(action_args)
-    remote_cmd = "cd %s && docker compose %s %s" % (
-        _shell_quote(path), file_str, action_str,
+    compose_str = " ".join(compose_cmd)
+    remote_cmd = "cd %s && %s %s %s" % (
+        _shell_quote(path), compose_str, file_str, action_str,
     )
     # SSH does not pass env; propagate DOCKER_HOST like _ssh_run does so a
     # rootless socket on the target is honored.
@@ -539,28 +541,30 @@ def _sync_compose_profiles(inst):
 
 
 def _dump_compose_failure(inst, include_sidecars=False):
-    """Print docker compose ps + logs to stderr after a failed 'up'.
+    """Print compose ps + logs to stderr after a failed 'up'.
 
     Matches the diagnostic block in roles/orchestrator/tasks/start.yml:
-    the caller usually rolls back (docker compose down) on failure,
-    which wipes the containers — so capturing ps/logs here, right
-    after the failed 'up' and before the rollback, is the only
-    reliable way to see why a container was unhealthy.
+    the caller usually rolls back (compose down) on failure, which wipes
+    the containers — so capturing ps/logs here, right after the failed
+    'up' and before the rollback, is the only reliable way to see why a
+    container was unhealthy.
     """
     host = inst.get("host") or "localhost"
     path = inst.get("path", "")
     devmode = inst.get("devMode", False)
     file_args = _compose_file_args(path, host, devmode, include_sidecars)
+    compose_cmd = _resolve_compose_cmd(inst)
+    compose_label = " ".join(compose_cmd)
 
     steps = [
-        (["ps", "-a"], "docker compose ps -a"),
-        (["logs", "--tail=200", "--no-color"], "docker compose logs (last 200)"),
+        (["ps", "-a"], "%s ps -a" % compose_label),
+        (["logs", "--tail=200", "--no-color"], "%s logs (last 200)" % compose_label),
     ]
     for action, label in steps:
         if _is_localhost(host):
             try:
                 result = subprocess.run(
-                    ["docker", "compose"] + file_args + action,
+                    compose_cmd + file_args + action,
                     cwd=path, capture_output=True, text=True, timeout=30,
                 )
                 output = result.stdout or result.stderr
@@ -569,10 +573,11 @@ def _dump_compose_failure(inst, include_sidecars=False):
         else:
             action_str = " ".join(action)
             file_str = " ".join(file_args)
+            compose_str = " ".join(compose_cmd)
             _rc, output = _ssh_run(
                 host,
-                "cd %s && docker compose %s %s" % (
-                    _shell_quote(path), file_str, action_str,
+                "cd %s && %s %s %s" % (
+                    _shell_quote(path), compose_str, file_str, action_str,
                 ),
             )
         print("--- %s ---" % label, file=sys.stderr)
@@ -645,10 +650,11 @@ def _exec_in_container(inst_id, inst, command, service="web"):
         except (subprocess.TimeoutExpired, OSError):
             return 1, ""
 
+    compose_cmd = _resolve_compose_cmd(inst)
     if _is_localhost(host):
         try:
             result = subprocess.run(
-                ["docker", "compose", "exec", "-T", service,
+                compose_cmd + ["exec", "-T", service,
                  "/bin/bash", "-c", command],
                 cwd=path, capture_output=True, text=True, timeout=30,
             )
@@ -656,10 +662,11 @@ def _exec_in_container(inst_id, inst, command, service="web"):
         except (subprocess.TimeoutExpired, OSError):
             return 1, ""
 
+    compose_str = " ".join(compose_cmd)
     rc, stdout = _ssh_run(
         host,
-        "cd %s && docker compose exec -T %s /bin/bash -c %s" % (
-            _shell_quote(path), service, _shell_quote(command),
+        "cd %s && %s exec -T %s /bin/bash -c %s" % (
+            _shell_quote(path), compose_str, service, _shell_quote(command),
         ),
     )
     return rc, stdout
@@ -723,17 +730,21 @@ def _stream_in_container(inst_id, inst, command, service="web",
             ]
             cwd = None
     elif _is_localhost(host):
-        argv = [
-            "docker", "compose", "exec", "-T", service,
+        compose_cmd = _resolve_compose_cmd(inst)
+        argv = compose_cmd + [
+            "exec", "-T", service,
             "/bin/bash", "-c", wrapped,
         ]
         cwd = path or None
     else:
+        compose_cmd = _resolve_compose_cmd(inst)
+        compose_str = " ".join(compose_cmd)
         target = _resolve_ssh_target(host)
         argv = ["ssh"] + _ssh_args() + [
             target,
-            "cd %s && docker compose exec -T %s /bin/bash -c %s" % (
-                _shell_quote(path), service, _shell_quote(wrapped),
+            "cd %s && %s exec -T %s /bin/bash -c %s" % (
+                _shell_quote(path), compose_str, service,
+                _shell_quote(wrapped),
             ),
         ]
         cwd = None
@@ -928,6 +939,69 @@ def _retry_on_ssh_reset(run, attempts=3):
     return rc
 
 
+def _read_env(path, key):
+    """Read a single value from an instance's .env file.
+
+    Parses KEY=VALUE lines (Docker Compose / Ansible format). Returns
+    the value string or None if the key is not found.
+    """
+    env_file = os.path.join(path, ".env")
+    try:
+        with open(env_file, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" in line:
+                    k, v = line.split("=", 1)
+                    if k.strip() == key:
+                        return v.strip()
+    except (OSError, IOError):
+        pass
+    return None
+
+
+def _resolve_compose_cmd(inst):
+    """Resolve the compose command for an instance.
+
+    Returns the command as a list of tokens (e.g. ["docker", "compose"]
+    or ["podman-compose"]). The instance's ``composeCommand`` registry
+    field overrides the default; when absent, the instance's ``.env``
+    file is checked for ``compose_command=``. Falls back to the classic
+    Docker form. The value is split on whitespace so that a single-token
+    override like ``podman-compose`` works, while the default
+    ``docker compose`` naturally yields two tokens.
+    """
+    raw = inst.get("composeCommand")
+    if raw:
+        return raw.split()
+    path = inst.get("path", "")
+    if path:
+        raw = _read_env(path, "compose_command")
+        if raw:
+            return raw.split()
+    return ["docker", "compose"]
+
+
+def _resolve_inspect_cmd(inst):
+    """Resolve the inspect (docker/podman) command for an instance.
+
+    Returns the command as a string (e.g. ``"docker"`` or ``"podman"``).
+    The instance's ``inspectCommand`` registry field overrides the
+    default; when absent, the instance's ``.env`` file is checked for
+    ``inspect_command=``.
+    """
+    raw = inst.get("inspectCommand")
+    if raw:
+        return raw
+    path = inst.get("path", "")
+    if path:
+        raw = _read_env(path, "inspect_command")
+        if raw:
+            return raw
+    return "docker"
+
+
 def _is_localhost(host):
     return host in ("localhost", "", None)
 
@@ -975,17 +1049,21 @@ def _docker_env(docker_host):
     return env
 
 
-def _check_running(instance_id, path, orchestrator, host, docker_host=None):
+def _check_running(instance_id, path, orchestrator, host, docker_host=None,
+                    compose_cmd=None):
     if orchestrator in ("kubernetes", "k8s"):
         return _check_running_k8s(instance_id, host)
-    return _check_running_compose(path, host, docker_host)
+    return _check_running_compose(path, host, docker_host, compose_cmd)
 
 
-def _check_running_compose(path, host, docker_host=None):
+def _check_running_compose(path, host, docker_host=None, compose_cmd=None):
+    if compose_cmd is None:
+        compose_cmd = ["docker", "compose"]
+    ps_cmd = compose_cmd + ["ps", "-q", "web"]
     if _is_localhost(host):
         try:
             result = subprocess.run(
-                ["docker", "compose", "ps", "-q", "web"],
+                ps_cmd,
                 cwd=path, capture_output=True, text=True, timeout=10,
                 env=_docker_env(docker_host),
             )
@@ -993,7 +1071,8 @@ def _check_running_compose(path, host, docker_host=None):
         except (subprocess.TimeoutExpired, OSError):
             return False
     else:
-        cmd = "cd %s && docker compose ps -q web" % _shell_quote(path)
+        ps_str = " ".join(ps_cmd)
+        cmd = "cd %s && %s" % (_shell_quote(path), ps_str)
         if docker_host:
             cmd = "DOCKER_HOST=%s %s" % (_shell_quote(docker_host), cmd)
         rc, stdout = _ssh_run(host, cmd)
@@ -1185,15 +1264,20 @@ def _gather_instance_info(inst_id, inst):
     # this one's rootless socket via a per-command DOCKER_HOST rather than the
     # process-global env another thread might read.
     docker_host = inst.get("dockerHost")
+    compose_cmd = _resolve_compose_cmd(inst)
     qpath = _shell_quote(path)
 
     if _is_localhost(host):
-        return _gather_local(inst_id, path, orchestrator, host, docker_host)
+        return _gather_local(inst_id, path, orchestrator, host, docker_host,
+                             compose_cmd)
 
     if orchestrator in ("kubernetes", "k8s"):
         return _gather_k8s(inst_id, path, host)
 
-    compose_ps = "cd %(p)s && docker compose ps -q web 2>/dev/null || true"
+    compose_str = " ".join(compose_cmd)
+    compose_ps = "cd %(p)s && %(c)s ps -q web 2>/dev/null || true" % {
+        "p": qpath, "c": compose_str,
+    }
     if docker_host:
         compose_ps = "DOCKER_HOST=%s %s" % (_shell_quote(docker_host), compose_ps)
     script = (
@@ -1231,13 +1315,15 @@ def _gather_instance_info(inst_id, inst):
     return _make_detail(inst_id, host, path, orchestrator, status, wikis)
 
 
-def _gather_local(inst_id, path, orchestrator, host, docker_host=None):
+def _gather_local(inst_id, path, orchestrator, host, docker_host=None,
+                   compose_cmd=None):
     dir_exists = os.path.isdir(path)
     wikis = _read_wikis(path, host) if dir_exists else []
 
     if not dir_exists:
         status = "NOT FOUND"
-    elif _check_running(inst_id, path, orchestrator, host, docker_host):
+    elif _check_running(inst_id, path, orchestrator, host, docker_host,
+                        compose_cmd):
         status = "RUNNING"
     else:
         status = "STOPPED"

--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -942,8 +942,9 @@ def _retry_on_ssh_reset(run, attempts=3):
 def _read_env(path, key):
     """Read a single value from an instance's .env file.
 
-    Parses KEY=VALUE lines (Docker Compose / Ansible format). Returns
-    the value string or None if the key is not found.
+    Parses KEY=VALUE lines and strips surrounding quotes, matching the
+    read semantics of roles/common/library/canasta_env.py — the module
+    that writes these files. Returns None if the key is not found.
     """
     env_file = os.path.join(path, ".env")
     try:
@@ -955,10 +956,17 @@ def _read_env(path, key):
                 if "=" in line:
                     k, v = line.split("=", 1)
                     if k.strip() == key:
-                        return v.strip()
+                        return _unquote(v.strip())
     except (OSError, IOError):
         pass
     return None
+
+
+def _unquote(value):
+    """Strip one layer of surrounding single or double quotes."""
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
 
 
 def _resolve_compose_cmd(inst):

--- a/direct_commands/backup.py
+++ b/direct_commands/backup.py
@@ -28,16 +28,18 @@ def cmd_backup_list(args):
         local_mount = "-v %s:%s" % (qrepo, qrepo)
 
     qpath = _helpers._shell_quote(path)
+    runtime = _helpers._resolve_inspect_cmd(inst)
     cmd = (
-        "docker volume create %(vol)s >/dev/null 2>&1; "
-        "docker run --rm -i "
+        "%(rt)s volume create %(vol)s >/dev/null 2>&1; "
+        "%(rt)s run --rm -i "
         "--env-file %(path)s/.env "
         "-v %(vol)s:/currentsnapshot "
         "%(local_mount)s "
         "restic/restic "
         "--cache-dir /tmp/restic-cache "
         "snapshots"
-    ) % {"vol": _helpers._shell_quote(bvol), "path": qpath, "local_mount": local_mount}
+    ) % {"vol": _helpers._shell_quote(bvol), "path": qpath,
+         "local_mount": local_mount, "rt": runtime}
 
     if _helpers._is_localhost(host):
         try:

--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -294,23 +294,25 @@ def _consistency_warnings(env, current_profiles, running_services, uses_cirrus,
     return warns
 
 
-def _gather_runtime(path, host):
+def _gather_runtime(path, host, inst=None):
     """(running_services, uses_cirrus, env_template_literals) for an instance,
     localhost or remote. env_template_literals maps each KEY to the literal
     value pinned in env.template, excluding placeholder (KEY={{...}}) lines and
     comments; empty when not gitops / no env.template."""
     d = _helpers._SENTINEL
     qpath = _helpers._shell_quote(path)
+    compose_cmd = _helpers._resolve_compose_cmd(inst or {"path": path})
+    compose_str = " ".join(compose_cmd)
     script = (
         "cd %(p)s 2>/dev/null && "
-        "docker compose ps --services --status running 2>/dev/null; "
+        "%(c)s ps --services --status running 2>/dev/null; "
         "echo '%(d)s'; "
         "grep -rqi cirrussearch %(p)s/config/settings 2>/dev/null "
         "&& echo USES_CIRRUS || echo NO_CIRRUS; "
         "echo '%(d)s'; "
         "grep -E '^[A-Za-z_][A-Za-z0-9_]*=' %(p)s/env.template 2>/dev/null "
         "| grep -v '={{'"
-    ) % {"p": qpath, "d": d}
+    ) % {"p": qpath, "d": d, "c": compose_str}
     if _helpers._is_localhost(host):
         try:
             out = subprocess.run(
@@ -362,7 +364,7 @@ def _instance_consistency_lines(inst):
         p.strip() for p in env.get("COMPOSE_PROFILES", "").split(",")
         if p.strip()
     ]
-    running, uses_cirrus, template_literals = _gather_runtime(path, host)
+    running, uses_cirrus, template_literals = _gather_runtime(path, host, inst)
     warns = _consistency_warnings(
         env, current, running, uses_cirrus, template_literals)
     lines = ["", "Instance consistency (%s):" % inst.get("id", "?")]

--- a/direct_commands/info.py
+++ b/direct_commands/info.py
@@ -475,7 +475,8 @@ def cmd_status(args):
 
     # Compose
     compose_cmd = _helpers._resolve_compose_cmd(inst)
-    running = _helpers._check_running_compose(path, host)
+    running = _helpers._check_running_compose(
+        path, host, compose_cmd=compose_cmd)
     print("Status:       %s" % ("RUNNING" if running else "STOPPED"))
     if not path:
         print("\n(no path on file — cannot inspect containers)")

--- a/direct_commands/info.py
+++ b/direct_commands/info.py
@@ -223,10 +223,12 @@ def _read_instance_image(inst_id, inst):
             % (_helpers._shell_quote(ns), _helpers._shell_quote(ns))
         )
     else:
+        compose_cmd = _helpers._resolve_compose_cmd(inst)
+        compose_str = " ".join(compose_cmd)
         probe_cmd = (
-            "cd %s && docker compose exec -T web sh -c "
+            "cd %s && %s exec -T web sh -c "
             "\"cat /tmp/canasta-version 2>/dev/null | sed -n '2p'\" 2>/dev/null"
-            % _helpers._shell_quote(path)
+            % (_helpers._shell_quote(path), compose_str)
         )
 
     if _helpers._is_localhost(host):
@@ -472,17 +474,18 @@ def cmd_status(args):
         return 0
 
     # Compose
+    compose_cmd = _helpers._resolve_compose_cmd(inst)
     running = _helpers._check_running_compose(path, host)
     print("Status:       %s" % ("RUNNING" if running else "STOPPED"))
     if not path:
         print("\n(no path on file — cannot inspect containers)")
         return 0
 
-    ps_cmd = "docker compose ps"
+    ps_cmd = compose_cmd + ["ps"]
     if _helpers._is_localhost(host):
         try:
             r = subprocess.run(
-                ps_cmd.split(),
+                ps_cmd,
                 cwd=path, capture_output=True, text=True, timeout=15,
             )
             rc, out = r.returncode, r.stdout

--- a/direct_commands/rebuild.py
+++ b/direct_commands/rebuild.py
@@ -11,7 +11,7 @@ from ._helpers import register
 def _list_buildable_services(inst, include_sidecars=False):
     """Return service names with a build: directive in the merged compose config.
 
-    Uses `docker compose config --format json` so docker itself
+    Uses compose config --format json so the compose tool itself
     handles the main + override + dev file merging — no need to
     parse YAML ourselves.
     """
@@ -19,11 +19,12 @@ def _list_buildable_services(inst, include_sidecars=False):
     path = inst.get("path", "")
     devmode = inst.get("devMode", False)
     file_args = _helpers._compose_file_args(path, host, devmode, include_sidecars)
+    compose_cmd = _helpers._resolve_compose_cmd(inst)
 
     if _helpers._is_localhost(host):
         try:
             result = subprocess.run(
-                ["docker", "compose"] + file_args + ["config", "--format", "json"],
+                compose_cmd + file_args + ["config", "--format", "json"],
                 cwd=path, capture_output=True, text=True, timeout=30,
             )
         except (subprocess.TimeoutExpired, OSError) as e:
@@ -31,21 +32,22 @@ def _list_buildable_services(inst, include_sidecars=False):
             return []
         if result.returncode != 0:
             print(
-                "Error: docker compose config failed: %s"
+                "Error: compose config failed: %s"
                 % (result.stderr or "").strip(),
                 file=sys.stderr,
             )
             return []
         stdout = result.stdout
     else:
+        compose_str = " ".join(compose_cmd)
         rc, stdout = _helpers._ssh_run(
             host,
-            "cd %s && docker compose %s config --format json" % (
-                _helpers._shell_quote(path), " ".join(file_args),
+            "cd %s && %s %s config --format json" % (
+                _helpers._shell_quote(path), compose_str, " ".join(file_args),
             ),
         )
         if rc != 0:
-            print("Error: docker compose config failed on %s" % host, file=sys.stderr)
+            print("Error: compose config failed on %s" % host, file=sys.stderr)
             return []
 
     try:

--- a/playbooks/_purge_host.yml
+++ b/playbooks/_purge_host.yml
@@ -49,7 +49,7 @@
     # dangling by the upgrade actually get removed.
     - name: Remove superseded Canasta image tags no container references
       ansible.builtin.command:
-        cmd: "docker image rm {{ _purge_image_ref }}"
+        cmd: "{{ inspect_command | default('docker') }} image rm {{ _purge_image_ref }}"
       loop: >-
         {{ _purge_images.stdout_lines
            | reject('search', ':<none>')
@@ -66,7 +66,7 @@
     # this cannot affect a stopped instance or any volume.
     - name: Prune dangling images (sidecar rebuild orphans)
       ansible.builtin.command:
-        cmd: docker image prune -f
+        cmd: "{{ inspect_command | default('docker') }} image prune -f"
       register: _purge_dangling
       changed_when: "'Total reclaimed space: 0B' not in _purge_dangling.stdout"
 

--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -33,7 +33,7 @@
   rescue:
     - name: Clean up on failure (destroy Compose containers)
       ansible.builtin.command:
-        cmd: "docker compose down -v"
+        cmd: "{{ compose_command | default('docker compose') }} down -v"
         chdir: "{{ instance_path | default(omit) }}"
       when:
         - instance_path is defined

--- a/playbooks/image_push.yml
+++ b/playbooks/image_push.yml
@@ -63,13 +63,13 @@
 - name: Build the image from the context
   ansible.builtin.command:
     cmd: >-
-      docker build -t localhost:5000/{{ _img_ref }}
+      {{ inspect_command | default('docker') }} build -t localhost:5000/{{ _img_ref }}
       {{ _img_build_arg_flags }} {{ context | quote }}
   changed_when: true
 
 - name: Push the image to the in-cluster registry
   ansible.builtin.command:
-    cmd: "docker push localhost:5000/{{ _img_ref }}"
+    cmd: "{{ inspect_command | default('docker') }} push localhost:5000/{{ _img_ref }}"
   changed_when: true
 
 - name: Report the cluster-pullable reference

--- a/roles/common/library/canasta_registry.py
+++ b/roles/common/library/canasta_registry.py
@@ -84,6 +84,16 @@ options:
       Docker daemon endpoint (DOCKER_HOST) for the instance's containers,
       stored as dockerHost in the registry.
     type: str
+  compose_command:
+    description: >-
+      Compose command override (e.g. "podman-compose" for Podman).
+      Stored as composeCommand in the registry.
+    type: str
+  inspect_command:
+    description: >-
+      Inspect command override (e.g. "podman" for Podman).
+      Stored as inspectCommand in the registry.
+    type: str
 """
 
 import json
@@ -133,6 +143,10 @@ def instance_to_dict(instance):
         result["buildArgs"] = instance["buildArgs"]
     if instance.get("dockerHost"):
         result["dockerHost"] = instance["dockerHost"]
+    if instance.get("composeCommand"):
+        result["composeCommand"] = instance["composeCommand"]
+    if instance.get("inspectCommand"):
+        result["inspectCommand"] = instance["inspectCommand"]
     return result
 
 
@@ -155,6 +169,8 @@ def run_module():
         build_args=dict(type="list", elements="str", required=False),
         host=dict(type="str", required=False),
         docker_host=dict(type="str", required=False),
+        compose_command=dict(type="str", required=False),
+        inspect_command=dict(type="str", required=False),
         filter_host=dict(type="str", required=False),
         config_dir=dict(type="str", required=False),
     )
@@ -238,6 +254,8 @@ def run_module():
             "buildFrom": module.params.get("build_from"),
             "buildArgs": module.params.get("build_args"),
             "dockerHost": module.params.get("docker_host"),
+            "composeCommand": module.params.get("compose_command"),
+            "inspectCommand": module.params.get("inspect_command"),
         })
 
         if inst_id in instances:

--- a/roles/create/tasks/_kubernetes_setup.yml
+++ b/roles/create/tasks/_kubernetes_setup.yml
@@ -90,10 +90,10 @@
 
     - name: Tag and push image to registry
       ansible.builtin.command:
-        cmd: "docker tag {{ _base_image }} localhost:5000/{{ _base_image }}"
+        cmd: "{{ inspect_command | default('docker') }} tag {{ _base_image }} localhost:5000/{{ _base_image }}"
       changed_when: true
 
     - name: Push image
       ansible.builtin.command:
-        cmd: "docker push localhost:5000/{{ _base_image }}"
+        cmd: "{{ inspect_command | default('docker') }} push localhost:5000/{{ _base_image }}"
       changed_when: true

--- a/roles/create/tasks/_register.yml
+++ b/roles/create/tasks/_register.yml
@@ -21,6 +21,8 @@
     orchestrator: "{{ orchestrator | default('compose') }}"
     host: "{{ _registry_host }}"
     docker_host: "{{ docker_host | default(_detected_docker_host | default(''), true) | default(omit, true) }}"
+    compose_command: "{{ compose_command | default(omit, true) }}"
+    inspect_command: "{{ inspect_command | default(omit, true) }}"
     managed_cluster: false
     build_from: "{{ build_from | default(omit) }}"
     build_args: "{{ build_arg | default(omit, true) }}"
@@ -36,6 +38,8 @@
     path: "{{ instance_path }}"
     orchestrator: "{{ orchestrator | default('compose') }}"
     docker_host: "{{ docker_host | default(_detected_docker_host | default(''), true) | default(omit, true) }}"
+    compose_command: "{{ compose_command | default(omit, true) }}"
+    inspect_command: "{{ inspect_command | default(omit, true) }}"
     managed_cluster: false
     build_from: "{{ build_from | default(omit) }}"
     build_args: "{{ build_arg | default(omit, true) }}"

--- a/roles/create/tasks/_validate_inputs.yml
+++ b/roles/create/tasks/_validate_inputs.yml
@@ -113,7 +113,7 @@
     - name: Probe for existing docker volumes
       ansible.builtin.command:
         argv:
-          - docker
+          - "{{ inspect_command | default('docker') }}"
           - volume
           - ls
           - --filter
@@ -133,8 +133,8 @@
           behind. Re-running would generate fresh DB passwords that
           do not match the existing volumes, producing an unrecoverable
           auth mismatch. To recover, list and remove the stale volumes
-          ('docker volume ls --filter name={{ id }}_' to list, then
-          'docker volume rm <name>' for each), then re-run.
+          ('{{ inspect_command | default("docker") }} volume ls --filter name={{ id }}_' to list, then
+          '{{ inspect_command | default("docker") }} volume rm <name>' for each), then re-run.
       when:
         - _stale_volumes.stdout is defined
         - _stale_volumes.stdout | trim | length > 0

--- a/roles/crowdsec/tasks/_resolve_cscli.yml
+++ b/roles/crowdsec/tasks/_resolve_cscli.yml
@@ -13,8 +13,8 @@
 
 - name: Build cscli prefix (Compose)
   ansible.builtin.set_fact:
-    _cscli_prefix: "docker compose exec -T crowdsec"
-    _cscli_argv: ['docker', 'compose', 'exec', '-T', 'crowdsec']
+    _cscli_prefix: "{{ compose_command }} exec -T crowdsec"
+    _cscli_argv: ['{{ compose_command }}', 'exec', '-T', 'crowdsec']
     _cscli_chdir: "{{ instance_path }}"
   when: instance_orchestrator | default('compose') == 'compose'
 

--- a/roles/crowdsec/tasks/_resolve_cscli.yml
+++ b/roles/crowdsec/tasks/_resolve_cscli.yml
@@ -14,7 +14,7 @@
 - name: Build cscli prefix (Compose)
   ansible.builtin.set_fact:
     _cscli_prefix: "{{ compose_command }} exec -T crowdsec"
-    _cscli_argv: ['{{ compose_command }}', 'exec', '-T', 'crowdsec']
+    _cscli_argv: "{{ compose_command.split() + ['exec', '-T', 'crowdsec'] }}"
     _cscli_chdir: "{{ instance_path }}"
   when: instance_orchestrator | default('compose') == 'compose'
 

--- a/roles/crowdsec/tasks/_restart_engine.yml
+++ b/roles/crowdsec/tasks/_restart_engine.yml
@@ -11,7 +11,7 @@
 
 - name: Restart the CrowdSec engine (Compose)
   ansible.builtin.command:
-    cmd: "docker compose restart crowdsec"
+    cmd: "{{ compose_command }} restart crowdsec"
     chdir: "{{ instance_path }}"
   changed_when: true
   when: instance_orchestrator | default('compose') == 'compose'

--- a/roles/devmode/tasks/enable.yml
+++ b/roles/devmode/tasks/enable.yml
@@ -63,31 +63,31 @@
 
     - name: Pull base image if from registry
       ansible.builtin.command:
-        cmd: "docker pull {{ _dev_base_image }}"
+        cmd: "{{ inspect_command }} pull {{ _dev_base_image }}"
       changed_when: true
       when: "'/' in _dev_base_image"
 
     - name: Create temporary container for code extraction
       ansible.builtin.command:
-        cmd: "docker create --name canasta-dev-extract {{ _dev_base_image }} sleep infinity"
+        cmd: "{{ inspect_command }} create --name canasta-dev-extract {{ _dev_base_image }} sleep infinity"
       register: _extract_container
       changed_when: true
 
     - name: Run create-symlinks.sh in temp container
       ansible.builtin.command:
-        cmd: "docker start canasta-dev-extract && docker exec canasta-dev-extract /create-symlinks.sh"
+        cmd: "{{ inspect_command }} start canasta-dev-extract && {{ inspect_command }} exec canasta-dev-extract /create-symlinks.sh"
       changed_when: true
       ignore_errors: true  # OK if script missing in image
 
     - name: Extract code from container
       ansible.builtin.shell:
-        cmd: "docker exec canasta-dev-extract tar -cf - -C /var/www/mediawiki/w . | tar -xf - -C mediawiki-code/"
+        cmd: "{{ inspect_command }} exec canasta-dev-extract tar -cf - -C /var/www/mediawiki/w . | tar -xf - -C mediawiki-code/"
         chdir: "{{ instance_path }}"
       changed_when: true
 
     - name: Remove temporary container
       ansible.builtin.command:
-        cmd: "docker rm -f canasta-dev-extract"
+        cmd: "{{ inspect_command }} rm -f canasta-dev-extract"
       changed_when: true
 
 # --- Consolidate user extensions/skins ---
@@ -174,7 +174,7 @@
 # --- Build xdebug image ---
 - name: Build xdebug-enabled image
   ansible.builtin.command:
-    cmd: "docker compose -f docker-compose.yml -f docker-compose.dev.yml build"
+    cmd: "{{ compose_command }} -f docker-compose.yml -f docker-compose.dev.yml build"
     chdir: "{{ instance_path }}"
   changed_when: true
 

--- a/roles/imagebuild/tasks/build_from_source.yml
+++ b/roles/imagebuild/tasks/build_from_source.yml
@@ -42,7 +42,7 @@
   block:
     - name: Build CanastaBase image
       ansible.builtin.command:
-        cmd: "docker build {{ _build_arg_flags }} -t canasta-base:local ."
+        cmd: "{{ inspect_command | default('docker') }} build {{ _build_arg_flags }} -t canasta-base:local ."
         chdir: "{{ build_from }}/CanastaBase"
       changed_when: true
 
@@ -80,7 +80,10 @@
 
 - name: Build Canasta image from source
   ansible.builtin.command:
-    cmd: "docker build --build-arg BASE_IMAGE={{ _base_image_arg }} {{ _build_arg_flags }} -t canasta:local ."
+    cmd: >-
+      {{ inspect_command | default('docker') }} build
+      --build-arg BASE_IMAGE={{ _base_image_arg }}
+      {{ _build_arg_flags }} -t canasta:local .
     chdir: "{{ build_from }}/Canasta"
   changed_when: true
 

--- a/roles/orchestrator/defaults/main.yml
+++ b/roles/orchestrator/defaults/main.yml
@@ -7,6 +7,13 @@ canasta_default_image: "ghcr.io/canastawiki/canasta:latest"
 # Wait-for-it timeout (seconds)
 canasta_db_wait_timeout: 10
 
+# Container runtime commands. Override for rootless Podman deployments:
+#   compose_command: "podman-compose"
+#   inspect_command: "podman"
+# The defaults use Docker; the compose_command is prefixed to -f arguments.
+compose_command: "docker compose"
+inspect_command: "docker"
+
 # Pinned k3s and helm versions for Kubernetes installs. Pinning keeps the
 # control plane and any workers on the same version (a later-joining worker
 # must not outpace the cp — Kubernetes version-skew policy) and avoids

--- a/roles/orchestrator/tasks/backup_discover_build_paths.yml
+++ b/roles/orchestrator/tasks/backup_discover_build_paths.yml
@@ -54,7 +54,7 @@
 
     - name: Render merged compose config as JSON
       ansible.builtin.command:
-        cmd: "docker compose config --format json"
+        cmd: "{{ compose_command }} config --format json"
         chdir: "{{ instance_path }}"
       register: _build_compose_config
       changed_when: false

--- a/roles/orchestrator/tasks/copy_from_container.yml
+++ b/roles/orchestrator/tasks/copy_from_container.yml
@@ -10,7 +10,7 @@
 - name: Copy file from container (Compose)
   ansible.builtin.command:
     cmd: >-
-      docker compose cp {{ (copy_service + ':' + copy_src) | quote }}
+      {{ compose_command }} cp {{ (copy_service + ':' + copy_src) | quote }}
       {{ copy_dest | quote }}
     chdir: "{{ instance_path }}"
   changed_when: true

--- a/roles/orchestrator/tasks/copy_into_container.yml
+++ b/roles/orchestrator/tasks/copy_into_container.yml
@@ -10,7 +10,7 @@
 - name: Copy file into container (Compose)
   ansible.builtin.command:
     cmd: >-
-      docker compose cp {{ copy_src | quote }}
+      {{ compose_command }} cp {{ copy_src | quote }}
       {{ (copy_service + ':' + copy_dest) | quote }}
     chdir: "{{ instance_path }}"
   changed_when: true

--- a/roles/orchestrator/tasks/delete_cleanup_files.yml
+++ b/roles/orchestrator/tasks/delete_cleanup_files.yml
@@ -11,7 +11,7 @@
 - name: Clean up container-owned files (Compose)
   ansible.builtin.command:
     cmd: >-
-      docker compose run --rm --no-deps -T web
+      {{ compose_command }} run --rm --no-deps -T web
       find /mediawiki/images /mediawiki/config /mediawiki/public_assets
       -mindepth 1 -delete
     chdir: "{{ instance_path }}"

--- a/roles/orchestrator/tasks/destroy.yml
+++ b/roles/orchestrator/tasks/destroy.yml
@@ -30,14 +30,14 @@
 
     - name: Destroy containers and volumes
       ansible.builtin.command:
-        cmd: "docker compose {{ _destroy_compose_files | join(' ') }} down -v --remove-orphans"
+        cmd: "{{ compose_command }} {{ _destroy_compose_files | join(' ') }} down -v --remove-orphans"
         chdir: "{{ instance_path }}"
       changed_when: true
       ignore_errors: true  # OK if containers already removed
 
     - name: Remove backup staging volume
       ansible.builtin.command:
-        cmd: "docker volume rm canasta-backup-{{ instance_path | basename }}"
+        cmd: "{{ inspect_command }} volume rm canasta-backup-{{ instance_path | basename }}"
       changed_when: true
       ignore_errors: true  # OK if volume doesn't exist
 

--- a/roles/orchestrator/tasks/exec.yml
+++ b/roles/orchestrator/tasks/exec.yml
@@ -33,7 +33,7 @@
 - name: Build exec command (Compose)
   ansible.builtin.set_fact:
     _exec_full_cmd: >-
-      docker compose exec -T
+      {{ compose_command }} exec -T
       {{ exec_service | default('web') }}
       {{ _exec_shell }} {{ exec_command | quote }}
     _exec_chdir: "{{ instance_path }}"

--- a/roles/orchestrator/tasks/k8s_build_sidecars.yml
+++ b/roles/orchestrator/tasks/k8s_build_sidecars.yml
@@ -32,7 +32,7 @@
     - name: Build each sidecar image from its context
       ansible.builtin.command:
         cmd: >-
-          docker build
+          {{ inspect_command | default('docker') }} build
           -t localhost:5000/canasta-{{ instance_id }}-{{ item.name }}:local
           {{ (instance_path ~ '/' ~ item.build) | quote }}
       loop: "{{ _bs_build }}"
@@ -43,7 +43,7 @@
     - name: Push each sidecar image to the registry
       ansible.builtin.command:
         cmd: >-
-          docker push
+          {{ inspect_command | default('docker') }} push
           localhost:5000/canasta-{{ instance_id }}-{{ item.name }}:local
       loop: "{{ _bs_build }}"
       loop_control:

--- a/roles/orchestrator/tasks/pull.yml
+++ b/roles/orchestrator/tasks/pull.yml
@@ -13,7 +13,7 @@
 
 - name: Get image ID before pull
   ansible.builtin.command:
-    cmd: "docker image inspect {{ _pull_image_env.value }} --format {% raw %}{{.Id}}{% endraw %}"
+    cmd: "{{ inspect_command }} image inspect {{ _pull_image_env.value }} --format {% raw %}{{.Id}}{% endraw %}"
   register: _pre_pull_id
   changed_when: false
   ignore_errors: true
@@ -28,12 +28,12 @@
     rx_name: "pull Compose images"
     rx_chdir: "{{ instance_path }}"
     rx_async: 1800
-    rx_cmd: "docker compose pull --ignore-buildable --ignore-pull-failures"
+    rx_cmd: "{{ compose_command }} pull --ignore-buildable --ignore-pull-failures"
   when: instance_orchestrator | default('compose') == 'compose'
 
 - name: Get image ID after pull
   ansible.builtin.command:
-    cmd: "docker image inspect {{ _pull_image_env.value }} --format {% raw %}{{.Id}}{% endraw %}"
+    cmd: "{{ inspect_command }} image inspect {{ _pull_image_env.value }} --format {% raw %}{{.Id}}{% endraw %}"
   register: _post_pull_id
   changed_when: false
   ignore_errors: true

--- a/roles/orchestrator/tasks/restore_instance.yml
+++ b/roles/orchestrator/tasks/restore_instance.yml
@@ -138,7 +138,7 @@
     - name: Clear backup volume before restore
       ansible.builtin.command:
         cmd: >-
-          docker run --rm
+          {{ inspect_command }} run --rm
           -v "canasta-backup-{{ instance_path | basename }}:/currentsnapshot"
           alpine sh -c 'rm -rf /currentsnapshot/* /currentsnapshot/.[!.]* 2>/dev/null || true'
       changed_when: true
@@ -170,7 +170,7 @@
       when: wiki is not defined
       ansible.builtin.shell:
         cmd: |
-          docker run --rm \
+          {{ inspect_command }} run --rm \
             -v "canasta-backup-{{ instance_path | basename }}:/currentsnapshot:ro" \
             -v "{{ instance_path }}:/install" \
             alpine sh -c '
@@ -206,7 +206,7 @@
       when: wiki is defined
       ansible.builtin.shell:
         cmd: >-
-          docker run --rm
+          {{ inspect_command }} run --rm
           -e W={{ wiki | quote }}
           -v "canasta-backup-{{ instance_path | basename }}:/currentsnapshot:ro"
           alpine sh -c 'test -f "/currentsnapshot/config/backup/db_$W.sql"'
@@ -227,7 +227,7 @@
       when: wiki is defined
       ansible.builtin.shell:
         cmd: |
-          docker run --rm \
+          {{ inspect_command }} run --rm \
             -e W={{ wiki | quote }} \
             -v "canasta-backup-{{ instance_path | basename }}:/currentsnapshot:ro" \
             -v "{{ instance_path }}:/install" \

--- a/roles/orchestrator/tasks/run_backup.yml
+++ b/roles/orchestrator/tasks/run_backup.yml
@@ -22,7 +22,7 @@
 
     - name: Ensure backup volume exists
       ansible.builtin.command:
-        cmd: "docker volume create {{ _bvol }}"
+        cmd: "{{ inspect_command }} volume create {{ _bvol }}"
       changed_when: true
 
     - name: Stage files into backup volume
@@ -33,7 +33,7 @@
         - name: Build and run staging container
           ansible.builtin.shell:
             cmd: |
-              docker run --rm \
+              {{ inspect_command }} run --rm \
                 -v {{ _bvol }}:/currentsnapshot \
               {% for src, dst in backup_volumes.items() %}
                 -v {{ src }}:/src{{ loop.index0 }}:ro \
@@ -109,7 +109,7 @@
     - name: Run restic container
       ansible.builtin.shell:
         cmd: |
-          docker run --rm -i \
+          {{ inspect_command }} run --rm -i \
             --env-file {{ instance_path }}/.env \
             -v {{ _bvol }}:/currentsnapshot \
           {% if _backup_local_repo %}

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -39,9 +39,21 @@
       ansible.builtin.debug:
         msg: "Starting containers..."
 
+    # The compose command can be overridden for podman deployments.
+    # When using rootless Podman instead of Docker, set
+    # compose_command: "podman-compose" in the instance .env or via
+    # extra-vars.  The -f flags are appended automatically by
+    # _compose_files above, so duplicating them here would break.
+    # compose_command and inspect_command are defined in
+    # roles/orchestrator/defaults/main.yml (override for Podman).
+    - name: Set compose and inspect commands
+      ansible.builtin.set_fact:
+        _compose_cmd: "{{ compose_command }}"
+        _inspect_cmd: "{{ inspect_command }}"
+
     - name: Start containers
       ansible.builtin.command:
-        cmd: "docker compose {{ _compose_files | join(' ') }} up -d"
+        cmd: "{{ _compose_cmd }} {{ _compose_files | join(' ') }} up -d"
         chdir: "{{ instance_path }}"
       register: _start_result
       changed_when: true
@@ -55,7 +67,7 @@
     # only reliable way to see WHY a container was unhealthy.
     - name: Capture compose state on failure
       ansible.builtin.command:
-        cmd: "docker compose {{ _compose_files | join(' ') }} ps -a"
+        cmd: "{{ _compose_cmd }} {{ _compose_files | join(' ') }} ps -a"
         chdir: "{{ instance_path }}"
       register: _start_ps
       changed_when: false
@@ -64,7 +76,7 @@
 
     - name: Capture compose logs on failure
       ansible.builtin.command:
-        cmd: "docker compose {{ _compose_files | join(' ') }} logs --tail=200 --no-color"
+        cmd: "{{ _compose_cmd }} {{ _compose_files | join(' ') }} logs --tail=200 --no-color"
         chdir: "{{ instance_path }}"
       register: _start_logs
       changed_when: false
@@ -100,9 +112,16 @@
     # "healthy" is the right gate. Custom images that do not declare a
     # HEALTHCHECK skip the wait (we trust them to define their own
     # readiness contract).
+    #
+    # Podman note: `podman inspect -f '{{.State.Health.Status}}'`
+    # returns the same Go template output as Docker for containers
+    # with a HEALTHCHECK.  Validated with Podman 4.3.1 (Debian 12
+    # Bookworm ARM64).  Earlier rootless Podman (<4.0) may not
+    # populate .State.Health at all; the `has` probe below skips
+    # gracefully in that case.
     - name: Get web container id
       ansible.builtin.command:
-        cmd: "docker compose {{ _compose_files | join(' ') }} ps -q web"
+        cmd: "{{ _compose_cmd }} {{ _compose_files | join(' ') }} ps -q web"
         chdir: "{{ instance_path }}"
       register: _start_web_cid
       changed_when: false
@@ -110,7 +129,7 @@
     - name: Probe whether web declares a healthcheck
       ansible.builtin.command:
         argv:
-          - docker
+          - "{{ _inspect_cmd }}"
           - inspect
           - "-f"
           - "{% raw %}{{if .State.Health}}has{{end}}{% endraw %}"
@@ -125,7 +144,7 @@
     - name: Wait for web container to report healthy
       ansible.builtin.command:
         argv:
-          - docker
+          - "{{ _inspect_cmd }}"
           - inspect
           - "-f"
           - "{% raw %}{{.State.Health.Status}}{% endraw %}"

--- a/roles/orchestrator/tasks/stop.yml
+++ b/roles/orchestrator/tasks/stop.yml
@@ -36,7 +36,7 @@
 
     - name: Stop containers
       ansible.builtin.command:
-        cmd: "docker compose {{ _compose_files | join(' ') }} down"
+        cmd: "{{ compose_command }} {{ _compose_files | join(' ') }} down"
         chdir: "{{ instance_path }}"
       changed_when: true
 

--- a/roles/orchestrator/tasks/sync_compose_profiles.yml
+++ b/roles/orchestrator/tasks/sync_compose_profiles.yml
@@ -76,7 +76,7 @@
     - name: Stop and remove containers for deactivated profiles
       ansible.builtin.command:
         cmd: >-
-          docker compose {{ _teardown_compose_files | join(' ') }}
+          {{ compose_command }} {{ _teardown_compose_files | join(' ') }}
           {{ _removed_profiles | map('regex_replace', '^', '--profile ') | join(' ') }}
           rm -sf
           {{ _removed_profiles | map('extract', _profile_services) | flatten | join(' ') }}

--- a/roles/orchestrator/tasks/upgrade_publish_rebuilt_image.yml
+++ b/roles/orchestrator/tasks/upgrade_publish_rebuilt_image.yml
@@ -8,12 +8,12 @@
 
 - name: Tag rebuilt image for the in-cluster registry (Kubernetes)
   ansible.builtin.command:
-    cmd: "docker tag {{ _built_image }} localhost:5000/{{ _built_image }}"
+    cmd: "{{ inspect_command | default('docker') }} tag {{ _built_image }} localhost:5000/{{ _built_image }}"
   changed_when: true
   when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
 
 - name: Push rebuilt image to the in-cluster registry (Kubernetes)
   ansible.builtin.command:
-    cmd: "docker push localhost:5000/{{ _built_image }}"
+    cmd: "{{ inspect_command | default('docker') }} push localhost:5000/{{ _built_image }}"
   changed_when: true
   when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']

--- a/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
+++ b/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
@@ -31,7 +31,7 @@
 
     - name: Render merged compose config as JSON
       ansible.builtin.command:
-        cmd: "docker compose {{ _upgrade_compose_files | join(' ') }} config --format json"
+        cmd: "{{ compose_command }} {{ _upgrade_compose_files | join(' ') }} config --format json"
         chdir: "{{ instance_path }}"
       register: _upgrade_compose_config
       changed_when: false
@@ -61,7 +61,7 @@
     - name: Get running web container image ID
       ansible.builtin.shell:
         cmd: >-
-          docker compose ps web --format {% raw %}'{{.Image}}'{% endraw %}
+          {{ compose_command }} ps web --format {% raw %}'{{.Image}}'{% endraw %}
         chdir: "{{ instance_path }}"
       register: _running_image
       changed_when: false
@@ -74,9 +74,9 @@
         key: CANASTA_IMAGE
       register: _configured_image
 
-    - name: Pull configured image if not on disk (handles buildable services skipped by docker compose pull)
+    - name: Pull configured image if not on disk (handles buildable services skipped by compose pull)
       ansible.builtin.command:
-        cmd: "docker pull {{ _configured_image.value }}"
+        cmd: "{{ inspect_command }} pull {{ _configured_image.value }}"
       register: _ensure_pull
       changed_when: "'Downloaded newer image' in (_ensure_pull.stdout | default(''))"
       ignore_errors: true
@@ -84,14 +84,14 @@
 
     - name: Get configured image ID
       ansible.builtin.command:
-        cmd: "docker image inspect {{ _configured_image.value }} --format {% raw %}{{.Id}}{% endraw %}"
+        cmd: "{{ inspect_command }} image inspect {{ _configured_image.value }} --format {% raw %}{{.Id}}{% endraw %}"
       register: _configured_id
       changed_when: false
       ignore_errors: true
 
     - name: Get running image ID
       ansible.builtin.command:
-        cmd: "docker image inspect {{ _running_image.stdout | trim }} --format {% raw %}{{.Id}}{% endraw %}"
+        cmd: "{{ inspect_command }} image inspect {{ _running_image.stdout | trim }} --format {% raw %}{{.Id}}{% endraw %}"
       register: _running_id
       changed_when: false
       ignore_errors: true
@@ -112,7 +112,7 @@
 # image when other services updated.
 - name: Rebuild buildable services if image was bumped (Compose)
   ansible.builtin.command:
-    cmd: "docker compose {{ _upgrade_compose_files | join(' ') }} build {{ item }}"
+    cmd: "{{ compose_command }} {{ _upgrade_compose_files | join(' ') }} build {{ item }}"
     chdir: "{{ instance_path }}"
   loop: "{{ _buildable_services | default([]) }}"
   changed_when: true

--- a/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
+++ b/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
@@ -39,7 +39,7 @@
     # volume behind on every instance that never had one.
     - name: Check whether the MySQL data volume exists
       ansible.builtin.command:
-        cmd: "docker volume inspect {{ _mig_volume }}"
+        cmd: "{{ inspect_command }} volume inspect {{ _mig_volume }}"
       register: _mig_volume_check
       changed_when: false
       failed_when: false
@@ -51,7 +51,7 @@
     - name: Detect MySQL 8.0 data on the volume
       ansible.builtin.command:
         cmd: >-
-          docker run --rm -v {{ _mig_volume }}:/data
+          {{ inspect_command }} run --rm -v {{ _mig_volume }}:/data
           alpine test -f /data/mysql.ibd
       register: _mig_detect
       changed_when: false
@@ -102,14 +102,14 @@
           block:
             - name: Remove any stale dump container
               ansible.builtin.command:
-                cmd: "docker rm -f {{ _mig_temp_container }}"
+                cmd: "{{ inspect_command }} rm -f {{ _mig_temp_container }}"
               changed_when: false
               failed_when: false
 
             - name: Start a temporary MySQL 8.0 container for the dump
               ansible.builtin.command:
                 cmd: >-
-                  docker run -d --name {{ _mig_temp_container }}
+                  {{ inspect_command }} run -d --name {{ _mig_temp_container }}
                   -v {{ _mig_volume }}:/var/lib/mysql
                   -e MYSQL_ROOT_PASSWORD={{ _mig_dbpass.value | quote }}
                   mysql:8.0
@@ -119,7 +119,7 @@
             - name: Wait for the temporary MySQL 8.0 server
               ansible.builtin.command:
                 cmd: >-
-                  docker exec -e MYSQL_PWD={{ _mig_dbpass.value | quote }}
+                  {{ inspect_command }} exec -e MYSQL_PWD={{ _mig_dbpass.value | quote }}
                   {{ _mig_temp_container }}
                   mysqladmin ping -h localhost --user=root --wait=60
               changed_when: false
@@ -135,7 +135,7 @@
             - name: Dump user databases from MySQL 8.0
               ansible.builtin.command:
                 cmd: >-
-                  docker exec -e MYSQL_PWD={{ _mig_dbpass.value | quote }}
+                  {{ inspect_command }} exec -e MYSQL_PWD={{ _mig_dbpass.value | quote }}
                   {{ _mig_temp_container }} bash -c
                   {{ _mig_dump_script | quote }}
               vars:
@@ -156,19 +156,19 @@
 
             - name: Copy the dump out of the temporary container
               ansible.builtin.command:
-                cmd: "docker cp {{ _mig_temp_container }}:/tmp/dump.sql {{ _mig_dump_host }}"
+                cmd: "{{ inspect_command }} cp {{ _mig_temp_container }}:/tmp/dump.sql {{ _mig_dump_host }}"
               changed_when: true
 
             - name: Remove the temporary MySQL 8.0 container
               ansible.builtin.command:
-                cmd: "docker rm -f {{ _mig_temp_container }}"
+                cmd: "{{ inspect_command }} rm -f {{ _mig_temp_container }}"
               changed_when: true
 
             # Empty the datadir so MariaDB initializes a fresh one on start.
             - name: Clear the MySQL data volume
               ansible.builtin.command:
                 cmd: >-
-                  docker run --rm -v {{ _mig_volume }}:/data
+                  {{ inspect_command }} run --rm -v {{ _mig_volume }}:/data
                   alpine sh -c 'rm -rf /data/* /data/..?* /data/.[!.]*'
               changed_when: true
 
@@ -194,7 +194,7 @@
 
             - name: Copy the dump into the MariaDB container
               ansible.builtin.command:
-                cmd: "docker compose cp {{ _mig_dump_host }} db:/tmp/dump.sql"
+                cmd: "{{ compose_command }} cp {{ _mig_dump_host }} db:/tmp/dump.sql"
                 chdir: "{{ instance_path }}"
               changed_when: true
 
@@ -239,7 +239,7 @@
           rescue:
             - name: Remove the temporary container after a failed migration
               ansible.builtin.command:
-                cmd: "docker rm -f {{ _mig_temp_container }}"
+                cmd: "{{ inspect_command }} rm -f {{ _mig_temp_container }}"
               changed_when: false
               failed_when: false
 

--- a/tests/unit/test_backup_volume_name_match.py
+++ b/tests/unit/test_backup_volume_name_match.py
@@ -44,7 +44,7 @@ def _removed_volume_name():
     for task in _walk(_tasks("destroy.yml")):
         cmd_mod = task.get("ansible.builtin.command") or task.get("command")
         cmd = cmd_mod.get("cmd", "") if isinstance(cmd_mod, dict) else ""
-        m = re.search(r"docker volume rm\s+(.+)$", cmd)
+        m = re.search(r"\{\{ inspect_command \}\} volume rm\s+(.+)$", cmd)
         if m:
             return m.group(1).strip()
     raise AssertionError("no `docker volume rm` command found in destroy.yml")

--- a/tests/unit/test_build_ansible_args_env_fallback.py
+++ b/tests/unit/test_build_ansible_args_env_fallback.py
@@ -1,0 +1,94 @@
+"""build_ansible_args' .env fallback must actually execute.
+
+Nothing else in the suite calls this function, so a NameError there —
+an unimported helper, say — passes every unit test, every linter and
+CodeQL, then crashes every Ansible-dispatched command against a
+registered instance. The narrow `except (OSError, IOError, KeyError)`
+around the block does not catch that class of error, so it is fatal
+rather than silently swallowed.
+
+These run the real function against a temporary registry.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+sys.path.insert(0, REPO_ROOT)
+
+import canasta  # noqa: E402
+
+
+@pytest.fixture
+def registry(tmp_path, monkeypatch):
+    """A config dir holding one local Compose instance."""
+    cfg = tmp_path / "cfg"
+    inst = tmp_path / "inst"
+    cfg.mkdir()
+    inst.mkdir()
+    (cfg / "conf.json").write_text(json.dumps({
+        "Instances": {
+            "demo": {
+                "path": str(inst),
+                "orchestrator": "compose",
+                "host": "localhost",
+            },
+        },
+    }))
+    monkeypatch.setenv("CANASTA_CONFIG_DIR", str(cfg))
+    return inst
+
+
+def _args(**kw):
+    class _A:
+        # Unset flags read as None rather than raising.
+        def __getattr__(self, name):
+            return None
+    a = _A()
+    a.verbose = False
+    for k, v in kw.items():
+        setattr(a, k, v)
+    return a
+
+
+def _definitions():
+    with open(os.path.join(REPO_ROOT, "meta", "command_definitions.yml")) as f:
+        return yaml.safe_load(f)
+
+
+def _extra_vars(argv):
+    """Read back the -e @file payload build_ansible_args wrote."""
+    path = argv[argv.index("-e") + 1].lstrip("@")
+    with open(path) as f:
+        return json.load(f)
+
+
+class TestEnvFallbackExecutes:
+    def test_runs_without_error(self, registry):
+        # The regression: an unimported helper raises NameError here,
+        # which the except clause does not catch.
+        argv = canasta.build_ansible_args(
+            "ansible-playbook", "reconcile", _args(id="demo"), _definitions())
+        assert argv
+
+    def test_reads_compose_command_from_env(self, registry):
+        (registry / ".env").write_text("compose_command=podman-compose\n")
+        argv = canasta.build_ansible_args(
+            "ansible-playbook", "reconcile", _args(id="demo"), _definitions())
+        assert _extra_vars(argv)["compose_command"] == "podman-compose"
+
+    def test_defaults_to_docker_without_an_override(self, registry):
+        argv = canasta.build_ansible_args(
+            "ansible-playbook", "reconcile", _args(id="demo"), _definitions())
+        assert _extra_vars(argv)["compose_command"] == "docker compose"
+
+    def test_missing_env_file_is_not_fatal(self, registry):
+        # No .env at all: the fallback must degrade to the default.
+        argv = canasta.build_ansible_args(
+            "ansible-playbook", "reconcile", _args(id="demo"), _definitions())
+        assert _extra_vars(argv)["inspect_command"] == "docker"

--- a/tests/unit/test_build_from_build_args.py
+++ b/tests/unit/test_build_from_build_args.py
@@ -32,6 +32,9 @@ def _text(path):
         return f.read()
 
 
+I = "{{ inspect_command | default('docker') }}"
+
+
 def test_create_exposes_repeatable_build_arg():
     with open(CMD_DEFS) as f:
         defs = yaml.safe_load(f)
@@ -48,13 +51,15 @@ def test_build_from_validates_key_value():
 
 def test_build_args_forwarded_to_canasta_base_build():
     txt = _text(BUILD_FROM)
-    assert "docker build {{ _build_arg_flags }} -t canasta-base:local" in txt
+    assert "%s build {{ _build_arg_flags }} -t canasta-base:local" % I in txt
 
 
 def test_build_args_forwarded_to_canasta_build_after_base_image():
     # user args come AFTER --build-arg BASE_IMAGE so a user BASE_IMAGE wins
     # (docker uses the last value for a repeated key).
-    txt = _text(BUILD_FROM)
+    # Whitespace-normalized: the cmd is a folded scalar, so the argument
+    # order is what matters, not how the line happens to wrap.
+    txt = " ".join(_text(BUILD_FROM).split())
     assert ("--build-arg BASE_IMAGE={{ _base_image_arg }} "
             "{{ _build_arg_flags }} -t canasta:local") in txt
 

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -1200,6 +1200,15 @@ class TestCrowdsecResolveCscli:
         content = self._content()
         assert "{{ compose_command }} exec -T crowdsec" in content
 
+    def test_compose_argv_splits_the_compose_command(self):
+        # _cscli_argv is consumed by `command:` with argv:, which execs
+        # directly without a shell. compose_command defaults to the
+        # two-word "docker compose", so embedding it as a single list
+        # element would look for a binary of that literal name.
+        content = self._content()
+        assert "compose_command.split()" in content
+        assert "['{{ compose_command }}'," not in content
+
     def test_k8s_prefix_targets_the_sidecar_container(self):
         # kubectl exec into the caddy pod, selecting the crowdsec sidecar.
         content = self._content()

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -1177,7 +1177,7 @@ class TestCrowdsecRestartEngine:
 
     def test_compose_restarts_only_the_service(self):
         content = self._content()
-        assert "docker compose restart crowdsec" in content
+        assert "{{ compose_command }} restart crowdsec" in content
 
     def test_k8s_rolls_the_caddy_deployment(self):
         # The engine is a sidecar in the caddy pod, so the K8s equivalent is a
@@ -1198,7 +1198,7 @@ class TestCrowdsecResolveCscli:
 
     def test_compose_prefix(self):
         content = self._content()
-        assert "docker compose exec -T crowdsec" in content
+        assert "{{ compose_command }} exec -T crowdsec" in content
 
     def test_k8s_prefix_targets_the_sidecar_container(self):
         # kubectl exec into the caddy pod, selecting the crowdsec sidecar.

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -3592,7 +3592,7 @@ class TestCanastaStatus:
             },
         )
         monkeypatch.setattr(direct_commands._helpers, "_check_running_compose",
-            lambda p, h: False,
+            lambda p, h, *a, **kw: False,
         )
         captured = {}
 
@@ -3620,7 +3620,8 @@ class TestCanastaStatus:
                 },
             },
         )
-        monkeypatch.setattr(direct_commands._helpers, "_check_running_compose", lambda p, h: True)
+        monkeypatch.setattr(direct_commands._helpers, "_check_running_compose",
+                            lambda p, h, *a, **kw: True)
         monkeypatch.setattr(
             subprocess, "run",
             lambda *a, **k: type("R", (), {"returncode": 0, "stdout": ""})(),

--- a/tests/unit/test_doctor_consistency.py
+++ b/tests/unit/test_doctor_consistency.py
@@ -161,7 +161,7 @@ class TestInstanceConsistencyLines:
                                "COMPOSE_PROFILES=varnish\n")
         monkeypatch.setattr(
             doctor, "_gather_runtime",
-            lambda path, host: (["web", "varnish", "db"], True, {}))
+            lambda path, host, inst=None: (["web", "varnish", "db"], True, {}))
         lines = doctor._instance_consistency_lines(inst)
         assert lines[1] == "Instance consistency (site):"
         body = " ".join(lines)
@@ -179,7 +179,7 @@ class TestInstanceConsistencyLines:
                                "COMPOSE_PROFILES=internal-db,varnish,crowdsec\n")
         monkeypatch.setattr(
             doctor, "_gather_runtime",
-            lambda path, host: (["web", "varnish", "crowdsec", "db"], False, {}))
+            lambda path, host, inst=None: (["web", "varnish", "crowdsec", "db"], False, {}))
         lines = doctor._instance_consistency_lines(inst)
         assert any("OK (" in line for line in lines)
 
@@ -193,7 +193,7 @@ class TestInstanceConsistencyLines:
                                "CANASTA_IMAGE=ghcr.io/canastawiki/canasta:3.5.12\n")
         monkeypatch.setattr(
             doctor, "_gather_runtime",
-            lambda path, host: (["web", "varnish", "db"], False,
+            lambda path, host, inst=None: (["web", "varnish", "db"], False,
                                 {"CANASTA_IMAGE":
                                  "ghcr.io/canastawiki/canasta:3.5.1"}))
         body = " ".join(doctor._instance_consistency_lines(inst))
@@ -213,7 +213,7 @@ class TestInstanceConsistencyLines:
                                "HTTP_PORT=8090\n")
         monkeypatch.setattr(
             doctor, "_gather_runtime",
-            lambda path, host: (["web", "db"], False, {"HTTP_PORT": "80"}))
+            lambda path, host, inst=None: (["web", "db"], False, {"HTTP_PORT": "80"}))
         body = " ".join(doctor._instance_consistency_lines(inst))
         assert "env.template disagrees with .env" in body
         assert "canasta reconcile" in body

--- a/tests/unit/test_exec_path_parity.py
+++ b/tests/unit/test_exec_path_parity.py
@@ -162,7 +162,7 @@ class TestStdinFlagParity:
             id="x", service="web", exec_args=["php"], stdin_file="/tmp/p.txt"))
         assert "-T" in captured["argv"]
         # Ansible compose build is always non-interactive (-T).
-        assert "docker compose exec -T" in EXEC_YML
+        assert "{{ compose_command }} exec -T" in EXEC_YML
 
 
 def _python_exec_argv(monkeypatch, service, exec_args, orchestrator="compose"):

--- a/tests/unit/test_image_push_build_args.py
+++ b/tests/unit/test_image_push_build_args.py
@@ -23,6 +23,9 @@ def _text(path):
         return f.read()
 
 
+I = "{{ inspect_command | default('docker') }}"
+
+
 def test_image_push_exposes_repeatable_build_arg():
     with open(CMD_DEFS) as f:
         defs = yaml.safe_load(f)
@@ -39,5 +42,5 @@ def test_playbook_validates_key_value():
 
 def test_build_args_forwarded_to_the_build_before_the_context():
     txt = _text(PLAYBOOK)
-    assert "docker build -t localhost:5000/{{ _img_ref }}" in txt
+    assert "%s build -t localhost:5000/{{ _img_ref }}" % I in txt
     assert "{{ _img_build_arg_flags }} {{ context | quote }}" in txt

--- a/tests/unit/test_mysql_to_mariadb_migration.py
+++ b/tests/unit/test_mysql_to_mariadb_migration.py
@@ -117,7 +117,7 @@ class TestDetectionMarker:
             None,
         )
         assert detect is not None, "detection must be a `test -f` on the volume"
-        assert "docker run" in detect and "-v" in detect, (
+        assert "{{ inspect_command }} run" in detect and "-v" in detect, (
             "detection must read the data volume from a throwaway container so "
             "it works even when the DB container is not running"
         )
@@ -133,7 +133,7 @@ class TestDumpFromDedicatedContainer:
 
     def test_temp_container_is_always_removed(self):
         # It must be torn down on both the happy path and the failure path.
-        removals = [c for c in _command_strings() if "docker rm -f" in c]
+        removals = [c for c in _command_strings() if "{{ inspect_command }} rm -f" in c]
         assert len(removals) >= 2, (
             "the temporary container must be removed on success and cleaned up "
             "again in the rescue path"
@@ -225,7 +225,7 @@ class TestVolumeExistenceCheck:
 
     def test_existence_check_uses_volume_inspect(self):
         assert any(
-            "docker volume inspect" in c for c in _command_strings()
+            "{{ inspect_command }} volume inspect" in c for c in _command_strings()
         ), "existence must be checked with docker volume inspect, not a run"
 
     def test_detection_skipped_when_volume_missing(self):

--- a/tests/unit/test_runtime_parameterization_complete.py
+++ b/tests/unit/test_runtime_parameterization_complete.py
@@ -1,0 +1,152 @@
+"""No executed command may hardcode the container runtime.
+
+compose_command / inspect_command exist so an instance can run under a
+different runtime. A single missed call site silently reverts to Docker
+for that one operation, which stays invisible until someone runs that
+command on a Podman host — and the Python fast path and the Ansible
+roles can drift apart from each other without anyone noticing.
+
+Only *executed* values are checked: Ansible `cmd:` / `argv:` / `*_cmd`
+facts, and command lists in Python. Task names, `msg:` text, comments
+and docstrings are prose and may say "docker compose" freely.
+"""
+
+import os
+import re
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+
+_SCANNED = ("canasta.py", "direct_commands", "playbooks", "roles")
+
+_SUBCOMMANDS = (r"compose\b|ps\b|inspect\b|volume\b|run\b|pull\b|rm\b|"
+                r"cp\b|exec\b|image\b|build\b|tag\b|push\b|create\b|"
+                r"start\b|login\b")
+
+# Strict: anchored so prose ("before `docker compose up`") does not match.
+# Values reaching it are whole command strings, so ^ is the common case.
+_RUNTIME = re.compile(
+    r"(?:^|[;&|]\s*|\$\(\s*)docker\s+"
+    r"(?:" + _SUBCOMMANDS + r")")
+
+# Loose: only for the staleness check, which asks whether an allowlisted
+# file still names a runtime anywhere — quoting and indentation vary.
+_MENTIONS = re.compile(r"\bdocker\s+(?:" + _SUBCOMMANDS + r")")
+_PY_LIST = re.compile(r"""\[\s*["']docker["']\s*,""")
+# A shell command in a string literal: the quote is immediately
+# followed by the runtime, which prose never is.
+_PY_CMD = re.compile(r"""["']docker\s+(?:""" + _SUBCOMMANDS + r""")""")
+
+# Keys whose values are executed.
+_CMD_KEYS = re.compile(r"(?:^|_)(?:cmd|argv)$")
+
+# path -> why this file legitimately names Docker.
+ALLOW = {
+    "roles/install/tasks/docker.yml":
+        "installs and verifies Docker itself",
+    "direct_commands/doctor.py":
+        "probes for Docker by name and reports the result",
+    "direct_commands/_helpers.py":
+        "defines the ['docker', 'compose'] default the overrides fall back to",
+    # Converted in the follow-up that reworks container-state queries;
+    # keeping them here would mean changing the same lines twice.
+    "roles/orchestrator/tasks/check_running.yml":
+        "container-state query, parameterized in the follow-up PR",
+    "roles/orchestrator/tasks/list_running_services.yml":
+        "container-state query, parameterized in the follow-up PR",
+    "roles/crowdsec/tasks/_preflight.yml":
+        "container-state query, parameterized in the follow-up PR",
+}
+
+
+def _templated(text):
+    return "compose_command" in text or "inspect_command" in text
+
+
+def _walk_yaml(node, hits, rel, key=None):
+    if isinstance(node, dict):
+        for k, v in node.items():
+            _walk_yaml(v, hits, rel, k)
+    elif isinstance(node, list):
+        for item in node:
+            _walk_yaml(item, hits, rel, key)
+    elif isinstance(node, str):
+        if key and _CMD_KEYS.search(str(key)) and not _templated(node):
+            if _RUNTIME.search(node):
+                hits.append((rel, str(key), node.strip().split("\n")[0][:80]))
+
+
+def _scan_yaml(rel, full):
+    hits = []
+    try:
+        with open(full) as f:
+            docs = list(yaml.safe_load_all(f))
+    except Exception:
+        return hits
+    for doc in docs:
+        _walk_yaml(doc, hits, rel)
+    return hits
+
+
+def _scan_python(rel, full):
+    hits = []
+    with open(full) as f:
+        for lineno, line in enumerate(f, 1):
+            stripped = line.strip()
+            if stripped.startswith("#") or _templated(line):
+                continue
+            # Message text, not an executed command.
+            if "print(" in line or "Error:" in line:
+                continue
+            if (_PY_LIST.search(line) or _PY_CMD.search(line)
+                    or _RUNTIME.search(line)):
+                hits.append((rel, str(lineno), stripped[:80]))
+    return hits
+
+
+def _iter_source():
+    for entry in _SCANNED:
+        target = os.path.join(REPO_ROOT, entry)
+        if os.path.isfile(target):
+            yield os.path.relpath(target, REPO_ROOT), target
+            continue
+        for root, _dirs, files in os.walk(target):
+            for name in sorted(files):
+                if name.endswith((".py", ".yml", ".yaml")):
+                    full = os.path.join(root, name)
+                    yield os.path.relpath(full, REPO_ROOT), full
+
+
+def _hardcoded_sites():
+    hits = []
+    for rel, full in _iter_source():
+        if rel in ALLOW:
+            continue
+        if rel.endswith((".yml", ".yaml")):
+            hits += _scan_yaml(rel, full)
+        else:
+            hits += _scan_python(rel, full)
+    return hits
+
+
+def test_no_executed_command_hardcodes_the_runtime():
+    hits = _hardcoded_sites()
+    assert not hits, (
+        "these executed commands hardcode the container runtime — use "
+        "compose_command / inspect_command, or add the file to ALLOW with "
+        "a reason:\n" + "\n".join("  %s [%s]  %s" % h for h in hits)
+    )
+
+
+def test_allowlist_entries_are_not_stale():
+    for rel in ALLOW:
+        full = os.path.join(REPO_ROOT, rel)
+        assert os.path.exists(full), "ALLOW names a missing file: %s" % rel
+        with open(full) as f:
+            content = f.read()
+        assert _MENTIONS.search(content) or _PY_LIST.search(content), (
+            "%s is allowlisted but no longer names a runtime — drop the "
+            "ALLOW entry" % rel
+        )

--- a/tests/unit/test_sidecar_render_wiring.py
+++ b/tests/unit/test_sidecar_render_wiring.py
@@ -24,6 +24,9 @@ def _text(path):
         return handle.read()
 
 
+I = "{{ inspect_command | default('docker') }}"
+
+
 def test_start_renders_sidecars_for_both_orchestrators():
     body = _text(START)
     assert "canasta_render_sidecars" in body
@@ -77,7 +80,7 @@ def test_build_task_pushes_to_in_cluster_registry():
                         "k8s_build_sidecars.yml")
     body = _text(path)
     assert "k8s_ensure_registry.yml" in body
-    assert "docker build" in body and "docker push" in body
+    assert "%s build" % I in body and "%s push" % I in body
     assert "localhost:5000/canasta-{{ instance_id }}-{{ item.name }}:local" in body
 
 


### PR DESCRIPTION
Part of #1139 and #1118. Part 2 of 5 splitting #1122 (which stays open as the tracking PR).

**Based on #1223** — review that first; this PR's diff is only meaningful on top of it.

Refactor authored by @hexmode; split out of #1122.

## What

Replaces the hardcoded `docker compose` and `docker` invocations with `compose_command` / `inspect_command` across the Ansible roles and the Python `direct_commands` fast path. Both default to Docker, so **this PR is intended to be a no-op for existing installs**.

Values resolve from the instance's registry entry (new `composeCommand` / `inspectCommand` fields), falling back to the instance `.env`.

This is the piece that closes the gap raised in review on #1122: `canasta start`/`stop`/`restart` for sidecar-less Compose instances run `_helpers._run_compose`, not Ansible, so parameterizing only the Ansible side would have left the runtime override inert on the path most users hit.

## One fix on top of the split

`fix(crowdsec): split compose_command when building the cscli argv` is not @hexmode's work — it is a fix for a regression the split surfaced, committed separately.

`_cscli_argv` is consumed by `command:` with `argv:`, which execs directly without a shell. Building it as `['{{ compose_command }}', 'exec', ...]` yields a single element `"docker compose"`, so every crowdsec subcommand (`ban`, `unban`, `alerts`, `reload`, `console enroll`) would look for a binary of that literal name — on plain Docker, not just Podman. Fixed with `compose_command.split()`, plus a regression test, since the existing test asserted only on the string prefix form and stayed green.

## Design note: the extra_vars shim

`canasta.py` unconditionally injects `compose_command` / `inspect_command` into `extra_vars`. That is not a convenience default — it is load-bearing, and worth understanding before review.

`roles/orchestrator/defaults/main.yml` declares both, but role defaults are scoped to their role, and `canasta.yml` has no `roles:` block — it dispatches per command via `include_tasks` / `include_role`. Three roles reference the variables from outside orchestrator's scope with no `| default(...)`:

| File | Bare references |
|---|---|
| `roles/upgrade/tasks/migrations/mysql_to_mariadb.yml` | 11 |
| `roles/devmode/tasks/enable.yml` | 6 |
| `roles/crowdsec/tasks/_resolve_cscli.yml` | 2 |
| `roles/crowdsec/tasks/_restart_engine.yml` | 1 |

Remove the injection and those 20 references become undefined-variable errors, taking out `canasta crowdsec ban`, `canasta devmode enable`, and the MySQL to MariaDB migration. The injection here is unconditional, so local and `--host` runs are both covered.

**The cost** is that extra-vars sit at the top of Ansible's precedence ladder (role defaults < `include_vars` < `set_fact` < extra-vars), so nothing lower can override them. That is inert in this PR, since the value is always the Docker default, but it constrains what #1226 can do — see the discussion there.

**Suggested follow-up, not folded in here:** `canasta.yml`'s `pre_tasks` already solves this exact problem twice, for `vars/secret_classification.yml` and `vars/tool_versions.yml`, with a comment naming the reason ("roles/*/defaults are role-scoped"). A `vars/compose_runtime.yml` loaded the same way would sit above role defaults but below `set_fact` and extra-vars — resolving all 20 references while still letting a runtime probe or an explicit `-e` win. That would replace the Python shim rather than patch it, and it deserves its own review.
