### PR TITLE
fix(security): set no_log on tasks that register a secret

### DIFF
--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -235,6 +235,7 @@
         path: "{{ instance_path }}/.env"
         state: read_all
       register: _se_caddy_env
+      no_log: true  # registers the whole .env, including passwords
 
     - name: Compute new active scheme/port/default
       vars:
@@ -359,6 +360,7 @@
         state: read
         key: CROWDSEC_BOUNCER_API_KEY
       register: _se_crowdsec_key
+      no_log: true  # holds the bouncer's API key
 
     - name: Advise on bouncer enrollment
       ansible.builtin.debug:

--- a/roles/config/tasks/_update_gitops_vars.yml
+++ b/roles/config/tasks/_update_gitops_vars.yml
@@ -71,6 +71,7 @@
         path: "{{ instance_path }}/.env"
         state: read_all
       register: _config_env_final
+      no_log: true  # registers the whole .env, including passwords
 
     - name: Propagate derived MW_SITE_FQDN/MW_SITE_SERVER to vars.yaml
       ansible.builtin.include_tasks: >-

--- a/roles/create/tasks/_envfile.yml
+++ b/roles/create/tasks/_envfile.yml
@@ -50,6 +50,7 @@
         state: read
         key: MYSQL_PASSWORD
       register: _ext_db_password
+      no_log: true  # holds the external database's password
 
     - name: Override root DB password with external DB password
       ansible.builtin.set_fact:
@@ -63,6 +64,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _env_for_port
+  no_log: true  # registers the whole .env, including passwords
 
 - name: Determine which port (if any) to append to the domain
   ansible.builtin.set_fact:

--- a/roles/create/tasks/_kubernetes_setup.yml
+++ b/roles/create/tasks/_kubernetes_setup.yml
@@ -49,6 +49,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _k8s_env_for_values
+  no_log: true  # registers the whole .env, including passwords
 
 - name: Set external DB facts for values.yaml template
   ansible.builtin.set_fact:

--- a/roles/crowdsec/tasks/_resolve_cscli.yml
+++ b/roles/crowdsec/tasks/_resolve_cscli.yml
@@ -18,6 +18,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _env_profiles_cscli
+  no_log: true  # registers the whole .env, including passwords
   when:
     - compose_command is search('podman')
     - instance_orchestrator | default('compose') == 'compose'

--- a/roles/crowdsec/tasks/_restart_engine.yml
+++ b/roles/crowdsec/tasks/_restart_engine.yml
@@ -16,6 +16,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _env_profiles_crowdsec
+  no_log: true  # registers the whole .env, including passwords
   when:
     - compose_command is search('podman')
     - instance_orchestrator | default('compose') == 'compose'

--- a/roles/crowdsec/tasks/bouncer_enroll.yml
+++ b/roles/crowdsec/tasks/bouncer_enroll.yml
@@ -14,6 +14,7 @@
     state: read
     key: CROWDSEC_BOUNCER_API_KEY
   register: _crowdsec_key
+  no_log: true  # holds the bouncer's API key
 
 # Poll until the LAPI answers; `cscli bouncers` calls fail until the engine
 # is up (it may still be booting straight after a start).

--- a/roles/devmode/tasks/enable.yml
+++ b/roles/devmode/tasks/enable.yml
@@ -149,6 +149,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _dev_env_phpstorm
+  no_log: true  # registers the whole .env, including passwords
 
 - name: Create .idea directories
   ansible.builtin.file:
@@ -178,6 +179,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _env_profiles_devmode
+  no_log: true  # registers the whole .env, including passwords
   when: compose_command is search('podman')
 
 - name: Build compose profile flags

--- a/roles/gitops/tasks/init_compose.yml
+++ b/roles/gitops/tasks/init_compose.yml
@@ -186,6 +186,7 @@
   ansible.builtin.slurp:
     src: "/tmp/canasta-gitcrypt-key"
   register: _gitcrypt_key_b64
+  no_log: true  # unlocks every encrypted file in the gitops repo
 
 - name: Save connection state before local key write
   ansible.builtin.set_fact:
@@ -235,6 +236,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _gitops_env
+  no_log: true  # registers the whole .env, including passwords
 
 - name: Generate env.template with placeholder syntax
   ansible.builtin.copy:

--- a/roles/gitops/tasks/join.yml
+++ b/roles/gitops/tasks/join.yml
@@ -277,6 +277,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _join_env
+  no_log: true  # registers the whole .env, including passwords
 
 - name: Read wikis for URL and password extraction
   canasta_wikis_yaml:

--- a/roles/mediawiki/tasks/generate_secret_key.yml
+++ b/roles/mediawiki/tasks/generate_secret_key.yml
@@ -32,6 +32,7 @@
   register: _secret_key_result
   changed_when: false
   when: not _keep_existing_secret_key
+  no_log: true  # holds the wiki's session-signing secret
 
 - name: Save MW_SECRET_KEY to .env
   canasta_env:

--- a/roles/mediawiki/tasks/wait_for_db.yml
+++ b/roles/mediawiki/tasks/wait_for_db.yml
@@ -7,6 +7,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _wait_db_env
+  no_log: true  # registers the whole .env, including passwords
 
 - name: Set DB host and port
   ansible.builtin.set_fact:

--- a/roles/orchestrator/tasks/backup_discover_build_paths.yml
+++ b/roles/orchestrator/tasks/backup_discover_build_paths.yml
@@ -59,6 +59,7 @@
         path: "{{ instance_path }}/.env"
         state: read_all
       register: _env_profiles_backup
+      no_log: true  # registers the whole .env, including passwords
       when: compose_command is search('podman')
 
     - name: Build compose profile flags

--- a/roles/orchestrator/tasks/crowdsec_autoenroll.yml
+++ b/roles/orchestrator/tasks/crowdsec_autoenroll.yml
@@ -26,6 +26,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _autoenroll_env
+  no_log: true  # registers the whole .env, including passwords
 
 - name: Register CAPI and enroll the CrowdSec bouncer when enabled
   when: _autoenroll_env.variables.CANASTA_ENABLE_CROWDSEC | default('false') | lower == 'true'

--- a/roles/orchestrator/tasks/destroy.yml
+++ b/roles/orchestrator/tasks/destroy.yml
@@ -35,6 +35,7 @@
         path: "{{ instance_path }}/.env"
         state: read_all
       register: _env_profiles_destroy
+      no_log: true  # registers the whole .env, including passwords
       when: compose_command is search('podman')
 
     - name: Build compose profile flags

--- a/roles/orchestrator/tasks/ensure_observability_credentials.yml
+++ b/roles/orchestrator/tasks/ensure_observability_credentials.yml
@@ -7,6 +7,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _env_obs
+  no_log: true  # registers the whole .env, including passwords
 
 - name: Check if observability is enabled
   ansible.builtin.set_fact:
@@ -62,6 +63,7 @@
             state: read
             key: OS_PASSWORD
           register: _os_pass
+          no_log: true  # holds the OpenSearch password
 
         - name: Generate bcrypt hash
           ansible.builtin.shell:

--- a/roles/orchestrator/tasks/exec.yml
+++ b/roles/orchestrator/tasks/exec.yml
@@ -37,6 +37,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _env_profiles_exec
+  no_log: true  # registers the whole .env, including passwords
   when:
     - compose_command is search('podman')
     - instance_orchestrator | default('compose') == 'compose'

--- a/roles/orchestrator/tasks/k8s_reconcile_caddy.yml
+++ b/roles/orchestrator/tasks/k8s_reconcile_caddy.yml
@@ -22,6 +22,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _reconcile_env
+  no_log: true  # registers the whole .env, including passwords
 
 - name: Read values.yaml for reconcile
   ansible.builtin.slurp:

--- a/roles/orchestrator/tasks/pull.yml
+++ b/roles/orchestrator/tasks/pull.yml
@@ -27,6 +27,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _env_profiles_pull
+  no_log: true  # registers the whole .env, including passwords
   when: compose_command is search('podman')
 
 - name: Build compose profile flags

--- a/roles/orchestrator/tasks/rewrite_caddy.yml
+++ b/roles/orchestrator/tasks/rewrite_caddy.yml
@@ -13,6 +13,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _env_caddy
+  no_log: true  # registers the whole .env, including passwords
 
 - name: Determine Caddyfile parameters
   ansible.builtin.set_fact:

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -59,6 +59,7 @@
         path: "{{ instance_path }}/.env"
         state: read_all
       register: _env_profiles_start
+      no_log: true  # registers the whole .env, including passwords
       when: compose_command is search('podman')
 
     - name: Build compose profile flags

--- a/roles/orchestrator/tasks/stop.yml
+++ b/roles/orchestrator/tasks/stop.yml
@@ -41,6 +41,7 @@
         path: "{{ instance_path }}/.env"
         state: read_all
       register: _env_profiles_stop
+      no_log: true  # registers the whole .env, including passwords
       when: compose_command is search('podman')
 
     - name: Build compose profile flags

--- a/roles/orchestrator/tasks/sync_compose_profiles.yml
+++ b/roles/orchestrator/tasks/sync_compose_profiles.yml
@@ -7,6 +7,7 @@
     path: "{{ instance_path }}/.env"
     state: read_all
   register: _env_profiles
+  no_log: true  # registers the whole .env, including passwords
 
 - name: Parse current profiles
   ansible.builtin.set_fact:

--- a/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
+++ b/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
@@ -36,6 +36,7 @@
         path: "{{ instance_path }}/.env"
         state: read_all
       register: _env_profiles_upgrade
+      no_log: true  # registers the whole .env, including passwords
       when: compose_command is search('podman')
 
     - name: Build compose profile flags

--- a/roles/upgrade/tasks/migrations/extract_secret_key.yml
+++ b/roles/upgrade/tasks/migrations/extract_secret_key.yml
@@ -36,6 +36,7 @@
             cmd: "python3 -c \"import secrets; print(secrets.token_hex(32))\""
           register: _sk_gen
           changed_when: false
+          no_log: true  # holds the wiki's session-signing secret
 
         - name: Save generated secret key
           canasta_env:

--- a/tests/unit/test_secret_registers_no_log.py
+++ b/tests/unit/test_secret_registers_no_log.py
@@ -1,0 +1,160 @@
+"""Repo-wide guard: tasks that register a secret must set no_log.
+
+The convention was already applied consistently to tasks that *store* a
+secret, but not to the tasks that *produce* one — the value lands in a
+registered variable of an unprotected task, which Ansible surfaces on -v
+and on failure. Six named-secret producers and every `read_all` of .env
+were exposed that way.
+
+Enforcing this per-file (as the install.php and extract_secret_key guards
+do) only protects the files someone thought to write a test for. These
+checks sweep every role task instead, so a new leak fails here rather
+than in the next review.
+"""
+
+import os
+import re
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+ROLES = os.path.join(REPO_ROOT, "roles")
+
+# Registered variable names that look like they hold a credential.
+_SECRETISH = re.compile(
+    r"(pass|passwd|password|secret|token|api_?key|credential|_key\b|key_)",
+    re.I,
+)
+
+# Registers whose names trip the pattern but which hold no secret value.
+# Each entry needs a reason: an unexplained exemption is how a real leak
+# gets waved through.
+_EXEMPT = {
+    "_gitops_key_exists": "stat result — a boolean, not the key",
+    "_app_secrets_stat": "stat result for config/secrets.env",
+    "_app_secrets_web_stat": "stat result for config/secrets-web",
+    "_app_secrets_web_raw": "config/secrets-web holds key NAMES, not values",
+}
+
+
+def _walk(tasks):
+    for t in tasks or []:
+        if not isinstance(t, dict):
+            continue
+        yield t
+        for nested in ("block", "rescue", "always"):
+            if nested in t:
+                yield from _walk(t[nested])
+
+
+def _all_tasks():
+    """Yield (relative path, task) for every task file under roles/."""
+    for root, _, files in os.walk(ROLES):
+        for name in sorted(files):
+            if not name.endswith((".yml", ".yaml")):
+                continue
+            path = os.path.join(root, name)
+            try:
+                with open(path) as f:
+                    doc = yaml.safe_load(f)
+            except yaml.YAMLError:
+                continue
+            if not isinstance(doc, list):
+                continue
+            rel = os.path.relpath(path, REPO_ROOT)
+            for task in _walk(doc):
+                yield rel, task
+
+
+class TestEnvReadAllIsNoLog:
+    """`state: read_all` registers the entire .env — MYSQL_PASSWORD,
+    MYSQL_ROOT_PASSWORD, MW_SECRET_KEY, the bouncer key, restic
+    credentials. There is no such thing as a safe unprotected one."""
+
+    def test_every_read_all_sets_no_log(self):
+        bare = [
+            "%s (register: %s)" % (rel, task.get("register"))
+            for rel, task in _all_tasks()
+            if isinstance(task.get("canasta_env"), dict)
+            and task["canasta_env"].get("state") == "read_all"
+            and not task.get("no_log")
+        ]
+        assert not bare, (
+            "canasta_env state=read_all registers the whole .env, including "
+            "every password in it. These tasks must set no_log: true:\n  "
+            + "\n  ".join(bare)
+        )
+
+    def test_the_guard_actually_finds_read_all_tasks(self):
+        """A refactor that renamed the module or the state would make the
+        check above vacuously pass."""
+        found = [
+            rel for rel, task in _all_tasks()
+            if isinstance(task.get("canasta_env"), dict)
+            and task["canasta_env"].get("state") == "read_all"
+        ]
+        assert len(found) > 10, (
+            "expected many read_all tasks; found %d — the guard is probably "
+            "no longer matching anything" % len(found)
+        )
+
+
+class TestSecretRegistersAreNoLog:
+    """Any task whose registered variable is named like a credential."""
+
+    def test_secret_named_registers_set_no_log(self):
+        bare = []
+        for rel, task in _all_tasks():
+            reg = task.get("register")
+            if not isinstance(reg, str) or not _SECRETISH.search(reg):
+                continue
+            if reg in _EXEMPT or task.get("no_log"):
+                continue
+            bare.append("%s (register: %s)" % (rel, reg))
+        assert not bare, (
+            "These tasks register a secret-looking value without "
+            "no_log: true. Add no_log, or add the name to _EXEMPT in this "
+            "file with the reason it is not a secret:\n  " + "\n  ".join(bare)
+        )
+
+    def test_exemptions_still_exist(self):
+        """A stale exemption silently widens the allowlist for whatever
+        name gets reused later."""
+        live = {
+            task["register"] for _, task in _all_tasks()
+            if isinstance(task.get("register"), str)
+        }
+        stale = sorted(set(_EXEMPT) - live)
+        assert not stale, (
+            "These names are exempted but no longer registered anywhere; "
+            "drop them from _EXEMPT: %s" % ", ".join(stale)
+        )
+
+
+class TestGeneratedSecretKeysAreNoLog:
+    """The generator tasks the name heuristic above cannot catch: their
+    registers (_sk_gen, _secret_key_result) hold a freshly minted
+    wgSecretKey but are not named like one."""
+
+    GENERATORS = (
+        os.path.join("roles", "mediawiki", "tasks", "generate_secret_key.yml"),
+        os.path.join("roles", "upgrade", "tasks", "migrations",
+                     "extract_secret_key.yml"),
+    )
+
+    def test_secret_key_generators_set_no_log(self):
+        checked = 0
+        for rel, task in _all_tasks():
+            if rel not in self.GENERATORS:
+                continue
+            cmd = str(task.get("ansible.builtin.command", ""))
+            if "token_hex" not in cmd:
+                continue
+            checked += 1
+            assert task.get("no_log"), (
+                "%s generates a wgSecretKey into '%s' without no_log: true"
+                % (rel, task.get("register"))
+            )
+        assert checked == 2, (
+            "expected both wgSecretKey generators; found %d" % checked
+        )


### PR DESCRIPTION
Sets `no_log: true` on every task that registers a secret.

Addresses item 1 of #1239. (Not `Closes` — item 4 of that issue is still open.)

## The pattern break

The convention was applied consistently to tasks that *store* a secret, but not to the tasks that *produce* one. The value lands in the registered result of an unprotected task, which Ansible surfaces on `-v` and on failure. In several cases the protected consumer sits directly below the unprotected producer.

The scope turned out to be larger than the issue first reported — 30 sites, in two shapes.

**Named-secret producers (7).** The git-crypt symmetric key slurped during gitops init, both `wgSecretKey` generators, the OpenSearch password, the external database password, and the CrowdSec bouncer key in two places. The seventh — `_ext_db_password` in `roles/create/tasks/_envfile.yml` — was missed in the original review and found by the guard added here.

**Every `canasta_env state: read_all` (23).** These register the entire `.env`: `MYSQL_PASSWORD`, `MYSQL_ROOT_PASSWORD`, `MW_SECRET_KEY`, the bouncer key, the restic credentials. Six already set `no_log`; the rest did not.

`tests/unit/test_install_secret_logging.py` already enforces exactly this rule — its docstring even explains why — but only for `install_single_wiki.yml`. Per-file guards only protect the files someone thought to write a test for, which is how these survived.

## Cost of `no_log` here

Checked before changing 23 tasks: `canasta_env` returns an empty dict for a missing file rather than failing, so the common "no .env yet" case does not produce a redacted failure. The six `read_all` tasks that already carried `no_log` set the precedent.

## The guard

`tests/unit/test_secret_registers_no_log.py` sweeps every task under `roles/` for both shapes.

- Exemptions are explicit and individually justified — three `stat` results, plus `config/secrets-web`, which holds key *names* rather than values. A second test fails if an exemption goes stale, so the allowlist cannot silently widen when a register name is reused.
- The name heuristic cannot catch `_sk_gen` / `_secret_key_result`, which hold a freshly minted `wgSecretKey` but are not named like one; those get a targeted check keyed on `token_hex`.
- Two anti-vacuity tests, because a guard that quietly stops matching is worse than no guard.

Negative-tested: removing a single `no_log` makes the sweep fail and name the exact file and register.

## Verification

- 1937 passed (1932 baseline + 5 new)
- `make lint`, `ruff`, and `scripts/validate_definitions.py` clean
- Every one of the 30 added lines is a single `no_log: true` with a one-line reason. No logic changed.
