### PR TITLE
fix(wiki-publish): fail the job when orphaned pages survive a prune

### DIFF
--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -977,14 +977,21 @@ def main():
             print("ERROR uploading %s: %s" % (title, e), file=sys.stderr)
             errors += 1
 
-    if args.prune:
-        errors += prune_orphans(client, pages)
+    publish_errors = errors
+    prune_errors = prune_orphans(client, pages) if args.prune else 0
 
-    if errors:
-        print(
-            "Failed to publish %d of %d pages" % (errors, len(pages)),
-            file=sys.stderr,
-        )
+    if publish_errors or prune_errors:
+        if publish_errors:
+            print(
+                "Failed to publish %d of %d pages"
+                % (publish_errors, len(pages)),
+                file=sys.stderr,
+            )
+        if prune_errors:
+            print(
+                "Failed to prune %d orphaned page(s)" % prune_errors,
+                file=sys.stderr,
+            )
         sys.exit(1)
     print("Done: %d pages published" % len(pages))
 
@@ -1053,16 +1060,20 @@ def prune_orphans(client, pages):
             print("Deleted orphan %s" % title)
         except PermissionDeniedError as e:
             # The bot can't delete (needs Administrators). Every orphan
-            # would fail the same way, so warn once with the full list
-            # for manual cleanup and don't fail the publish job.
+            # would fail the same way, so stop after the first and report
+            # the whole list at once. Counted as an error: a green job
+            # with a stale page still live reads as "nothing to do", and
+            # the page then survives indefinitely. Clears itself once the
+            # orphans are deleted or the bot is granted the right.
             remaining = orphans[i:]
             print(
-                "WARNING: cannot delete orphaned %s pages (%s). "
-                "%d page(s) need manual deletion by an administrator: %s"
+                "ERROR: cannot delete orphaned %s pages (%s). "
+                "%d page(s) need manual deletion by an administrator, or "
+                "grant the publish account the delete right: %s"
                 % (PAGE_PREFIX, e, len(remaining), ", ".join(remaining)),
                 file=sys.stderr,
             )
-            return errors
+            return errors + len(remaining)
         except Exception as e:
             print(
                 "ERROR deleting %s: %s" % (title, e), file=sys.stderr

--- a/tests/unit/test_wiki_publish.py
+++ b/tests/unit/test_wiki_publish.py
@@ -783,9 +783,13 @@ class TestPruneOrphans:
         assert errors == 0
         assert client.deleted == []
 
-    def test_permission_denied_warns_not_fails(self):
-        """If the bot lacks delete rights, prune must not fail the
-        publish job — warn and leave the orphans for an admin."""
+    def test_permission_denied_counts_every_undeleted_orphan(self):
+        """If the bot lacks delete rights the orphans survive, so this
+        is an error, not a warning. A green job with a stale page still
+        live reads as 'nothing to do', and the page then survives
+        indefinitely — which is how 'CLI:Canasta wiki check' outlived
+        its rename. Clears itself once the orphans are gone or the
+        account is granted the right."""
         generated = [(wp.PAGE_PREFIX + "canasta create", "x")]
         existing = [
             wp.PAGE_PREFIX + "canasta create",
@@ -799,10 +803,21 @@ class TestPruneOrphans:
             ),
         )
         errors = wp.prune_orphans(client, generated)
-        assert errors == 0
+        assert errors == 2, "both surviving orphans must be counted"
         # Stops after the first denial (all would fail identically).
         assert len(client.delete_attempts) == 1
         assert client.deleted == []
+
+    def test_permission_denied_with_no_orphans_is_not_an_error(self):
+        """Nothing to delete means the missing right cost nothing, so a
+        publish with no orphans must stay green regardless of rights."""
+        generated = [(wp.PAGE_PREFIX + "canasta create", "x")]
+        client = _StubClient(
+            100, [wp.PAGE_PREFIX + "canasta create"],
+            delete_exc=wp.PermissionDeniedError("not an admin"),
+        )
+        assert wp.prune_orphans(client, generated) == 0
+        assert client.delete_attempts == []
 
     def test_non_permission_error_still_counts(self):
         """A non-permission deletion failure is still a real error."""


### PR DESCRIPTION
Makes `wiki_publish.py --prune` fail the job when orphaned pages survive.

Closes item 2 of #1241.

## The problem

The pruning logic is correct — title normalization, a safety valve against mass deletion, all of it. CI does pass `--prune`. But the publish account lacks the `delete` right, so `prune_orphans` caught `PermissionDeniedError`, printed one warning, and returned `0`.

The result: a green job, a warning buried in a log nobody reads, and the orphan alive indefinitely. That is exactly how `CLI:Canasta wiki check` outlived its rename and still sits on the wiki next to the correct `CLI:Canasta wiki-check`.

A previous round filed the orphaned-pages problem (#723) and closed it on the strength of the `--prune` implementation. The implementation was fine; the permission was never granted, so the fix never took effect. Nothing surfaced that.

## The change

Count every orphan that could not be deleted and exit non-zero. Publish failures and prune failures are reported separately, so the summary line says which one broke instead of folding prune errors into a "failed to publish N of M pages" count that would not add up.

It still stops after the first denial — every orphan would fail identically — and still reports the full remaining list for manual cleanup.

**This is self-clearing.** A run with no orphans stays green regardless of rights, because a missing right costs nothing when there is nothing to delete. The job goes green again as soon as either the orphans are deleted or the account is granted the right.

Note that it will be red until one of those happens, since one orphan is currently live. That is the intended signal.

## Tests

`test_permission_denied_warns_not_fails` asserted the old behavior and has been rewritten as `test_permission_denied_counts_every_undeleted_orphan`, with the reasoning in the docstring. Added a companion asserting the no-orphans case stays green regardless of rights, so the fix cannot regress into failing every run.

74 wiki-publish tests pass; 1941 overall. `make lint` and `ruff` clean.
