### PR TITLE
fix: query container state via the runtime's ps with compose labels

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -969,6 +969,19 @@ def _unquote(value):
     return value
 
 
+def _compose_project(path):
+    """The compose project name for an instance directory.
+
+    Compose derives it from the directory basename, lowercased — and
+    rejects uppercase outright, so the lowering is not optional. The
+    CLI creates instance directories named after the instance id, whose
+    other permitted characters are already valid to compose.
+    """
+    if not path:
+        return ""
+    return os.path.basename(os.path.abspath(path)).lower()
+
+
 def _resolve_compose_cmd(inst):
     """Resolve the compose command for an instance.
 
@@ -1067,7 +1080,17 @@ def _check_running(instance_id, path, orchestrator, host, docker_host=None,
 def _check_running_compose(path, host, docker_host=None, compose_cmd=None):
     if compose_cmd is None:
         compose_cmd = ["docker", "compose"]
-    ps_cmd = compose_cmd + ["ps", "-q", "web"]
+    # podman-compose's `ps` takes no service argument, so query the
+    # native runtime by label instead. `ps` is a daemon-level call —
+    # cwd does not scope it — so the project filter is what keeps this
+    # from matching another instance's web container.
+    runtime = "podman" if "podman" in compose_cmd[0] else "docker"
+    ps_cmd = [
+        runtime, "ps",
+        "--filter", "label=com.docker.compose.project=%s" % _compose_project(path),
+        "--filter", "label=com.docker.compose.service=web",
+        "--format", "{{.ID}}",
+    ]
     if _is_localhost(host):
         try:
             result = subprocess.run(
@@ -1283,9 +1306,12 @@ def _gather_instance_info(inst_id, inst):
         return _gather_k8s(inst_id, path, host)
 
     compose_str = " ".join(compose_cmd)
-    compose_ps = "cd %(p)s && %(c)s ps -q web 2>/dev/null || true" % {
-        "p": qpath, "c": compose_str,
-    }
+    runtime = "podman" if "podman" in compose_cmd[0] else "docker"
+    compose_ps = (
+        "%(r)s ps --filter label=com.docker.compose.project=%(proj)s "
+        "--filter label=com.docker.compose.service=web "
+        "--format '{{.ID}}' 2>/dev/null || true"
+    ) % {"r": runtime, "proj": _shell_quote(_compose_project(path))}
     if docker_host:
         compose_ps = "DOCKER_HOST=%s %s" % (_shell_quote(docker_host), compose_ps)
     script = (

--- a/roles/crowdsec/tasks/_preflight.yml
+++ b/roles/crowdsec/tasks/_preflight.yml
@@ -18,8 +18,12 @@
   when: instance_orchestrator | default('compose') == 'compose'
   block:
     - name: List running services
-      ansible.builtin.command:
-        cmd: "docker compose ps --services --filter status=running"
+      ansible.builtin.shell:
+        cmd: >-
+          {{ inspect_command | default('docker') }}
+          ps --filter status=running
+          --filter label=com.docker.compose.project
+          --format {% raw %}{{.Label "com.docker.compose.service"}}{% endraw %}
         chdir: "{{ instance_path }}"
       register: _crowdsec_running
       changed_when: false

--- a/roles/crowdsec/tasks/_preflight.yml
+++ b/roles/crowdsec/tasks/_preflight.yml
@@ -22,7 +22,7 @@
         cmd: >-
           {{ inspect_command | default('docker') }}
           ps --filter status=running
-          --filter label=com.docker.compose.project
+          --filter label=com.docker.compose.project={{ instance_path | basename | lower }}
           --format {% raw %}{{.Label "com.docker.compose.service"}}{% endraw %}
         chdir: "{{ instance_path }}"
       register: _crowdsec_running

--- a/roles/orchestrator/tasks/check_running.yml
+++ b/roles/orchestrator/tasks/check_running.yml
@@ -5,7 +5,10 @@
 
 - name: Build check command for orchestrator
   ansible.builtin.set_fact:
-    _check_cmd: "docker compose ps -q web"
+    _check_cmd: >-
+      {{ inspect_command | default('docker') }}
+      ps --filter label=com.docker.compose.service=web
+      --format {% raw %}{{.ID}}{% endraw %}
     _check_chdir: "{{ instance_path }}"
   when: instance_orchestrator | default('compose') == 'compose'
 

--- a/roles/orchestrator/tasks/check_running.yml
+++ b/roles/orchestrator/tasks/check_running.yml
@@ -7,7 +7,8 @@
   ansible.builtin.set_fact:
     _check_cmd: >-
       {{ inspect_command | default('docker') }}
-      ps --filter label=com.docker.compose.service=web
+      ps --filter label=com.docker.compose.project={{ instance_path | basename | lower }}
+      --filter label=com.docker.compose.service=web
       --format {% raw %}{{.ID}}{% endraw %}
     _check_chdir: "{{ instance_path }}"
   when: instance_orchestrator | default('compose') == 'compose'

--- a/roles/orchestrator/tasks/list_running_services.yml
+++ b/roles/orchestrator/tasks/list_running_services.yml
@@ -5,8 +5,12 @@
 # Output: _running_services (newline-separated names, may be empty)
 
 - name: Get service list (Compose)
-  ansible.builtin.command:
-    cmd: "docker compose ps --services --filter status=running"
+  ansible.builtin.shell:
+    cmd: >-
+      {{ inspect_command | default('docker') }}
+      ps --filter status=running
+      --filter label=com.docker.compose.project
+      --format {% raw %}{{.Label "com.docker.compose.service"}}{% endraw %}
     chdir: "{{ instance_path }}"
   register: _list_services_compose
   changed_when: false

--- a/roles/orchestrator/tasks/list_running_services.yml
+++ b/roles/orchestrator/tasks/list_running_services.yml
@@ -9,7 +9,7 @@
     cmd: >-
       {{ inspect_command | default('docker') }}
       ps --filter status=running
-      --filter label=com.docker.compose.project
+      --filter label=com.docker.compose.project={{ instance_path | basename | lower }}
       --format {% raw %}{{.Label "com.docker.compose.service"}}{% endraw %}
     chdir: "{{ instance_path }}"
   register: _list_services_compose

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -121,7 +121,7 @@
     # gracefully in that case.
     - name: Get web container id
       ansible.builtin.command:
-        cmd: "{{ _compose_cmd }} {{ _compose_files | join(' ') }} ps -q web"
+        cmd: "{{ _inspect_cmd }} ps --filter label=com.docker.compose.service=web --format {% raw %}{{.ID}}{% endraw %}"
         chdir: "{{ instance_path }}"
       register: _start_web_cid
       changed_when: false

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -121,7 +121,11 @@
     # gracefully in that case.
     - name: Get web container id
       ansible.builtin.command:
-        cmd: "{{ _inspect_cmd }} ps --filter label=com.docker.compose.service=web --format {% raw %}{{.ID}}{% endraw %}"
+        cmd: >-
+          {{ _inspect_cmd }} ps
+          --filter label=com.docker.compose.project={{ instance_path | basename | lower }}
+          --filter label=com.docker.compose.service=web
+          --format {% raw %}{{.ID}}{% endraw %}
         chdir: "{{ instance_path }}"
       register: _start_web_cid
       changed_when: false

--- a/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
+++ b/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
@@ -61,7 +61,9 @@
     - name: Get running web container image ID
       ansible.builtin.shell:
         cmd: >-
-          {{ compose_command }} ps web --format {% raw %}'{{.Image}}'{% endraw %}
+          {{ inspect_command | default('docker') }}
+          ps --filter label=com.docker.compose.service=web
+          --format {% raw %}'{{.Image}}'{% endraw %}
         chdir: "{{ instance_path }}"
       register: _running_image
       changed_when: false

--- a/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
+++ b/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
@@ -62,7 +62,8 @@
       ansible.builtin.shell:
         cmd: >-
           {{ inspect_command | default('docker') }}
-          ps --filter label=com.docker.compose.service=web
+          ps --filter label=com.docker.compose.project={{ instance_path | basename | lower }}
+          --filter label=com.docker.compose.service=web
           --format {% raw %}'{{.Image}}'{% endraw %}
         chdir: "{{ instance_path }}"
       register: _running_image

--- a/tests/unit/test_container_state_project_scoped.py
+++ b/tests/unit/test_container_state_project_scoped.py
@@ -1,0 +1,114 @@
+"""Container-state queries must be scoped to one compose project.
+
+`compose ps` is scoped by the directory it runs in. Its replacement,
+`docker ps --filter label=...`, is a daemon-level query — cwd and
+Ansible's `chdir` have no effect on it — so filtering only by
+`com.docker.compose.service=web` matches that service in *every*
+compose project on the host.
+
+Multiple instances per host is a supported configuration, so without a
+project filter `canasta list` reports stopped instances as RUNNING, and
+start.yml's health gate can wait on a container belonging to a
+different wiki.
+
+The project name is the instance directory's basename, lowercased.
+Both runtimes agree: Docker Compose lowercases the derived name and
+rejects uppercase outright; podman-compose 1.6.0 does
+`project_name = dir_basename.lower()` then strips anything outside
+`[-_a-z0-9]` (podman_compose.py:2607, norm_re at :109). Every character
+a Canasta instance id permits survives that.
+"""
+
+import os
+import re
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+
+_SERVICE_FILTER = "label=com.docker.compose.service"
+_PROJECT_FILTER = "label=com.docker.compose.project"
+
+# Every file that queries container state by label.
+_QUERY_FILES = (
+    "roles/crowdsec/tasks/_preflight.yml",
+    "roles/orchestrator/tasks/check_running.yml",
+    "roles/orchestrator/tasks/list_running_services.yml",
+    "roles/orchestrator/tasks/start.yml",
+    "roles/orchestrator/tasks/upgrade_rebuild_buildable.yml",
+)
+
+
+def _read(rel):
+    with open(os.path.join(REPO_ROOT, rel)) as f:
+        return f.read()
+
+
+def _tasks_using_labels(content):
+    """Command bodies that filter on a compose label, one per match."""
+    return [
+        block for block in re.split(r"\n\s*-\s+name:", content)
+        if _SERVICE_FILTER in block or _PROJECT_FILTER in block
+    ]
+
+
+class TestAnsibleQueriesAreScoped:
+    def test_every_label_query_carries_a_project_filter(self):
+        unscoped = []
+        for rel in _QUERY_FILES:
+            for block in _tasks_using_labels(_read(rel)):
+                if _PROJECT_FILTER not in block:
+                    unscoped.append(rel)
+        assert not unscoped, (
+            "these label queries are not scoped to a project, so they "
+            "match every compose project on the host: %s" % sorted(set(unscoped))
+        )
+
+    def test_project_is_the_lowercased_instance_dir(self):
+        for rel in _QUERY_FILES:
+            content = _read(rel)
+            for block in _tasks_using_labels(content):
+                m = re.search(
+                    re.escape(_PROJECT_FILTER) + r"=\{\{([^}]+)\}\}", block)
+                assert m, "%s: project filter has no Jinja value" % rel
+                expr = m.group(1)
+                assert "basename" in expr and "lower" in expr, (
+                    "%s: project must be the instance dir basename, "
+                    "lowercased — got %r" % (rel, expr.strip())
+                )
+
+    def test_no_bare_project_existence_filter(self):
+        # `--filter label=com.docker.compose.project` with no value
+        # matches anything compose created, which is the bug.
+        for rel in _QUERY_FILES:
+            for line in _read(rel).split("\n"):
+                if _PROJECT_FILTER in line:
+                    assert (_PROJECT_FILTER + "=") in line, (
+                        "%s: bare project filter matches all projects: %s"
+                        % (rel, line.strip())
+                    )
+
+
+class TestPythonQueriesAreScoped:
+    def _helpers(self):
+        return _read("direct_commands/_helpers.py")
+
+    def test_label_queries_include_the_project(self):
+        content = self._helpers()
+        service_hits = content.count(_SERVICE_FILTER)
+        project_hits = content.count(_PROJECT_FILTER)
+        assert service_hits > 0, "no label query found"
+        assert project_hits >= service_hits, (
+            "%d service-label queries but only %d project filters"
+            % (service_hits, project_hits)
+        )
+
+    def test_project_helper_lowercases_the_basename(self):
+        import sys
+        sys.path.insert(0, REPO_ROOT)
+        from direct_commands._helpers import _compose_project
+        assert _compose_project("/srv/instances/MyWiki") == "mywiki"
+        assert _compose_project("/srv/instances/dev") == "dev"
+        assert _compose_project("/a/My-Wiki_1") == "my-wiki_1"
+        # Trailing slash must not yield an empty project.
+        assert _compose_project("/srv/instances/dev/") == "dev"
+        assert _compose_project("") == ""

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -580,7 +580,7 @@ class TestCrowdsecEnrollRole:
         assert "not in ['compose']" not in preflight, (
             "the Compose-only refusal must be gone — K8s is supported"
         )
-        assert "docker compose ps" in preflight
+        assert "{{ inspect_command | default('docker') }}" in preflight
         assert "kubectl get pods" in preflight
         assert "crowdsec=true" in preflight
 

--- a/tests/unit/test_runtime_parameterization_complete.py
+++ b/tests/unit/test_runtime_parameterization_complete.py
@@ -50,14 +50,6 @@ ALLOW = {
         "probes for Docker by name and reports the result",
     "direct_commands/_helpers.py":
         "defines the ['docker', 'compose'] default the overrides fall back to",
-    # Converted in the follow-up that reworks container-state queries;
-    # keeping them here would mean changing the same lines twice.
-    "roles/orchestrator/tasks/check_running.yml":
-        "container-state query, parameterized in the follow-up PR",
-    "roles/orchestrator/tasks/list_running_services.yml":
-        "container-state query, parameterized in the follow-up PR",
-    "roles/crowdsec/tasks/_preflight.yml":
-        "container-state query, parameterized in the follow-up PR",
 }
 
 


### PR DESCRIPTION
Addresses #1222. Part 3 of 5 splitting #1122 (which stays open as the tracking PR).

**Based on #1224** — review that first.

Authored by @hexmode; split out of #1122 **unchanged**, which means the project-scoping problem described in #1222 is still present in this branch. It is isolated here precisely so it can be fixed or reverted without touching the rest of the Podman work.

## What

`podman-compose ps` does not accept a service name as a positional argument, so `compose ps -q web`, `compose ps --services --filter status=running`, and `compose ps web --format` have no podman-compose equivalent. This queries the native runtime instead and selects by the `com.docker.compose.service` label.

## Blocking before merge: this is not project-scoped

`docker ps` is a daemon-level query — `chdir` / `cwd` does not scope it — so `--filter label=com.docker.compose.service=web` matches that service in **every** compose project on the host. Verified by running it from an unrelated directory and getting another instance's container back.

On a host with two or more instances:

- `canasta list` reports stopped instances as RUNNING once any one instance is up
- `start.yml`'s `_start_web_cid` goes multi-line and is passed as a single argv element to `inspect -f`, so the health gate inspects a foreign container or spins the full 60 × 10s
- `canasta upgrade` compares against whichever instance `docker ps` lists first
- `list_running_services` and the crowdsec preflight report another instance's services

Options are written up in #1222. The cheapest is to keep `compose ps` on the Docker path and use the label form only for Podman — but that still needs a project predicate on the Podman path.

## Also needs confirming

`{{.Label "com.docker.compose.service"}}` is used in `list_running_services.yml` and `crowdsec/_preflight.yml`. Podman's `ps` template context exposes `Labels` as a map; which Podman version was the Docker-compat `.Label` *function* validated against?