### PR TITLE
fix(start): skip the health gate when the runtime reports no health status

### DIFF
--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -133,12 +133,12 @@
     # HEALTHCHECK skip the wait (we trust them to define their own
     # readiness contract).
     #
-    # Podman note: `podman inspect -f '{{.State.Health.Status}}'`
-    # returns the same Go template output as Docker for containers
-    # with a HEALTHCHECK.  Validated with Podman 4.3.1 (Debian 12
-    # Bookworm ARM64).  Earlier rootless Podman (<4.0) may not
-    # populate .State.Health at all; the `has` probe below skips
-    # gracefully in that case.
+    # Runtimes disagree on what "no health data" looks like: Podman
+    # 4.9.3 reports a non-nil .State.Health whose Status is empty, older
+    # Podman omits .State.Health entirely, and Docker reports a real
+    # status. So the probe renders the status itself rather than testing
+    # the struct for presence — an empty render means "nothing to wait
+    # on" on every runtime, with no version knowledge encoded.
     - name: Get web container id
       ansible.builtin.command:
         cmd: >-
@@ -166,13 +166,13 @@
           containers as soon as the session that started them ends.
       when: _start_web_cid.stdout | trim == ''
 
-    - name: Probe whether web declares a healthcheck
+    - name: Probe whether web reports a health status
       ansible.builtin.command:
         argv:
           - "{{ _inspect_cmd }}"
           - inspect
           - "-f"
-          - "{% raw %}{{if .State.Health}}has{{end}}{% endraw %}"
+          - "{% raw %}{{if .State.Health}}{{.State.Health.Status}}{{end}}{% endraw %}"
           - "{{ _start_web_cid.stdout | trim }}"
       register: _start_web_has_health
       changed_when: false
@@ -196,7 +196,7 @@
       until: _start_web_health.stdout | trim == 'healthy'
       when:
         - _start_web_cid.stdout | trim != ''
-        - _start_web_has_health.stdout | default('') | trim == 'has'
+        - _start_web_has_health.stdout | default('') | trim != ''
 
     # Register CAPI + auto-enroll the bouncer when CrowdSec is on. Shared
     # with the K8s start path and create. crowdsec_autoenroll is false only

--- a/tests/unit/test_start_health_gate_probe.py
+++ b/tests/unit/test_start_health_gate_probe.py
@@ -1,0 +1,98 @@
+"""The health gate must skip when the runtime reports no health status.
+
+Runtimes disagree on what a container without usable health data looks
+like. Podman 4.9.3 reports a non-nil `.State.Health` whose `Status` is
+empty; older Podman omits `.State.Health` entirely; Docker reports a
+real status.
+
+The gate used to probe `{{if .State.Health}}has{{end}}` and wait
+whenever that matched. On Podman 4.9.3 it matched while the status
+stayed empty, so `canasta create` spun for the full 60 x 10s and then
+failed on an empty-string comparison that told the operator nothing.
+
+Probing the status itself makes an empty render mean "nothing to wait
+on" everywhere, with no per-version knowledge encoded.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+START = os.path.join(REPO_ROOT, "roles", "orchestrator", "tasks", "start.yml")
+
+
+def _tasks():
+    out = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            out.append(node)
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for i in node:
+                walk(i)
+
+    with open(START) as f:
+        walk(yaml.safe_load(f))
+    return [t for t in out if isinstance(t, dict) and "name" in t]
+
+
+def _task(substring):
+    for t in _tasks():
+        if substring in str(t.get("name", "")):
+            return t
+    return None
+
+
+class TestHealthProbeRendersTheStatus:
+    def test_probe_renders_the_status_not_the_struct(self):
+        probe = _task("health status")
+        assert probe is not None, (
+            "start.yml must probe the web container's health status "
+            "before waiting on it"
+        )
+        argv = " ".join(str(a) for a in probe["ansible.builtin.command"]["argv"])
+        assert ".State.Health.Status" in argv, (
+            "the probe must render the status itself — testing "
+            "`{{if .State.Health}}` alone matches on Podman 4.9.3, where "
+            "the struct exists but the status is empty"
+        )
+
+    def test_probe_tolerates_a_missing_health_struct(self):
+        probe = _task("health status")
+        argv = " ".join(str(a) for a in probe["ansible.builtin.command"]["argv"])
+        assert "if .State.Health" in argv, (
+            "the status render must stay guarded by an `if`, or inspect "
+            "errors out on runtimes that omit .State.Health entirely"
+        )
+
+
+class TestHealthWaitIsGatedOnANonEmptyStatus:
+    def test_wait_skips_when_no_status_is_reported(self):
+        wait = _task("Wait for web container to report healthy")
+        assert wait is not None
+        conditions = [str(c) for c in wait["when"]]
+        assert any(
+            "_start_web_has_health" in c and "!= ''" in c for c in conditions
+        ), (
+            "the wait must be gated on a non-empty reported status; "
+            "an equality check against a sentinel re-introduces the "
+            "10-minute stall on runtimes that report no status"
+        )
+
+    def test_wait_still_requires_a_running_container(self):
+        wait = _task("Wait for web container to report healthy")
+        conditions = [str(c) for c in wait["when"]]
+        assert any("_start_web_cid" in c for c in conditions), (
+            "the wait must still be gated on a web container existing"
+        )
+
+    def test_wait_still_waits_for_healthy(self):
+        wait = _task("Wait for web container to report healthy")
+        assert "healthy" in str(wait.get("until", "")), (
+            "the gate must still wait for 'healthy' — it exists to stop "
+            "install.php racing composer"
+        )

--- a/tests/unit/test_start_verifies_running.py
+++ b/tests/unit/test_start_verifies_running.py
@@ -72,7 +72,7 @@ class TestStartFailsWhenNothingIsRunning:
         check_at = next(
             i for i, n in enumerate(names) if "no web container is running" in n)
         probe_at = next(
-            i for i, n in enumerate(names) if "declares a healthcheck" in n)
+            i for i, n in enumerate(names) if "health status" in n)
         assert get_at < check_at < probe_at, (
             "the check belongs between reading the container id and the "
             "health probe that is skipped when it is empty"


### PR DESCRIPTION
Fixes #1281.

`canasta create` could not complete on Podman 4.9.3 / podman-compose 1.3.0 (Ubuntu 24.04). The web health gate waited out its full 60 × 10s and then failed the play:

```
fatal: [localhost]: FAILED! => {"attempts": 60,
  "cmd": ["podman", "inspect", "-f", "{{.State.Health.Status}}", "301218948b65"],
  "rc": 0, "stdout": ""}
```

## Cause

The gate was guarded by a probe rendering `{{if .State.Health}}has{{end}}`, on the assumption that a runtime with no health data omits `.State.Health`. Podman 4.9.3 instead reports the struct as non-nil with an empty `Status`, so the guard matched, the wait ran, and the status it was waiting for never appeared. The result was a ten-minute stall ending in an empty-string comparison that gave the operator nothing to work with.

The comment above the guard recorded that it had been verified on Podman 4.3.1 — the behavior differs on 4.9.3.

## Fix

Probe the status itself rather than the presence of the struct, and gate the wait on that render being non-empty. Every "no usable health signal" case now takes the same path — older Podman omitting `.State.Health`, Podman 4.9.3 leaving `Status` empty, and a custom image with no `HEALTHCHECK` — with no per-version knowledge encoded in the playbook.

The `if` guard is kept so `inspect` does not error on runtimes that omit the field entirely.

## Verification

Confirmed against a real Docker daemon that behavior is unchanged there:

| container | old probe | new probe |
|---|---|---|
| with `--health-cmd` | `has` | `healthy` |
| no healthcheck | *(empty)* | *(empty)* |

So a healthy container still gates the wait, and one without a healthcheck still skips it.

`tests/unit/test_start_health_gate_probe.py` pins the behavior: the probe must render the status, keep the `if` guard, and the wait must be gated on a non-empty status rather than a sentinel. 2079 unit tests, yamllint, and `validate_definitions.py` pass.

## Note

This was found by the Podman CI lane in #1279, which is blocked on this fix — the lane cannot go green until `create` works on Podman. #1282 (rescue cleanup hitting EACCES under rootless Podman) sits behind this one and is only reachable once this is in.

Not verified on Podman directly — there is no Podman host in this environment. The #1279 lane will exercise it.