### PR TITLE
feat: validate the canasta examples on canasta.wiki

### DIFF
--- a/.github/workflows/wiki-examples.yml
+++ b/.github/workflows/wiki-examples.yml
@@ -1,0 +1,49 @@
+---
+# Check that the canasta examples on canasta.wiki still run.
+#
+# The CLI: namespace is generated and correct by construction; the
+# hand-written Help: pages drift. Both directions are caught here:
+#
+#   - pull_request on the command definitions: a PR that renames or
+#     removes a flag fails until the wiki examples using it are updated.
+#   - schedule: catches drift introduced by a wiki edit, which no repo
+#     event would ever trigger. This is the more common direction.
+#
+# Deliberately separate from wiki-publish.yml: publishing the generated
+# CLI: reference must not be blocked by a stale hand-written example.
+
+name: Wiki Examples
+
+on:
+  pull_request:
+    paths:
+      - 'meta/command_definitions.yml'
+      - 'scripts/validate_wiki_examples.py'
+      - '.github/workflows/wiki-examples.yml'
+  schedule:
+    # Mondays, 07:00 UTC.
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      # Exit 1 means real drift; exit 2 means the wiki was unreachable
+      # and nothing was checked. Both fail the job — a skipped run must
+      # never look like a clean one.
+      - name: Validate wiki examples
+        run: python scripts/validate_wiki_examples.py

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test-unit test-integration test lint docs validate audit-coverage clean build-info
+.PHONY: test-unit test-integration test lint docs validate validate-wiki audit-coverage clean build-info
 
 VENV := .venv
 PYTHON := $(VENV)/bin/python
@@ -44,6 +44,12 @@ docs: venv
 
 validate: venv
 	$(PYTHON) scripts/validate_definitions.py
+
+# Check the canasta examples on canasta.wiki against the command
+# definitions. Hits the network; not part of 'lint' for that reason.
+# Exit 1 = a stale example, exit 2 = the wiki was unreachable.
+validate-wiki: venv
+	$(PYTHON) scripts/validate_wiki_examples.py
 
 # --- Coverage audit ----------------------------------------------------------
 # Static report of which canasta commands have at least one integration

--- a/scripts/validate_wiki_examples.py
+++ b/scripts/validate_wiki_examples.py
@@ -28,6 +28,7 @@ import os
 import re
 import shlex
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -37,6 +38,14 @@ import yaml
 DEFAULT_API = "https://canasta.wiki/w/api.php"
 HELP_NAMESPACE = 12
 USER_AGENT = "canasta-cli-example-validator"
+HTTP_TIMEOUT = 30  # seconds
+# Backoff schedule shared with the publish script: 15s, 30s, 60s, 120s, 120s.
+MAX_RETRIES = 5
+RETRY_BACKOFF_BASE = 15
+RETRY_BACKOFF_MAX = 120
+# The API caps content fetches per request; 20 keeps every batch a single
+# round trip with no continuation.
+TITLES_PER_REQUEST = 20
 
 DEFINITIONS_PATH = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "..",
@@ -236,25 +245,62 @@ def validate_page(page, wikitext, table, definitions):
 # --- Page sources ------------------------------------------------------
 
 
-def _get(url):
+def _get(api_url, params, sleep=time.sleep):
+    """GET a MediaWiki API query, retrying when the API does not answer.
+
+    Connect timeouts from CI runners to this wiki are a known, recurring
+    failure that the publish script hit too, so the backoff schedule
+    matches the one there: 15s, 30s, 60s, 120s, 120s. A 4xx is not
+    retried — the request arrived and was rejected.
+    """
+    url = api_url + "?" + urllib.parse.urlencode(dict(params, format="json",
+                                                      formatversion=2))
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(request, timeout=30) as response:
-        return json.load(response)
-
-
-def fetch_pages(api_url, namespace=HELP_NAMESPACE):
-    """Yield (title, wikitext) for every page in the namespace."""
-    listing = _get(
-        "%s?action=query&list=allpages&apnamespace=%d&aplimit=500&format=json"
-        % (api_url, namespace)
-    )
-    for page in listing["query"]["allpages"]:
-        title = page["title"]
-        parsed = _get(
-            "%s?action=parse&page=%s&prop=wikitext&format=json"
-            % (api_url, urllib.parse.quote(title))
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT) as resp:
+                return json.load(resp)
+        except urllib.error.HTTPError as exc:
+            if exc.code < 500 and exc.code != 429:
+                raise
+            failure = exc
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            failure = exc
+        if attempt == MAX_RETRIES:
+            raise failure
+        delay = min(RETRY_BACKOFF_BASE * (2 ** attempt), RETRY_BACKOFF_MAX)
+        print(
+            "  wiki did not answer (%s); retrying in %ds" % (failure, delay),
+            file=sys.stderr,
         )
-        yield title, parsed["parse"]["wikitext"]["*"]
+        sleep(delay)
+
+
+def fetch_pages(api_url, namespace=HELP_NAMESPACE, sleep=time.sleep):
+    """Yield (title, wikitext) for every page in the namespace.
+
+    Content is fetched in batches rather than one parse call per page:
+    38 pages is 3 requests instead of 39, which matters mostly because
+    every request is another chance to hit the timeout above.
+    """
+    listing = _get(api_url, {
+        "action": "query", "list": "allpages",
+        "apnamespace": namespace, "aplimit": 500,
+    }, sleep=sleep)
+    titles = [p["title"] for p in listing["query"]["allpages"]]
+
+    for start in range(0, len(titles), TITLES_PER_REQUEST):
+        batch = titles[start:start + TITLES_PER_REQUEST]
+        result = _get(api_url, {
+            "action": "query", "prop": "revisions",
+            "rvprop": "content", "rvslots": "main",
+            "titles": "|".join(batch),
+        }, sleep=sleep)
+        for page in result.get("query", {}).get("pages", []):
+            revisions = page.get("revisions")
+            if not revisions:
+                continue  # missing or empty page
+            yield page["title"], revisions[0]["slots"]["main"]["content"]
 
 
 def read_pages(directory):

--- a/scripts/validate_wiki_examples.py
+++ b/scripts/validate_wiki_examples.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Check that the `canasta` examples on canasta.wiki still run.
+
+The CLI: namespace is generated from meta/command_definitions.yml and is
+correct by construction. The hand-written Help: pages are not: a renamed
+flag or a removed command leaves copy-paste examples that fail, and
+nothing notices. This validates every shell example on every Help: page
+against the same command definitions the CLI is built from.
+
+Only fenced shell blocks are scanned — those are the copy-pasteable
+examples. Prose mentions of a command in <code> tags are not commands
+and would produce noise.
+
+Usage:
+    # Against the live wiki
+    python scripts/validate_wiki_examples.py
+
+    # Against a directory of .txt files holding page wikitext
+    python scripts/validate_wiki_examples.py --pages-dir /tmp/pages
+
+Exits non-zero if any example names a command or flag that does not
+exist.
+"""
+
+import argparse
+import json
+import os
+import re
+import shlex
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import yaml
+
+DEFAULT_API = "https://canasta.wiki/w/api.php"
+HELP_NAMESPACE = 12
+USER_AGENT = "canasta-cli-example-validator"
+
+DEFINITIONS_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..",
+    "meta", "command_definitions.yml",
+)
+
+# Positionals that swallow everything after them: whatever follows is
+# passed to another program (php, a maintenance script), so its flags
+# are not ours to validate.
+PASSTHROUGH_POSITIONALS = ("exec_args", "script_args")
+
+SHELL_BLOCK = re.compile(
+    r"<syntaxhighlight\b[^>]*\blang=\"(?:bash|sh|shell|console)\"[^>]*>"
+    r"(.*?)</syntaxhighlight>",
+    re.DOTALL | re.IGNORECASE,
+)
+
+INVOCATION = re.compile(r"^(?:sudo\s+)?canasta(?:-native|-docker)?(?:\s|$)")
+
+
+def canasta_segment(text):
+    """The `canasta ...` part of a shell line, or None.
+
+    Handles a `$ ` prompt and compound lines: the invocation is not
+    always the first thing on the line (`cd /path && canasta delete`),
+    and anything downstream of a pipe is another program.
+    """
+    text = re.sub(r"^\s*\$\s+", "", text.strip())
+    for segment in re.split(r"\|\||&&|[|;]", text):
+        segment = segment.strip()
+        if INVOCATION.match(segment):
+            return segment
+    return None
+
+
+# --- Command table -----------------------------------------------------
+
+
+def load_definitions(path=DEFINITIONS_PATH):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def build_command_table(definitions):
+    """Map a tuple of CLI tokens -> command definition.
+
+    Group commands are stored as `group_sub`, and a group name may
+    itself contain an underscore (`storage_setup`), so the group has to
+    be matched longest-first before the remainder is treated as the
+    subcommand.
+    """
+    groups = sorted(
+        (g["name"] for g in definitions.get("command_groups", [])),
+        key=len, reverse=True,
+    )
+    table = {}
+    for command in definitions["commands"]:
+        name = command["name"]
+        for group in groups:
+            if name.startswith(group + "_"):
+                sub = name[len(group) + 1:].replace("_", "-")
+                table[tuple(group.split("_") + [sub])] = command
+                break
+        else:
+            table[(name.replace("_", "-"),)] = command
+    return table
+
+
+def flag_spec(command, definitions):
+    """Return (long flags, short flags, has_passthrough) for a command."""
+    longs = {"--help", "--verbose"}
+    shorts = {"-h", "-v"}
+    passthrough = False
+    for param in command.get("parameters") or []:
+        if param.get("positional"):
+            if param["name"] in PASSTHROUGH_POSITIONALS:
+                passthrough = True
+            continue
+        # `long:` overrides the flag spelling (host_name -> --name).
+        longs.add("--" + (param.get("long") or param["name"]).replace("_", "-"))
+        if param.get("short"):
+            shorts.add("-" + param["short"])
+    for param in definitions.get("global_flags") or []:
+        longs.add("--" + param["name"].replace("_", "-"))
+        if param.get("short"):
+            shorts.add("-" + param["short"])
+    return longs, shorts, passthrough
+
+
+# --- Extraction --------------------------------------------------------
+
+
+def iter_shell_lines(wikitext):
+    """Yield (line number, command line) for each canasta invocation in a
+    fenced shell block.
+
+    Backslash continuations are joined first: a flag sitting alone on a
+    continuation line is part of the command above it, and skipping
+    those was how a whole class of examples went unchecked.
+    """
+    for match in SHELL_BLOCK.finditer(wikitext):
+        first_line = wikitext.count("\n", 0, match.start(1)) + 1
+        raw = match.group(1)
+        joined, offsets, buffer, start = [], [], "", None
+        for offset, line in enumerate(raw.split("\n")):
+            stripped = line.strip()
+            if start is None:
+                start = offset
+            if stripped.endswith("\\"):
+                buffer += stripped[:-1].strip() + " "
+                continue
+            joined.append((buffer + stripped).strip())
+            offsets.append(start)
+            buffer, start = "", None
+        if buffer:
+            joined.append(buffer.strip())
+            offsets.append(start or 0)
+        for text, offset in zip(joined, offsets):
+            if canasta_segment(text):
+                yield first_line + offset, text
+
+
+def tokenize(line):
+    """Split a shell example into argv, or None if it cannot be parsed.
+
+    Placeholders (<domain>, <NODE1_IP>) become a literal so shlex does
+    not choke, and only the first command of a pipeline is ours.
+    """
+    text = canasta_segment(line)
+    if text is None:
+        return None
+    text = re.sub(r"<[^>\s]*>", "PLACEHOLDER", text)
+    text = re.sub(r"\s+#.*$", "", text)
+    try:
+        tokens = shlex.split(text)
+    except ValueError:
+        return None
+    tokens = [t for t in tokens if t != "sudo"]
+    return tokens[1:] if tokens else None  # drop the `canasta` itself
+
+
+# --- Validation --------------------------------------------------------
+
+
+class Finding:
+    def __init__(self, page, line, kind, detail, example):
+        self.page = page
+        self.line = line
+        self.kind = kind
+        self.detail = detail
+        self.example = example
+
+    def __str__(self):
+        return "%s:%s: %s %s\n    %s" % (
+            self.page, self.line, self.kind, self.detail, self.example,
+        )
+
+
+def validate_example(tokens, table, definitions):
+    """Return (kind, detail) for the first problem found, else None."""
+    command = rest = None
+    for width in (3, 2, 1):
+        if tuple(tokens[:width]) in table:
+            command = table[tuple(tokens[:width])]
+            rest = tokens[width:]
+            break
+    if command is None:
+        return "unknown command:", " ".join(tokens[:2]) or "(empty)"
+
+    longs, shorts, passthrough = flag_spec(command, definitions)
+    for token in rest:
+        if token == "--":
+            break
+        if passthrough and not token.startswith("-"):
+            # First bare token starts the passed-through command line.
+            break
+        if token.startswith("--"):
+            if token.split("=")[0] not in longs:
+                return "unknown flag:", token.split("=")[0]
+        elif re.match(r"^-[A-Za-z]$", token) and token not in shorts:
+            return "unknown flag:", token
+    return None
+
+
+def validate_page(page, wikitext, table, definitions):
+    findings = []
+    for line_no, line in iter_shell_lines(wikitext):
+        tokens = tokenize(line)
+        if not tokens:
+            continue
+        problem = validate_example(tokens, table, definitions)
+        if problem:
+            findings.append(Finding(page, line_no, problem[0], problem[1], line))
+    return findings
+
+
+# --- Page sources ------------------------------------------------------
+
+
+def _get(url):
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def fetch_pages(api_url, namespace=HELP_NAMESPACE):
+    """Yield (title, wikitext) for every page in the namespace."""
+    listing = _get(
+        "%s?action=query&list=allpages&apnamespace=%d&aplimit=500&format=json"
+        % (api_url, namespace)
+    )
+    for page in listing["query"]["allpages"]:
+        title = page["title"]
+        parsed = _get(
+            "%s?action=parse&page=%s&prop=wikitext&format=json"
+            % (api_url, urllib.parse.quote(title))
+        )
+        yield title, parsed["parse"]["wikitext"]["*"]
+
+
+def read_pages(directory):
+    for name in sorted(os.listdir(directory)):
+        if not name.endswith(".txt"):
+            continue
+        with open(os.path.join(directory, name)) as f:
+            yield name[:-4].replace("__", "/"), f.read()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate canasta.wiki shell examples against the CLI"
+    )
+    parser.add_argument("--api", default=DEFAULT_API, help="MediaWiki API URL")
+    parser.add_argument(
+        "--pages-dir",
+        help="Read page wikitext from .txt files instead of the network",
+    )
+    parser.add_argument(
+        "--namespace", type=int, default=HELP_NAMESPACE,
+        help="Namespace id to scan (default: %d, Help:)" % HELP_NAMESPACE,
+    )
+    args = parser.parse_args()
+
+    definitions = load_definitions()
+    table = build_command_table(definitions)
+
+    source = (read_pages(args.pages_dir) if args.pages_dir
+              else fetch_pages(args.api, args.namespace))
+
+    findings, pages, examples = [], 0, 0
+    try:
+        for title, wikitext in source:
+            pages += 1
+            examples += sum(1 for _ in iter_shell_lines(wikitext))
+            findings.extend(validate_page(title, wikitext, table, definitions))
+    except (urllib.error.URLError, OSError, KeyError, ValueError) as exc:
+        # Exit 2, not 1: an unreachable wiki is an infrastructure problem,
+        # and reporting it as "no findings" would be a false green.
+        print(
+            "ERROR: could not read pages from %s (%s). No examples were "
+            "checked." % (args.api, exc),
+            file=sys.stderr,
+        )
+        return 2
+
+    print("Checked %d examples across %d pages" % (examples, pages))
+    if not findings:
+        print("All examples match the current command definitions.")
+        return 0
+
+    print("", file=sys.stderr)
+    for finding in findings:
+        print(finding, file=sys.stderr)
+    print(
+        "\n%d example(s) reference a command or flag that does not exist."
+        % len(findings),
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_validate_wiki_examples.py
+++ b/tests/unit/test_validate_wiki_examples.py
@@ -6,8 +6,12 @@ wiki constructs that look like drift but are not (passthrough args,
 placeholders, prose, non-shell blocks).
 """
 
+import json
 import os
 import sys
+import urllib.error
+
+import pytest
 
 SCRIPTS_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "scripts"),
@@ -249,3 +253,133 @@ class TestAgainstRealDefinitions:
                 assert tokens, example
                 problem = v.validate_example(tokens, table, definitions)
                 assert problem is None, "%s -> %s" % (example, problem)
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = json.dumps(payload).encode()
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _FakeUrlopen:
+    """Replays a scripted sequence of responses/exceptions."""
+
+    def __init__(self, *outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = []
+
+    def __call__(self, request, timeout=None):
+        self.calls.append(request.full_url)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return _FakeResponse(outcome)
+
+
+def _http_error(code):
+    return urllib.error.HTTPError("u", code, "boom", {}, None)
+
+
+class TestRequestRetry:
+    """Connect timeouts from CI runners to this wiki are a known
+    recurring failure — the first CI run of this validator hit one."""
+
+    def test_retries_then_succeeds(self, monkeypatch):
+        fake = _FakeUrlopen(
+            urllib.error.URLError("timed out"),
+            urllib.error.URLError("timed out"),
+            {"ok": True},
+        )
+        monkeypatch.setattr(v.urllib.request, "urlopen", fake)
+        slept = []
+        assert v._get("https://w/api.php", {"action": "query"},
+                      sleep=slept.append) == {"ok": True}
+        assert len(fake.calls) == 3
+        assert slept == [15, 30], "backoff must match the publish script"
+
+    def test_gives_up_after_the_cap(self, monkeypatch):
+        fake = _FakeUrlopen(*[urllib.error.URLError("timed out")] * 20)
+        monkeypatch.setattr(v.urllib.request, "urlopen", fake)
+        with pytest.raises(urllib.error.URLError):
+            v._get("https://w/api.php", {}, sleep=lambda _: None)
+        assert len(fake.calls) == v.MAX_RETRIES + 1
+
+    def test_backoff_is_capped(self, monkeypatch):
+        fake = _FakeUrlopen(*([urllib.error.URLError("x")] * 5 + [{"ok": 1}]))
+        monkeypatch.setattr(v.urllib.request, "urlopen", fake)
+        slept = []
+        v._get("https://w/api.php", {}, sleep=slept.append)
+        assert slept == [15, 30, 60, 120, 120]
+
+    def test_server_errors_are_retried(self, monkeypatch):
+        for code in (500, 503, 429):
+            fake = _FakeUrlopen(_http_error(code), {"ok": True})
+            monkeypatch.setattr(v.urllib.request, "urlopen", fake)
+            assert v._get("https://w/api.php", {},
+                          sleep=lambda _: None) == {"ok": True}
+            assert len(fake.calls) == 2, "HTTP %d should retry" % code
+
+    def test_client_errors_are_not_retried(self, monkeypatch):
+        """A 4xx means the request arrived and was rejected; retrying
+        only delays the failure."""
+        fake = _FakeUrlopen(_http_error(404), {"ok": True})
+        monkeypatch.setattr(v.urllib.request, "urlopen", fake)
+        with pytest.raises(urllib.error.HTTPError):
+            v._get("https://w/api.php", {}, sleep=lambda _: None)
+        assert len(fake.calls) == 1
+
+
+class TestBatchedFetch:
+    """Every request is another chance to hit the timeout above, so
+    content is fetched in batches rather than one call per page."""
+
+    @staticmethod
+    def _listing(n):
+        return {"query": {"allpages": [
+            {"title": "Help:Page %d" % i} for i in range(n)
+        ]}}
+
+    @staticmethod
+    def _content(titles):
+        return {"query": {"pages": [
+            {"title": t, "revisions": [
+                {"slots": {"main": {"content": "text of %s" % t}}}
+            ]} for t in titles
+        ]}}
+
+    def test_batches_titles(self, monkeypatch):
+        n = v.TITLES_PER_REQUEST * 2 + 1
+        titles = ["Help:Page %d" % i for i in range(n)]
+        fake = _FakeUrlopen(
+            self._listing(n),
+            self._content(titles[:v.TITLES_PER_REQUEST]),
+            self._content(titles[v.TITLES_PER_REQUEST:v.TITLES_PER_REQUEST * 2]),
+            self._content(titles[v.TITLES_PER_REQUEST * 2:]),
+        )
+        monkeypatch.setattr(v.urllib.request, "urlopen", fake)
+        pages = list(v.fetch_pages("https://w/api.php", sleep=lambda _: None))
+        assert len(pages) == n
+        # One listing plus ceil(n / batch) content requests — not one per page.
+        assert len(fake.calls) == 4
+
+    def test_pages_without_content_are_skipped(self, monkeypatch):
+        fake = _FakeUrlopen(
+            self._listing(2),
+            {"query": {"pages": [
+                {"title": "Help:Page 0", "missing": True},
+                {"title": "Help:Page 1", "revisions": [
+                    {"slots": {"main": {"content": "body"}}}
+                ]},
+            ]}},
+        )
+        monkeypatch.setattr(v.urllib.request, "urlopen", fake)
+        pages = list(v.fetch_pages("https://w/api.php", sleep=lambda _: None))
+        assert pages == [("Help:Page 1", "body")]

--- a/tests/unit/test_validate_wiki_examples.py
+++ b/tests/unit/test_validate_wiki_examples.py
@@ -1,0 +1,251 @@
+"""Tests for scripts/validate_wiki_examples.py.
+
+The validator's job is to fail on real drift without crying wolf, so
+these cover both directions: the drift classes seen in practice, and the
+wiki constructs that look like drift but are not (passthrough args,
+placeholders, prose, non-shell blocks).
+"""
+
+import os
+import sys
+
+SCRIPTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "scripts"),
+)
+sys.path.insert(0, SCRIPTS_DIR)
+
+import validate_wiki_examples as v  # noqa: E402
+
+
+DEFINITIONS = {
+    "global_flags": [
+        {"name": "help", "short": "h"},
+        {"name": "verbose", "short": "v"},
+    ],
+    "command_groups": [
+        {"name": "backup"}, {"name": "backup_schedule"},
+        {"name": "storage"}, {"name": "storage_setup"},
+        {"name": "host"}, {"name": "maintenance"}, {"name": "gitops"},
+    ],
+    "commands": [
+        {"name": "restart", "parameters": [{"name": "id", "short": "i",
+                                            "type": "string"}]},
+        {"name": "create", "parameters": [
+            {"name": "id", "short": "i", "type": "string"},
+            {"name": "wiki", "short": "w", "type": "string"},
+        ]},
+        {"name": "backup_purge", "parameters": [
+            {"name": "keep_within", "type": "string"},
+        ]},
+        {"name": "backup_schedule_set", "parameters": [
+            {"name": "purge_older_than", "type": "string"},
+        ]},
+        {"name": "storage_setup_nfs", "parameters": [
+            {"name": "host", "short": "H", "type": "string"},
+            {"name": "install_server", "type": "bool"},
+        ]},
+        # `long:` renames the flag — --name, not --host-name.
+        {"name": "host_add", "parameters": [
+            {"name": "host_name", "long": "name", "short": "n",
+             "type": "string"},
+        ]},
+        {"name": "maintenance_script", "parameters": [
+            {"name": "id", "short": "i", "type": "string"},
+            {"name": "script_args", "positional": True},
+        ]},
+        {"name": "gitops_status", "parameters": [
+            {"name": "id", "short": "i", "type": "string"},
+        ]},
+    ],
+}
+
+TABLE = v.build_command_table(DEFINITIONS)
+
+# The stub above could drift from the real schema; a few tests run the
+# same code against the shipped definitions.
+REAL_DEFINITIONS = v.load_definitions()
+REAL_TABLE = v.build_command_table(REAL_DEFINITIONS)
+
+
+def check(line):
+    """Validate one example line; return the finding detail or None."""
+    tokens = v.tokenize(line)
+    if not tokens:
+        return None
+    problem = v.validate_example(tokens, TABLE, DEFINITIONS)
+    return None if problem is None else " ".join(problem)
+
+
+def block(body, lang="bash"):
+    return '<syntaxhighlight lang="%s" copy=1>\n%s\n</syntaxhighlight>' % (
+        lang, body,
+    )
+
+
+class TestCommandResolution:
+    def test_plain_command(self):
+        assert check("canasta restart -i mywiki") is None
+
+    def test_two_token_group_command(self):
+        assert check("canasta backup purge --keep-within 30d") is None
+
+    def test_three_token_group_command(self):
+        """`backup_schedule_set` splits into three CLI tokens, and the
+        group name itself contains an underscore."""
+        assert check('canasta backup schedule set "0 2 * * *"') is None
+
+    def test_group_with_underscore_in_its_name(self):
+        assert check(
+            "canasta storage setup nfs --host node1 --install-server"
+        ) is None
+
+    def test_unknown_command_is_reported(self):
+        assert "unknown command" in check("canasta frobnicate -i x")
+
+    def test_renamed_command_is_reported(self):
+        """A command that used to exist under another name."""
+        assert "unknown command" in check("canasta crowdsec enroll")
+
+
+class TestFlagValidation:
+    def test_unknown_long_flag(self):
+        assert check("canasta restart --host node1 -i x") == (
+            "unknown flag: --host"
+        )
+
+    def test_unknown_short_flag(self):
+        assert check("canasta restart -Z") == "unknown flag: -Z"
+
+    def test_nonexistent_flag_on_a_destructive_command(self):
+        """The `backup purge --dry-run` class: a documented safety flag
+        that does not exist, where the recovery is to drop it and run
+        the destructive command for real."""
+        assert check("canasta backup purge --keep-within 30d --dry-run") == (
+            "unknown flag: --dry-run"
+        )
+
+    def test_long_override_is_honored(self):
+        """host_add declares `long: name`, so --name is correct and
+        --host-name is not."""
+        assert check("canasta host add --name prod1") is None
+        assert "unknown flag" in check("canasta host add --host-name prod1")
+
+    def test_flag_with_inline_value(self):
+        assert check("canasta create --id=mywiki") is None
+        assert check("canasta create --nope=x") == "unknown flag: --nope"
+
+    def test_global_flags_are_accepted(self):
+        assert check("canasta restart --verbose") is None
+        assert check("canasta restart -h") is None
+
+    def test_negative_number_is_not_a_flag(self):
+        assert check("canasta backup purge --keep-within -1") is None
+
+
+class TestPassthroughArguments:
+    """Flags after a passthrough positional belong to another program."""
+
+    def test_script_flags_are_not_ours(self):
+        assert check(
+            "canasta maintenance script createAndPromote.php U --bureaucrat"
+        ) is None
+
+    def test_our_flags_before_the_script_still_checked(self):
+        assert check(
+            "canasta maintenance script -Q foo.php --bureaucrat"
+        ) == "unknown flag: -Q"
+
+    def test_double_dash_stops_validation(self):
+        assert check("canasta restart -i x -- php -m") is None
+
+
+class TestLineExtraction:
+    def test_only_shell_blocks_are_scanned(self):
+        """A yaml/php block can contain anything; prose mentions of a
+        command in <code> tags are not runnable examples."""
+        text = "\n".join([
+            block("canasta restart --host x"),
+            block("canasta: --host x", lang="yaml"),
+            "Run <code>canasta restart --host x</code> to restart.",
+        ])
+        assert len(list(v.iter_shell_lines(text))) == 1
+
+    def test_backslash_continuations_are_joined(self):
+        """A flag alone on a continuation line is part of the command
+        above it — checking only the first line misses it entirely."""
+        text = block(
+            "canasta storage setup nfs \\\n"
+            "  --host node1 \\\n"
+            "  --bogus-flag"
+        )
+        lines = list(v.iter_shell_lines(text))
+        assert len(lines) == 1
+        assert check(lines[0][1]) == "unknown flag: --bogus-flag"
+
+    def test_line_numbers_point_at_the_command(self):
+        text = "intro\n\n" + block("echo hi\ncanasta restart -i x")
+        (line_no, _), = list(v.iter_shell_lines(text))
+        assert text.split("\n")[line_no - 1].startswith("canasta restart")
+
+    def test_prompts_and_list_markers(self):
+        assert list(v.iter_shell_lines(block("$ canasta restart -i x")))
+
+    def test_non_canasta_lines_ignored(self):
+        text = block("kubectl get pods\ndocker compose ps")
+        assert list(v.iter_shell_lines(text)) == []
+
+    def test_wrapper_names_are_recognized(self):
+        text = block("canasta-native restart -i x\ncanasta-docker restart -i x")
+        assert len(list(v.iter_shell_lines(text))) == 2
+
+
+class TestTokenizing:
+    def test_placeholders_do_not_break_parsing(self):
+        assert check("canasta restart -i <your-instance>") is None
+
+    def test_trailing_comment_is_stripped(self):
+        assert check("canasta restart -i x   # restart it") is None
+
+    def test_only_the_first_command_of_a_pipeline(self):
+        assert check("canasta restart -i x | grep ok") is None
+
+    def test_unparseable_line_is_skipped_not_crashed(self):
+        assert v.tokenize("canasta restart -i 'unbalanced") is None
+
+    def test_bare_command_name(self):
+        assert check("canasta restart") is None
+
+
+class TestEndToEnd:
+    def test_clean_page_produces_no_findings(self):
+        text = block("canasta restart -i mywiki\ncanasta backup purge "
+                     "--keep-within 30d")
+        assert v.validate_page("Help:X", text, TABLE, DEFINITIONS) == []
+
+    def test_findings_carry_page_line_and_example(self):
+        text = "lead\n" + block("canasta restart --host node1")
+        finding, = v.validate_page("Help:X", text, TABLE, DEFINITIONS)
+        assert finding.page == "Help:X"
+        assert "--host" in finding.detail
+        assert "canasta restart --host node1" in finding.example
+        assert "Help:X" in str(finding)
+
+
+class TestAgainstRealDefinitions:
+    """The stub table above could drift from the real schema; these run
+    the same code against meta/command_definitions.yml."""
+
+    def test_every_command_is_reachable(self):
+        definitions, table = REAL_DEFINITIONS, REAL_TABLE
+        assert len(table) >= len(definitions["commands"])
+
+    def test_documented_examples_all_validate(self):
+        """Each command's own `examples:` must pass — they are the
+        canonical usage, so a failure means the validator is wrong."""
+        definitions, table = REAL_DEFINITIONS, REAL_TABLE
+        for command in definitions["commands"]:
+            for example in command.get("examples") or []:
+                tokens = v.tokenize(example)
+                assert tokens, example
+                problem = v.validate_example(tokens, table, definitions)
+                assert problem is None, "%s -> %s" % (example, problem)


### PR DESCRIPTION
Adds `scripts/validate_wiki_examples.py`, which checks every `canasta` example on canasta.wiki against `meta/command_definitions.yml`.

Follows up the review that produced #1240.

## Why

The `CLI:` namespace is generated from the command definitions, so it is correct by construction — 105 pages, zero flag mismatches. The hand-written `Help:` pages have no such guarantee, and nothing checked them. Every broken example found in the last review was on a hand-maintained page:

- `Help:Backup and restore` documented `canasta backup purge --dry-run`, a flag that did not exist, on a command that **permanently deletes snapshots**. The natural recovery from the argparse error was to drop the flag and run the real purge.
- Four multi-node walkthrough examples passed `--host` to commands that reject it.

Both classes are mechanically detectable.

## What it catches

Run against a snapshot of the wiki taken before those fixes, it reports all five — including the `gitops init --host` case that the manual review missed:

```
Help:User journeys/Canasta multi-node on AWS EC2 with k3s:212: unknown flag: --host
    canasta gitops init --host node1 --id mywiki --name dev ...
Help:User journeys/Canasta multi-node on AWS EC2 with k3s:223: unknown flag: --host
    canasta gitops status --host node1 --id mywiki
...
5 example(s) reference a command or flag that does not exist.
```

Against the wiki as it stands now: 392 examples across 38 pages, clean.

## Avoiding false positives

A checker that cries wolf gets ignored, so the wiki constructs that merely *look* like drift are handled explicitly, each with a test:

- **Only fenced shell blocks are scanned.** Prose mentions of a command in `<code>` tags are not runnable examples, and `lang="yaml"` / `lang="php"` blocks can contain anything.
- **Passthrough arguments are not ours.** `canasta maintenance script createAndPromote.php U --bureaucrat` passes `--bureaucrat` to the script; validation stops at the first bare token after a `REMAINDER` positional, and at `--`.
- **`long:` overrides are honored.** `host_add` declares `long: name`, so `--name` is correct and `--host-name` is not.
- **Group commands resolve longest-first**, since a group name can itself contain an underscore (`storage_setup` → `storage setup nfs`).
- **Placeholders, `$` prompts, trailing comments, and pipelines** are normalized; an unparseable line is skipped rather than crashing the run.
- **Backslash continuations are joined first.** A flag alone on a continuation line is part of the command above it — an earlier prototype checked only the first line and silently missed that whole class.

Two of these were bugs the tests found in the validator itself: a `$ ` prompt made a line invisible, and `cd /path && canasta delete -y` (a real example in the definitions) parsed the wrong segment. The test that runs the validator against every command's own `examples:` is what caught the second — those are canonical usage, so a failure there means the validator is wrong, not the docs.

## Wiring

A separate workflow, not part of `wiki-publish.yml` — publishing the generated `CLI:` reference must not be blocked by a stale hand-written example.

- **`pull_request`** on `meta/command_definitions.yml`: a PR that renames or removes a flag fails until the examples using it are updated.
- **Weekly schedule**: the only thing that catches drift introduced by a *wiki* edit, which no repo event would ever trigger. Given that all five findings last round came from wiki-side text, this is the more valuable trigger.
- **`workflow_dispatch`** for ad-hoc runs, plus `make validate-wiki` locally. Not part of `make lint`, since it needs the network.

Exit codes are distinct: `1` is real drift, `2` is an unreachable wiki with nothing checked. Both fail the job — a skipped run must never look like a clean one.

## Verification

31 unit tests; 1977 overall. `make lint` and `ruff` clean. Verified against the live wiki, a clean snapshot, a pre-fix snapshot, and an unreachable host.
