### PR TITLE
fix(podman): read COMPOSE_PROFILES on the host that has the .env

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -971,6 +971,42 @@ def _unquote(value):
     return value
 
 
+# Cache per (host, path, key): _resolve_compose_cmd is called on every
+# compose invocation, and an ssh round-trip each time would be felt in
+# `canasta list` across several remote instances.
+_REMOTE_ENV_CACHE = {}
+
+
+def _read_env_for(inst, key):
+    """Read a key from an instance's .env, wherever that instance lives.
+
+    The file sits on the instance's host, so a remote instance has to be
+    read over ssh. Reading the controller's filesystem for a remote path
+    silently returns nothing, which the caller cannot distinguish from
+    "not set" — that is how remote podman instances lost their compose
+    profiles entirely.
+    """
+    path = inst.get("path", "")
+    if not path:
+        return None
+    host = inst.get("host") or "localhost"
+    if _is_localhost(host):
+        return _read_env(path, key)
+
+    ck = (host, path, key)
+    if ck in _REMOTE_ENV_CACHE:
+        return _REMOTE_ENV_CACHE[ck]
+    rc, out = _ssh_run(host, "sed -n %s %s 2>/dev/null" % (
+        _shell_quote("s/^%s=//p" % key),
+        _shell_quote(path.rstrip("/") + "/.env"),
+    ))
+    value = None
+    if rc == 0 and out.strip():
+        value = _unquote(out.strip().split("\n")[0].strip()) or None
+    _REMOTE_ENV_CACHE[ck] = value
+    return value
+
+
 def _compose_project(path):
     """The compose project name for an instance directory.
 
@@ -999,10 +1035,7 @@ def _compose_profile_args(inst):
     """
     if not _is_podman_compose(inst):
         return []
-    path = inst.get("path", "")
-    if not path:
-        return []
-    raw = _read_env(path, "COMPOSE_PROFILES")
+    raw = _read_env_for(inst, "COMPOSE_PROFILES")
     if not raw:
         return []
     profiles = [p.strip() for p in raw.split(",") if p.strip()]
@@ -1026,9 +1059,13 @@ def _resolve_compose_cmd(inst):
     raw = inst.get("composeCommand")
     if raw:
         return raw.split()
-    path = inst.get("path", "")
-    if path:
-        raw = _read_env(path, "compose_command")
+    # The .env fallback is deliberately local-only. These resolvers run
+    # on every compose invocation, so they must not do I/O; and reading
+    # the controller's filesystem for a remote instance's path is at
+    # best useless, at worst the wrong file. Remote instances carry the
+    # value in the registry.
+    if _is_localhost(inst.get("host") or "localhost"):
+        raw = _read_env(inst.get("path", ""), "compose_command")
         if raw:
             return raw.split()
     return ["docker", "compose"]
@@ -1045,9 +1082,13 @@ def _resolve_inspect_cmd(inst):
     raw = inst.get("inspectCommand")
     if raw:
         return raw
-    path = inst.get("path", "")
-    if path:
-        raw = _read_env(path, "inspect_command")
+    # The .env fallback is deliberately local-only. These resolvers run
+    # on every compose invocation, so they must not do I/O; and reading
+    # the controller's filesystem for a remote instance's path is at
+    # best useless, at worst the wrong file. Remote instances carry the
+    # value in the registry.
+    if _is_localhost(inst.get("host") or "localhost"):
+        raw = _read_env(inst.get("path", ""), "inspect_command")
         if raw:
             return raw
     return "docker"

--- a/tests/unit/test_remote_env_reads.py
+++ b/tests/unit/test_remote_env_reads.py
@@ -1,0 +1,119 @@
+"""An instance's .env must be read on the host that has it.
+
+`inst["path"]` points at the instance directory on *its own host*. For a
+remote instance that path does not exist on the controller, so reading
+it locally returns nothing — and nothing is indistinguishable from "the
+key is unset".
+
+That is how remote podman instances lost their compose profiles:
+_compose_profile_args read COMPOSE_PROFILES from the controller, got
+None, returned no --profile flags, and every profiled service (the
+database included) was silently omitted from `up`.
+"""
+
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+sys.path.insert(0, REPO_ROOT)
+
+from direct_commands import _helpers  # noqa: E402
+
+
+PODMAN = {"composeCommand": "podman-compose", "inspectCommand": "podman"}
+
+
+def _remote(**kw):
+    inst = {"path": "/home/op/canasta/site", "host": "someremote"}
+    inst.update(kw)
+    return inst
+
+
+def _local(tmp_path, body, **kw):
+    (tmp_path / ".env").write_text(body)
+    inst = {"path": str(tmp_path), "host": "localhost"}
+    inst.update(kw)
+    return inst
+
+
+class TestLocalInstancesStillReadLocally:
+    def test_reads_the_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(_helpers, "_ssh_run", _fail_if_called)
+        inst = _local(tmp_path, "COMPOSE_PROFILES=varnish,internal-db\n", **PODMAN)
+        assert _helpers._compose_profile_args(inst) == [
+            "--profile", "varnish", "--profile", "internal-db"]
+
+
+def _fail_if_called(*a, **kw):
+    raise AssertionError("a local instance must not be read over ssh")
+
+
+class TestRemoteInstancesReadOverSsh:
+    def test_profiles_come_from_the_remote_env(self, monkeypatch):
+        calls = []
+
+        def fake_ssh(host, cmd):
+            calls.append((host, cmd))
+            return 0, "varnish,internal-db\n"
+
+        monkeypatch.setattr(_helpers, "_ssh_run", fake_ssh)
+        _helpers._REMOTE_ENV_CACHE.clear()
+        args = _helpers._compose_profile_args(_remote(**PODMAN))
+
+        assert args == ["--profile", "varnish", "--profile", "internal-db"], (
+            "profiles were not read from the instance's own host, so "
+            "profiled services would be omitted from up/down"
+        )
+        assert calls and calls[0][0] == "someremote"
+        assert "/home/op/canasta/site/.env" in calls[0][1]
+
+    def test_the_resolvers_do_not_reach_over_ssh(self, monkeypatch):
+        # _resolve_compose_cmd runs on every compose invocation, so it
+        # must stay free of I/O. Remote instances carry the runtime in
+        # the registry; the .env fallback is local-only by design.
+        monkeypatch.setattr(_helpers, "_ssh_run", _fail_if_called)
+        assert _helpers._resolve_compose_cmd(_remote()) == ["docker", "compose"]
+        assert _helpers._resolve_inspect_cmd(_remote()) == "docker"
+
+    def test_the_registry_still_wins_for_remote(self, monkeypatch):
+        monkeypatch.setattr(_helpers, "_ssh_run", _fail_if_called)
+        assert _helpers._resolve_compose_cmd(_remote(**PODMAN)) == [
+            "podman-compose"]
+
+    def test_the_read_is_cached(self, monkeypatch):
+        calls = []
+
+        def counting_ssh(host, cmd):
+            calls.append(cmd)
+            return 0, "varnish\n"
+
+        monkeypatch.setattr(_helpers, "_ssh_run", counting_ssh)
+        _helpers._REMOTE_ENV_CACHE.clear()
+        inst = _remote(**PODMAN)
+        for _ in range(4):
+            _helpers._compose_profile_args(inst)
+        assert len(calls) == 1, (
+            "one ssh round-trip per compose call would be felt in "
+            "`canasta list` across several remote instances"
+        )
+
+    def test_a_failed_read_is_not_a_value(self, monkeypatch):
+        monkeypatch.setattr(_helpers, "_ssh_run", lambda h, c: (255, ""))
+        _helpers._REMOTE_ENV_CACHE.clear()
+        assert _helpers._compose_profile_args(_remote(**PODMAN)) == []
+
+    def test_quoted_values_are_unwrapped(self, monkeypatch):
+        monkeypatch.setattr(
+            _helpers, "_ssh_run", lambda h, c: (0, '"varnish"\n'))
+        _helpers._REMOTE_ENV_CACHE.clear()
+        assert _helpers._compose_profile_args(_remote(**PODMAN)) == [
+            "--profile", "varnish"]
+
+
+class TestDockerInstancesAreUnaffected:
+    def test_no_profile_flags_for_docker(self, monkeypatch):
+        monkeypatch.setattr(_helpers, "_ssh_run", _fail_if_called)
+        # Not podman: the function returns before any .env read.
+        assert _helpers._compose_profile_args(
+            _remote(composeCommand="docker compose")) == []


### PR DESCRIPTION
Fixes #1264. Found and verified on a real rootless-podman host (podman 5.4.2, podman-compose 1.3.0, Debian 13).

## The bug

`inst["path"]` is the instance directory **on its own host**. `_compose_profile_args` read `COMPOSE_PROFILES` from it with a plain local open, so for a remote instance it read a path that does not exist on the controller, got `None`, and returned no `--profile` flags.

podman-compose ignores `COMPOSE_PROFILES` in `.env` — that is the entire reason those flags exist — so every profiled service was silently dropped:

```
$ podman ps -a
podtest_web_1    Up
podtest_caddy_1  Created
# db and varnish absent entirely; web sat in wait-for-it against db:3306
```

Nothing warned that profiles had been requested and not applied.

## Fix

Read it over ssh when the instance is remote, cached per `(host, path, key)`. `_compose_profile_args` is called from `_run_compose`, which already opens an ssh connection for remote instances, so this introduces no new class of round-trip.

**`_resolve_compose_cmd` / `_resolve_inspect_cmd` had the same silent wrong-host read** in their `.env` fallback. I initially routed those through the ssh reader too — and two existing tests caught it, because those resolvers run on *every* compose invocation and must not do I/O. They are now explicitly local-only, which is both cheap and honest: a remote instance carries its runtime in the registry, and reading the controller's filesystem for a remote path is at best useless and at worst the wrong file.

## Verified live

Same host that produced the bug, before and after:

```
before:  podtest_web_1 Up   podtest_caddy_1 Created        # db, varnish absent
after:   podtest_db_1 Up (healthy)  podtest_web_1 Up  podtest_varnish_1 Up (healthy)
```

And with the database present, the wiki works: `db:3306 is available after 0 seconds`, `HTTP 200` from the web container.

## Test

`test_remote_env_reads.py` — 8 tests: local instances still read locally and never touch ssh, remote profiles come from the remote `.env`, the resolvers stay I/O-free, the registry still wins, the read is cached, a failed read is not mistaken for a value, quoted values are unwrapped, and Docker instances are unaffected.

## Bearing on #1160

With this fixed, inter-container DNS on podman-compose **works**: `web` resolves `db` to `10.89.0.2` (`db.dns.podman`) and reaches `db:3306`. #1160 does not reproduce on this version pairing — worth re-testing there before treating it as open.