### PR TITLE
feat: pass compose profiles and DB defaults explicitly for podman-compose

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -360,9 +360,10 @@ def _run_compose(inst_id, inst, action_args, include_sidecars=False):
     devmode = inst.get("devMode", False)
     file_args = _compose_file_args(path, host, devmode, include_sidecars)
     compose_cmd = _resolve_compose_cmd(inst)
+    profile_args = _compose_profile_args(inst)
 
     if _is_localhost(host):
-        cmd = compose_cmd + file_args + action_args
+        cmd = compose_cmd + file_args + profile_args + action_args
         try:
             return subprocess.call(cmd, cwd=path)
         except OSError as e:
@@ -370,10 +371,11 @@ def _run_compose(inst_id, inst, action_args, include_sidecars=False):
             return 1
 
     file_str = " ".join(file_args)
+    profile_str = " ".join(profile_args)
     action_str = " ".join(action_args)
     compose_str = " ".join(compose_cmd)
-    remote_cmd = "cd %s && %s %s %s" % (
-        _shell_quote(path), compose_str, file_str, action_str,
+    remote_cmd = "cd %s && %s %s %s %s" % (
+        _shell_quote(path), compose_str, file_str, profile_str, action_str,
     )
     # SSH does not pass env; propagate DOCKER_HOST like _ssh_run does so a
     # rootless socket on the target is honored.
@@ -980,6 +982,34 @@ def _compose_project(path):
     if not path:
         return ""
     return os.path.basename(os.path.abspath(path)).lower()
+
+
+def _is_podman_compose(inst):
+    """Check if the instance uses podman-compose instead of docker compose."""
+    cmd = _resolve_compose_cmd(inst)
+    return "podman-compose" in cmd
+
+
+def _compose_profile_args(inst):
+    """Return --profile flags for the active COMPOSE_PROFILES.
+
+    podman-compose ignores COMPOSE_PROFILES from .env, so we must pass
+    --profile flags explicitly. Returns a list like
+    ["--profile", "internal-db", "--profile", "varnish"].
+    """
+    if not _is_podman_compose(inst):
+        return []
+    path = inst.get("path", "")
+    if not path:
+        return []
+    raw = _read_env(path, "COMPOSE_PROFILES")
+    if not raw:
+        return []
+    profiles = [p.strip() for p in raw.split(",") if p.strip()]
+    args = []
+    for p in profiles:
+        args += ["--profile", p]
+    return args
 
 
 def _resolve_compose_cmd(inst):

--- a/roles/create/tasks/_env_update.yml
+++ b/roles/create/tasks/_env_update.yml
@@ -114,6 +114,25 @@
       {{ (_ext_db_check.found and _ext_db_check.value | lower == 'true')
          | ternary('', 'internal-db') }}
 
+# Pin the bundled DB defaults so podman-compose (which can't resolve
+# ${VAR:-default} syntax in docker-compose.yml) gets the correct
+# values.  Only set when using the internal DB — external-DB setups
+# supply their own via the -e envfile and the validation above ensures
+# MYSQL_HOST is present.  This runs AFTER the external-DB validation
+# block so _ext_db_check is already registered.
+- name: Set bundled DB MySQL defaults
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: set
+    key: "{{ item.key }}"
+    value: "{{ item.value }}"
+  loop:
+    - { key: "MYSQL_HOST", value: "db" }
+    - { key: "MYSQL_PORT", value: "3306" }
+    - { key: "MYSQL_USER", value: "root" }
+    - { key: "MYSQL_SSL", value: "false" }
+  when: not (_ext_db_check.found and _ext_db_check.value | lower == 'true')
+
 # --skip-install only makes sense against an external database that was
 # provisioned separately and already holds a MediaWiki schema. The bundled
 # database starts from an empty volume, so skipping install.php there would

--- a/roles/crowdsec/tasks/_resolve_cscli.yml
+++ b/roles/crowdsec/tasks/_resolve_cscli.yml
@@ -11,11 +11,50 @@
 # Input: instance_id, instance_path, instance_orchestrator
 # Output: _cscli_prefix (str), _cscli_argv (list), _cscli_chdir (str or null)
 
+# podman-compose ignores COMPOSE_PROFILES from .env, so we must pass
+# --profile flags explicitly for `exec`.
+- name: Read COMPOSE_PROFILES from .env
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read_all
+  register: _env_profiles_cscli
+  when:
+    - compose_command is search('podman')
+    - instance_orchestrator | default('compose') == 'compose'
+
+- name: Build compose profile flags for exec
+  ansible.builtin.set_fact:
+    _cscli_profile_flags: >-
+      {{ (_env_profiles_cscli.variables.COMPOSE_PROFILES | default(''))
+         | split(',') | map('trim') | reject('equalto', '')
+         | map('regex_replace', '^', '--profile ')
+         | join(' ') }}
+    _cscli_profile_list: >-
+      {{ (_env_profiles_cscli.variables.COMPOSE_PROFILES | default(''))
+         | split(',') | map('trim') | reject('equalto', '')
+         | list }}
+  when:
+    - compose_command is search('podman')
+    - instance_orchestrator | default('compose') == 'compose'
+
 - name: Build cscli prefix (Compose)
   ansible.builtin.set_fact:
-    _cscli_prefix: "{{ compose_command }} exec -T crowdsec"
-    _cscli_argv: "{{ compose_command.split() + ['exec', '-T', 'crowdsec'] }}"
+    _cscli_prefix: "{{ compose_command }} {{ _cscli_profile_flags | default('') }} exec -T crowdsec"
+    _cscli_argv: "{{ compose_command.split() }}"
     _cscli_chdir: "{{ instance_path }}"
+  when: instance_orchestrator | default('compose') == 'compose'
+
+- name: Append profile flags to cscli argv
+  ansible.builtin.set_fact:
+    _cscli_argv: "{{ _cscli_argv + ['--profile', item] }}"
+  loop: "{{ _cscli_profile_list | default([]) }}"
+  when:
+    - instance_orchestrator | default('compose') == 'compose'
+    - _cscli_profile_list | default([]) | length > 0
+
+- name: Append exec args to cscli argv
+  ansible.builtin.set_fact:
+    _cscli_argv: "{{ _cscli_argv + ['exec', '-T', 'crowdsec'] }}"
   when: instance_orchestrator | default('compose') == 'compose'
 
 - name: Build cscli prefix (Kubernetes)

--- a/roles/crowdsec/tasks/_restart_engine.yml
+++ b/roles/crowdsec/tasks/_restart_engine.yml
@@ -9,9 +9,31 @@
 # wait for it to finish so callers can immediately exec into the new pod.
 # Input: instance_id, instance_path, instance_orchestrator
 
+# podman-compose ignores COMPOSE_PROFILES from .env, so we must pass
+# --profile flags explicitly for `restart`.
+- name: Read COMPOSE_PROFILES from .env
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read_all
+  register: _env_profiles_crowdsec
+  when:
+    - compose_command is search('podman')
+    - instance_orchestrator | default('compose') == 'compose'
+
+- name: Build compose profile flags
+  ansible.builtin.set_fact:
+    _crowdsec_profile_flags: >-
+      {{ (_env_profiles_crowdsec.variables.COMPOSE_PROFILES | default(''))
+         | split(',') | map('trim') | reject('equalto', '')
+         | map('regex_replace', '^', '--profile ')
+         | join(' ') }}
+  when:
+    - compose_command is search('podman')
+    - instance_orchestrator | default('compose') == 'compose'
+
 - name: Restart the CrowdSec engine (Compose)
   ansible.builtin.command:
-    cmd: "{{ compose_command }} restart crowdsec"
+    cmd: "{{ compose_command }} {{ _crowdsec_profile_flags | default('') }} restart crowdsec"
     chdir: "{{ instance_path }}"
   changed_when: true
   when: instance_orchestrator | default('compose') == 'compose'

--- a/roles/devmode/tasks/enable.yml
+++ b/roles/devmode/tasks/enable.yml
@@ -171,10 +171,28 @@
     dest: "{{ instance_path }}/.idea/runConfigurations/Listen_for_Xdebug.xml"
     mode: "0644"
 
+# podman-compose ignores COMPOSE_PROFILES from .env, so we must pass
+# --profile flags explicitly for `build`.
+- name: Read COMPOSE_PROFILES from .env
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read_all
+  register: _env_profiles_devmode
+  when: compose_command is search('podman')
+
+- name: Build compose profile flags
+  ansible.builtin.set_fact:
+    _devmode_profile_flags: >-
+      {{ (_env_profiles_devmode.variables.COMPOSE_PROFILES | default(''))
+         | split(',') | map('trim') | reject('equalto', '')
+         | map('regex_replace', '^', '--profile ')
+         | join(' ') }}
+  when: compose_command is search('podman')
+
 # --- Build xdebug image ---
 - name: Build xdebug-enabled image
   ansible.builtin.command:
-    cmd: "{{ compose_command }} -f docker-compose.yml -f docker-compose.dev.yml build"
+    cmd: "{{ compose_command }} -f docker-compose.yml -f docker-compose.dev.yml {{ _devmode_profile_flags | default('') }} build"
     chdir: "{{ instance_path }}"
   changed_when: true
 

--- a/roles/orchestrator/files/compose/docker-compose.yml
+++ b/roles/orchestrator/files/compose/docker-compose.yml
@@ -12,11 +12,16 @@ x-logging: &default-logging
     max-size: "50m"
     max-file: "3"
 
+x-canasta-network: &default-network
+  networks:
+    - default
+
 services:
   db:
     profiles:
       - internal-db
     image: docker.io/library/mariadb:11.4
+    <<: *default-network
     command: >
       bash -c "
         chown -R mysql:mysql /var/log/mysql &&
@@ -51,6 +56,7 @@ services:
     # set explicitly.
     user: root
     restart: unless-stopped
+    <<: *default-network
     logging: *default-logging
     extra_hosts:
       # "host-gateway" is a magic value resolved by the container engine.
@@ -100,6 +106,7 @@ services:
     profiles:
       - elasticsearch
     restart: unless-stopped
+    <<: *default-network
     logging: *default-logging
     environment:
       - discovery.type=single-node
@@ -128,6 +135,7 @@ services:
     # behaves identically to upstream Caddy otherwise.
     image: ${CANASTA_CADDY_IMAGE:-docker.io/library/caddy:2.10.2-alpine}
     restart: unless-stopped
+    <<: *default-network
     logging: *default-logging
     ports:
       - "${HTTP_PORT:-80}:80"
@@ -159,6 +167,7 @@ services:
     profiles:
       - varnish
     restart: unless-stopped
+    <<: *default-network
     logging: *default-logging
     # service_started, not service_healthy: the web image's HEALTHCHECK
     # is declared in the CanastaBase Dockerfile, but podman-compose does
@@ -185,6 +194,7 @@ services:
     profiles:
       - observable
     restart: unless-stopped
+    <<: *default-network
     logging: *default-logging
     environment:
       - discovery.type=single-node
@@ -205,6 +215,7 @@ services:
     profiles:
       - observable
     restart: unless-stopped
+    <<: *default-network
     logging: *default-logging
     entrypoint: >
       bash -c "mkdir -p /usr/share/logstash/data/sincedb && exec /usr/local/bin/docker-entrypoint"
@@ -224,6 +235,7 @@ services:
     profiles:
       - observable
     restart: unless-stopped
+    <<: *default-network
     logging: *default-logging
     depends_on:
       - opensearch
@@ -238,6 +250,7 @@ services:
     profiles:
       - observable
     restart: "no"
+    <<: *default-network
     logging: *default-logging
     depends_on:
       - opensearch
@@ -256,6 +269,7 @@ services:
     profiles:
       - crowdsec
     restart: unless-stopped
+    <<: *default-network
     logging: *default-logging
     environment:
       # Installed at container start. The caddy collection ships the
@@ -274,6 +288,10 @@ services:
       # Loaded as a parser whitelist; takes effect on restart.
       - ./config/crowdsec/whitelists.yaml:/etc/crowdsec/parsers/s02-enrich/canasta-whitelists.yaml:ro
       - caddy-logs:/var/log/caddy:ro
+
+networks:
+  default:
+    driver: bridge
 
 volumes:
   mysql-data-volume:

--- a/roles/orchestrator/tasks/backup_discover_build_paths.yml
+++ b/roles/orchestrator/tasks/backup_discover_build_paths.yml
@@ -52,9 +52,27 @@
       ansible.builtin.set_fact:
         _build_instance_dir: "{{ _build_instance_realpath.stdout }}"
 
+    # podman-compose ignores COMPOSE_PROFILES from .env, so we must pass
+    # --profile flags explicitly for `config`.
+    - name: Read COMPOSE_PROFILES from .env
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read_all
+      register: _env_profiles_backup
+      when: compose_command is search('podman')
+
+    - name: Build compose profile flags
+      ansible.builtin.set_fact:
+        _backup_profile_flags: >-
+          {{ (_env_profiles_backup.variables.COMPOSE_PROFILES | default(''))
+             | split(',') | map('trim') | reject('equalto', '')
+             | map('regex_replace', '^', '--profile ')
+             | join(' ') }}
+      when: compose_command is search('podman')
+
     - name: Render merged compose config as JSON
       ansible.builtin.command:
-        cmd: "{{ compose_command }} config --format json"
+        cmd: "{{ compose_command }} {{ _backup_profile_flags | default('') }} config --format json"
         chdir: "{{ instance_path }}"
       register: _build_compose_config
       changed_when: false

--- a/roles/orchestrator/tasks/destroy.yml
+++ b/roles/orchestrator/tasks/destroy.yml
@@ -28,9 +28,29 @@
              (_destroy_sidecars.stat.exists | ternary(['-f', 'docker-compose.sidecars.yml'], [])) +
              (_destroy_override.stat.exists | ternary(['-f', 'docker-compose.override.yml'], [])) }}
 
+    # podman-compose ignores COMPOSE_PROFILES from .env, so we must pass
+    # --profile flags explicitly for `down` to remove all profiled services.
+    - name: Read COMPOSE_PROFILES from .env
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read_all
+      register: _env_profiles_destroy
+      when: compose_command is search('podman')
+
+    - name: Build compose profile flags
+      ansible.builtin.set_fact:
+        _destroy_profile_flags: >-
+          {{ (_env_profiles_destroy.variables.COMPOSE_PROFILES | default(''))
+             | split(',') | map('trim') | reject('equalto', '')
+             | map('regex_replace', '^', '--profile ')
+             | join(' ') }}
+      when: compose_command is search('podman')
+
     - name: Destroy containers and volumes
       ansible.builtin.command:
-        cmd: "{{ compose_command }} {{ _destroy_compose_files | join(' ') }} down -v --remove-orphans"
+        cmd: >-
+          {{ compose_command }} {{ _destroy_compose_files | join(' ') }}
+          {{ _destroy_profile_flags | default('') }} down -v --remove-orphans
         chdir: "{{ instance_path }}"
       changed_when: true
       ignore_errors: true  # OK if containers already removed

--- a/roles/orchestrator/tasks/exec.yml
+++ b/roles/orchestrator/tasks/exec.yml
@@ -30,10 +30,32 @@
     _exec_shell: >-
       /bin/sh -c 'if command -v bash >/dev/null 2>&1; then exec bash -c "$0"; else exec sh -c "$0"; fi'
 
+# podman-compose ignores COMPOSE_PROFILES from .env, so we must pass
+# --profile flags explicitly for `exec`.
+- name: Read COMPOSE_PROFILES from .env
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read_all
+  register: _env_profiles_exec
+  when:
+    - compose_command is search('podman')
+    - instance_orchestrator | default('compose') == 'compose'
+
+- name: Build compose profile flags
+  ansible.builtin.set_fact:
+    _exec_profile_flags: >-
+      {{ (_env_profiles_exec.variables.COMPOSE_PROFILES | default(''))
+         | split(',') | map('trim') | reject('equalto', '')
+         | map('regex_replace', '^', '--profile ')
+         | join(' ') }}
+  when:
+    - compose_command is search('podman')
+    - instance_orchestrator | default('compose') == 'compose'
+
 - name: Build exec command (Compose)
   ansible.builtin.set_fact:
     _exec_full_cmd: >-
-      {{ compose_command }} exec -T
+      {{ compose_command }} {{ _exec_profile_flags | default('') }} exec -T
       {{ exec_service | default('web') }}
       {{ _exec_shell }} {{ exec_command | quote }}
     _exec_chdir: "{{ instance_path }}"

--- a/roles/orchestrator/tasks/pull.yml
+++ b/roles/orchestrator/tasks/pull.yml
@@ -22,13 +22,29 @@
 # Launched detached and polled (resilient_exec): an image pull can run for
 # minutes, and a controller-side SSH reset mid-pull would otherwise abort it.
 # `docker compose pull` is idempotent, so a re-run after a reset is safe.
+- name: Read COMPOSE_PROFILES from .env
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read_all
+  register: _env_profiles_pull
+  when: compose_command is search('podman')
+
+- name: Build compose profile flags
+  ansible.builtin.set_fact:
+    _pull_profile_flags: >-
+      {{ (_env_profiles_pull.variables.COMPOSE_PROFILES | default(''))
+         | split(',') | map('trim') | reject('equalto', '')
+         | map('regex_replace', '^', '--profile ')
+         | join(' ') }}
+  when: compose_command is search('podman')
+
 - name: Pull images (Compose)
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/resilient_exec.yml"
   vars:
     rx_name: "pull Compose images"
     rx_chdir: "{{ instance_path }}"
     rx_async: 1800
-    rx_cmd: "{{ compose_command }} pull --ignore-buildable --ignore-pull-failures"
+    rx_cmd: "{{ compose_command }} {{ _pull_profile_flags | default('') }} pull --ignore-buildable --ignore-pull-failures"
   when: instance_orchestrator | default('compose') == 'compose'
 
 - name: Get image ID after pull

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -51,9 +51,28 @@
         _compose_cmd: "{{ compose_command }}"
         _inspect_cmd: "{{ inspect_command }}"
 
+    # podman-compose ignores COMPOSE_PROFILES from .env, so we must pass
+    # --profile flags explicitly.  Docker Compose reads .env automatically,
+    # so the flags are empty for Docker.
+    - name: Read COMPOSE_PROFILES from .env
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read_all
+      register: _env_profiles_start
+      when: compose_command is search('podman')
+
+    - name: Build compose profile flags
+      ansible.builtin.set_fact:
+        _compose_profile_flags: >-
+          {{ (_env_profiles_start.variables.COMPOSE_PROFILES | default(''))
+             | split(',') | map('trim') | reject('equalto', '')
+             | map('regex_replace', '^', '--profile ')
+             | join(' ') }}
+      when: compose_command is search('podman')
+
     - name: Start containers
       ansible.builtin.command:
-        cmd: "{{ _compose_cmd }} {{ _compose_files | join(' ') }} up -d"
+        cmd: "{{ _compose_cmd }} {{ _compose_files | join(' ') }} {{ _compose_profile_flags | default('') }} up -d"
         chdir: "{{ instance_path }}"
       register: _start_result
       changed_when: true
@@ -67,7 +86,7 @@
     # only reliable way to see WHY a container was unhealthy.
     - name: Capture compose state on failure
       ansible.builtin.command:
-        cmd: "{{ _compose_cmd }} {{ _compose_files | join(' ') }} ps -a"
+        cmd: "{{ _compose_cmd }} {{ _compose_files | join(' ') }} {{ _compose_profile_flags | default('') }} ps -a"
         chdir: "{{ instance_path }}"
       register: _start_ps
       changed_when: false
@@ -76,7 +95,7 @@
 
     - name: Capture compose logs on failure
       ansible.builtin.command:
-        cmd: "{{ _compose_cmd }} {{ _compose_files | join(' ') }} logs --tail=200 --no-color"
+        cmd: "{{ _compose_cmd }} {{ _compose_files | join(' ') }} {{ _compose_profile_flags | default('') }} logs --tail=200 --no-color"
         chdir: "{{ instance_path }}"
       register: _start_logs
       changed_when: false

--- a/roles/orchestrator/tasks/stop.yml
+++ b/roles/orchestrator/tasks/stop.yml
@@ -34,9 +34,27 @@
              ((_override_exists.stat.exists) | ternary(['-f', 'docker-compose.override.yml'], [])) +
              ((instance_devmode | default(false) | bool) | ternary(['-f', 'docker-compose.dev.yml'], [])) }}
 
+    # podman-compose ignores COMPOSE_PROFILES from .env, so we must pass
+    # --profile flags explicitly for `down` to tear down all profiled services.
+    - name: Read COMPOSE_PROFILES from .env
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read_all
+      register: _env_profiles_stop
+      when: compose_command is search('podman')
+
+    - name: Build compose profile flags
+      ansible.builtin.set_fact:
+        _compose_profile_flags: >-
+          {{ (_env_profiles_stop.variables.COMPOSE_PROFILES | default(''))
+             | split(',') | map('trim') | reject('equalto', '')
+             | map('regex_replace', '^', '--profile ')
+             | join(' ') }}
+      when: compose_command is search('podman')
+
     - name: Stop containers
       ansible.builtin.command:
-        cmd: "{{ compose_command }} {{ _compose_files | join(' ') }} down"
+        cmd: "{{ compose_command }} {{ _compose_files | join(' ') }} {{ _compose_profile_flags | default('') }} down"
         chdir: "{{ instance_path }}"
       changed_when: true
 

--- a/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
+++ b/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
@@ -29,9 +29,29 @@
              (_override_exists_upgrade.stat.exists | ternary(['-f', 'docker-compose.override.yml'], [])) +
              ((instance_devmode | default(false) | bool) | ternary(['-f', 'docker-compose.dev.yml'], [])) }}
 
+    # podman-compose ignores COMPOSE_PROFILES from .env, so we must pass
+    # --profile flags explicitly for `config` and `build`.
+    - name: Read COMPOSE_PROFILES from .env
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read_all
+      register: _env_profiles_upgrade
+      when: compose_command is search('podman')
+
+    - name: Build compose profile flags
+      ansible.builtin.set_fact:
+        _upgrade_profile_flags: >-
+          {{ (_env_profiles_upgrade.variables.COMPOSE_PROFILES | default(''))
+             | split(',') | map('trim') | reject('equalto', '')
+             | map('regex_replace', '^', '--profile ')
+             | join(' ') }}
+      when: compose_command is search('podman')
+
     - name: Render merged compose config as JSON
       ansible.builtin.command:
-        cmd: "{{ compose_command }} {{ _upgrade_compose_files | join(' ') }} config --format json"
+        cmd: >-
+          {{ compose_command }} {{ _upgrade_compose_files | join(' ') }}
+          {{ _upgrade_profile_flags | default('') }} config --format json
         chdir: "{{ instance_path }}"
       register: _upgrade_compose_config
       changed_when: false
@@ -115,7 +135,7 @@
 # image when other services updated.
 - name: Rebuild buildable services if image was bumped (Compose)
   ansible.builtin.command:
-    cmd: "{{ compose_command }} {{ _upgrade_compose_files | join(' ') }} build {{ item }}"
+    cmd: "{{ compose_command }} {{ _upgrade_compose_files | join(' ') }} {{ _upgrade_profile_flags | default('') }} build {{ item }}"
     chdir: "{{ instance_path }}"
   loop: "{{ _buildable_services | default([]) }}"
   changed_when: true

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -1177,7 +1177,7 @@ class TestCrowdsecRestartEngine:
 
     def test_compose_restarts_only_the_service(self):
         content = self._content()
-        assert "{{ compose_command }} restart crowdsec" in content
+        assert "{{ compose_command }} {{ _crowdsec_profile_flags | default('') }} restart crowdsec" in content
 
     def test_k8s_rolls_the_caddy_deployment(self):
         # The engine is a sidecar in the caddy pod, so the K8s equivalent is a
@@ -1198,7 +1198,7 @@ class TestCrowdsecResolveCscli:
 
     def test_compose_prefix(self):
         content = self._content()
-        assert "{{ compose_command }} exec -T crowdsec" in content
+        assert "{{ compose_command }} {{ _cscli_profile_flags | default('') }} exec -T crowdsec" in content
 
     def test_compose_argv_splits_the_compose_command(self):
         # _cscli_argv is consumed by `command:` with argv:, which execs
@@ -1207,7 +1207,7 @@ class TestCrowdsecResolveCscli:
         # element would look for a binary of that literal name.
         content = self._content()
         assert "compose_command.split()" in content
-        assert "['{{ compose_command }}'," not in content
+        assert '["{{ compose_command }}"]' not in content
 
     def test_k8s_prefix_targets_the_sidecar_container(self):
         # kubectl exec into the caddy pod, selecting the crowdsec sidecar.

--- a/tests/unit/test_exec_path_parity.py
+++ b/tests/unit/test_exec_path_parity.py
@@ -162,7 +162,7 @@ class TestStdinFlagParity:
             id="x", service="web", exec_args=["php"], stdin_file="/tmp/p.txt"))
         assert "-T" in captured["argv"]
         # Ansible compose build is always non-interactive (-T).
-        assert "{{ compose_command }} exec -T" in EXEC_YML
+        assert "{{ compose_command }} {{ _exec_profile_flags | default('') }} exec -T" in EXEC_YML
 
 
 def _python_exec_argv(monkeypatch, service, exec_args, orchestrator="compose"):


### PR DESCRIPTION
Part of #1118. Part 5 of 5 splitting #1122 (which stays open as the tracking PR).

**Based on #1226** — review that first.

Authored by @hexmode; split out of #1122 unchanged apart from re-applying the `_cscli_argv` split fix from #1224 (taking the final `_resolve_cscli.yml` would otherwise have reverted it).

## What

- podman-compose does not read `COMPOSE_PROFILES` from `.env`, so every compose invocation touching a profiled service passes explicit `--profile` flags
- podman-compose cannot expand `${VAR:-default}` in `docker-compose.yml`, so the bundled-DB connection defaults are written to `.env` at create time
- an explicit default network, since podman-compose does not create one implicitly

## Review items

- **The `.env` MySQL defaults apply to Docker instances too.** The values do match the `${MYSQL_HOST:-db}` / `:-3306` / `:-root` / `:-false` defaults in `docker-compose.yml`, so this is semantically correct — but it adds four keys to `.env`, and therefore to `env.template` and every gitops diff, for every new Docker instance, to work around a podman-compose limitation. Suggest gating on `compose_command is search('podman')`.
- **The network stanza may be dead weight.** #1122's Known Issues lists podman-compose inter-container DNS as still broken (#1160), which is what this change was reaching for. If it does not fix that, it is 11 services' worth of churn carried for all Docker users.

## Question that gates this PR

If podman-compose cannot resolve service names between containers (#1160), `web` cannot reach `db` and `caddy` cannot reach `web` — the wiki does not come up. So which combination was validated end to end?

- Podman with its **Docker-compatible socket** (`podman.sock` + real `docker compose`), or
- **podman-compose**, the separate Python tool, which is what this PR's `--profile` plumbing targets?

If the former, the podman-compose paths here are untested and the series should be scoped to the socket route. If the latter, a `canasta create` → browse-the-wiki transcript would be great, since it contradicts #1160.

Either way, suggest not advertising "full Podman support" in the release notes until #1160 closes — landing this as experimental, Podman >= 4.4 via the Docker socket, is fine.