### PR TITLE
fix(install): advertise and enforce the valid package names

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -722,6 +722,20 @@ def hoist_flags_from_remainder(args):
         setattr(args, pos_name, new_args)
 
 
+def _positional_choices(param, name):
+    """argparse kwargs constraining a positional to a fixed set of values.
+
+    A positional with `choices` deliberately drops `metavar`: argparse
+    prints the choice set in the usage line only when no metavar shadows
+    it, and advertising the valid values is the point. Without choices,
+    the uppercase metavar is kept.
+    """
+    choices = param.get("choices")
+    if choices:
+        return {"choices": choices}
+    return {"metavar": name.upper()}
+
+
 def add_params_to_parser(parser, params):
     """Add command parameters to an argparse parser based on definitions."""
     for param in params:
@@ -769,7 +783,7 @@ def add_params_to_parser(parser, params):
                     nargs="+" if required else "*",
                     default=default,
                     help=desc,
-                    metavar=name.upper(),
+                    **_positional_choices(param, name)
                 )
             else:
                 parser.add_argument(
@@ -777,7 +791,7 @@ def add_params_to_parser(parser, params):
                     nargs="?",
                     default=default,
                     help=desc,
-                    metavar=name.upper(),
+                    **_positional_choices(param, name)
                 )
         elif ptype == "bool":
             parser.add_argument(

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -841,9 +841,10 @@ commands:
         positional: true
         multi: true
         required: true
+        choices: [docker, k8s-cp, k8s-worker, git-crypt, sops, canasta]
         description: >-
           Dependencies to install (docker, k8s-cp, k8s-worker,
-          git-crypt, canasta)
+          git-crypt, sops, canasta)
       - name: public_ip
         type: string
         multi: true

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -1,7 +1,7 @@
 ---
 # canasta install - Install dependencies on the target host.
 # Accepts one or more package names: docker, k8s-cp, k8s-worker,
-# git-crypt, canasta.
+# git-crypt, sops, canasta.
 
 # When --id is given without --host, resolve the instance's registered
 # host and switch the connection to it. This lets `canasta install

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -1015,9 +1015,32 @@ class TestInstallCommand:
         assert args.packages == ["docker"]
 
     def test_install_multiple_packages(self, parser):
-        args = parser.parse_args(["install", "docker", "k3s", "git-crypt"])
+        # Was `k3s` — the internal name k8s-cp maps to, and the
+        # user-facing name back when install shipped. It kept parsing
+        # after the rename only because nothing constrained the argument.
+        args = parser.parse_args(["install", "docker", "k8s-cp", "git-crypt"])
         assert args.command == "install"
-        assert args.packages == ["docker", "k3s", "git-crypt"]
+        assert args.packages == ["docker", "k8s-cp", "git-crypt"]
+
+    def test_install_rejects_an_unknown_package(self, parser, capsys):
+        # argparse rejects it outright: before, anything parsed and only
+        # the playbook caught it, after a venv + Ansible startup.
+        with pytest.raises(SystemExit):
+            parser.parse_args(["install", "dokcer"])
+        assert "invalid choice" in capsys.readouterr().err
+
+    def test_install_usage_names_every_package(self, parser, capsys):
+        # The point of the choices list: `canasta install` with no
+        # arguments has to answer "what can I install?".
+        with pytest.raises(SystemExit):
+            parser.parse_args(["install"])
+        err = capsys.readouterr().err
+        for pkg in ("docker", "k8s-cp", "k8s-worker",
+                    "git-crypt", "sops", "canasta"):
+            assert pkg in err, (
+                "usage must list %s; an opaque PACKAGES metavar leaves the "
+                "valid values undiscoverable" % pkg
+            )
 
     def test_install_with_host(self, data):
         from argparse import Namespace


### PR DESCRIPTION
Fixes #1286. Fixes #1287.

## Before

```
$ canasta install
usage: canasta install [-h] [-H HOST] [--docker-host DOCKER_HOST] [-i ID]
                       [--public-ip PUBLIC_IP] [--cp-host CP_HOST]
                       PACKAGES [PACKAGES ...]
canasta install: error: the following arguments are required: PACKAGES
```

No valid value named anywhere. And nothing constrained the argument, so `canasta install dokcer` started a venv and loaded Ansible before the playbook rejected it.

## After

```
$ canasta install
usage: canasta install [-h] [-H HOST] [--docker-host DOCKER_HOST] [-i ID]
                       [--public-ip PUBLIC_IP] [--cp-host CP_HOST]
                       {docker,k8s-cp,k8s-worker,git-crypt,sops,canasta}
                       [{docker,k8s-cp,k8s-worker,git-crypt,sops,canasta} ...]
canasta install: error: the following arguments are required: packages

$ canasta install dokcer
canasta install: error: argument packages: invalid choice: 'dokcer'
  (choose from docker, k8s-cp, k8s-worker, git-crypt, sops, canasta) Did you mean 'docker'?
```

The did-you-mean suggestion comes free: `canasta.py` already parses argparse's "invalid choice" error, it just had no positional producing one.

## Changes

- `canasta.py`: positionals forward `choices`, and omit `metavar` when they have one. `metavar` shadows argparse's choice listing, so keeping it would enforce the set while leaving it invisible — verified both ways. Positionals without choices are untouched (`uninstall`, `maintenance exec`, `config set` still show their metavar).
- `meta/command_definitions.yml`: `choices` on the `packages` positional; `sops` added to the description, which listed five of six.
- `playbooks/install.yml`: same `sops` omission in the header comment. The playbook's own validation is kept as defense in depth — it also guards the Ansible entry point — it is just no longer the first thing to catch a typo.

## Behavior change worth a look

`k3s` and `k3s-worker` no longer parse.

They are the internal names `k8s-cp` / `k8s-worker` map to. They were the *user-facing* names when `install` shipped in #197 (`canasta install k3s` was a documented example), and after the rename they kept working only because nothing constrained the argument and the post-mapping validation list still contains them. They have been undocumented everywhere since — `long_description`, the argument description, and the validation error all describe the six-name set.

The stale unit test asserting `k3s` parses is updated; that test is how this surfaced. If you would rather keep them as back-compat aliases, say so — but they cannot be hidden from the usage line, so accepting them means advertising eight names, two of them deprecated duplicates.

## Verification

2081 unit tests pass, `validate_definitions.py` passes, yamllint clean, `ruff --select F401` clean, and `generate_docs.py` regenerates `docs/commands/install.md` with all six packages. New tests cover the rejection, the did-you-mean path, and that the usage line names every package.