### PR TITLE
fix(uninstall): refuse to remove a worker holding PersistentVolumes

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -901,6 +901,11 @@ commands:
           host. Canasta SSHs there after stopping the agent and runs
           'kubectl delete node <hostname>' so the Node entry is cleaned
           up. Ignored on control-plane uninstalls.
+      - name: force
+        type: bool
+        description: >-
+          Proceed even when the target node holds PersistentVolumes whose
+          data the uninstall would destroy.
       - name: "yes"
         short: "y"
         type: bool

--- a/roles/install/tasks/uninstall_k3s.yml
+++ b/roles/install/tasks/uninstall_k3s.yml
@@ -66,6 +66,67 @@
   changed_when: false
   when: _k3s_role_label == 'worker'
 
+# A local-path PV lives on the node that provisioned it, and the k3s
+# uninstall removes /var/lib/rancher/k3s — so detaching a worker deletes
+# any volume bound there. The database of a multi-node instance is the
+# common case: it uses local-path by default and lands wherever the
+# scheduler put it. Ask the control plane what would be lost, first.
+- name: Guard volumes pinned to a worker being removed
+  when: _k3s_role_label == 'worker'
+  block:
+    - name: Resolve cp-host SSH target for the volume check
+      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_cp_host_ssh.yml"
+
+    - name: List PersistentVolumes pinned to a node
+      ansible.builtin.command:
+        argv:
+          - ssh
+          - -o
+          - StrictHostKeyChecking=accept-new
+          - "{{ _cp_ssh_target }}"
+          - >-
+            sudo k3s kubectl get pv -o
+            jsonpath='{range .items[?(@.spec.nodeAffinity)]}
+            {.spec.claimRef.namespace}/{.spec.claimRef.name}{"\t"}
+            {.spec.nodeAffinity.required.nodeSelectorTerms[*].matchExpressions[*].values[*]}
+            {"\n"}{end}'
+      delegate_to: localhost
+      register: _pinned_pvs
+      changed_when: false
+      failed_when: false
+
+    - name: Select the volumes this uninstall would destroy
+      ansible.builtin.set_fact:
+        _doomed_volumes: >-
+          {{ (_pinned_pvs.stdout_lines | default([]))
+             | map('trim') | reject('equalto', '')
+             | select('search', '(^|\s)'
+                      ~ (_worker_hostname_raw.stdout | trim) ~ '(\s|$)')
+             | map('regex_replace', '\s.*$', '')
+             | list }}
+
+    - name: Refuse to destroy volumes bound to this node
+      ansible.builtin.fail:
+        msg: >-
+          Uninstalling k3s from '{{ _worker_hostname_raw.stdout | trim }}'
+          would destroy {{ _doomed_volumes | length }} PersistentVolume(s)
+          stored on it: {{ _doomed_volumes | join(', ') }}.
+          Their data lives under /var/lib/rancher/k3s on that node and the
+          uninstall removes it. Back up or migrate the affected instances
+          first, or pass --force to proceed and lose the data.
+      when:
+        - _doomed_volumes | length > 0
+        - not (force | default(false) | bool)
+
+    - name: Warn that pinned volumes are being destroyed
+      ansible.builtin.debug:
+        msg: >-
+          --force given: destroying {{ _doomed_volumes | length }}
+          PersistentVolume(s) on this node: {{ _doomed_volumes | join(', ') }}.
+      when:
+        - _doomed_volumes | length > 0
+        - force | default(false) | bool
+
 - name: Uninstall k3s
   when: _k3s_uninstall_script | length > 0
   become: true

--- a/tests/unit/test_uninstall_pv_guard.py
+++ b/tests/unit/test_uninstall_pv_guard.py
@@ -1,0 +1,132 @@
+"""Removing a k3s worker must not silently delete volumes stored on it.
+
+A local-path PersistentVolume lives on the node that provisioned it, and
+`k3s-uninstall.sh` removes /var/lib/rancher/k3s wholesale — so detaching
+a worker destroys any volume bound there. This is the common case, not
+an exotic one: a Canasta instance's database uses local-path by default
+and lands wherever the scheduler put it.
+
+This actually happened: `canasta uninstall k8s --host small --cp-host
+big` reported success and took a live instance's database with it. The
+only symptom afterwards was a Pending pod whose message said nothing
+about the node having been removed on purpose.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+UNINSTALL = os.path.join(
+    REPO_ROOT, "roles", "install", "tasks", "uninstall_k3s.yml")
+DEFINITIONS = os.path.join(REPO_ROOT, "meta", "command_definitions.yml")
+
+
+def _tasks():
+    with open(UNINSTALL) as f:
+        return yaml.safe_load(f) or []
+
+
+def _names():
+    return [str(t.get("name", "")) for t in _tasks() if isinstance(t, dict)]
+
+
+def _guard():
+    return next(
+        (t for t in _tasks()
+         if isinstance(t, dict) and "Guard volumes" in str(t.get("name", ""))),
+        None,
+    )
+
+
+class TestGuardExists:
+    def test_a_guard_task_is_present(self):
+        assert _guard(), (
+            "nothing checks for volumes pinned to the worker before the "
+            "uninstall destroys them"
+        )
+
+    def test_it_only_applies_to_workers(self):
+        # A control-plane uninstall discards the whole cluster by design.
+        assert "worker" in str(_guard().get("when", ""))
+
+
+class TestGuardRunsBeforeTheDestruction:
+    def test_it_precedes_the_uninstall_script(self):
+        names = _names()
+        guard_at = next(i for i, n in enumerate(names) if "Guard volumes" in n)
+        uninstall_at = next(i for i, n in enumerate(names) if n == "Uninstall k3s")
+        assert guard_at < uninstall_at, (
+            "the guard runs after the uninstall — by then the data is gone"
+        )
+
+    def test_it_uses_the_hostname_captured_before_uninstall(self):
+        # Node names come from the OS hostname, captured earlier in the
+        # file; asking the node itself afterwards would be too late.
+        names = _names()
+        capture_at = next(
+            i for i, n in enumerate(names) if "Capture worker hostname" in n)
+        guard_at = next(i for i, n in enumerate(names) if "Guard volumes" in n)
+        assert capture_at < guard_at
+
+
+class TestGuardBehavior:
+    def _subtasks(self):
+        return _guard().get("block", [])
+
+    def test_it_refuses_by_default(self):
+        fail = next(
+            (t for t in self._subtasks()
+             if "ansible.builtin.fail" in t), None)
+        assert fail, "the guard warns but never refuses"
+        when = " ".join(fail.get("when", [])) if isinstance(
+            fail.get("when"), list) else str(fail.get("when"))
+        assert "_doomed_volumes | length > 0" in when
+        assert "force" in when, "there must be an escape hatch"
+
+    def test_the_message_names_the_volumes(self):
+        fail = next(t for t in self._subtasks() if "ansible.builtin.fail" in t)
+        msg = str(fail["ansible.builtin.fail"]["msg"])
+        assert "_doomed_volumes | join" in msg, (
+            "say which volumes would be lost, not just that some would be"
+        )
+        assert "--force" in msg, "point at the way forward"
+
+    def test_force_still_warns(self):
+        msgs = [
+            str(t.get("ansible.builtin.debug", {}).get("msg", ""))
+            for t in self._subtasks()
+        ]
+        assert any("force" in m and "_doomed_volumes" in m for m in msgs), (
+            "proceeding under --force should still say what is being destroyed"
+        )
+
+    def test_matching_is_not_position_dependent(self):
+        # The remote jsonpath is a folded scalar, so YAML injects spaces
+        # into the output. Anchored matching silently found nothing.
+        setter = next(
+            t for t in self._subtasks()
+            if "ansible.builtin.set_fact" in t
+            and "_doomed_volumes" in str(t["ansible.builtin.set_fact"])
+        )
+        expr = str(setter["ansible.builtin.set_fact"]["_doomed_volumes"])
+        assert "trim" in expr, (
+            "lines must be trimmed — folding the jsonpath pads them"
+        )
+        assert "\\t" not in expr, (
+            "do not match on a literal tab; the folded scalar turns the "
+            "separator into arbitrary whitespace"
+        )
+
+
+class TestForceFlagIsDeclared:
+    def test_uninstall_accepts_force(self):
+        with open(DEFINITIONS) as f:
+            defs = yaml.safe_load(f)
+        cmd = next(c for c in defs["commands"] if c["name"] == "uninstall")
+        params = [p["name"] for p in cmd.get("parameters", [])]
+        assert "force" in params, (
+            "the guard tells the operator to pass --force, so the command "
+            "has to accept it"
+        )


### PR DESCRIPTION
Fixes #1252. This one destroyed a live instance's database during e2e testing, so the fix is verified against real infrastructure rather than only unit-tested.

## The bug

A `local-path` PV lives on the node that provisioned it, and `k3s-uninstall.sh` removes `/var/lib/rancher/k3s` wholesale. Detaching a worker therefore deletes any volume bound there — silently:

```
$ canasta uninstall k8s --host small --cp-host big -y
Kubernetes (worker) uninstalled.
Removed Node 'small' from control plane.       # exit 0, no mention of data
```

The only later symptom was a Pending pod whose message says nothing about the node having been removed on purpose:

```
0/1 nodes are available: 1 node(s) didn't match PersistentVolume's node affinity
```

This is the common case, not an exotic one. An instance's database uses `local-path` by default and lands wherever the scheduler put it — in the K8s e2e run for this series, the new instance's db went to the worker unprompted. Any multi-node instance is a coin flip on data loss.

## Fix

Before running the uninstall, ask the control plane which PVs are pinned to the target node and refuse when there are any, naming their claims. `--force` proceeds and still says what it is destroying.

The check is worker-only: a control-plane uninstall discards the cluster by design.

## Verified live, both paths

With a `local-path` PV pinned to the worker:

```
$ canasta uninstall k8s --host small --cp-host big -y
Error: Uninstalling k3s from 'small' would destroy 1 PersistentVolume(s) stored on it:
default/guardtest. Their data lives under /var/lib/rancher/k3s on that node and the
uninstall removes it. Back up or migrate the affected instances first, or pass --force
to proceed and lose the data.
exit=2
```

Cluster afterwards: still 2 nodes, PV intact, agent still running — nothing touched. Then:

```
$ canasta uninstall k8s --host small --cp-host big --force -y
--force given: destroying 1 PersistentVolume(s) on this node: default/guardtest.
Kubernetes (worker) uninstalled.
exit=0
```

## Two implementation notes for review

**Ordering.** The guard runs *after* the hostname is captured but *before* the uninstall script — the node name comes from the OS hostname, which has to be read while the node is still reachable, and the check is worthless once the data is gone. A test asserts both orderings.

**Whitespace-tolerant matching.** The remote jsonpath is a folded YAML scalar, so YAML injects spaces into the output. My first version anchored on a literal tab and silently matched nothing — the failure mode being that the guard would never fire, which is exactly the bug it is meant to prevent. It now tokenizes instead, and a test asserts the literal tab is not reintroduced.

## Test

`test_uninstall_pv_guard.py` — 9 tests covering the guard's existence, worker-only scope, both orderings, refuse-by-default, the message naming volumes and `--force`, the force path still warning, and the whitespace-tolerance point above. Also asserts `--force` is declared on the command, since the error message tells operators to use it.