### PR TITLE
fix: do not report success when the instance is not running

### DIFF
--- a/roles/orchestrator/tasks/create_preflight.yml
+++ b/roles/orchestrator/tasks/create_preflight.yml
@@ -74,6 +74,59 @@
         (_docker_check.rc | default(1) != 0)
         and (_podman_check.rc | default(1) != 0)
 
+    # Rootless Podman has two prerequisites that are invisible until the
+    # instance silently fails: systemd reaps the containers when the
+    # session that started them ends unless the user lingers, and
+    # rootlessport cannot bind 80/443 while the unprivileged port floor
+    # sits above them. Both are cheap to check and confusing to diagnose.
+    - name: Check rootless Podman prerequisites
+      when: compose_command | default('docker compose') is search('podman')
+      block:
+        - name: Ask Podman whether it is rootless
+          ansible.builtin.command:
+            cmd: podman info --format {% raw %}{{.Host.Security.Rootless}}{% endraw %}
+          register: _podman_rootless
+          changed_when: false
+          failed_when: false
+
+        - name: Read lingering and the unprivileged port floor
+          ansible.builtin.shell:
+            cmd: |
+              printf '%s\n' "$(loginctl show-user "$(id -un)" --property=Linger 2>/dev/null | cut -d= -f2)"
+              printf '%s\n' "$(cat /proc/sys/net/ipv4/ip_unprivileged_port_start 2>/dev/null)"
+          register: _rootless_facts
+          changed_when: false
+          failed_when: false
+          when: _podman_rootless.stdout | default('') | trim == 'true'
+
+        - name: Fail when lingering is off
+          ansible.builtin.fail:
+            msg: >-
+              Rootless Podman on this host has lingering disabled, so
+              systemd stops the containers as soon as the session that
+              started them ends — the instance would be created and then
+              immediately die. Enable it with
+              'sudo loginctl enable-linger "$(id -un)"' on the target,
+              then retry.
+          when:
+            - _podman_rootless.stdout | default('') | trim == 'true'
+            - (_rootless_facts.stdout_lines | default([]))[0] | default('') | trim != 'yes'
+
+        - name: Fail when privileged ports are out of reach
+          ansible.builtin.fail:
+            msg: >-
+              Rootless Podman cannot bind ports 80 and 443 on this host:
+              net.ipv4.ip_unprivileged_port_start is
+              {{ (_rootless_facts.stdout_lines | default([]))[1] | default('?') }}.
+              Caddy would fail to start with "rootlessport cannot expose
+              privileged port 80". Either lower the floor with
+              'sudo sysctl net.ipv4.ip_unprivileged_port_start=80' (persist
+              it in /etc/sysctl.d/), or set HTTP_PORT and HTTPS_PORT above
+              1024 for this instance.
+          when:
+            - _podman_rootless.stdout | default('') | trim == 'true'
+            - ((_rootless_facts.stdout_lines | default([]))[1] | default('0') | trim | int) > 80
+
     # Port 80/443 conflict detection for Compose. Compose's caddy
     # service binds host ports 80 and 443; if anything else is
     # already serving on them, `docker compose up` will either fail

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -150,6 +150,22 @@
       register: _start_web_cid
       changed_when: false
 
+    # `ps` without -a lists only running containers, so an empty result
+    # means the stack is not up. `up -d` exiting 0 does not rule that out:
+    # with rootless podman and no lingering, systemd kills the containers
+    # the moment the ssh session ends. Without this check the health gate
+    # below is merely skipped and the run reports success.
+    - name: Fail when no web container is running after start
+      ansible.builtin.fail:
+        msg: >-
+          Started the containers, but no running 'web' container is present
+          for instance '{{ instance_id }}'. The instance is not up — check
+          'canasta list' and the container logs on the host. On rootless
+          Podman this is usually lingering: without
+          'sudo loginctl enable-linger <user>', systemd stops the
+          containers as soon as the session that started them ends.
+      when: _start_web_cid.stdout | trim == ''
+
     - name: Probe whether web declares a healthcheck
       ansible.builtin.command:
         argv:

--- a/tests/unit/test_start_verifies_running.py
+++ b/tests/unit/test_start_verifies_running.py
@@ -1,0 +1,129 @@
+"""A start that leaves nothing running must not report success.
+
+`up -d` exiting 0 does not mean the stack is up. On rootless Podman
+without lingering, systemd reaps the containers the moment the session
+that started them ends — so `canasta create` printed "Done." and exited
+0 against an instance whose every container was already dead.
+
+The health gate below could not catch it: it is guarded on the web
+container id being non-empty, so "no container at all" read as "nothing
+to wait for" and was skipped.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+START = os.path.join(REPO_ROOT, "roles", "orchestrator", "tasks", "start.yml")
+PREFLIGHT = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "create_preflight.yml")
+
+
+def _tasks(path):
+    out = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            out.append(node)
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for i in node:
+                walk(i)
+
+    with open(path) as f:
+        walk(yaml.safe_load(f))
+    return out
+
+
+def _names(path):
+    return [str(t.get("name", "")) for t in _tasks(path) if isinstance(t, dict)]
+
+
+class TestStartFailsWhenNothingIsRunning:
+    def _task(self):
+        return next(
+            (t for t in _tasks(START)
+             if "no web container is running" in str(t.get("name", ""))),
+            None,
+        )
+
+    def test_the_check_exists(self):
+        assert self._task(), (
+            "start reports success without confirming anything is running"
+        )
+
+    def test_it_triggers_on_an_empty_container_id(self):
+        when = str(self._task().get("when", ""))
+        assert "_start_web_cid.stdout" in when and "== ''" in when, (
+            "an empty `ps` result is the signal that nothing is up"
+        )
+
+    def test_it_fails_rather_than_warns(self):
+        assert "ansible.builtin.fail" in self._task(), (
+            "a debug message would still leave the run reporting success"
+        )
+
+    def test_it_runs_before_the_health_gate(self):
+        names = _names(START)
+        get_at = next(i for i, n in enumerate(names) if n == "Get web container id")
+        check_at = next(
+            i for i, n in enumerate(names) if "no web container is running" in n)
+        probe_at = next(
+            i for i, n in enumerate(names) if "declares a healthcheck" in n)
+        assert get_at < check_at < probe_at, (
+            "the check belongs between reading the container id and the "
+            "health probe that is skipped when it is empty"
+        )
+
+    def test_the_message_points_at_lingering(self):
+        msg = str(self._task()["ansible.builtin.fail"]["msg"])
+        assert "linger" in msg.lower(), (
+            "rootless Podman is the common cause; name it rather than "
+            "leaving the operator to discover systemd reaped the stack"
+        )
+
+
+class TestRootlessPodmanPrerequisites:
+    def _guard(self):
+        return next(
+            (t for t in _tasks(PREFLIGHT)
+             if "rootless Podman prerequisites" in str(t.get("name", ""))),
+            None,
+        )
+
+    def test_the_guard_exists(self):
+        assert self._guard(), (
+            "nothing checks the two rootless-Podman prerequisites, so a "
+            "create succeeds and the instance dies immediately"
+        )
+
+    def test_it_only_applies_to_podman(self):
+        assert "podman" in str(self._guard().get("when", "")).lower()
+
+    def test_it_checks_lingering(self):
+        body = yaml.dump(self._guard())
+        assert "Linger" in body, "lingering is not checked"
+        assert "enable-linger" in body, "say how to fix it"
+
+    def test_it_checks_the_privileged_port_floor(self):
+        body = yaml.dump(self._guard())
+        assert "ip_unprivileged_port_start" in body, (
+            "rootless podman cannot bind 80/443 above the floor; caddy "
+            "silently stays in Created"
+        )
+        assert "HTTP_PORT" in body, (
+            "offer the alternative of running on unprivileged ports"
+        )
+
+    def test_both_checks_fail_rather_than_warn(self):
+        fails = [
+            t for t in self._guard().get("block", [])
+            if "ansible.builtin.fail" in t
+        ]
+        assert len(fails) >= 2, (
+            "both prerequisites leave a non-functional instance, so both "
+            "should stop the create rather than print a warning"
+        )


### PR DESCRIPTION
Fixes #1265. Found and verified on a real rootless-podman host (podman 5.4.2, Debian 13).

## The core bug is not podman-specific

`up -d` exiting 0 does not mean the stack is up, and nothing checked. The health gate is guarded on the web container id being non-empty:

```yaml
when: _start_web_cid.stdout | trim != ''
```

So "no container at all" read as "nothing to wait for", the gate was skipped, and the run reported success:

```
$ canasta create -i podtest -w main -n small.acknowledge.wiki -H small
Starting containers...
Done.                      # exit 0

$ podman ps -a
podtest_db_1       Exited (0)
podtest_web_1      Exited (137)     # SIGKILL
podtest_caddy_1    Created          # never started
podtest_varnish_1  Exited (64)
```

Now it fails. `ps` without `-a` lists only running containers, so an empty result is precisely the "nothing is up" signal.

## Why rootless Podman exposed it

Two prerequisites that are invisible until the instance quietly dies:

**Lingering.** Without it, systemd reaps the user's processes when the session that started them ends — Ansible connects, starts the containers, disconnects, and they are killed. The exit codes above are that: varnish SIGTERM, web SIGKILL, db a clean stop.

**The privileged port floor.** `rootlessport` cannot bind 80/443 while `net.ipv4.ip_unprivileged_port_start` is above them, and caddy simply stays in `Created`:

```
rootlessport cannot expose privileged port 80, you can add
'net.ipv4.ip_unprivileged_port_start=80' to /etc/sysctl.conf (currently 1024)
```

Both are now checked in the create preflight, where the operator can act, each naming the exact remediation.

Note this is the requirement @hexmode's sysctl block in #1122 was addressing. That block was dropped for *how* it worked — `become: yes` during create, running for Kubernetes too, persisting to `/etc/sysctl.conf`, no Linux guard — but the underlying need is real, and this surfaces it without silently sudo-editing the host.

## Verified live, all three states

```
# port floor 1024, lingering on
Error: Rootless Podman cannot bind ports 80 and 443 on this host:
net.ipv4.ip_unprivileged_port_start is 1024. ... Either lower the floor with
'sudo sysctl net.ipv4.ip_unprivileged_port_start=80' ... or set HTTP_PORT and
HTTPS_PORT above 1024.                                               exit 2

# port floor 80, lingering off
Error: Rootless Podman on this host has lingering disabled, so systemd stops
the containers as soon as the session that started them ends ... Enable it
with 'sudo loginctl enable-linger "$(id -un)"'.                      exit 2

# both satisfied
Done.                                                                exit 0
podtest_db_1 Up (healthy)  podtest_web_1 Up  podtest_caddy_1 Up  podtest_varnish_1 Up (healthy)
$ curl -sL https://small.acknowledge.wiki/w/api.php?...   -> HTTP 200
```

That last one is, as far as I can tell, the first fully working Canasta instance on rootless Podman — reachable externally with a real certificate. It needs #1266 as well, which fixes the profiled services (`db`, `varnish`) being dropped on remote podman instances.

## Test

`test_start_verifies_running.py` — 10 tests: the check exists, triggers on an empty id, fails rather than warns, sits between reading the id and the health probe it precedes, and names lingering; plus the preflight guard existing, being podman-only, checking both prerequisites with remediation, and failing rather than warning on both. All 10 fail against current `main`.