### PR TITLE
feat: detect Podman as the container runtime

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -82,11 +82,30 @@ if [[ -f "$PINNED_TAG_FILE" ]]; then
 fi
 IMAGE="${CANASTA_CLI_IMAGE:-${CANASTA_ANSIBLE_IMAGE:-ghcr.io/canastawiki/canasta-ansible:$DEFAULT_TAG}}"
 
+# Choose container engine: prefer docker if available, fall back to podman.
+if command -v docker &>/dev/null; then
+    CONTAINER_ENGINE=docker
+elif command -v podman &>/dev/null; then
+    CONTAINER_ENGINE=podman
+else
+    echo "Error: neither docker nor podman found on PATH. Install one and try again." >&2
+    exit 1
+fi
+
 # Base mounts: Docker socket + registry + current directory + $HOME.
 # The container runs as the invoking user's UID/GID so that any files
 # written to mounted paths end up owned by the host user, not root.
 if [[ "${DOCKER_HOST:-}" == unix://* ]]; then
     DOCKER_SOCK_PATH="${DOCKER_HOST#unix://}"
+elif [[ "$CONTAINER_ENGINE" == "podman" ]]; then
+    runtime="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+    if [[ -S "$runtime/podman/podman.sock" ]]; then
+        DOCKER_SOCK_PATH="$runtime/podman/podman.sock"
+    elif [[ -S "/run/podman/podman.sock" ]]; then
+        DOCKER_SOCK_PATH="/run/podman/podman.sock"
+    else
+        DOCKER_SOCK_PATH="/var/run/docker.sock"
+    fi
 else
     DOCKER_SOCK_PATH="/var/run/docker.sock"
 fi
@@ -101,8 +120,8 @@ fi
 DOCKER_SOCK_GID=""
 if [[ -S "$DOCKER_SOCK_PATH" ]]; then
     if [[ -z "${CANASTA_DOCKER_DRY_RUN:-}" ]] \
-        && docker image inspect "$IMAGE" >/dev/null 2>&1; then
-        DOCKER_SOCK_GID="$(docker run --rm \
+        && "$CONTAINER_ENGINE" image inspect "$IMAGE" >/dev/null 2>&1; then
+        DOCKER_SOCK_GID="$("$CONTAINER_ENGINE" run --rm \
             -v "$DOCKER_SOCK_PATH:/var/run/docker.sock" \
             --entrypoint stat "$IMAGE" -c '%g' /var/run/docker.sock 2>/dev/null || true)"
     fi
@@ -267,15 +286,15 @@ if [[ ! -f "$CANASTA_PASSWD" ]]; then
     PASSWD_STALE=true
 elif [[ -z "${CANASTA_DOCKER_DRY_RUN:-}" ]]; then
     # Regenerate if the image changed (after upgrade) or UID changed.
-    PASSWD_IMAGE_ID=$(docker inspect --format '{{.Id}}' "$IMAGE" 2>/dev/null || true)
+    PASSWD_IMAGE_ID=$("$CONTAINER_ENGINE" inspect --format '{{.Id}}' "$IMAGE" 2>/dev/null || true)
     if [[ -n "$PASSWD_IMAGE_ID" ]] && ! grep -q "# $PASSWD_IMAGE_ID" "$CANASTA_PASSWD" 2>/dev/null; then
         PASSWD_STALE=true
     fi
 fi
 if [[ "$PASSWD_STALE" == "true" ]]; then
     if [[ -z "${CANASTA_DOCKER_DRY_RUN:-}" ]]; then
-        docker run --rm --entrypoint cat "$IMAGE" /etc/passwd > "$CANASTA_PASSWD" 2>/dev/null || true
-        PASSWD_IMAGE_ID=$(docker inspect --format '{{.Id}}' "$IMAGE" 2>/dev/null || true)
+        "$CONTAINER_ENGINE" run --rm --entrypoint cat "$IMAGE" /etc/passwd > "$CANASTA_PASSWD" 2>/dev/null || true
+        PASSWD_IMAGE_ID=$("$CONTAINER_ENGINE" inspect --format '{{.Id}}' "$IMAGE" 2>/dev/null || true)
         echo "# $PASSWD_IMAGE_ID" >> "$CANASTA_PASSWD"
     else
         # Stub passwd file for tests so the read-only mount source exists.
@@ -612,7 +631,7 @@ for arg in "$@"; do
             WRAPPER_URL="https://raw.githubusercontent.com/CanastaWiki/Canasta-CLI/${WRAPPER_REF}/canasta-docker"
 
             echo "Pulling canasta-ansible image ($IMAGE)..."
-            docker pull "$IMAGE"
+            "$CONTAINER_ENGINE" pull "$IMAGE"
 
             # Update the wrapper script itself if the upstream differs.
             if command -v curl &>/dev/null; then
@@ -730,25 +749,25 @@ if [[ -n "$SCHEDULE_CRONTAB_FILE" ]]; then
     DOCKER_RUN_FLAGS+=(-e "CANASTA_HOST_CRONTAB=$SCHEDULE_CRONTAB_FILE")
 fi
 
-# Detect if `docker` is actually a podman shim (e.g. the podman-docker
+# Detect if the engine is actually a podman shim (e.g. the podman-docker
 # package on Debian/Fedora installs /usr/bin/docker as a wrapper that
 # calls podman). Rootless podman remaps --user 1000:1000 in the
 # container to a host subuid (e.g. 100999), so writes to bind-mounted
 # host paths look like a foreign UID even though the host user owns
 # them. `--userns=keep-id` opts out of that remap and keeps in-
 # container UIDs equal to host UIDs. Podman-only flag — Docker rejects
-# it. Detection by `docker --version` output is intentional: shell
-# aliases aren't expanded in non-interactive scripts, but binary
+# it. Detection by `$CONTAINER_ENGINE --version` output is intentional:
+# shell aliases aren't expanded in non-interactive scripts, but binary
 # wrappers (the common case) do report "podman" here.
 ENGINE_OPTS=()
-if docker --version 2>/dev/null | grep -qi 'podman'; then
+if "$CONTAINER_ENGINE" --version 2>/dev/null | grep -qi 'podman'; then
     ENGINE_OPTS+=(--userns=keep-id)
 fi
 
 # Dry-run mode for tests: print the assembled docker run command, one
 # argument per line, and exit. Does not invoke docker.
 if [[ -n "${CANASTA_DOCKER_DRY_RUN:-}" ]]; then
-    printf 'docker\n'
+    printf '%s\n' "$CONTAINER_ENGINE"
     for a in run ${ENGINE_OPTS[@]+"${ENGINE_OPTS[@]}"} --rm "${DOCKER_RUN_FLAGS[@]}" "${MOUNTS[@]}" "$IMAGE" "$@" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}; do
         printf '%s\n' "$a"
     done
@@ -763,7 +782,7 @@ if [[ -n "$SCHEDULE_CRONTAB_FILE" ]]; then
     crontab -l > "$SCHEDULE_CRONTAB_FILE" 2>/dev/null || : > "$SCHEDULE_CRONTAB_FILE"
     _crontab_before="$(cksum < "$SCHEDULE_CRONTAB_FILE")"
     _sched_rc=0
-    docker run ${ENGINE_OPTS[@]+"${ENGINE_OPTS[@]}"} --rm "${DOCKER_RUN_FLAGS[@]}" \
+    "$CONTAINER_ENGINE" run ${ENGINE_OPTS[@]+"${ENGINE_OPTS[@]}"} --rm "${DOCKER_RUN_FLAGS[@]}" \
         "${MOUNTS[@]}" \
         "$IMAGE" "$@" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} || _sched_rc=$?
     _crontab_after="$(cksum < "$SCHEDULE_CRONTAB_FILE")"
@@ -781,6 +800,6 @@ if [[ -n "$SCHEDULE_CRONTAB_FILE" ]]; then
     exit "$_sched_rc"
 fi
 
-exec docker run ${ENGINE_OPTS[@]+"${ENGINE_OPTS[@]}"} --rm "${DOCKER_RUN_FLAGS[@]}" \
+exec "$CONTAINER_ENGINE" run ${ENGINE_OPTS[@]+"${ENGINE_OPTS[@]}"} --rm "${DOCKER_RUN_FLAGS[@]}" \
     "${MOUNTS[@]}" \
     "$IMAGE" "$@" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}

--- a/canasta-docker
+++ b/canasta-docker
@@ -157,6 +157,12 @@ MOUNTS=(
     --user "$(id -u):$(id -g)"
 )
 
+# We want the user's config to be available, but the ssh configuration doesn't read it even though it is already
+# mounted.  So we'll mount the user's .ssh/config to somewhere where it is read.
+if [[ -f "$HOME/.ssh/config" ]]; then
+    MOUNTS+=(-v "$HOME/.ssh/config:/etc/ssh/ssh_config.d/zz-user.conf")
+fi
+
 # Set Ansible temp + home directories to /tmp when running as a non-root user
 # in rootless Docker. On rootless Docker, the UID/GID mapping causes directory
 # ownership to appear as nobody:nogroup to the container process even though

--- a/canasta.py
+++ b/canasta.py
@@ -1473,13 +1473,25 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
         except (OSError, IOError, KeyError):
             pass
 
-    # Always set a value, even the default one: the variables are
-    # declared in the orchestrator role's defaults, so tasks in other
-    # roles (crowdsec, devmode, upgrade) that reference them are out of
-    # that scope and would otherwise see them undefined.
-    if "compose_command" not in extra_vars:
-        extra_vars["compose_command"] = "docker compose"
-        extra_vars["inspect_command"] = "docker"
+    # Auto-detect container runtime: when compose_command was not set
+    # (no registry field, no .env, no CLI override), probe Docker then
+    # Podman and inject the right runtime so create/start work without
+    # manual .env setup. Sets a default even when Docker is available
+    # to shield downstream templates that reference compose_command
+    # from outside the orchestrator role's variable scope.
+    #
+    # Skip for remote operations (--host): the local machine's PATH
+    # doesn't reflect what's installed on the remote. Ansible's
+    # create_preflight.yml will probe the remote and set facts.
+    if "compose_command" not in extra_vars and not host_value:
+        docker_avail = shutil.which("docker") is not None
+        podman_avail = shutil.which("podman") is not None
+        if not docker_avail and podman_avail:
+            extra_vars["compose_command"] = "podman-compose"
+            extra_vars["inspect_command"] = "podman"
+        else:
+            extra_vars["compose_command"] = "docker compose"
+            extra_vars["inspect_command"] = "docker"
     vars_file = tempfile.NamedTemporaryFile(
         mode="w", suffix=".json", prefix="canasta-vars-",
         delete=False,

--- a/canasta.py
+++ b/canasta.py
@@ -1452,46 +1452,35 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
     # execvp replaces this process. Stale files are cleaned up by
     # _cleanup_stale_vars_files() at the start of each invocation.
 
-    # When the registry lacks composeCommand/inspectCommand (e.g.
-    # instances created before Podman support), fall back to reading
-    # from the instance's .env file so Ansible gets the values.
+    # Runtime resolution: a registry entry (composeCommand /
+    # inspectCommand) wins, then the instance's .env for instances
+    # created before those fields existed.
+    #
+    # Nothing else is injected. An extra-var outranks every other
+    # source, including the set_fact that create_preflight.yml's
+    # runtime probe uses, so guessing a runtime here would silently
+    # override a probe that actually asked the target what it runs.
+    # Detection belongs to that probe; the play-scope default in
+    # vars/compose_runtime.yml covers everything in between.
     if "compose_command" not in extra_vars:
         try:
             inst = resolve_instance(
                 getattr(args, "id", None)
             ) if os.path.isfile(get_config_file_path()) else {}
             path = inst.get("path", "")
-            if path:
-                env_val = _read_env(path, "compose_command")
-                if env_val:
-                    extra_vars["compose_command"] = env_val
-                env_val = _read_env(path, "inspect_command")
-                if env_val:
-                    extra_vars["inspect_command"] = env_val
+            # The .env sits on the instance's host, so it is only
+            # readable from here when that host is this machine.
+            is_local = (inst.get("host") or "localhost") in ("localhost", "")
+            if path and is_local and not host_value:
+                for _key in ("compose_command", "inspect_command"):
+                    env_val = _read_env(path, _key)
+                    if env_val:
+                        extra_vars[_key] = env_val
         except SystemExit:
             pass
         except (OSError, IOError, KeyError):
             pass
 
-    # Auto-detect container runtime: when compose_command was not set
-    # (no registry field, no .env, no CLI override), probe Docker then
-    # Podman and inject the right runtime so create/start work without
-    # manual .env setup. Sets a default even when Docker is available
-    # to shield downstream templates that reference compose_command
-    # from outside the orchestrator role's variable scope.
-    #
-    # Skip for remote operations (--host): the local machine's PATH
-    # doesn't reflect what's installed on the remote. Ansible's
-    # create_preflight.yml will probe the remote and set facts.
-    if "compose_command" not in extra_vars and not host_value:
-        docker_avail = shutil.which("docker") is not None
-        podman_avail = shutil.which("podman") is not None
-        if not docker_avail and podman_avail:
-            extra_vars["compose_command"] = "podman-compose"
-            extra_vars["inspect_command"] = "podman"
-        else:
-            extra_vars["compose_command"] = "docker compose"
-            extra_vars["inspect_command"] = "docker"
     vars_file = tempfile.NamedTemporaryFile(
         mode="w", suffix=".json", prefix="canasta-vars-",
         delete=False,

--- a/canasta.yml
+++ b/canasta.yml
@@ -61,6 +61,11 @@
       ansible.builtin.include_vars:
         file: vars/tool_versions.yml
 
+    # Container runtime commands, shared across roles — one source.
+    - name: Load container runtime commands
+      ansible.builtin.include_vars:
+        file: vars/compose_runtime.yml
+
     - name: Validate command exists
       ansible.builtin.assert:
         that: command in (canasta_commands.commands | map(attribute='name'))

--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -33,7 +33,8 @@ runtime="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"; _sock=""; for s in "$runtime/p
 command -v canasta >/dev/null 2>&1 && { canasta version >/dev/null 2>&1 && echo OK || echo BROKEN; } || echo MISSING; echo "$D"
 cdir="$(dirname "$(readlink -f "$(command -v canasta 2>/dev/null)" 2>/dev/null)" 2>/dev/null)"; if [ -n "$cdir" ] && [ -d "$cdir/.git" ]; then { [ -w "$cdir/.git" ] && echo WRITABLE || echo NOT_WRITABLE; } else echo NA; fi; echo "$D"
 command -v sops >/dev/null 2>&1 && echo OK || echo MISSING; echo "$D"
-command -v age-keygen >/dev/null 2>&1 && echo OK || echo MISSING
+command -v age-keygen >/dev/null 2>&1 && echo OK || echo MISSING; echo "$D"
+podman --version 2>&1 || echo MISSING
 """
 
 
@@ -73,6 +74,7 @@ def _parse_doctor(stdout, hostname):
     # controller.
     sops = p(20) if len(parts) > 20 else "MISSING"
     age = p(21) if len(parts) > 21 else "MISSING"
+    podman_version = p(22) if len(parts) > 22 else "MISSING"
 
     lines = [
         "Canasta Dependency Check (%s)" % hostname,
@@ -120,6 +122,34 @@ def _parse_doctor(stdout, hostname):
             "  Rootless socket: none detected "
             "(default /var/run/docker.sock)"
         )
+
+    if podman_version != "MISSING":
+        ver = podman_version
+        # Parse "podman version 4.3.1" → "4.3.1"
+        m = re.search(r'(\d+\.\d+\.\d+)', ver)
+        if m:
+            ver_str = m.group(1)
+            parts = [int(x) for x in ver_str.split(".")]
+            # Pad to 3 components for comparison
+            while len(parts) < 3:
+                parts.append(0)
+            if parts < [4, 4, 0]:
+                lines.append(
+                    "  Podman:          %s — WARNING: podman < 4.4 has a "
+                    "known Docker API bug that causes 'docker compose up' to "
+                    "fail with EOF on container start. "
+                    "Install podman >= 4.4 or set compose_command=podman-compose "
+                    "in the instance .env."
+                    % ver_str
+                )
+            else:
+                lines.append(
+                    "  Podman:          %s (OK)" % ver_str
+                )
+        else:
+            lines.append(
+                "  Podman:          %s (version unknown)" % ver
+            )
 
     lines.append("")
     lines.append("Kubernetes (optional):")
@@ -627,8 +657,13 @@ def cmd_doctor(args):
     docker = parts[1].strip() if len(parts) > 1 else "MISSING"
     compose = parts[2].strip() if len(parts) > 2 else "MISSING"
     daemon = parts[3].strip() if len(parts) > 3 else "NOT_RUNNING"
-    if "Docker" not in docker or "Docker Compose" not in compose or daemon != "OK":
-        print("\nMissing core dependencies. Install Docker and ensure the daemon is running.",
+    podman_version = parts[22].strip() if len(parts) > 22 else "MISSING"
+    if "Docker" in docker and "Docker Compose" in compose and daemon == "OK":
+        pass
+    elif podman_version != "MISSING":
+        pass
+    else:
+        print("\nMissing core dependencies. Install Docker or Podman and ensure a runtime is running.",
               file=sys.stderr)
         return 1
 

--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -34,8 +34,20 @@ command -v canasta >/dev/null 2>&1 && { canasta version >/dev/null 2>&1 && echo 
 cdir="$(dirname "$(readlink -f "$(command -v canasta 2>/dev/null)" 2>/dev/null)" 2>/dev/null)"; if [ -n "$cdir" ] && [ -d "$cdir/.git" ]; then { [ -w "$cdir/.git" ] && echo WRITABLE || echo NOT_WRITABLE; } else echo NA; fi; echo "$D"
 command -v sops >/dev/null 2>&1 && echo OK || echo MISSING; echo "$D"
 command -v age-keygen >/dev/null 2>&1 && echo OK || echo MISSING; echo "$D"
-podman --version 2>&1 || echo MISSING
+command -v podman >/dev/null 2>&1 && podman --version 2>/dev/null || echo MISSING
 """
+
+
+def _has_container_runtime(docker, compose, daemon, podman_version):
+    """True when the host can actually run containers.
+
+    podman_version is matched on the expected output rather than on the
+    absence of the MISSING sentinel — a failed probe still prints text
+    containing the word "podman".
+    """
+    if "Docker" in docker and "Docker Compose" in compose and daemon == "OK":
+        return True
+    return "podman version" in podman_version.lower()
 
 
 def _parse_doctor(stdout, hostname):
@@ -123,23 +135,26 @@ def _parse_doctor(stdout, hostname):
             "(default /var/run/docker.sock)"
         )
 
-    if podman_version != "MISSING":
+    if "podman version" in podman_version.lower():
         ver = podman_version
         # Parse "podman version 4.3.1" → "4.3.1"
         m = re.search(r'(\d+\.\d+\.\d+)', ver)
         if m:
             ver_str = m.group(1)
-            parts = [int(x) for x in ver_str.split(".")]
-            # Pad to 3 components for comparison
-            while len(parts) < 3:
-                parts.append(0)
-            if parts < [4, 4, 0]:
+            # Not `parts` — that name is the split doctor output the
+            # p() helper above reads.
+            ver_parts = [int(x) for x in ver_str.split(".")]
+            while len(ver_parts) < 3:
+                ver_parts.append(0)
+            if ver_parts < [4, 4, 0]:
                 lines.append(
                     "  Podman:          %s — WARNING: podman < 4.4 has a "
                     "known Docker API bug that causes 'docker compose up' to "
                     "fail with EOF on container start. "
-                    "Install podman >= 4.4 or set compose_command=podman-compose "
-                    "in the instance .env."
+                    "Install podman >= 4.4, or pin the runtime for one "
+                    "instance: compose_command=podman-compose in a local "
+                    "instance's .env, or composeCommand in its registry "
+                    "entry for a remote one."
                     % ver_str
                 )
             else:
@@ -658,11 +673,7 @@ def cmd_doctor(args):
     compose = parts[2].strip() if len(parts) > 2 else "MISSING"
     daemon = parts[3].strip() if len(parts) > 3 else "NOT_RUNNING"
     podman_version = parts[22].strip() if len(parts) > 22 else "MISSING"
-    if "Docker" in docker and "Docker Compose" in compose and daemon == "OK":
-        pass
-    elif podman_version != "MISSING":
-        pass
-    else:
+    if not _has_container_runtime(docker, compose, daemon, podman_version):
         print("\nMissing core dependencies. Install Docker or Podman and ensure a runtime is running.",
               file=sys.stderr)
         return 1

--- a/roles/orchestrator/defaults/main.yml
+++ b/roles/orchestrator/defaults/main.yml
@@ -7,13 +7,6 @@ canasta_default_image: "ghcr.io/canastawiki/canasta:latest"
 # Wait-for-it timeout (seconds)
 canasta_db_wait_timeout: 10
 
-# Container runtime commands. Override for rootless Podman deployments:
-#   compose_command: "podman-compose"
-#   inspect_command: "podman"
-# The defaults use Docker; the compose_command is prefixed to -f arguments.
-compose_command: "docker compose"
-inspect_command: "docker"
-
 # Pinned k3s and helm versions for Kubernetes installs. Pinning keeps the
 # control plane and any workers on the same version (a later-joining worker
 # must not outpace the cp — Kubernetes version-skew policy) and avoids

--- a/roles/orchestrator/tasks/create_preflight.yml
+++ b/roles/orchestrator/tasks/create_preflight.yml
@@ -24,19 +24,59 @@
       ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/detect_docker_socket.yml"
       when: (docker_host | default('')) == ''
 
-    - name: Check Docker is available
-      ansible.builtin.command:
-        cmd: docker info
-      register: _docker_check
-      changed_when: false
-      ignore_errors: true  # OK if Docker not installed
+    # Probe the available container runtime (Docker or Podman) before
+    # any state mutation. When compose_command is set to a Podman-based
+    # command (e.g. podman-compose), probe podman info instead of
+    # docker info so Podman-only hosts pass the preflight gate.
+    #
+    # For remote operations (--host), compose_command may not reflect
+    # what's actually on the remote host (local auto-detection was
+    # skipped). Probe both runtimes and set facts so downstream tasks
+    # get the correct command.
+    - name: Check container runtime is available
+      when: (compose_command | default('docker compose') is search('podman'))
+      block:
+        - name: Probe podman info (compose_command is podman-based)
+          ansible.builtin.command:
+            cmd: podman info
+          register: _docker_check
+          changed_when: false
+          ignore_errors: true
 
-    - name: Fail if Docker not available
+    - name: Probe Docker then Podman for remote/detected runtime
+      when: not (compose_command | default('docker compose') is search('podman'))
+      block:
+        - name: Probe docker info
+          ansible.builtin.command:
+            cmd: docker info
+          register: _docker_check
+          changed_when: false
+          ignore_errors: true
+
+        - name: Probe podman info (fallback)
+          ansible.builtin.command:
+            cmd: podman info
+          register: _podman_check
+          changed_when: false
+          ignore_errors: true
+
+        - name: Set compose_command to podman-compose if Docker absent but Podman present
+          ansible.builtin.set_fact:
+            compose_command: podman-compose
+            inspect_command: podman
+          when:
+            - _docker_check.rc | default(1) != 0
+            - _podman_check.rc | default(1) == 0
+
+    - name: Fail if container runtime not available
       ansible.builtin.fail:
         msg: >-
-          Docker is not available on this host.
+          No container runtime is available on this host.
+          Docker and Podman are both absent or unreachable.
           Run 'canasta doctor' to check all dependencies.
-      when: _docker_check.rc | default(0) != 0
+      when: >-
+        (_docker_check.rc | default(1) != 0)
+        and (_podman_check.rc | default(1) != 0)
 
     # Port 80/443 conflict detection for Compose. Compose's caddy
     # service binds host ports 80 and 443; if anything else is

--- a/roles/orchestrator/tasks/create_preflight.yml
+++ b/roles/orchestrator/tasks/create_preflight.yml
@@ -24,15 +24,11 @@
       ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/detect_docker_socket.yml"
       when: (docker_host | default('')) == ''
 
-    # Probe the available container runtime (Docker or Podman) before
-    # any state mutation. When compose_command is set to a Podman-based
-    # command (e.g. podman-compose), probe podman info instead of
-    # docker info so Podman-only hosts pass the preflight gate.
-    #
-    # For remote operations (--host), compose_command may not reflect
-    # what's actually on the remote host (local auto-detection was
-    # skipped). Probe both runtimes and set facts so downstream tasks
-    # get the correct command.
+    # Probe the target's runtime before any state mutation. This is the
+    # only place detection happens — the CLI never guesses, so the
+    # set_fact below is what makes a Podman-only host work, local or
+    # remote. When compose_command already names a Podman command (from
+    # the registry or .env), probe podman directly instead.
     - name: Check container runtime is available
       when: (compose_command | default('docker compose') is search('podman'))
       block:

--- a/tests/unit/test_build_ansible_args_env_fallback.py
+++ b/tests/unit/test_build_ansible_args_env_fallback.py
@@ -82,13 +82,16 @@ class TestEnvFallbackExecutes:
             "ansible-playbook", "reconcile", _args(id="demo"), _definitions())
         assert _extra_vars(argv)["compose_command"] == "podman-compose"
 
-    def test_defaults_to_docker_without_an_override(self, registry):
+    def test_no_override_injects_nothing(self, registry):
+        # Without an instance-specific value there must be no extra-var:
+        # the default now lives in vars/compose_runtime.yml, at a
+        # precedence create_preflight.yml's probe can still override.
         argv = canasta.build_ansible_args(
             "ansible-playbook", "reconcile", _args(id="demo"), _definitions())
-        assert _extra_vars(argv)["compose_command"] == "docker compose"
+        assert "compose_command" not in _extra_vars(argv)
 
     def test_missing_env_file_is_not_fatal(self, registry):
-        # No .env at all: the fallback must degrade to the default.
+        # No .env at all: the lookup must degrade quietly, not raise.
         argv = canasta.build_ansible_args(
             "ansible-playbook", "reconcile", _args(id="demo"), _definitions())
-        assert _extra_vars(argv)["inspect_command"] == "docker"
+        assert "inspect_command" not in _extra_vars(argv)

--- a/tests/unit/test_compose_runtime_precedence.py
+++ b/tests/unit/test_compose_runtime_precedence.py
@@ -1,0 +1,105 @@
+"""compose_command / inspect_command must resolve at play scope, not as
+an extra-var.
+
+Extra-vars sit at the top of Ansible's precedence ladder (role defaults
+< include_vars < set_fact < extra-vars), so anything canasta.py injects
+silently outranks create_preflight.yml's runtime probe. Injecting a
+guessed default there makes the probe dead code, and the CLI's own PATH
+is not evidence about a remote target.
+
+vars/compose_runtime.yml is loaded play-global instead: above role
+defaults so every role sees it, below set_fact so the probe wins, and
+below extra-vars so an explicit -e still overrides.
+"""
+
+import os
+import re
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+VARS_FILE = os.path.join(REPO_ROOT, "vars", "compose_runtime.yml")
+CANASTA_YML = os.path.join(REPO_ROOT, "canasta.yml")
+ORCH_DEFAULTS = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "defaults", "main.yml")
+CANASTA_PY = os.path.join(REPO_ROOT, "canasta.py")
+
+_KEYS = ("compose_command", "inspect_command")
+
+
+def _read(path):
+    with open(path) as f:
+        return f.read()
+
+
+class TestPlayScopeDefaults:
+    def test_vars_file_defines_both_commands(self):
+        data = yaml.safe_load(_read(VARS_FILE))
+        for key in _KEYS:
+            assert key in data, "%s missing from vars/compose_runtime.yml" % key
+        assert data["compose_command"] == "docker compose"
+        assert data["inspect_command"] == "docker"
+
+    def test_canasta_yml_loads_it_in_pre_tasks(self):
+        play = yaml.safe_load(_read(CANASTA_YML))[0]
+        loaded = [
+            t["ansible.builtin.include_vars"]["file"]
+            for t in play.get("pre_tasks", [])
+            if "ansible.builtin.include_vars" in t
+            and isinstance(t["ansible.builtin.include_vars"], dict)
+        ]
+        assert "vars/compose_runtime.yml" in loaded, (
+            "canasta.yml must include_vars vars/compose_runtime.yml in "
+            "pre_tasks — role defaults are role-scoped, and crowdsec, "
+            "devmode and upgrade reference these variables from outside "
+            "the orchestrator role. Loaded: %s" % loaded
+        )
+
+    def test_not_also_declared_in_orchestrator_defaults(self):
+        # One source only: a role default would shadow nothing (it is
+        # lower precedence) but would drift silently.
+        data = yaml.safe_load(_read(ORCH_DEFAULTS)) or {}
+        dupes = [k for k in _KEYS if k in data]
+        assert not dupes, (
+            "%s declared in both vars/compose_runtime.yml and the "
+            "orchestrator role defaults" % dupes
+        )
+
+
+class TestNoGuessedExtraVar:
+    """canasta.py may pass through an instance-specific value, but must
+    not inject a guessed one."""
+
+    def test_does_not_probe_the_local_path_for_a_runtime(self):
+        content = _read(CANASTA_PY)
+        for probe in ('shutil.which("docker")', 'shutil.which("podman")'):
+            assert probe not in content, (
+                "canasta.py probes the controller's PATH (%s) and injects "
+                "the result as an extra-var. That outranks "
+                "create_preflight.yml's set_fact, so the probe that "
+                "actually asks the target is discarded — and the "
+                "controller's PATH says nothing about a remote host." % probe
+            )
+
+    def test_does_not_inject_a_blanket_default(self):
+        content = _read(CANASTA_PY)
+        assert not re.search(
+            r'extra_vars\[\s*["\']compose_command["\']\s*\]\s*=\s*'
+            r'["\']docker compose["\']', content), (
+            "canasta.py assigns the Docker default into extra_vars. The "
+            "default belongs in vars/compose_runtime.yml, where set_fact "
+            "can still override it."
+        )
+
+    def test_env_fallback_is_scoped_to_local_instances(self):
+        # The instance .env lives on the instance's host; reading it from
+        # the controller is only meaningful when that host is this one.
+        content = _read(CANASTA_PY)
+        assert "_read_env" in content
+        block = content[content.index("Runtime resolution"):]
+        block = block[:block.index("vars_file = tempfile")]
+        assert "host_value" in block and "localhost" in block, (
+            "the .env fallback must skip remote instances — it reads a "
+            "path that only exists on the instance's own host"
+        )

--- a/tests/unit/test_doctor_podman_probe.py
+++ b/tests/unit/test_doctor_podman_probe.py
@@ -1,0 +1,119 @@
+"""The podman probe must not let a missing binary look like a runtime.
+
+`podman --version 2>&1 || echo MISSING` captures the shell's own
+"command not found" onto stdout, so the field is non-empty even when
+podman is absent. Testing `!= "MISSING"` then reports podman on every
+Docker-only host — and, worse, satisfies cmd_doctor's core-dependency
+gate on a host with no container runtime at all.
+
+Every other probe in _DOCTOR_SCRIPT avoids this by testing for a
+substring of the expected output; these tests hold the podman probe to
+the same contract.
+"""
+
+import inspect
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+
+from direct_commands import doctor  # noqa: E402
+from direct_commands import _helpers  # noqa: E402
+
+
+D = _helpers._SENTINEL
+
+# Field order in _DOCTOR_SCRIPT; podman is field 22 (appended last).
+_PODMAN_IDX = 22
+
+
+def _stdout(docker="Docker version 27.0.0", compose="Docker Compose v2.29.0",
+            daemon="OK", podman="MISSING"):
+    fields = ["Python 3.12.0"] * (_PODMAN_IDX + 1)
+    fields[1] = docker
+    fields[2] = compose
+    fields[3] = daemon
+    fields[_PODMAN_IDX] = podman
+    return (D + "\n").join(fields)
+
+
+# What the shell actually produces when podman is not installed.
+_NOT_FOUND = "sh: 1: podman: command not found\nMISSING"
+
+
+class TestProbeIsGuarded:
+    def test_script_guards_on_command_v(self):
+        assert "command -v podman" in doctor._DOCTOR_SCRIPT, (
+            "the podman probe must be guarded by `command -v`, or the "
+            "shell's not-found message lands on stdout and reads as output"
+        )
+
+    def test_script_does_not_merge_stderr_into_the_probe(self):
+        line = [ln for ln in doctor._DOCTOR_SCRIPT.splitlines()
+                if "podman --version" in ln]
+        assert line, "no podman version probe found"
+        assert "podman --version 2>&1" not in line[0], (
+            "`podman --version 2>&1` folds the not-found message into "
+            "stdout: %r" % line[0]
+        )
+
+
+class TestReportLine:
+    def _lines(self, podman):
+        return doctor._parse_doctor(_stdout(podman=podman), "h")
+
+    def test_absent_podman_is_not_reported(self):
+        for absent in ("MISSING", _NOT_FOUND):
+            assert "Podman:" not in self._lines(absent), (
+                "reported Podman for %r" % absent
+            )
+
+    def test_recent_podman_reports_ok(self):
+        assert "4.9.3 (OK)" in self._lines("podman version 4.9.3")
+
+    def test_old_podman_warns(self):
+        body = self._lines("podman version 4.3.1")
+        assert "4.3.1" in body and "WARNING" in body
+
+    def test_parse_doctor_binds_parts_exactly_once(self):
+        # `parts` is the split doctor output that the p(i) closure reads.
+        # Rebinding it mid-function (e.g. to hold version components)
+        # breaks every later p() call. Nothing calls p() after the podman
+        # block today, so this cannot be caught behaviorally — but the
+        # file's convention is to append each new probe at the end and
+        # index it, so the next one added would hit it.
+        src = inspect.getsource(doctor._parse_doctor)
+        binds = re.findall(r"^\s*parts\s*=[^=]", src, re.M)
+        assert len(binds) == 1, (
+            "`parts` is assigned %d times in _parse_doctor; it must only "
+            "be the initial split: %s" % (len(binds), binds)
+        )
+
+
+class TestCoreDependencyGate:
+    """cmd_doctor returns 1 when no container runtime is present. That is
+    the command's only hard failure."""
+
+    def _rc(self, **kw):
+        out = _stdout(**kw)
+        parts = out.split(D + "\n")
+        return 0 if doctor._has_container_runtime(
+            parts[1].strip(), parts[2].strip(), parts[3].strip(),
+            parts[_PODMAN_IDX].strip()) else 1
+
+    def test_no_runtime_at_all_fails(self):
+        assert self._rc(docker="MISSING", compose="MISSING",
+                        daemon="NOT_RUNNING", podman=_NOT_FOUND) == 1, (
+            "a host with neither Docker nor podman installed must fail the "
+            "gate — the not-found text is output, not a runtime"
+        )
+
+    def test_docker_only_passes(self):
+        assert self._rc(podman=_NOT_FOUND) == 0
+
+    def test_podman_only_passes(self):
+        assert self._rc(docker="MISSING", compose="MISSING",
+                        daemon="NOT_RUNNING",
+                        podman="podman version 4.9.3") == 0

--- a/vars/compose_runtime.yml
+++ b/vars/compose_runtime.yml
@@ -1,0 +1,9 @@
+---
+# Container runtime commands, play-global so crowdsec/devmode/upgrade
+# see them too (roles/*/defaults are role-scoped). Loaded by canasta.yml.
+#
+# Precedence is the point: include_vars sits above role defaults but
+# below set_fact, so create_preflight.yml's runtime probe can override
+# these, and an explicit -e still wins over both.
+compose_command: "docker compose"
+inspect_command: "docker"


### PR DESCRIPTION
Part of #1118. Part 4 of 5 splitting #1122 (which stays open as the tracking PR).

**Based on #1225** — review that first.

Authored by @hexmode; split out of #1122 unchanged.

## What

- `canasta-docker` selects an engine (docker, else podman) and resolves the rootless podman socket
- `canasta.py` injects `podman-compose` / `podman` when Docker is absent locally
- `create_preflight.yml` probes both runtimes so a Podman-only host passes the gate
- `canasta doctor` reports the podman version and warns below 4.4

A second commit mounts the user's `~/.ssh/config` into the container where ssh actually reads it. Unrelated to Podman — kept as its own commit so it can be split off or reverted independently.

## Not carried over from #1122

The `create_preflight.yml` block that raised `net.ipv4.ip_unprivileged_port_start` is **deliberately excluded**. It ran at top level (so on Kubernetes creates too), escalated with `become: yes` during `canasta create`, and persistently rewrote `/etc/sysctl.conf` via `sysctl_set` + `reload`, with no `ansible_system == 'Linux'` guard — the `/proc` slurp fails outright on a macOS target.

`canasta doctor` already detects this condition and prints the exact sudo commands for the operator to run. If we want to automate it, it needs its own issue: opt-in flag, Linux-only, Compose-only, non-persistent.

## Review items

- **`CONTAINER_ENGINE` is not honored as an override**, though #1122's description said it was. `canasta-docker` assigns it unconditionally, so there is no way to select Podman on a host that has both. One line (`CONTAINER_ENGINE="${CONTAINER_ENGINE:-...}"`) would make the code match the claim; alternatively the claim should be dropped. Left alone deliberately — it is not a regression, and which way to resolve it is the author's call.

## Fixed on top of the split: runtime resolution moved to play scope

`fix: resolve the container runtime at play scope, not as an extra-var` is not @hexmode's work — it fixes a problem the split surfaced, committed separately.

As originally written this PR could not work. Extra-vars are the top of Ansible's precedence ladder (role defaults < `include_vars` < `set_fact` < extra-vars), so the runtime `canasta.py` injected outranked `create_preflight.yml`'s `set_fact`. The probe ran, decided the runtime, and was discarded. Three consequences:

1. **The remote probe was dead code** — detection never took effect wherever the CLI had injected a value.
2. **`--host` left the variables undefined** — the `not host_value` gate skipped injection entirely, and the `.env` fallback read a *local* path that does not exist for a remote instance. That broke 20 bare references in `roles/upgrade/` (11), `roles/devmode/` (6) and `roles/crowdsec/` (3), which sit outside the orchestrator role that declared the defaults. `_resolve_cscli.yml`'s `when: compose_command is search('podman')` also raises on an undefined variable rather than evaluating false.
3. **The guard missed the common remote path** — `host_value` is only set by an explicit `-H`, so a registry-resolved remote instance had the *controller's* PATH decide the runtime for the *remote* target.

**The fix:** `vars/compose_runtime.yml`, loaded play-global in `canasta.yml`'s `pre_tasks` beside `secret_classification.yml` and `tool_versions.yml` — the pattern this repo already uses for exactly this problem, with a comment naming it ("roles/*/defaults are role-scoped"). It sits above role defaults so every role resolves the variables, and below `set_fact` so the probe wins.

`canasta.py` no longer guesses: the `shutil.which` probe and the blanket default are gone, and it passes through only an instance-specific value from the registry or from a *local* instance's `.env`. `create_preflight.yml` becomes the single detection point, and its `docker info` / `podman info` probe is a better test than `which` — it asks whether the daemon responds, which also covers Docker being installed with its daemon down while Podman runs.

The duplicate declaration in `roles/orchestrator/defaults/main.yml` is removed so there is one source.

Six tests cover the precedence contract, each mutation-tested: dropping the `include_vars`, re-adding the role default, reinstating the blanket default, and reinstating the PATH probe all fail.


## Second fix on top of the split: the podman probe

`fix(doctor): a missing podman must not read as a present one` is likewise not @hexmode's work.

`podman --version 2>&1 || echo MISSING` captures the shell's own "command not found" onto stdout, so the field was non-empty on any host without podman. `!= "MISSING"` was therefore always true: every Docker-only host got a spurious `Podman: ... (version unknown)` line, and because the new core-dependency gate accepts *either* runtime, a host with **neither** Docker nor podman exited 0 from the one check in `canasta doctor` meant to fail hard. That is a regression of existing behavior — before this PR the same host returned 1.

The probe is now guarded with `command -v` and matched on its expected output, which is what the other 21 probes in the script already do. Note that matching merely `"podman"` is not enough — the not-found message contains that word — so the test is `"podman version"`. The gate moved into `_has_container_runtime()` so it has one definition and is directly testable.

Also fixed: the version parse bound its components to `parts`, the split doctor output that the `p(i)` closure reads. Harmless today because no `p()` call follows, but the file's convention is to append each probe at the end and index it, so the next one added would have hit it. Nine tests, each mutation-tested; the shadowing one is a source check, since a latent bug has no behavior to assert on.

The `podman < 4.4` warning text also now points at the registry field for remote instances, since the CLI reads `.env` only for local ones.
