### PR TITLE
docs: note that the canasta-ansible name is pinned deliberately

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,9 @@
 ---
 # Build and push canasta-ansible Docker image.
 #
+# The canasta-ansible image name is pinned, not stale: it is a published
+# artifact that existing installs pull by tag.
+#
 # Triggers:
 #   - push to main: builds image, tags it 'main' + 'latest'. If the
 #     pushed commit changed VERSION, additionally tags 'X.Y.Z' / 'X.Y'

--- a/get-canasta.sh
+++ b/get-canasta.sh
@@ -332,6 +332,8 @@ install_docker_mode() {
 # --- Native mode install (Linux) --------------------------------------------
 
 install_native_linux() {
+    # The canasta-ansible name is pinned, not stale: it matches the
+    # published image tag and the prefix on already-installed hosts.
     local install_dir="${PREFIX:-/opt/canasta-ansible}"
 
     need_sudo
@@ -411,6 +413,8 @@ install_native_linux() {
 # --- Native mode install (macOS) --------------------------------------------
 
 install_native_macos() {
+    # The canasta-ansible name is pinned, not stale: it matches the
+    # published image tag and the prefix on already-installed hosts.
     local install_dir="${PREFIX:-${HOME}/canasta-ansible}"
 
     need_cmd git

--- a/roles/install/tasks/canasta.yml
+++ b/roles/install/tasks/canasta.yml
@@ -2,6 +2,9 @@
 # Install canasta-native on the target host.
 # Clones the repo, sets up venv + deps, creates symlinks.
 # Idempotent — skips if canasta is already installed.
+#
+# The /opt/canasta-ansible prefix is pinned, not stale: it matches the
+# published image name and the path on already-installed hosts.
 
 - name: Fail if targeting localhost
   ansible.builtin.fail:


### PR DESCRIPTION
Adds a comment at each site where the pre-rename `canasta-ansible` name survives, stating that it is pinned on purpose.

Closes item 4 of #1239.

The name persists in three places: the install prefix (`/opt/canasta-ansible` on Linux, `~/canasta-ansible` on macOS), the same prefix throughout the install role, and the published image `ghcr.io/canastawiki/canasta-ansible`. Changing any of them breaks existing installs — the image tag is a published artifact, and the prefix is where the CLI already lives on every host that has it.

Comments-only; no logic touched. Verified `bash -n get-canasta.sh`, `make lint`, and the unit suite.

This closes the last open item on #1239.
