### PR TITLE
chore(tests): make a regex-bearing docstring raw

### DIFF
--- a/tests/unit/test_backup_schedule_k8s.py
+++ b/tests/unit/test_backup_schedule_k8s.py
@@ -538,7 +538,7 @@ class TestSharedBackupRBAC:
 
 
 class TestK8sRestoreImportRegexNotDoubleEscaped:
-    """The restore loop's regex `'^db_.*\.sql$'` and the secrets-
+    r"""The restore loop's regex `'^db_.*\.sql$'` and the secrets-
     filename regex `'^secrets-.+\.yaml$'` must use a SINGLE backslash
     in the YAML block scalar context. With `\\.` (two), Ansible's
     Jinja parses the literal `\\.` regex which is "literal backslash


### PR DESCRIPTION
Makes a docstring raw in `tests/unit/test_backup_schedule_k8s.py`.

Addresses item 5 of #1239.

The docstring quotes the regexes under test, so it contains `\.`, which Python reads as an invalid escape sequence. It was the only warning in an otherwise clean unit run.

No `filterwarnings` gate was added: the repo has no `pytest.ini` / `pyproject.toml`, and introducing one solely for this would be a structural change beyond the fix. Worth considering separately if warnings should fail CI.

Verified with `python -W error::SyntaxWarning -m compileall` over `tests/`, `roles/`, `scripts/`, `direct_commands/`, and `canasta.py` — no other occurrences. 1940 passed, warning-free.
