### PR TITLE
fix(podman): render the merged Compose config without --format json

### DIFF
--- a/roles/orchestrator/tasks/backup_discover_build_paths.yml
+++ b/roles/orchestrator/tasks/backup_discover_build_paths.yml
@@ -71,15 +71,26 @@
              | join(' ') }}
       when: compose_command is search('podman')
 
-    - name: Render merged compose config as JSON
+    # podman-compose has no --format option and exits 2 on it; its default
+    # output is YAML. Ask Docker for JSON as before and parse both with
+    # from_yaml, which reads JSON too.
+    - name: Select compose config format flag
+      ansible.builtin.set_fact:
+        _backup_config_format: >-
+          {{ '' if compose_command is search('podman') else '--format json' }}
+
+    - name: Render merged compose config
       ansible.builtin.command:
-        cmd: "{{ compose_command }} {{ _backup_profile_flags | default('') }} config --format json"
+        cmd: >-
+          {{ compose_command }} {{ _backup_profile_flags | default('') }}
+          config {{ _backup_config_format }}
         chdir: "{{ instance_path }}"
       register: _build_compose_config
       changed_when: false
-      # The rendered config interpolates .env values (including
+      # Docker's rendered config interpolates .env values (including
       # MYSQL_PASSWORD); keep it out of task logs. The variable is still
-      # usable below - only its display is suppressed.
+      # usable below - only its display is suppressed. (podman-compose
+      # leaves ${VAR} uninterpolated, but the guard costs nothing.)
       no_log: true
 
     # Pull out just the build sections. The secret-bearing remainder of the
@@ -88,7 +99,7 @@
     - name: Extract build sections
       ansible.builtin.set_fact:
         _build_specs: >-
-          {{ (_build_compose_config.stdout | from_json).services | dict2items
+          {{ (_build_compose_config.stdout | from_yaml).services | dict2items
              | map(attribute='value.build') | select('defined') | list }}
 
     # `docker compose config` resolves build.context to an absolute path and

--- a/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
+++ b/roles/orchestrator/tasks/upgrade_rebuild_buildable.yml
@@ -48,11 +48,22 @@
              | join(' ') }}
       when: compose_command is search('podman')
 
-    - name: Render merged compose config as JSON
+    # podman-compose has no --format option and exits 2 on it; its default
+    # output is YAML. Ask Docker for JSON as before and parse both with
+    # from_yaml, which reads JSON too. Without this the command failed and
+    # `failed_when: false` turned that into an empty service list, so
+    # buildable services were silently never rebuilt on Podman.
+    - name: Select compose config format flag
+      ansible.builtin.set_fact:
+        _upgrade_config_format: >-
+          {{ '' if compose_command is search('podman') else '--format json' }}
+
+    - name: Render merged compose config
       ansible.builtin.command:
         cmd: >-
           {{ compose_command }} {{ _upgrade_compose_files | join(' ') }}
-          {{ _upgrade_profile_flags | default('') }} config --format json
+          {{ _upgrade_profile_flags | default('') }}
+          config {{ _upgrade_config_format }}
         chdir: "{{ instance_path }}"
       register: _upgrade_compose_config
       changed_when: false
@@ -61,7 +72,7 @@
     - name: Extract buildable service names
       ansible.builtin.set_fact:
         _buildable_services: >-
-          {{ ((_upgrade_compose_config.stdout | from_json).services
+          {{ ((_upgrade_compose_config.stdout | from_yaml).services
               | default({})
               | dict2items
               | selectattr('value.build', 'defined')

--- a/tests/unit/test_compose_config_format_by_runtime.py
+++ b/tests/unit/test_compose_config_format_by_runtime.py
@@ -1,0 +1,120 @@
+"""Rendering the merged Compose model must work on both runtimes.
+
+`config --format json` is Docker Compose v2 only. podman-compose 1.3.0
+has no --format option and exits 2, which produced two different
+failures:
+
+  backup_discover_build_paths.yml pipes the output through a parse
+  filter with no failed_when, so backup could not discover build paths
+  at all on Podman.
+
+  upgrade_rebuild_buildable.yml carries `failed_when: false`, so the
+  failure became an empty service list and buildable services were
+  silently never rebuilt -- a success report covering skipped work.
+
+podman-compose's default output is YAML, and YAML is a superset of JSON,
+so one parse filter (from_yaml) reads both runtimes' output and only the
+flag has to vary.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+TASKS = os.path.join(REPO_ROOT, "roles", "orchestrator", "tasks")
+BACKUP = os.path.join(TASKS, "backup_discover_build_paths.yml")
+UPGRADE = os.path.join(TASKS, "upgrade_rebuild_buildable.yml")
+
+SITES = (BACKUP, UPGRADE)
+
+
+def _tasks(path):
+    out = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            out.append(node)
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for i in node:
+                walk(i)
+
+    with open(path) as f:
+        walk(yaml.safe_load(f))
+    return out
+
+
+def _named(path, needle):
+    return next(
+        (t for t in _tasks(path)
+         if needle.lower() in str(t.get("name", "")).lower()), None)
+
+
+def _render_cmd(path):
+    return str(_named(path, "Render merged compose config")
+               ["ansible.builtin.command"]["cmd"])
+
+
+def _format_fact(path):
+    task = _named(path, "Select compose config format flag")
+    body = task["ansible.builtin.set_fact"]
+    return str(next(iter(body.values())))
+
+
+class TestTheFlagIsNotHardcoded:
+    def test_no_literal_format_json(self):
+        for path in SITES:
+            assert "--format json" not in _render_cmd(path), (
+                "%s hands --format json to podman-compose, which exits 2"
+                % os.path.basename(path)
+            )
+
+    def test_the_command_interpolates_a_format_fact(self):
+        for path in SITES:
+            assert "config_format" in _render_cmd(path)
+
+    def test_the_bare_subcommand_survives(self):
+        # Dropping the flag must leave `config` itself in place.
+        for path in SITES:
+            assert "config " in _render_cmd(path)
+
+
+class TestTheFlagIsChosenByRuntime:
+    def test_docker_still_gets_json(self):
+        for path in SITES:
+            assert "--format json" in _format_fact(path)
+
+    def test_podman_gets_nothing(self):
+        for path in SITES:
+            expr = _format_fact(path)
+            assert "podman" in expr
+            assert expr.index("''") < expr.index("podman"), (
+                "inverted, this sends --format json to podman exactly where "
+                "it fails"
+            )
+
+    def test_the_selector_is_not_itself_gated(self):
+        # A `when: podman` guard leaves the fact undefined on Docker, and
+        # the render command interpolates it directly.
+        for path in SITES:
+            assert "when" not in _named(
+                path, "Select compose config format flag")
+
+
+class TestParsingAcceptsBothOutputs:
+    def test_no_site_still_uses_from_json(self):
+        for path in SITES:
+            with open(path) as f:
+                body = f.read()
+            assert "from_json" not in body, (
+                "%s still parses with from_json, which cannot read "
+                "podman-compose's YAML output" % os.path.basename(path)
+            )
+
+    def test_both_sites_parse_with_from_yaml(self):
+        for path in SITES:
+            with open(path) as f:
+                assert "from_yaml" in f.read()

--- a/tests/unit/test_upgrade_rebuild.py
+++ b/tests/unit/test_upgrade_rebuild.py
@@ -38,13 +38,18 @@ class TestDynamicBuildableServiceDetection:
             "rather than hardcoding `web` (#562, gap 2)"
         )
 
-    def test_uses_merged_compose_config_json(self):
+    def test_uses_merged_compose_config(self):
+        # The point is that detection queries the *merged* model (main +
+        # override + dev), not the override file alone. The output format
+        # is incidental and now varies by runtime: podman-compose has no
+        # --format option, so the flag is chosen per runtime and both
+        # outputs are read with from_yaml. See
+        # test_compose_config_format_by_runtime.py.
         with open(REBUILD_TASKS) as f:
             content = f.read()
-        assert "config --format json" in content, (
-            "Buildable-service detection must use `docker compose "
-            "config --format json` so the main + override + dev "
-            "merge is what's queried, not just the override file"
+        assert "config {{ _upgrade_config_format }}" in content, (
+            "Buildable-service detection must query the merged compose "
+            "config, not just the override file"
         )
 
     def test_extract_uses_build_attribute(self):


### PR DESCRIPTION
Fixes #1276

`config --format json` is Docker Compose v2 only. podman-compose 1.3.0 has no `--format` option at all and exits 2:

```
usage: podman-compose config [-h] [--no-normalize] [--services]
$ podman-compose config --format json ; echo $?
2
```

## Two call sites, two different failures

**`backup_discover_build_paths.yml`** parses the output with no `failed_when`, so `canasta backup` could not discover build paths at all on Podman — a hard failure.

**`upgrade_rebuild_buildable.yml`** carries `failed_when: false`, so the failure became an empty service list and buildable services were **silently never rebuilt**. The upgrade reported success having skipped the work. This is the worse of the two, and the reason the issue was not noticed earlier.

## Why the fix is one flag

podman-compose's default output is YAML, and YAML is a superset of JSON — so `from_yaml` reads both runtimes' output and only the flag has to vary. Docker still gets `--format json`; nothing about the Docker path changes.

Confirmed rather than assumed, since it is the load-bearing claim — `yaml.safe_load` round-trips a realistic `docker compose config --format json` payload including `:`, `#`, `{}` and `*` inside values:

```
from_yaml parses docker JSON: True
build context preserved: /srv/inst/build
awkward scalar preserved: 'a: b #c {d} *e &f'
```

## The semantic dependency also holds

`backup_discover_build_paths.yml` relies on `config` resolving `build.context` to an absolute path while leaving `build.dockerfile` relative to it. podman-compose behaves identically (podman 5.4.2 / podman-compose 1.3.0):

```
build section: {'context': '/tmp/pmcfg/ctxdir', 'dockerfile': 'Dockerfile.custom'}
context absolute? True
```

So the downstream top-level-path computation is unaffected.

## Please look at this in review

This broke an existing test. `test_upgrade_rebuild.py::test_uses_merged_compose_config_json` asserted the literal string `config --format json`, but its stated intent is that detection queries the *merged* model (main + override + dev) rather than the override file alone — the output format was incidental to that. I rewrote it to assert the intent and cross-referenced the new test rather than working around it. Changing another test to accommodate a fix deserves a second opinion.

## Tests

`tests/unit/test_compose_config_format_by_runtime.py` covers both call sites: no literal `--format json`, Docker still gets it, podman gets nothing, the selector is not itself gated on podman (which would leave the fact undefined on Docker), and neither site still parses with `from_json`.

`make test-unit` 2067 passed · `make lint` clean · `make validate` 87 commands, 69 playbooks.

## Sequencing

#1277 (pull flags) comes first in practice — an upgrade only reaches this rebuild step after the pull step succeeds. Once both land, a full `canasta upgrade` against a live rootless-Podman instance exercises the whole path; I have one standing by.