### PR TITLE
fix(wiki-publish): retry transient transport failures

### DIFF
--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -27,8 +27,10 @@ import os
 import re
 import sys
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
+import http.client
 import http.cookiejar
 
 import yaml
@@ -49,6 +51,15 @@ RETRYABLE_ERROR_CODES = {"ratelimited", "maxlag"}
 MAX_EDIT_RETRIES = 5
 RETRY_BACKOFF_BASE = 15  # seconds; doubled each retry, capped at the max
 RETRY_BACKOFF_MAX = 120
+
+# Transport-level failures worth retrying: the request never reached the
+# API, or the wiki answered with a status that means "try again". These
+# are distinct from RETRYABLE_ERROR_CODES, which are API replies to a
+# request that did arrive. The first request a run makes is the login
+# token fetch, so without this a momentary blip fails the publish before
+# a single page is written and silently leaves the reference stale.
+RETRYABLE_HTTP_STATUS = {429, 500, 502, 503, 504}
+MAX_CONNECT_RETRIES = 5
 
 
 def _retry_delay(attempt):
@@ -802,18 +813,60 @@ class MediaWikiClient:
         )
         self._login(user, password)
 
+    def _open(self, target, data=None):
+        """Open `target` and return the decoded JSON body, retrying
+        transient transport failures with backoff.
+
+        `target` is a URL string or a prepared Request. Anything that
+        means the API never answered — connection timeout, reset, DNS,
+        a 5xx or 429 — is retried; a 4xx is a real error and is not.
+        """
+        req = (
+            urllib.request.Request(target, data=data)
+            if isinstance(target, str) else target
+        )
+        last = None
+        for attempt in range(MAX_CONNECT_RETRIES + 1):
+            try:
+                with self.opener.open(req, timeout=HTTP_TIMEOUT) as resp:
+                    return json.loads(resp.read())
+            except urllib.error.HTTPError as exc:
+                # HTTPError is a URLError subclass, so it must be caught
+                # first to keep 4xx from being retried.
+                if exc.code not in RETRYABLE_HTTP_STATUS:
+                    raise
+                last = exc
+            except (
+                urllib.error.URLError,
+                http.client.HTTPException,
+                TimeoutError,
+                ConnectionError,
+            ) as exc:
+                last = exc
+            if attempt >= MAX_CONNECT_RETRIES:
+                break
+            delay = _retry_delay(attempt)
+            print(
+                "Cannot reach %s (%s); retrying in %ds (%d/%d)"
+                % (self.api_url, last, delay, attempt + 1,
+                   MAX_CONNECT_RETRIES),
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+        raise RuntimeError(
+            "Could not reach the wiki API at %s after %d attempts: %s"
+            % (self.api_url, MAX_CONNECT_RETRIES + 1, last)
+        )
+
     def _post(self, params):
         data = urllib.parse.urlencode(params).encode()
-        req = urllib.request.Request(self.api_url, data=data)
-        with self.opener.open(req, timeout=HTTP_TIMEOUT) as resp:
-            return json.loads(resp.read())
+        return self._open(self.api_url, data=data)
 
     def _get_token(self, token_type):
         url = "%s?action=query&meta=tokens&type=%s&format=json" % (
             self.api_url, token_type,
         )
-        with self.opener.open(url, timeout=HTTP_TIMEOUT) as resp:
-            data = json.loads(resp.read())
+        data = self._open(url)
         return data["query"]["tokens"][token_type + "token"]
 
     def _login(self, user, password):
@@ -870,8 +923,7 @@ class MediaWikiClient:
             "%s?action=query&meta=siteinfo&siprop=namespaces&format=json"
             % self.api_url
         )
-        with self.opener.open(url, timeout=HTTP_TIMEOUT) as resp:
-            data = json.loads(resp.read())
+        data = self._open(url)
         for ns in data["query"]["namespaces"].values():
             if name in (ns.get("*"), ns.get("canonical")):
                 return ns["id"]
@@ -888,8 +940,7 @@ class MediaWikiClient:
             )
             if apcontinue:
                 url += "&apcontinue=" + urllib.parse.quote(apcontinue)
-            with self.opener.open(url, timeout=HTTP_TIMEOUT) as resp:
-                data = json.loads(resp.read())
+            data = self._open(url)
             titles.extend(
                 p["title"] for p in data["query"]["allpages"]
             )

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -10,6 +10,7 @@ import os
 import sys
 
 import pytest
+import urllib.error
 
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
@@ -944,6 +945,92 @@ class TestEditRetry:
         assert wp._retry_delay(1) == wp.RETRY_BACKOFF_BASE * 2
         # Far-out attempts saturate at the cap.
         assert wp._retry_delay(20) == wp.RETRY_BACKOFF_MAX
+
+
+class TestConnectRetry:
+    """The publish job died twice at the login token fetch with
+    `URLError: <urlopen error timed out>`, before a single page was
+    written, leaving the CLI: reference stale. Transport failures must
+    back off and retry like the API-level ones already do."""
+
+    class _Resp:
+        def __init__(self, body):
+            self._body = body
+
+        def read(self):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def _client(self, responses):
+        """Client whose opener yields `responses` in order; an exception
+        instance in the list is raised instead of returned."""
+        c = object.__new__(wp.MediaWikiClient)
+        c.api_url = "https://wiki.example/w/api.php"
+        calls = []
+
+        class FakeOpener:
+            def open(self, req, timeout=None):
+                calls.append(req)
+                item = responses[len(calls) - 1]
+                if isinstance(item, Exception):
+                    raise item
+                return TestConnectRetry._Resp(item)
+
+        c.opener = FakeOpener()
+        return c, calls
+
+    def _timeout(self):
+        return urllib.error.URLError(TimeoutError("timed out"))
+
+    def _http_error(self, code):
+        return urllib.error.HTTPError(
+            "https://wiki.example/w/api.php", code, "boom", {}, None,
+        )
+
+    def test_retries_timeout_then_succeeds(self, monkeypatch):
+        c, calls = self._client([
+            self._timeout(), self._timeout(), b'{"ok": true}',
+        ])
+        sleeps = []
+        monkeypatch.setattr(wp.time, "sleep", sleeps.append)
+        assert c._open(c.api_url) == {"ok": True}
+        assert len(calls) == 3
+        assert sleeps == [wp._retry_delay(0), wp._retry_delay(1)]
+
+    def test_gives_up_after_max_retries(self, monkeypatch):
+        c, calls = self._client(
+            [self._timeout()] * (wp.MAX_CONNECT_RETRIES + 1)
+        )
+        monkeypatch.setattr(wp.time, "sleep", lambda s: None)
+        with pytest.raises(RuntimeError, match="Could not reach the wiki API"):
+            c._open(c.api_url)
+        assert len(calls) == wp.MAX_CONNECT_RETRIES + 1
+
+    def test_server_error_is_retried(self, monkeypatch):
+        c, calls = self._client([self._http_error(503), b'{"ok": true}'])
+        monkeypatch.setattr(wp.time, "sleep", lambda s: None)
+        assert c._open(c.api_url) == {"ok": True}
+        assert len(calls) == 2
+
+    def test_client_error_is_not_retried(self, monkeypatch):
+        c, calls = self._client([self._http_error(404)])
+        monkeypatch.setattr(wp.time, "sleep", lambda s: None)
+        with pytest.raises(urllib.error.HTTPError):
+            c._open(c.api_url)
+        assert len(calls) == 1
+
+    def test_login_token_fetch_retries(self, monkeypatch):
+        """The exact failure seen in CI: the run's first request."""
+        token = b'{"query": {"tokens": {"logintoken": "abc123+"}}}'
+        c, calls = self._client([self._timeout(), token])
+        monkeypatch.setattr(wp.time, "sleep", lambda s: None)
+        assert c._get_token("login") == "abc123+"
+        assert len(calls) == 2
 
 
 class TestReflowProse:


### PR DESCRIPTION
Fixes #1257.

Routes every `MediaWikiClient` request through a single `_open()` helper that backs off and retries when the API did not answer: connection timeouts, resets, DNS failures, and 429/5xx responses. A 4xx still raises immediately, since it means the request arrived and was rejected — `HTTPError` is caught ahead of `URLError` (its parent) to keep client errors out of the retry path. Backoff reuses `_retry_delay`, so the schedule matches the existing edit-retry path: 15s, 30s, 60s, 120s, 120s.

Five new tests: retry-then-succeed with asserted delays, give-up after the cap, 503 retried, 404 not retried, and the login token fetch specifically — the request that actually failed in CI.

`make test-unit` (1945 passed), `make lint`, and `make validate` are green; `--dry-run` still generates all 105 pages.

Note this is mitigation, not a diagnosis: both failures were connect timeouts from the GitHub runner while the wiki answered normally elsewhere, which would also be consistent with the runner's egress being blocked. Retrying survives a blip, not a sustained ban — see the issue.