### PR TITLE
fix(crowdsec): pass the service-label query as argv, not through a shell

### DIFF
--- a/roles/crowdsec/tasks/_preflight.yml
+++ b/roles/crowdsec/tasks/_preflight.yml
@@ -18,12 +18,16 @@
   when: instance_orchestrator | default('compose') == 'compose'
   block:
     - name: List running services
-      ansible.builtin.shell:
-        cmd: >-
-          {{ inspect_command | default('docker') }}
-          ps --filter status=running
-          --filter label=com.docker.compose.project={{ instance_path | basename | lower }}
-          --format {% raw %}{{.Label "com.docker.compose.service"}}{% endraw %}
+      ansible.builtin.command:
+        argv:
+          - "{{ inspect_command | default('docker') }}"
+          - ps
+          - --filter
+          - status=running
+          - --filter
+          - "label=com.docker.compose.project={{ instance_path | basename | lower }}"
+          - --format
+          - '{% raw %}{{.Label "com.docker.compose.service"}}{% endraw %}'
         chdir: "{{ instance_path }}"
       register: _crowdsec_running
       changed_when: false

--- a/roles/orchestrator/tasks/list_running_services.yml
+++ b/roles/orchestrator/tasks/list_running_services.yml
@@ -5,12 +5,16 @@
 # Output: _running_services (newline-separated names, may be empty)
 
 - name: Get service list (Compose)
-  ansible.builtin.shell:
-    cmd: >-
-      {{ inspect_command | default('docker') }}
-      ps --filter status=running
-      --filter label=com.docker.compose.project={{ instance_path | basename | lower }}
-      --format {% raw %}{{.Label "com.docker.compose.service"}}{% endraw %}
+  ansible.builtin.command:
+    argv:
+      - "{{ inspect_command | default('docker') }}"
+      - ps
+      - --filter
+      - status=running
+      - --filter
+      - "label=com.docker.compose.project={{ instance_path | basename | lower }}"
+      - --format
+      - '{% raw %}{{.Label "com.docker.compose.service"}}{% endraw %}'
     chdir: "{{ instance_path }}"
   register: _list_services_compose
   changed_when: false

--- a/tests/unit/test_container_query_no_shell_splitting.py
+++ b/tests/unit/test_container_query_no_shell_splitting.py
@@ -1,0 +1,107 @@
+"""A Go template containing whitespace must never be passed unquoted.
+
+`{{.Label "com.docker.compose.service"}}` has a space in it. Handed to
+`ansible.builtin.shell:` without quoting, /bin/sh splits it into two
+words and docker rejects the call with "docker ps accepts no
+arguments" — which took out every crowdsec Compose subcommand and
+`backup restore`.
+
+Ansible resolves its own `{{ jinja }}` before building the argument
+vector, so only text inside `{% raw %}` survives that far; those are
+the templates this checks. `command:` with `argv:` avoids the problem
+entirely — each element is one argument, whatever it contains.
+"""
+
+import os
+import re
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+
+# Files whose tasks query the container runtime with a Go template.
+_QUERY_FILES = (
+    "roles/crowdsec/tasks/_preflight.yml",
+    "roles/orchestrator/tasks/list_running_services.yml",
+    "roles/orchestrator/tasks/check_running.yml",
+    "roles/orchestrator/tasks/start.yml",
+    "roles/orchestrator/tasks/upgrade_rebuild_buildable.yml",
+)
+
+_CMD_MODULES = ("ansible.builtin.command", "command")
+_RAW_BLOCK = re.compile(
+    r"\{%\s*raw\s*%\}(?P<body>.*?)\{%\s*endraw\s*%\}", re.S)
+
+
+def _read(rel):
+    with open(os.path.join(REPO_ROOT, rel)) as f:
+        return f.read()
+
+
+def _tasks(rel):
+    """Task dicts from a file, with raw markers stripped so the Go
+    templates survive YAML parsing as plain scalars."""
+    text = _read(rel).replace("{% raw %}", "").replace("{% endraw %}", "")
+    out = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            out.append(node)
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(yaml.safe_load(text))
+    return out
+
+
+def _unprotected_templates():
+    """(file, template) for raw Go templates holding whitespace that
+    nothing quotes — those split into multiple arguments."""
+    hits = []
+    for rel in _QUERY_FILES:
+        text = _read(rel)
+        for m in _RAW_BLOCK.finditer(text):
+            body = m.group("body")
+            if not re.search(r"\s", body):
+                continue                      # nothing to split
+            if body[0] in "'\"" and body[-1] == body[0]:
+                continue                      # quoted inside the raw block
+            line_start = text.rfind("\n", 0, m.start()) + 1
+            if re.search(r"['\"]", text[line_start:m.start()]):
+                continue                      # quoted by the enclosing scalar
+            hits.append((rel, body[:70]))
+    return hits
+
+
+def test_no_unquoted_go_template_contains_whitespace():
+    hits = _unprotected_templates()
+    assert not hits, (
+        "these Go templates contain whitespace but nothing quotes them, so "
+        "they are split into separate arguments — use command: with argv:, "
+        "or quote them:\n" + "\n".join("  %s\n    %s" % h for h in hits)
+    )
+
+
+def test_the_service_label_queries_use_argv():
+    # The two that regressed. Assert the fixed shape directly, so a
+    # revert to shell: fails here even if the quoting looks plausible.
+    for rel in ("roles/crowdsec/tasks/_preflight.yml",
+                "roles/orchestrator/tasks/list_running_services.yml"):
+        flat = [
+            str(a)
+            for task in _tasks(rel)
+            for mod in _CMD_MODULES
+            if isinstance(task.get(mod), dict) and "argv" in task[mod]
+            for a in task[mod]["argv"]
+        ]
+        assert any("com.docker.compose.service" in a for a in flat), (
+            "%s must query the service label through command: argv:, so the "
+            "template is never parsed by a shell" % rel
+        )
+        assert any(a.strip().startswith("{{.Label") for a in flat), (
+            "%s: the Go template must be its own argv element" % rel
+        )


### PR DESCRIPTION
Fixes #1231. Found in a hands-on Compose e2e against merged `main`.

## The bug

`--format {{.Label "com.docker.compose.service"}}` sat unquoted inside an `ansible.builtin.shell:` task. The template contains a space, so `/bin/sh` split it into `{{.Label` and `com.docker.compose.service}}`, and docker rejected the whole invocation:

```
$ canasta crowdsec status -i e2e-compose
Error: The command exited with a non-zero return code.
 (cmd: docker ps --filter status=running --filter label=com.docker.compose.project=e2e-compose --format {{.Label "com.docker.compose.service"}})
docker: 'docker ps' accepts no arguments
```

That broke every crowdsec Compose subcommand, and `canasta backup restore`, which reaches the same query through the start path's CrowdSec autoenroll — aborting at exit 2 before restoring anything.

## The fix

Both tasks move from `shell:` to `command:` with `argv:`. Each element is one argument regardless of its contents, so no shell parsing happens and the template arrives intact. This matches how `start.yml` already passes its `-f` template to `docker inspect`.

Verified against the live instance the bug was found on — the error is gone and the query returns the service list correctly:

```
varnish
web
caddy
db
```

## Test

`test_container_query_no_shell_splitting.py` checks that no Go template containing whitespace is left unquoted, across all five files that query the runtime by template. It only inspects text inside `{% raw %}` — Ansible resolves its own `{{ jinja }}` before the argument vector is built, so those are not a hazard, and an earlier draft of this test produced a false positive on `{{ inspect_command | default('docker') }}` for exactly that reason.

Confirmed it fails on unmodified `main` and passes with the fix.

## Note on the guard below it

`_preflight.yml`'s `when: "'crowdsec' not in (_crowdsec_running.stdout_lines | default([]))"` would also have misfired on the empty result, refusing with "the crowdsec service is not running" while it was running. Fixing the query fixes that too, but the guard is worth a look independently — `default([])` turns a failed probe into a confident negative.

## Coverage gap

The suite has an `Integration: Kubernetes CrowdSec` job and no Compose equivalent, which is why this shipped green through five PRs. A Compose scenario — enable, `status`, `ban`, `unban` — would have caught it and is cheap to add.