### PR TITLE
refactor: share the wiki API retry helper between both scripts

### DIFF
--- a/scripts/validate_wiki_examples.py
+++ b/scripts/validate_wiki_examples.py
@@ -23,26 +23,24 @@ exist.
 """
 
 import argparse
-import json
 import os
 import re
 import shlex
 import sys
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
 
 import yaml
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import wiki_http  # noqa: E402
+
 DEFAULT_API = "https://canasta.wiki/w/api.php"
 HELP_NAMESPACE = 12
 USER_AGENT = "canasta-cli-example-validator"
-HTTP_TIMEOUT = 30  # seconds
-# Backoff schedule shared with the publish script: 15s, 30s, 60s, 120s, 120s.
-MAX_RETRIES = 5
-RETRY_BACKOFF_BASE = 15
-RETRY_BACKOFF_MAX = 120
+# Backoff and timeout are shared with the publish script via wiki_http.
+MAX_RETRIES = wiki_http.MAX_CONNECT_RETRIES
 # The API caps content fetches per request; 20 keeps every batch a single
 # round trip with no continuation.
 TITLES_PER_REQUEST = 20
@@ -245,38 +243,21 @@ def validate_page(page, wikitext, table, definitions):
 # --- Page sources ------------------------------------------------------
 
 
-def _get(api_url, params, sleep=time.sleep):
+def _get(api_url, params, sleep=None):
     """GET a MediaWiki API query, retrying when the API does not answer.
 
-    Connect timeouts from CI runners to this wiki are a known, recurring
-    failure that the publish script hit too, so the backoff schedule
-    matches the one there: 15s, 30s, 60s, 120s, 120s. A 4xx is not
-    retried — the request arrived and was rejected.
+    Shares wiki_http's opener so this and the publish script keep one
+    backoff schedule between them.
     """
     url = api_url + "?" + urllib.parse.urlencode(dict(params, format="json",
                                                       formatversion=2))
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    for attempt in range(MAX_RETRIES + 1):
-        try:
-            with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT) as resp:
-                return json.load(resp)
-        except urllib.error.HTTPError as exc:
-            if exc.code < 500 and exc.code != 429:
-                raise
-            failure = exc
-        except (urllib.error.URLError, TimeoutError, OSError) as exc:
-            failure = exc
-        if attempt == MAX_RETRIES:
-            raise failure
-        delay = min(RETRY_BACKOFF_BASE * (2 ** attempt), RETRY_BACKOFF_MAX)
-        print(
-            "  wiki did not answer (%s); retrying in %ds" % (failure, delay),
-            file=sys.stderr,
-        )
-        sleep(delay)
+    return wiki_http.open_json(
+        urllib.request.urlopen, request, api_url=api_url, sleep=sleep,
+    )
 
 
-def fetch_pages(api_url, namespace=HELP_NAMESPACE, sleep=time.sleep):
+def fetch_pages(api_url, namespace=HELP_NAMESPACE, sleep=None):
     """Yield (title, wikitext) for every page in the namespace.
 
     Content is fetched in batches rather than one parse call per page:
@@ -338,7 +319,8 @@ def main():
             pages += 1
             examples += sum(1 for _ in iter_shell_lines(wikitext))
             findings.extend(validate_page(title, wikitext, table, definitions))
-    except (urllib.error.URLError, OSError, KeyError, ValueError) as exc:
+    except (RuntimeError, urllib.error.URLError, OSError,
+            KeyError, ValueError) as exc:
         # Exit 2, not 1: an unreachable wiki is an infrastructure problem,
         # and reporting it as "no findings" would be a false green.
         print(

--- a/scripts/wiki_http.py
+++ b/scripts/wiki_http.py
@@ -1,0 +1,86 @@
+"""Shared HTTP access to the canasta.wiki MediaWiki API.
+
+Both wiki scripts talk to the same API from the same CI runners and hit
+the same failure: a request that never gets an answer, while the wiki
+serves fine from elsewhere. Each had grown its own copy of the backoff
+schedule, which is how two copies drift into disagreeing about how long
+to wait.
+"""
+
+import http.client
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+HTTP_TIMEOUT = 30  # seconds; a hung wiki API must not stall the caller
+
+RETRY_BACKOFF_BASE = 15  # seconds; doubled each retry, capped at the max
+RETRY_BACKOFF_MAX = 120
+MAX_CONNECT_RETRIES = 5
+
+# Statuses that mean "the request arrived but try again". Anything else
+# in the 4xx range is a real error: retrying only delays the report.
+RETRYABLE_HTTP_STATUS = {429, 500, 502, 503, 504}
+
+# Transport failures where the request never reached the API at all.
+TRANSPORT_ERRORS = (
+    urllib.error.URLError,
+    http.client.HTTPException,
+    TimeoutError,
+    ConnectionError,
+)
+
+
+def retry_delay(attempt):
+    """Backoff (seconds) before retry number `attempt` (0-based)."""
+    return min(RETRY_BACKOFF_BASE * (2 ** attempt), RETRY_BACKOFF_MAX)
+
+
+def open_json(open_target, target, data=None, api_url=None,
+              timeout=HTTP_TIMEOUT, sleep=None):
+    """Open `target`, return the decoded JSON body, retry if unanswered.
+
+    `open_target` is the caller's opener callable — an authenticated
+    session's `opener.open` or a bare `urllib.request.urlopen` — so a
+    caller keeps its own cookies and headers.
+
+    `target` is a URL string or a prepared Request. Anything meaning the
+    API never answered (connection timeout, reset, DNS, a 5xx or 429) is
+    retried; a 4xx is raised straight through.
+
+    `sleep` is resolved at call time when not given, so patching
+    `time.sleep` still takes effect.
+    """
+    request = (
+        urllib.request.Request(target, data=data)
+        if isinstance(target, str) else target
+    )
+    where = api_url or getattr(request, "full_url", target)
+    last = None
+    for attempt in range(MAX_CONNECT_RETRIES + 1):
+        try:
+            with open_target(request, timeout=timeout) as response:
+                return json.loads(response.read())
+        except urllib.error.HTTPError as exc:
+            # HTTPError is a URLError subclass, so it must be caught
+            # first to keep 4xx from being retried.
+            if exc.code not in RETRYABLE_HTTP_STATUS:
+                raise
+            last = exc
+        except TRANSPORT_ERRORS as exc:
+            last = exc
+        if attempt >= MAX_CONNECT_RETRIES:
+            break
+        delay = retry_delay(attempt)
+        print(
+            "Cannot reach %s (%s); retrying in %ds (%d/%d)"
+            % (where, last, delay, attempt + 1, MAX_CONNECT_RETRIES),
+            file=sys.stderr,
+        )
+        (sleep or time.sleep)(delay)
+    raise RuntimeError(
+        "Could not reach the wiki API at %s after %d attempts: %s"
+        % (where, MAX_CONNECT_RETRIES + 1, last)
+    )

--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -22,7 +22,6 @@ Usage:
 """
 
 import argparse
-import json
 import os
 import re
 import sys
@@ -36,35 +35,31 @@ import http.cookiejar
 import yaml
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, SCRIPT_DIR)
+import wiki_http  # noqa: E402
 REPO_ROOT = os.path.dirname(SCRIPT_DIR)
 DEFINITIONS_PATH = os.path.join(REPO_ROOT, "meta", "command_definitions.yml")
 
 PAGE_PREFIX = "CLI:"
 EDIT_DELAY = 2  # seconds between edits
-HTTP_TIMEOUT = 30  # seconds; a hung wiki API must not stall the publish
 
 # Transient API errors worth retrying rather than failing the publish:
 # 'ratelimited' is the wiki throttling the bot when a single run changes
 # many pages; 'maxlag' is the DB-replication backpressure guard. Without
 # backoff a single throttle leaves the rest of the namespace stale.
+# These are API replies to a request that did arrive, unlike the
+# transport failures wiki_http retries.
 RETRYABLE_ERROR_CODES = {"ratelimited", "maxlag"}
 MAX_EDIT_RETRIES = 5
-RETRY_BACKOFF_BASE = 15  # seconds; doubled each retry, capped at the max
-RETRY_BACKOFF_MAX = 120
 
-# Transport-level failures worth retrying: the request never reached the
-# API, or the wiki answered with a status that means "try again". These
-# are distinct from RETRYABLE_ERROR_CODES, which are API replies to a
-# request that did arrive. The first request a run makes is the login
-# token fetch, so without this a momentary blip fails the publish before
-# a single page is written and silently leaves the reference stale.
-RETRYABLE_HTTP_STATUS = {429, 500, 502, 503, 504}
-MAX_CONNECT_RETRIES = 5
-
-
-def _retry_delay(attempt):
-    """Backoff (seconds) before retry number `attempt` (0-based)."""
-    return min(RETRY_BACKOFF_BASE * (2 ** attempt), RETRY_BACKOFF_MAX)
+# Re-exported so the edit-retry path below and the transport retries in
+# wiki_http share one backoff schedule instead of two copies of it.
+HTTP_TIMEOUT = wiki_http.HTTP_TIMEOUT
+RETRY_BACKOFF_BASE = wiki_http.RETRY_BACKOFF_BASE
+RETRY_BACKOFF_MAX = wiki_http.RETRY_BACKOFF_MAX
+MAX_CONNECT_RETRIES = wiki_http.MAX_CONNECT_RETRIES
+RETRYABLE_HTTP_STATUS = wiki_http.RETRYABLE_HTTP_STATUS
+_retry_delay = wiki_http.retry_delay
 
 
 class PermissionDeniedError(RuntimeError):
@@ -815,47 +810,9 @@ class MediaWikiClient:
 
     def _open(self, target, data=None):
         """Open `target` and return the decoded JSON body, retrying
-        transient transport failures with backoff.
-
-        `target` is a URL string or a prepared Request. Anything that
-        means the API never answered — connection timeout, reset, DNS,
-        a 5xx or 429 — is retried; a 4xx is a real error and is not.
-        """
-        req = (
-            urllib.request.Request(target, data=data)
-            if isinstance(target, str) else target
-        )
-        last = None
-        for attempt in range(MAX_CONNECT_RETRIES + 1):
-            try:
-                with self.opener.open(req, timeout=HTTP_TIMEOUT) as resp:
-                    return json.loads(resp.read())
-            except urllib.error.HTTPError as exc:
-                # HTTPError is a URLError subclass, so it must be caught
-                # first to keep 4xx from being retried.
-                if exc.code not in RETRYABLE_HTTP_STATUS:
-                    raise
-                last = exc
-            except (
-                urllib.error.URLError,
-                http.client.HTTPException,
-                TimeoutError,
-                ConnectionError,
-            ) as exc:
-                last = exc
-            if attempt >= MAX_CONNECT_RETRIES:
-                break
-            delay = _retry_delay(attempt)
-            print(
-                "Cannot reach %s (%s); retrying in %ds (%d/%d)"
-                % (self.api_url, last, delay, attempt + 1,
-                   MAX_CONNECT_RETRIES),
-                file=sys.stderr,
-            )
-            time.sleep(delay)
-        raise RuntimeError(
-            "Could not reach the wiki API at %s after %d attempts: %s"
-            % (self.api_url, MAX_CONNECT_RETRIES + 1, last)
+        transient transport failures with backoff."""
+        return wiki_http.open_json(
+            self.opener.open, target, data=data, api_url=self.api_url,
         )
 
     def _post(self, params):

--- a/tests/unit/test_validate_wiki_examples.py
+++ b/tests/unit/test_validate_wiki_examples.py
@@ -308,7 +308,7 @@ class TestRequestRetry:
     def test_gives_up_after_the_cap(self, monkeypatch):
         fake = _FakeUrlopen(*[urllib.error.URLError("timed out")] * 20)
         monkeypatch.setattr(v.urllib.request, "urlopen", fake)
-        with pytest.raises(urllib.error.URLError):
+        with pytest.raises(RuntimeError, match="Could not reach the wiki API"):
             v._get("https://w/api.php", {}, sleep=lambda _: None)
         assert len(fake.calls) == v.MAX_RETRIES + 1
 

--- a/tests/unit/test_wiki_http.py
+++ b/tests/unit/test_wiki_http.py
@@ -1,0 +1,135 @@
+"""Tests for scripts/wiki_http.py, the shared MediaWiki API access.
+
+The publish script and the example validator talk to the same API from
+the same runners and hit the same unanswered-request failure. They used
+to carry a copy of the backoff schedule each; the point of this module
+is that there is now one, so the drift guard below matters as much as
+the behavior tests.
+"""
+
+import os
+import sys
+import time
+import urllib.error
+
+import pytest
+
+SCRIPTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "scripts"),
+)
+sys.path.insert(0, SCRIPTS_DIR)
+
+import wiki_http  # noqa: E402
+import wiki_publish  # noqa: E402
+import validate_wiki_examples  # noqa: E402
+
+
+class _Response:
+    def __init__(self, body):
+        self.body = body
+
+    def read(self):
+        return self.body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _Opener:
+    def __init__(self, *outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = 0
+
+    def __call__(self, request, timeout=None):
+        self.calls += 1
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return _Response(outcome)
+
+
+def _http_error(code):
+    return urllib.error.HTTPError("https://w/api.php", code, "x", {}, None)
+
+
+class TestRetryDelay:
+    def test_doubles_then_caps(self):
+        delays = [wiki_http.retry_delay(i) for i in range(6)]
+        assert delays == [15, 30, 60, 120, 120, 120]
+
+
+class TestOpenJson:
+    def test_decodes_the_body(self):
+        opener = _Opener(b'{"ok": true}')
+        assert wiki_http.open_json(opener, "https://w/api.php") == {"ok": True}
+
+    def test_retries_transport_failure(self):
+        opener = _Opener(urllib.error.URLError("timed out"), b'{"ok": 1}')
+        slept = []
+        assert wiki_http.open_json(
+            opener, "https://w/api.php", sleep=slept.append,
+        ) == {"ok": 1}
+        assert opener.calls == 2
+        assert slept == [15]
+
+    def test_gives_up_with_a_clear_error(self):
+        opener = _Opener(*[urllib.error.URLError("x")] * 10)
+        with pytest.raises(RuntimeError, match="Could not reach the wiki API"):
+            wiki_http.open_json(
+                opener, "https://w/api.php", sleep=lambda _: None,
+            )
+        assert opener.calls == wiki_http.MAX_CONNECT_RETRIES + 1
+
+    @pytest.mark.parametrize("code", sorted(wiki_http.RETRYABLE_HTTP_STATUS))
+    def test_retryable_statuses(self, code):
+        opener = _Opener(_http_error(code), b'{"ok": 1}')
+        assert wiki_http.open_json(
+            opener, "https://w/api.php", sleep=lambda _: None,
+        ) == {"ok": 1}
+        assert opener.calls == 2
+
+    @pytest.mark.parametrize("code", [400, 401, 403, 404, 409])
+    def test_client_errors_are_not_retried(self, code):
+        """The request arrived and was rejected; retrying only delays
+        the report."""
+        opener = _Opener(_http_error(code))
+        with pytest.raises(urllib.error.HTTPError):
+            wiki_http.open_json(
+                opener, "https://w/api.php", sleep=lambda _: None,
+            )
+        assert opener.calls == 1
+
+    def test_sleep_defaults_to_time_sleep_at_call_time(self, monkeypatch):
+        """Resolved per call, not captured at import, so patching
+        time.sleep still takes effect."""
+        slept = []
+        monkeypatch.setattr(time, "sleep", slept.append)
+        opener = _Opener(urllib.error.URLError("x"), b'{"ok": 1}')
+        wiki_http.open_json(opener, "https://w/api.php")
+        assert slept == [15]
+
+
+class TestNoDuplicateSchedules:
+    """A second copy of these numbers is what the extraction removed."""
+
+    def test_publisher_shares_the_schedule(self):
+        assert wiki_publish.RETRY_BACKOFF_BASE is wiki_http.RETRY_BACKOFF_BASE
+        assert wiki_publish.RETRY_BACKOFF_MAX is wiki_http.RETRY_BACKOFF_MAX
+        assert wiki_publish.MAX_CONNECT_RETRIES is wiki_http.MAX_CONNECT_RETRIES
+        assert wiki_publish.HTTP_TIMEOUT is wiki_http.HTTP_TIMEOUT
+        assert wiki_publish._retry_delay is wiki_http.retry_delay
+
+    def test_validator_shares_the_schedule(self):
+        assert (validate_wiki_examples.MAX_RETRIES
+                is wiki_http.MAX_CONNECT_RETRIES)
+
+    def test_neither_module_redefines_the_backoff(self):
+        for module in (wiki_publish, validate_wiki_examples):
+            source = open(module.__file__).read()
+            assert "RETRY_BACKOFF_BASE = 15" not in source, (
+                "%s redefines the backoff instead of using wiki_http"
+                % os.path.basename(module.__file__)
+            )


### PR DESCRIPTION
Extracts the shared MediaWiki API access into `scripts/wiki_http.py`.

Follow-up to #1258 and #1261, which independently added retry-with-backoff to the same API. Both scripts talk to the same wiki from the same runners and hit the same failure — a request that never gets an answer — so they had each grown their own copy of the timeout, the backoff schedule, and the retryable-status set. Two copies is how they drift into disagreeing about how long to wait.

## What moved

The timeout, the schedule (15s, 30s, 60s, 120s, 120s), the retryable-status set, and the retry loop itself. Each caller passes its own opener, so the publisher keeps its authenticated cookie-jar session and the validator keeps its plain `urlopen`.

`wiki_publish.py` loses 55 lines. Its edit-retry path (`ratelimited` / `maxlag`) now reuses the same delay function instead of a second one.

## No behavior change

The clearest evidence: **the retry tests added in #1258 pass untouched**. Two details made that possible, and both are worth knowing before editing this again:

- Those tests patch `wp.time.sleep`, which is the *global* `time` module, so the patch still reaches the shared module. `open_json` therefore resolves `time.sleep` at call time rather than capturing it at import — capturing it would silently break every one of those patches. There is a test pinning that behavior.
- `_retry_delay`, `RETRY_BACKOFF_BASE`, `RETRY_BACKOFF_MAX`, `MAX_CONNECT_RETRIES`, `HTTP_TIMEOUT`, and `RETRYABLE_HTTP_STATUS` are re-exported from `wiki_publish`, so existing references keep working.

## The drift guard

`tests/unit/test_wiki_http.py` (18 tests) covers the retry behavior directly, and then asserts the property this change exists to protect: both modules resolve to the *same* schedule objects, and neither source re-introduces a local `RETRY_BACKOFF_BASE = 15`. Without that, a later edit quietly re-adds a constant and the two schedules diverge again.

## Verification

2018 tests pass; `make lint`, `make validate`, and `ruff` clean. Live checks: the validator still reports 392 examples across 38 pages clean, and `wiki_publish.py --dry-run` still generates all 104 pages.
