### PR TITLE
fix(upgrade): use the instance's own container runtime

### DIFF
--- a/playbooks/_upgrade_single.yml
+++ b/playbooks/_upgrade_single.yml
@@ -12,6 +12,16 @@
     instance_path: "{{ _inst.value.path }}"
     instance_orchestrator: "{{ _inst.value.orchestrator | default('compose') }}"
     instance_devmode: "{{ _inst.value.devMode | default(false) }}"
+    # Without these, every step of the upgrade uses the play-scope
+    # default runtime: `docker compose pull` against a podman host fails
+    # on a missing Docker socket, and the profile flags pull.yml builds
+    # for podman are never applied.
+    compose_command: >-
+      {{ _inst.value.composeCommand
+         | default(_upgrade_default_compose_command) }}
+    inspect_command: >-
+      {{ _inst.value.inspectCommand
+         | default(_upgrade_default_inspect_command) }}
     _instance_host: "{{ _inst.value.host | default('localhost') }}"
 
 - name: Switch connection to instance host

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -39,6 +39,15 @@
 - name: Upgrade each instance
   when: not (dry_run | default(false) | bool)
   block:
+    # Each iteration overwrites compose_command/inspect_command, so the
+    # per-instance fallback cannot reference them: an instance with no
+    # recorded runtime would inherit the previous instance's. Keep the
+    # play-scope defaults under names the loop never assigns.
+    - name: Remember the default container runtime
+      ansible.builtin.set_fact:
+        _upgrade_default_compose_command: "{{ compose_command }}"
+        _upgrade_default_inspect_command: "{{ inspect_command }}"
+
     - name: Upgrade instances
       ansible.builtin.include_tasks: _upgrade_single.yml
       loop: "{{ _upgrade_instances.instances | dict2items }}"

--- a/tests/unit/test_upgrade_uses_instance_runtime.py
+++ b/tests/unit/test_upgrade_uses_instance_runtime.py
@@ -1,0 +1,97 @@
+"""upgrade has to act on an instance with the runtime that built it.
+
+_upgrade_single.yml read path/orchestrator/devMode/host off the registry
+record but not composeCommand/inspectCommand, so every step ran with the
+play-scope default. On a rootless Podman host that means `docker compose
+pull` against a missing Docker socket, and the podman profile flags
+pull.yml builds are never applied.
+
+The fallback cannot reference compose_command itself: upgrade loops over
+instances and set_fact persists, so an instance with no recorded runtime
+would inherit the previous instance's podman command.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+SINGLE = os.path.join(REPO_ROOT, "playbooks", "_upgrade_single.yml")
+UPGRADE = os.path.join(REPO_ROOT, "playbooks", "upgrade.yml")
+
+
+def _tasks(path):
+    out = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            out.append(node)
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for i in node:
+                walk(i)
+
+    with open(path) as f:
+        walk(yaml.safe_load(f))
+    return out
+
+
+def _named(path, needle):
+    return next(
+        (t for t in _tasks(path)
+         if needle.lower() in str(t.get("name", "")).lower()), None)
+
+
+def _facts():
+    return _named(SINGLE, "Set instance facts")["ansible.builtin.set_fact"]
+
+
+class TestRuntimeComesFromTheRegistry:
+    def test_the_facts_are_set(self):
+        for key in ("compose_command", "inspect_command"):
+            assert key in _facts(), (
+                "%s is not taken from the registry, so the upgrade runs "
+                "`docker compose` against a podman host" % key
+            )
+
+    def test_they_come_from_the_instance_record(self):
+        assert "composeCommand" in str(_facts()["compose_command"])
+        assert "inspectCommand" in str(_facts()["inspect_command"])
+
+
+class TestTheFallbackDoesNotLeakBetweenInstances:
+    def test_defaults_are_captured_before_the_loop(self):
+        saver = _named(UPGRADE, "Remember the default container runtime")
+        assert saver, (
+            "nothing preserves the play-scope defaults, so the per-instance "
+            "fallback has only the previous iteration's value to fall back to"
+        )
+        body = saver["ansible.builtin.set_fact"]
+        assert body["_upgrade_default_compose_command"] == "{{ compose_command }}"
+        assert body["_upgrade_default_inspect_command"] == "{{ inspect_command }}"
+
+    def test_it_runs_before_the_loop(self):
+        names = [str(t.get("name", "")) for t in _tasks(UPGRADE)]
+        save_at = names.index("Remember the default container runtime")
+        loop_at = names.index("Upgrade instances")
+        assert save_at < loop_at
+
+    def test_the_fallback_uses_the_preserved_default(self):
+        for key, want in (
+            ("compose_command", "_upgrade_default_compose_command"),
+            ("inspect_command", "_upgrade_default_inspect_command"),
+        ):
+            expr = str(_facts()[key])
+            assert want in expr, (
+                "%s falls back to a value the loop overwrites, so a docker "
+                "instance following a podman one inherits podman" % key
+            )
+
+    def test_the_fallback_is_not_self_referential(self):
+        # `default(compose_command)` reads the fact this same task sets.
+        assert "default(compose_command)" not in str(
+            _facts()["compose_command"]).replace(" ", "")
+        assert "default(inspect_command)" not in str(
+            _facts()["inspect_command"]).replace(" ", "")


### PR DESCRIPTION
Fixes #1270

`canasta upgrade` fails on a rootless Podman instance with a Docker error:

```
Pulling Canasta container images...
Error: pull Compose images failed (rc=1): unable to get image
'docker.io/library/varnish:7.0.2-alpine': Cannot connect to the Docker
daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

`playbooks/_upgrade_single.yml` took `path`, `orchestrator`, `devMode` and `host` off the registry record but not `composeCommand`/`inspectCommand`, so every step of the upgrade ran with the play-scope default. `roles/orchestrator/tasks/pull.yml` is already correctly parameterized — it even branches on `compose_command is search('podman')` to build profile flags — it just never received the right values, so each of those branches took the Docker path.

Same defect as #1267, fixed for `delete` in #1269, in a different playbook.

## The loop makes this not quite a copy of #1269

`delete` handles one instance, so its `| default(compose_command)` fallback is safe. `upgrade` loops over instances and `set_fact` persists across iterations, so the same expression would read the value the *previous* iteration set: one Podman instance would poison every later instance that has no recorded runtime, silently switching it to `podman-compose`.

So the play captures the pristine defaults once before the loop, under names the loop never assigns, and the per-instance fallback uses those.

## Tests

`tests/unit/test_upgrade_uses_instance_runtime.py` — the facts come from the registry record, the defaults are captured before the loop, and the fallback is not self-referential (which is the leak above).

`make test-unit` 2059 passed · `make lint` clean · `make validate` 87 commands, 69 playbooks.

## Not covered by the tests

These are structural assertions over the YAML; they cannot prove the pull actually succeeds. Worth an e2e `canasta upgrade` against a real Podman instance before merge — I have one standing by on a test host and can run it.