### PR TITLE
fix(wiki-publish): label menu entries with the display name

### DIFF
--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -740,7 +740,12 @@ def generate_all_pages(data):
             # page) followed by per-subcommand links.
             if name in cmd_index:
                 link = cmd_page_title(name)
-                menu_lines.append("*** %s | canasta %s" % (link, name))
+                # Label from the display name, not the internal one, so
+                # 'wiki_check' reads 'canasta wiki-check' and matches the
+                # page the link points at.
+                menu_lines.append(
+                    "*** %s | canasta %s" % (link, cmd_display_name(name))
+                )
             elif name in SUBCOMMAND_GROUPS:
                 # Synthetic group page (hand-curated, not auto-generated).
                 menu_lines.append(


### PR DESCRIPTION
Fixes #1250.

Routes the CLI reference menu's leaf-entry labels through `cmd_display_name()` so they match the pages they link to. Today this only changes `canasta wiki_check` to `canasta wiki-check`; verified by generating the menu and confirming no label contains an underscore.

`make validate`, `make lint`, and `make test-unit` (1932 passed) are green.