### PR TITLE
fix(delete): tear down with the instance's own runtime, and clean up after it

### DIFF
--- a/roles/delete/tasks/main.yml
+++ b/roles/delete/tasks/main.yml
@@ -57,6 +57,13 @@
       {{ _delete_query.instance.devMode | default(false) }}
     instance_managed_cluster: >-
       {{ _delete_query.instance.managedCluster | default(false) }}
+    # Without these, destroy.yml tears the instance down with the wrong
+    # runtime: `docker compose down` against a podman host removes
+    # nothing, and the containers outlive the instance.
+    compose_command: >-
+      {{ _delete_query.instance.composeCommand | default(compose_command) }}
+    inspect_command: >-
+      {{ _delete_query.instance.inspectCommand | default(inspect_command) }}
     _instance_registered: true
     _instance_host: >-
       {{ _delete_query.instance.host | default('localhost') }}
@@ -309,9 +316,30 @@
 # 'length > 5' rejects '/', '/a', '/ab', '/abc' — values short enough to
 # be plausibly the result of a corrupted registry or unset variable, and
 # 'find / -mindepth 1 -delete' is unrecoverable.
+# Rootless Podman maps the container's root to a subuid, so files the
+# containers wrote into the instance directory are owned by that subuid
+# and the operator's own `rm` cannot touch them. `podman unshare` enters
+# the namespace where those ids map back, which is the only way to
+# remove them without root.
+- name: Detect rootless Podman before cleaning the directory
+  ansible.builtin.command:
+    cmd: podman info --format {% raw %}{{.Host.Security.Rootless}}{% endraw %}
+  register: _delete_podman_rootless
+  changed_when: false
+  failed_when: false
+  when: inspect_command | default('docker') is search('podman')
+
+- name: Note whether the directory needs namespace-aware removal
+  ansible.builtin.set_fact:
+    _delete_unshare: >-
+      {{ 'podman unshare '
+         if (_delete_podman_rootless.stdout | default('') | trim) == 'true'
+         else '' }}
+
 - name: Remove instance directory contents
   ansible.builtin.command:
-    cmd: "find {{ instance_path | quote }} -mindepth 1 -delete"
+    cmd: >-
+      {{ _delete_unshare }}find {{ instance_path | quote }} -mindepth 1 -delete
     chdir: "/"
   changed_when: true
   when:
@@ -322,7 +350,7 @@
 
 - name: Remove empty instance directory
   ansible.builtin.command:
-    cmd: "rmdir {{ instance_path | quote }}"
+    cmd: "{{ _delete_unshare }}rmdir {{ instance_path | quote }}"
     chdir: "/"
   changed_when: true
   when:
@@ -336,8 +364,11 @@
     msg: >-
       Instance '{{ instance_id }}' deleted from registry. Note: the
       instance directory '{{ instance_path }}' could not be fully removed
-      (likely because it is the current working directory). Run 'cd ..'
-      then 'rmdir {{ instance_path }}' to clean it up.
+      — usually because it is the current working directory, in which case
+      'cd ..' then 'rmdir {{ instance_path }}' clears it. Under rootless
+      Podman the leftovers are owned by a subuid instead, and only
+      'podman unshare rm -rf {{ instance_path }}' can remove them.
+      Leaving them in place blocks recreating an instance with this id.
   when:
     - instance_path | default('') | length > 0
     - _rmdir is failed

--- a/tests/unit/test_delete_uses_instance_runtime.py
+++ b/tests/unit/test_delete_uses_instance_runtime.py
@@ -1,0 +1,117 @@
+"""delete has to tear an instance down with the runtime that built it.
+
+Two failures compounded on rootless Podman:
+
+The delete path set instance_id/path/orchestrator from its registry
+query but not composeCommand/inspectCommand, so destroy.yml fell back
+to the play-scope default and ran `docker compose down` against a
+podman host. That removes nothing, and the containers outlived the
+instance.
+
+Then the directory cleanup used a plain `find -delete` with
+ignore_errors. Rootless Podman maps the container's root to a subuid,
+so files the containers wrote are owned by that subuid and the
+operator's own rm cannot remove them. The leftovers then blocked
+recreating an instance with the same id, because create refuses a
+non-empty target directory.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+DELETE = os.path.join(REPO_ROOT, "roles", "delete", "tasks", "main.yml")
+
+
+def _tasks():
+    out = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            out.append(node)
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for i in node:
+                walk(i)
+
+    with open(DELETE) as f:
+        walk(yaml.safe_load(f))
+    return out
+
+
+def _named(needle):
+    return next(
+        (t for t in _tasks()
+         if needle.lower() in str(t.get("name", "")).lower()), None)
+
+
+class TestRuntimeComesFromTheRegistry:
+    def test_the_facts_are_set(self):
+        facts = _named("Set instance facts from registry")
+        assert facts, "no task sets instance facts from the registry"
+        body = facts["ansible.builtin.set_fact"]
+        for key in ("compose_command", "inspect_command"):
+            assert key in body, (
+                "%s is not taken from the registry, so destroy.yml uses the "
+                "default runtime — `docker compose down` against a podman "
+                "host removes nothing and the containers survive" % key
+            )
+
+    def test_they_come_from_the_instance_record(self):
+        body = _named("Set instance facts from registry")["ansible.builtin.set_fact"]
+        assert "composeCommand" in str(body["compose_command"])
+        assert "inspectCommand" in str(body["inspect_command"])
+
+    def test_they_fall_back_rather_than_blank(self):
+        body = _named("Set instance facts from registry")["ansible.builtin.set_fact"]
+        # An instance predating the registry fields must not end up with
+        # an empty runtime.
+        assert "default(compose_command)" in str(body["compose_command"])
+        assert "default(inspect_command)" in str(body["inspect_command"])
+
+
+class TestDirectoryRemovalEntersTheUserNamespace:
+    def test_rootless_podman_is_detected(self):
+        probe = _named("Detect rootless Podman")
+        assert probe, "nothing detects rootless podman before cleanup"
+        assert "Rootless" in str(probe["ansible.builtin.command"]["cmd"])
+        assert "podman" in str(probe.get("when", "")).lower(), (
+            "the probe should only run when the instance uses podman"
+        )
+
+    def test_the_prefix_is_only_set_for_rootless(self):
+        setter = _named("namespace-aware removal")
+        assert setter, "no fact decides whether to use podman unshare"
+        expr = str(setter["ansible.builtin.set_fact"]["_delete_unshare"])
+        assert "podman unshare" in expr
+        assert "'true'" in expr, (
+            "the prefix must be gated on podman reporting rootless, not on "
+            "podman merely being present — rootful podman needs no unshare"
+        )
+
+    def test_both_removals_use_the_prefix(self):
+        for name in ("Remove instance directory contents",
+                     "Remove empty instance directory"):
+            cmd = str(_named(name)["ansible.builtin.command"]["cmd"])
+            assert "_delete_unshare" in cmd, (
+                "%s cannot remove subuid-owned files without entering the "
+                "user namespace" % name
+            )
+
+
+class TestTheWarningExplainsBothCauses:
+    def test_it_covers_the_subuid_case(self):
+        msg = str(_named("could not be removed")["ansible.builtin.debug"]["msg"])
+        assert "podman unshare" in msg, (
+            "the old message blamed the working directory, which is wrong "
+            "for subuid-owned leftovers and leaves no way forward"
+        )
+
+    def test_it_says_why_it_matters(self):
+        msg = str(_named("could not be removed")["ansible.builtin.debug"]["msg"])
+        assert "recreat" in msg.lower(), (
+            "leftovers block reusing the instance id; say so"
+        )


### PR DESCRIPTION
Fixes #1267. Found and verified on a real rootless-podman host (podman 5.4.2, Debian 13).

## Two compounding failures

**The wrong runtime.** `delete` set `instance_id`/`instance_path`/`orchestrator` from its registry query but never `composeCommand`/`inspectCommand`, so `destroy.yml` fell back to the play-scope default and ran `docker compose down` against a podman host. That removes nothing — and the leftovers then blocked the next create by holding port 80:

```
$ canasta delete -i podtest -y
Instance 'podtest' deleted.
$ podman ps
podtest_db_1  podtest_web_1  podtest_caddy_1  podtest_varnish_1     # all still Up

$ canasta create -i podtest ...
Error: Port 80 is already in use on this host
```

The registry record had the runtime all along — the delete path just never read it.

**Subuid-owned leftovers.** Rootless Podman maps the container's root to a subuid, so files the containers wrote into the instance directory are owned by it:

```
$ ls -ld ~/canasta/podtest/config/settings
drwxrwxr-x cicalese:100032
$ rm -rf ~/canasta/podtest
rm: cannot remove '.../config/settings': Permission denied
```

`find -delete` under `ignore_errors: true` swallowed that, and the warning blamed the current working directory — wrong here, and it offered no way forward. Because `create` refuses a non-empty target directory, the instance id became unusable.

## Fix

Take `compose_command`/`inspect_command` from the registry record, and prefix the directory removal with `podman unshare` when podman reports rootless — that enters the namespace where those subuids map back to the operator. The warning now explains both causes and says why leftovers matter.

Deliberately gated on **rootless**, not merely on podman: rootful podman writes files as real root and needs no unshare.

## Verified live, full round trip

| | before | after |
|---|---|---|
| containers | 4 still running | **0** |
| volumes | 5 | **0** |
| instance directory | 11 entries, undeletable | **removed** |
| recreate same id | blocked | **succeeds** |

That last row is the one that mattered: rebuilding from scratch is the natural loop when testing Podman support, and it previously dead-ended after the first delete.

## Test

`test_delete_uses_instance_runtime.py` — 8 tests: the runtime facts are set, come from the instance record, and fall back rather than blank; rootless podman is detected and the unshare prefix is gated on `'true'` rather than on podman being present; both removals use the prefix; and the warning covers the subuid case and says it blocks recreation. All 8 fail against current `main`.

Note this is the third instance of the same family — something in a container writes to a host path as root and locks the operator out of their own files. The others were #1205 (K8s restic repo) and #1245 (Compose restic repo).