### PR TITLE
fix(restore): distinguish a failed restore from a failed restart

### DIFF
--- a/roles/backup/tasks/restore.yml
+++ b/roles/backup/tasks/restore.yml
@@ -86,10 +86,29 @@
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/orchestrator/tasks/restore_instance.yml
 
+# Everything above this point is the restore proper: the snapshot's files
+# and databases are already in place once it completes. A failure in the
+# restart therefore means "restored but not running", which is a very
+# different situation from "restore failed" — and re-running the restore
+# is the wrong response to it.
 - name: Restart instance after restore
-  ansible.builtin.include_role:
-    name: instance_lifecycle
-    tasks_from: restart.yml
+  block:
+    - name: Start the instance with the restored state
+      ansible.builtin.include_role:
+        name: instance_lifecycle
+        tasks_from: restart.yml
+  rescue:
+    - name: Report a restore that succeeded with a failed restart
+      ansible.builtin.fail:
+        msg: >-
+          The restore completed: files and databases from snapshot
+          {{ _resolved_snapshot }} are in place. Only the post-restore
+          restart failed (see the error above).
+
+          Do not re-run the restore — the data is already restored.
+          Bring the instance up with
+          'canasta start --id {{ instance_id }}' and confirm with
+          'canasta list'.
 
 # The snapshot restored config/backup-schedule.yml (if the instance had a
 # schedule); re-materialize the crontab on the instance's host so the

--- a/tests/unit/test_restore_outcome_reporting.py
+++ b/tests/unit/test_restore_outcome_reporting.py
@@ -1,0 +1,102 @@
+"""A restore that exits non-zero must say whether the data landed.
+
+The snapshot's files and databases are both restored by
+`restore_instance.yml`; the instance restart happens after it. So a
+failure in the restart means "restored but not running" — the data is
+already in place and re-running the restore is the wrong response.
+
+Before this, both outcomes surfaced as a bare non-zero exit, so an
+operator seeing a failed restore would reasonably assume nothing had
+happened and retry, or worse, reach for an older snapshot.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+RESTORE = os.path.join(REPO_ROOT, "roles", "backup", "tasks", "restore.yml")
+RESTORE_INSTANCE = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "restore_instance.yml")
+
+
+def _tasks(path):
+    with open(path) as f:
+        return yaml.safe_load(f) or []
+
+
+def _named(tasks, needle):
+    return [
+        t for t in tasks
+        if isinstance(t, dict) and needle.lower() in str(t.get("name", "")).lower()
+    ]
+
+
+class TestRestorePrecedesRestart:
+    """The premise the message depends on: if the restart ever moved
+    ahead of the data restore, the reassurance below would be false."""
+
+    def test_restore_comes_before_the_restart(self):
+        names = [
+            str(t.get("name", "")) for t in _tasks(RESTORE)
+            if isinstance(t, dict)
+        ]
+        restore_at = next(
+            i for i, n in enumerate(names) if "Restore from snapshot" in n)
+        restart_at = next(
+            i for i, n in enumerate(names) if "Restart instance after" in n)
+        assert restore_at < restart_at, (
+            "the restart must follow the restore — the rescue message tells "
+            "the operator their data is already in place"
+        )
+
+    def test_the_database_import_is_part_of_the_restore_step(self):
+        # Not merely the file copy: the message claims databases too.
+        with open(RESTORE_INSTANCE) as f:
+            body = f.read()
+        assert "Import each wiki database dump" in body, (
+            "restore_instance.yml no longer imports databases; the rescue "
+            "message in restore.yml claims it does"
+        )
+
+
+class TestFailedRestartIsReportedAsSuch:
+    def test_the_restart_has_a_rescue(self):
+        restart = _named(_tasks(RESTORE), "Restart instance after")
+        assert restart, "no post-restore restart task found"
+        assert "rescue" in restart[0], (
+            "an unguarded restart failure is indistinguishable from a failed "
+            "restore — wrap it so the outcome can be reported"
+        )
+
+    def test_the_message_says_the_data_is_restored(self):
+        restart = _named(_tasks(RESTORE), "Restart instance after")[0]
+        msg = " ".join(
+            str(t.get("ansible.builtin.fail", {}).get("msg", ""))
+            for t in restart["rescue"]
+        ).lower()
+        assert "restore completed" in msg, (
+            "the rescue must state the restore itself succeeded"
+        )
+        assert "do not re-run the restore" in msg, (
+            "the operator's instinct on a non-zero exit is to retry; the "
+            "message has to head that off"
+        )
+
+    def test_the_message_names_the_recovery_command(self):
+        restart = _named(_tasks(RESTORE), "Restart instance after")[0]
+        msg = " ".join(
+            str(t.get("ansible.builtin.fail", {}).get("msg", ""))
+            for t in restart["rescue"]
+        )
+        assert "canasta start" in msg, (
+            "say how to finish the job, not just what went wrong"
+        )
+
+    def test_it_still_exits_non_zero(self):
+        # Restored-but-stopped is not success; the run must still fail.
+        restart = _named(_tasks(RESTORE), "Restart instance after")[0]
+        assert any(
+            "ansible.builtin.fail" in t for t in restart["rescue"]
+        ), "the rescue must re-fail — the instance is not running"


### PR DESCRIPTION
Fixes #1232 — after correcting that issue, which originally described a partial-restore problem that does not occur. See the correction comment there.

## What actually happens

`roles/backup/tasks/restore.yml` runs in this order:

```
85: Restore from snapshot           <- restore_instance.yml: files (:169) AND databases (:264)
89: Restart instance after restore  <- instance_lifecycle -> start.yml
```

So by the time the restart runs, the snapshot's files and databases are already in place. A failure there means **restored but not running** — yet it surfaced as a bare non-zero exit, indistinguishable from a restore that never happened.

That is the dangerous part. An operator seeing a failed `backup restore` reasonably concludes nothing happened and retries, or reaches for an older snapshot. Both are the wrong response to an instance that is fully restored and merely stopped.

## Fix

Wrap the restart in `block`/`rescue`. On failure the message states the restore completed, tells the operator not to re-run it, and names `canasta start` as the way to finish. It still exits non-zero — restored-but-stopped is not success.

Verified the mechanism against real Ansible rather than assuming `rescue` catches a dynamically included role:

```
$ ansible-playbook play.yml     # include_role -> a task that fails
[ERROR]: Task failed: Action failed: RESCUE FIRED: restore completed; only the restart failed.
localhost : ok=1 changed=0 unreachable=0 failed=1 skipped=0 rescued=1 ignored=0
```

`rescued=1` with `failed=1`: the rescue runs, the message is emitted, and the run still fails.

## Test

`test_restore_outcome_reporting.py` covers the rescue and its wording, plus two tests for the **premise** the message rests on — that the restore step precedes the restart, and that `restore_instance.yml` still imports databases rather than only copying files. If either ever changes, the reassurance becomes false and those tests fail rather than the message quietly starting to lie.

4 of the 6 fail against current `main`; the 2 that pass are the premise checks, which already hold.

## Note

This was originally filed as a transactionality bug. Reordering and rollback were both considered and neither applies: there is nothing to reorder, and rolling back would mean undoing a *successful* restore because a restart failed. The residual issue was purely that the outcome was unreportable, which is what this changes.