### PR TITLE
chore: remove the common role's dead defaults and vars

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,5 +1,0 @@
----
-# Default values for the common role.
-
-# Default Canasta image (overridden by canasta.yml from CANASTA_VERSION)
-canasta_default_image: "ghcr.io/canastawiki/canasta:latest"

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -1,8 +1,0 @@
----
-# Reserved wiki IDs that cannot be used
-canasta_reserved_wiki_ids:
-  - settings
-  - images
-  - w
-  - wiki
-  - wikis


### PR DESCRIPTION
Removes `roles/common/defaults/main.yml` and `roles/common/vars/main.yml`.

Addresses item 2 of #1239.

Ansible loads a role's `defaults/` and `vars/` only via the `roles:` keyword, `include_role`, or `import_role`. The `common` role is reached exclusively through `include_tasks` with explicit paths and is never named in an `include_role` (there are no `roles:` keywords and no `import_role` anywhere in the repo), so neither file has ever been read.

Both also held stale duplicates of live values, which is the reason to delete rather than wire them up:

- `vars/main.yml` — `canasta_reserved_wiki_ids`, a copy of `RESERVED_WIKI_IDS` in `roles/common/module_utils/canasta_validate.py`, which is what actually enforces the rule. Two lists, no parity guard.
- `defaults/main.yml` — `canasta_default_image` pinned to `:latest`, while the live value comes from `canasta.yml` and is derived from `CANASTA_VERSION`.

Note that `roles/orchestrator/defaults/main.yml` has its own `canasta_default_image`, also `:latest`. That one *does* load, but is always shadowed by the play var, so it is left alone here — changing it would alter the fallback if the play var ever went missing, which is a separate judgment call.

Verified: 1940 passed, `make lint` and `validate_definitions` clean.
