### PR TITLE
fix(docker): make the passwd entry win over a colliding image account

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -157,12 +157,6 @@ MOUNTS=(
     --user "$(id -u):$(id -g)"
 )
 
-# We want the user's config to be available, but the ssh configuration doesn't read it even though it is already
-# mounted.  So we'll mount the user's .ssh/config to somewhere where it is read.
-if [[ -f "$HOME/.ssh/config" ]]; then
-    MOUNTS+=(-v "$HOME/.ssh/config:/etc/ssh/ssh_config.d/zz-user.conf")
-fi
-
 # Set Ansible temp + home directories to /tmp when running as a non-root user
 # in rootless Docker. On rootless Docker, the UID/GID mapping causes directory
 # ownership to appear as nobody:nogroup to the container process even though
@@ -314,9 +308,18 @@ fi
 # sshd rejects after too many auth failures because no `canasta` user
 # exists there. See #478.
 _CANASTA_DOCKER_USER="$(id -un 2>/dev/null || echo "${USER:-canasta}")"
-if ! grep -q "^[^:]*:[^:]*:$(id -u):" "$CANASTA_PASSWD" 2>/dev/null; then
-    echo "${_CANASTA_DOCKER_USER}:x:$(id -u):$(id -g):${_CANASTA_DOCKER_USER}:$HOME:/bin/sh" >> "$CANASTA_PASSWD"
-fi
+# Ours must replace, not defer to, any entry the image already has for
+# this UID. The image ships accounts at 0-10, 13, 33, 34, 38, 39, 42 and
+# 65534; on a collision getpwuid() would return that account's home, so
+# ssh reads the wrong ~/.ssh/config and ansible_user_id names the image
+# account instead of the operator. $HOME being mounted does not help —
+# OpenSSH resolves ~ from the passwd entry, not from $HOME.
+_PASSWD_TMP="$(mktemp)"
+awk -F: -v uid="$(id -u)" '$1 ~ /^#/ || $3 != uid' "$CANASTA_PASSWD" > "$_PASSWD_TMP" 2>/dev/null || true
+printf '%s:x:%s:%s:%s:%s:/bin/sh\n' \
+    "$_CANASTA_DOCKER_USER" "$(id -u)" "$(id -g)" \
+    "$_CANASTA_DOCKER_USER" "$HOME" >> "$_PASSWD_TMP"
+mv "$_PASSWD_TMP" "$CANASTA_PASSWD"
 MOUNTS+=(-v "$CANASTA_PASSWD:/etc/passwd:ro")
 # Add only the groups the container actually needs: the Docker socket
 # GID (for docker commands) and www-data (for writing to container-

--- a/tests/unit/test_canasta_docker.py
+++ b/tests/unit/test_canasta_docker.py
@@ -482,6 +482,60 @@ def _shell_quote(s):
     return "'" + s.replace("'", "'\\''") + "'"
 
 
+class TestPasswdEntryWinsOverImageAccount:
+    """The image ships accounts at UIDs 0-10, 13, 33, 34, 38, 39, 42 and
+    65534. When the operator's UID collides with one, our entry has to
+    replace it — getpwuid() otherwise returns that account's home, so
+    OpenSSH reads the wrong ~/.ssh/config (it resolves ~ from the passwd
+    entry, not $HOME) and ansible_user_id names the image account. See
+    #1235.
+    """
+
+    def _passwd_after_run(self, seeded):
+        config_dir = tempfile.mkdtemp(prefix="cd-", dir="/tmp")
+        _run_dry_tmpdirs.append(config_dir)
+        passwd_path = os.path.join(config_dir, ".canasta-passwd")
+        with open(passwd_path, "w") as f:
+            f.write(seeded)
+        run_dry(["version"], env={"CANASTA_CONFIG_DIR": config_dir})
+        with open(passwd_path) as f:
+            return [
+                line.strip() for line in f
+                if line.strip() and not line.startswith("#")
+            ]
+
+    def test_colliding_image_entry_is_replaced(self):
+        uid = str(os.getuid())
+        # An image account squatting on the operator's UID.
+        seeded = "www-data:x:%s:33:www-data:/var/www:/usr/sbin/nologin\n" % uid
+        entries = self._passwd_after_run(seeded)
+
+        mine = [e for e in entries if e.split(":")[2] == uid]
+        assert len(mine) == 1, (
+            "expected exactly one entry for UID %s, got %d:\n%s"
+            % (uid, len(mine), "\n".join(entries))
+        )
+        home = mine[0].split(":")[5]
+        assert home == os.environ["HOME"], (
+            "passwd home is %r, not the operator's %r — ssh would read "
+            "%s/.ssh/config instead of the mounted one"
+            % (home, os.environ["HOME"], home)
+        )
+
+    def test_other_image_accounts_are_left_alone(self):
+        uid = str(os.getuid())
+        seeded = (
+            "root:x:0:0:root:/root:/bin/bash\n"
+            "www-data:x:%s:33:www-data:/var/www:/usr/sbin/nologin\n"
+            "nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin\n"
+        ) % uid
+        entries = self._passwd_after_run(seeded)
+        uids = [e.split(":")[2] for e in entries]
+        assert "0" in uids and "65534" in uids, (
+            "unrelated image accounts must survive:\n%s" % "\n".join(entries)
+        )
+
+
 class TestPasswdEntryUsesHostUsername:
     """The /etc/passwd that canasta-docker bind-mounts into the
     container has to carry the host operator's actual login name as


### PR DESCRIPTION
Fixes #1235. @hexmode — this is the alternative to the `zz-user.conf` mount; the reasoning is below and I'd rather agree on it than just swap it out.

## The failure you hit

`ssh: Could not resolve hostname canasta-staging` is ssh falling back to DNS because it never read your `~/.ssh/config`, so the `Host canasta-staging` block — and its `HostName` — never applied.

The cause is not that `$HOME` is unmounted. It is mounted, and `HOME` is exported. But **OpenSSH resolves `~` from the passwd entry, not from `$HOME`**, and `canasta-docker` only appended a passwd entry for the invoking UID when the image did not already have one:

```bash
if ! grep -q "^[^:]*:[^:]*:$(id -u):" "$CANASTA_PASSWD" 2>/dev/null; then
```

The image ships accounts at UIDs 0-10, 13, 33, 34, 38, 39, 42 and 65534. If your host UID collides with any of them, the append is skipped and `getpwuid()` hands ssh that account's home instead of yours.

## Demonstrated

Same container, same mounted `$HOME`, only the passwd entry differs:

| | getpwuid home | `ssh -G github.com` → hostname |
|---|---|---|
| colliding entry (`www-data` on the UID) | `/var/www` | `github.com` — **alias not applied** |
| this fix | `/Users/cicalese` | `ssh.github.com` ✓ |
| your `zz-user.conf` mount, passwd still colliding | `/var/www` | `ssh.github.com` ✓ |

So both approaches fix the hostname. The difference is what else they fix.

## Why the passwd entry rather than the mount

`ansible_user_id` comes from the same `getpwuid` lookup, so on a collision it reports the image account rather than you — which is very likely what made the sysctl block's `when: ansible_user_id != 'root'` fire and attempt `become` in a container with no `sudo`. The mount does not touch that; this does. Same for anything else resolving `~` or the current user, git's author fallback included.

One thing I could **not** confirm either way: whether `IdentityFile ~/.ssh/...` still breaks under the mount, since `~` would expand against `/var/www`. `ssh -G` prints the literal config value rather than the expanded path, so it does not settle it. If your config uses `~`-relative keys and you got past the hostname error only to hit an auth failure, that would be the reason — worth knowing before we pick.

The change replaces any existing line for the UID instead of deferring to it, and drops the mount as redundant. Keeping both would read the same file at two precedence levels (`/etc/ssh/ssh_config` ranks *below* `~/.ssh/config`) — harmless, but no reason to carry it.

## Test

`TestPasswdEntryWinsOverImageAccount` seeds a passwd file with `www-data` squatting on the invoking UID and asserts our entry replaces it while unrelated accounts survive. Confirmed it fails against the old guard.

**What would settle this quickly:** what does `id -u` report on that host? If it is in the list above, this is confirmed rather than inferred, and I would expect the mount to be unnecessary once this lands.