### PR TITLE
docs(restore): state that a restore rewinds tables, not the database

### DIFF
--- a/roles/backup/tasks/restore.yml
+++ b/roles/backup/tasks/restore.yml
@@ -122,3 +122,6 @@
     msg: >-
       Restored {{ ("wiki '" ~ wiki ~ "' from") if wiki is defined else "from" }}
       snapshot {{ _resolved_snapshot }}.
+      Database tables present in the snapshot were replaced; any table
+      created since it was taken (a later extension install, a MediaWiki
+      upgrade) still exists.

--- a/roles/orchestrator/tasks/restore_instance.yml
+++ b/roles/orchestrator/tasks/restore_instance.yml
@@ -4,6 +4,10 @@
 # Compose: optional safety backup -> restic restore into the backup
 #   volume -> copy files to host -> preserve DB password -> import DB
 #   dumps -> re-render gitops templates.
+#
+# The DB import replaces the tables present in the dump; tables added
+# since the snapshot (a later extension install, a MediaWiki upgrade)
+# remain. Config files are replaced outright.
 # Kubernetes: delegate to restore_k8s.yml (pod-based restore + DB and
 #   Secret handling) -> preserve DB password in the restored .env.
 #
@@ -261,6 +265,10 @@
         state: read
       register: _restore_wikis
 
+    # The dump carries DROP TABLE + CREATE TABLE per table, so tables it
+    # contains are replaced wholesale. Tables created after the snapshot
+    # are absent from it and survive the import — a restore rewinds the
+    # snapshot's tables, it does not reset the database.
     - name: Import each wiki database dump
       when: wiki is not defined
       ansible.builtin.include_tasks: exec.yml


### PR DESCRIPTION
Documents #1242 rather than changing the behavior, per the discussion there.

## What was undocumented

The DB restore replays a per-table dump — 58 `DROP TABLE IF EXISTS` and 58 `CREATE TABLE` in the instance I measured. Tables the snapshot contains are replaced wholesale, so their rows correctly return to the snapshot's state. Tables created *after* the snapshot are absent from the dump, so nothing drops them and they survive.

Verified in a remote e2e: planted a config marker and a new database table after taking a snapshot, then restored. The config marker reverted; the table was still there.

That is defensible — dropping the database outright would be destructive in a way the current behavior is not, and would need care around the DB user and grants. But it was unstated, so "restore" read as "return the instance to the snapshot" and quietly did not for the database.

## Where it is now said

- `restore_instance.yml` at the import site, and in the file header that summarizes the flow.
- The result the operator sees, since the case that matters — restoring past an extension install or a MediaWiki upgrade — is exactly when someone would otherwise assume those tables were gone.
- [Help:Backup and restore](https://canasta.wiki/wiki/Help:Backup_and_restore) on canasta.wiki, under *Restoring a backup*, including that the leftover tables sit unused rather than causing errors and can be dropped by hand for a clean state.

No behavior change; no test changes.