### PR TITLE
fix(create): make the port-conflict preflight work off Linux

### DIFF
--- a/roles/orchestrator/tasks/create_preflight.yml
+++ b/roles/orchestrator/tasks/create_preflight.yml
@@ -93,25 +93,51 @@
     # sudo. The k3s probe also catches a stopped-but-not-cleaned k3s
     # (rules may still be present after `systemctl stop` alone), so
     # the message points at k3s-killall too.
+    # ss is iproute2 (Linux only); lsof is the macOS default and common
+    # on Linux. Try both, and make "no probe available" its own outcome —
+    # an unrunnable check must not read as "port is free", which is what
+    # `failed_when: false` plus an empty stdout used to produce.
     - name: Probe for userspace listener on port 80
-      ansible.builtin.command:
-        argv:
-          - ss
-          - -tlnH
-          - sport = :80
+      ansible.builtin.shell:
+        cmd: |
+          if command -v ss >/dev/null 2>&1; then
+            ss -tlnH "sport = :80"
+          elif command -v lsof >/dev/null 2>&1; then
+            lsof -nP -iTCP:80 -sTCP:LISTEN 2>/dev/null | tail -n +2
+          else
+            echo "CANASTA_PORT_PROBE_UNAVAILABLE"
+          fi
       register: _port80_listener
       changed_when: false
       failed_when: false
 
     - name: Probe for userspace listener on port 443
-      ansible.builtin.command:
-        argv:
-          - ss
-          - -tlnH
-          - sport = :443
+      ansible.builtin.shell:
+        cmd: |
+          if command -v ss >/dev/null 2>&1; then
+            ss -tlnH "sport = :443"
+          elif command -v lsof >/dev/null 2>&1; then
+            lsof -nP -iTCP:443 -sTCP:LISTEN 2>/dev/null | tail -n +2
+          else
+            echo "CANASTA_PORT_PROBE_UNAVAILABLE"
+          fi
       register: _port443_listener
       changed_when: false
       failed_when: false
+
+    # Neither tool present: say so rather than let a check that never ran
+    # look like a clean result. Not fatal — a missing lsof/ss should not
+    # block a create on an otherwise healthy host.
+    - name: Warn when the port check could not run
+      ansible.builtin.debug:
+        msg: >-
+          Could not check whether ports 80 and 443 are free: neither `ss`
+          nor `lsof` is available on this host. If something else is
+          already serving on them, compose will fail to bind (or caddy
+          will start while traffic lands on the other service).
+      when: >-
+        "CANASTA_PORT_PROBE_UNAVAILABLE" in
+        (_port80_listener.stdout | default(''))
 
     - name: Fail if port 80 is already in use
       ansible.builtin.fail:
@@ -121,7 +147,9 @@
           `canasta create` (Compose) needs ports 80 and 443 free for
           the caddy service. Stop the conflicting service or use a
           different host.
-      when: _port80_listener.stdout | default('') | trim | length > 0
+      when:
+        - _port80_listener.stdout | default('') | trim | length > 0
+        - '"CANASTA_PORT_PROBE_UNAVAILABLE" not in (_port80_listener.stdout | default(""))'
 
     - name: Fail if port 443 is already in use
       ansible.builtin.fail:
@@ -131,7 +159,9 @@
           `canasta create` (Compose) needs ports 80 and 443 free for
           the caddy service. Stop the conflicting service or use a
           different host.
-      when: _port443_listener.stdout | default('') | trim | length > 0
+      when:
+        - _port443_listener.stdout | default('') | trim | length > 0
+        - '"CANASTA_PORT_PROBE_UNAVAILABLE" not in (_port443_listener.stdout | default(""))'
 
     - name: Probe whether k3s is running
       ansible.builtin.command:

--- a/tests/unit/test_port_preflight_portable.py
+++ b/tests/unit/test_port_preflight_portable.py
@@ -1,0 +1,107 @@
+"""The port-conflict preflight must work off Linux, and must not treat
+a check it could not run as a clean result.
+
+It probed with `ss`, which is iproute2 and absent on macOS. Paired with
+`failed_when: false` that produced empty stdout, which the gate below
+read as "port is free" — so on a Mac the guard passed silently while
+ports 80/443 were demonstrably held, and the conflict surfaced later as
+an opaque Docker bind error. macOS localhost Compose is the frontend
+development workflow, so that is the case the guard exists for.
+"""
+
+import os
+import re
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+PREFLIGHT = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "create_preflight.yml")
+
+_SENTINEL = "CANASTA_PORT_PROBE_UNAVAILABLE"
+
+
+def _read():
+    with open(PREFLIGHT) as f:
+        return f.read()
+
+
+def _tasks():
+    out = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            out.append(node)
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for i in node:
+                walk(i)
+
+    walk(yaml.safe_load(_read()))
+    return out
+
+
+def _probe_tasks():
+    return [
+        t for t in _tasks()
+        if isinstance(t.get("name"), str)
+        and re.match(r"Probe for userspace listener on port \d+", t["name"])
+    ]
+
+
+class TestProbeIsPortable:
+    def test_both_ports_are_probed(self):
+        ports = sorted(
+            re.search(r"port (\d+)", t["name"]).group(1)
+            for t in _probe_tasks()
+        )
+        assert ports == ["443", "80"], "expected probes for 80 and 443, got %s" % ports
+
+    def test_probe_falls_back_when_ss_is_absent(self):
+        for task in _probe_tasks():
+            cmd = task.get("ansible.builtin.shell", {}).get("cmd", "")
+            assert "command -v ss" in cmd, (
+                "%s must test for ss rather than assume it" % task["name"])
+            assert "lsof" in cmd, (
+                "%s has no non-Linux fallback; ss is iproute2-only"
+                % task["name"])
+
+    def test_unavailable_probe_is_distinguishable(self):
+        # The bug: an unrunnable probe and a free port both produced
+        # empty stdout, so they were indistinguishable downstream.
+        for task in _probe_tasks():
+            cmd = task.get("ansible.builtin.shell", {}).get("cmd", "")
+            assert _SENTINEL in cmd, (
+                "%s must emit a sentinel when no probe tool exists, or "
+                "'could not check' is silently read as 'port is free'"
+                % task["name"])
+
+
+class TestFailureGateIgnoresTheSentinel:
+    def _fail_tasks(self):
+        return [
+            t for t in _tasks()
+            if isinstance(t.get("name"), str)
+            and t["name"].startswith("Fail if port")
+        ]
+
+    def test_both_gates_exist(self):
+        assert len(self._fail_tasks()) == 2
+
+    def test_sentinel_does_not_trip_the_failure(self):
+        for task in self._fail_tasks():
+            when = task.get("when")
+            when_text = " ".join(when) if isinstance(when, list) else str(when)
+            assert _SENTINEL in when_text, (
+                "%s would abort the create when the probe merely could not "
+                "run — the sentinel must be excluded" % task["name"]
+            )
+
+    def test_a_missing_probe_is_reported_not_swallowed(self):
+        names = [t.get("name") for t in _tasks() if isinstance(t.get("name"), str)]
+        assert any("port check could not run" in n for n in names), (
+            "nothing tells the operator the check was skipped; a guard that "
+            "silently does nothing is worse than no guard"
+        )


### PR DESCRIPTION
Fixes #1230. Found in a hands-on Compose e2e on a macOS controller.

## The bug

The probe assumed `ss`:

```yaml
argv: [ss, -tlnH, "sport = :80"]
register: _port80_listener
failed_when: false
```

`ss` is iproute2 — Linux only. On macOS the binary is missing, `failed_when: false` swallows it, `stdout` is empty, and the gate below reads that as "port is free":

```yaml
when: _port80_listener.stdout | default('') | trim | length > 0
```

The check therefore passed silently on every macOS host, whatever was bound. The conflict then surfaced at container start as an opaque Docker bind error — the exact outcome the preflight exists to prevent.

This matters because macOS localhost Compose is a supported configuration (it is the frontend-development workflow) and running several instances on one machine is normal there. The comment above the probe even names "a docker-proxy from another canasta" as a target case.

## Fix

Try `ss`, fall back to `lsof` (default on macOS, common on Linux), and emit a sentinel when neither exists.

The sentinel is the part that matters beyond portability: previously "the probe could not run" and "nothing is listening" were both empty stdout and thus indistinguishable. Now an unrunnable check produces a warning rather than a silent pass, and does not block the create — a missing `lsof` should not stop work on an otherwise healthy host.

Behavior verified directly, all three branches:

| state | probe output | outcome |
|---|---|---|
| port 80 held | `com.docke 23786 ... TCP *:80 (LISTEN)` | fails, names the process |
| port 9999 free | *(empty)* | proceeds |
| no `ss`, no `lsof` | `CANASTA_PORT_PROBE_UNAVAILABLE` | warns, proceeds |

And end to end on the machine that exposed it, with 80/443 held by another instance:

```
$ canasta create -i port-check -w main -n localhost
Error: Port 80 is already in use on this host: com.docke 23786 cicalese 247u IPv6 ... TCP *:80 (LISTEN).
`canasta create` (Compose) needs ports 80 and 443 free for the caddy service.
Stop the conflicting service or use a different host.
```

That same command previously ran straight past the guard.

## Note on `lsof` output

`lsof` prints a header row when something is listening and nothing at all when the port is free, so the existing emptiness test still holds; the header is stripped with `tail -n +2` to keep the failure message to the matching line. `ss -tlnH` already suppresses its header.

## Test

`test_port_preflight_portable.py` asserts both ports are probed, that the probe does not assume `ss`, that an unrunnable probe is distinguishable, that the sentinel cannot trip the failure gate, and that a skipped check is reported. Confirmed 4 of the 6 fail against the current code.

The adjacent k3s probe is unaffected — `systemctl` is also absent on macOS, but a Mac cannot be running k3s in the relevant sense, so a vacuous pass there is harmless.