### PR TITLE
test(integration): pin the suite to the checked-out tree

### DIFF
--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -60,11 +60,26 @@ class TestInstance:
                 % (self.http_port, self.https_port)
             )
 
-    def run(self, *args):
-        """Run a canasta command in verbose mode. Returns (stdout, returncode)."""
+    def cli_env(self):
+        """Environment for a CLI invocation under test.
+
+        CANASTA_SELF_UPDATED pins the suite to the checked-out tree.
+        `canasta upgrade` otherwise self-updates before running its
+        playbook: it decides whether to move with `git merge-base
+        --is-ancestor <latest tag> HEAD`, which cannot succeed in CI's
+        depth-1 clone, so it checks out the release tag and re-execs.
+        Every later test — and the upgrade path itself — would then run
+        the released CLI instead of the code under test.
+        """
         env = os.environ.copy()
         env["CANASTA_CONFIG_DIR"] = self.config_dir
         env["ANSIBLE_CONFIG"] = os.path.join(REPO_ROOT, "ansible.cfg")
+        env["CANASTA_SELF_UPDATED"] = "1"
+        return env
+
+    def run(self, *args):
+        """Run a canasta command in verbose mode. Returns (stdout, returncode)."""
+        env = self.cli_env()
         # Run in verbose mode for CI feedback
         cmd = [CANASTA_BIN, "--verbose"] + list(args)
         print("  $ canasta %s" % " ".join(args), flush=True)
@@ -80,9 +95,7 @@ class TestInstance:
 
     def run_quiet(self, *args):
         """Run without --verbose for parseable output."""
-        env = os.environ.copy()
-        env["CANASTA_CONFIG_DIR"] = self.config_dir
-        env["ANSIBLE_CONFIG"] = os.path.join(REPO_ROOT, "ansible.cfg")
+        env = self.cli_env()
         cmd = [CANASTA_BIN] + list(args)
         print("  $ canasta %s" % " ".join(args), flush=True)
         result = subprocess.run(

--- a/tests/unit/test_integration_harness_pins_checkout.py
+++ b/tests/unit/test_integration_harness_pins_checkout.py
@@ -1,0 +1,66 @@
+"""The integration suite must test the checked-out tree, not a release.
+
+`canasta upgrade` self-updates before running its playbook. It decides
+whether to move with `git merge-base --is-ancestor <latest tag> HEAD`,
+which cannot succeed in CI's depth-1 clone -- the history is not there,
+so the check fails even when HEAD genuinely descends from the tag. The
+CLI concludes it is behind, checks out the release tag, and re-execs.
+
+Two consequences, both silent: every test sequenced after `upgrade` runs
+the released CLI, and `canasta upgrade` itself runs the released upgrade
+path -- so the upgrade leg never exercised a branch's changes to it.
+
+CANASTA_SELF_UPDATED short-circuits the guard at the top of
+self_update_cli(). These are structural guards; the behavior itself is
+only observable in a shallow clone.
+"""
+
+import os
+import re
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+RUNNER = os.path.join(REPO_ROOT, "tests", "integration", "run_tests.py")
+CLI = os.path.join(REPO_ROOT, "canasta.py")
+
+
+def _runner():
+    with open(RUNNER) as f:
+        return f.read()
+
+
+class TestHarnessPinsTheCheckout:
+    def test_the_env_disables_self_update(self):
+        assert 'CANASTA_SELF_UPDATED' in _runner(), (
+            "the integration harness must set CANASTA_SELF_UPDATED, or "
+            "`canasta upgrade` rewrites the checkout mid-run and later "
+            "tests silently run the released CLI"
+        )
+
+    def test_every_cli_invocation_shares_that_env(self):
+        # Both entry points must go through the one builder; a second
+        # hand-rolled env dict is how the pin gets lost again.
+        src = _runner()
+        assert src.count("env = self.cli_env()") == 2, (
+            "run() and run_quiet() must both build their environment via "
+            "cli_env(), so the pin cannot be dropped from one of them"
+        )
+        assert "env[\"CANASTA_CONFIG_DIR\"]" in src
+        assert src.count("env[\"CANASTA_CONFIG_DIR\"]") == 1, (
+            "the environment should be assembled in exactly one place"
+        )
+
+
+class TestTheGuardStillExists:
+    """The pin is worthless if the CLI stops honoring the variable."""
+
+    def test_self_update_honors_the_env_var(self):
+        with open(CLI) as f:
+            src = f.read()
+        assert re.search(
+            r'if os\.environ\.get\(\s*["\']CANASTA_SELF_UPDATED["\']\s*\)', src
+        ), (
+            "self_update_cli() must keep its CANASTA_SELF_UPDATED early "
+            "return; the integration harness relies on it to stay on the "
+            "code under test"
+        )


### PR DESCRIPTION
Fixes #1290.

Partway through a run, the integration suite stops testing the code it was launched on. `canasta upgrade` self-updates before running its playbook, and in CI that replaces the checkout with the latest release tag.

This matters most for the post-merge run, which is the only integration signal there is: the checkout starts as merged `main` and is swapped for the last release mid-run.

## Mechanism

`self_update_cli()` decides whether to move with `git merge-base --is-ancestor <latest tag> HEAD`. CI checks out at `fetch-depth: 1`, and that check cannot succeed in a shallow clone — the history is not present — so it fails even when HEAD genuinely descends from the tag. The CLI concludes it is behind the latest release, runs `git checkout v4.14.0`, and re-execs.

## Reproduced directly

Against a throwaway depth-1 clone, calling `self_update_cli()` alone — no test suite involved:

| | HEAD before | HEAD after |
|---|---|---|
| without `CANASTA_SELF_UPDATED` | `e85f48f` (main) | `24ae667` — detached at **v4.14.0** |
| with `CANASTA_SELF_UPDATED=1` | `e85f48f` (main) | `e85f48f` — untouched |

## Impact

Narrower than it first looks, and worth stating precisely:

| Scope | Affected |
|---|---|
| Tests before `upgrade` (`lifecycle`, `import`) | No — real merged code |
| `canasta upgrade` itself | **Yes** — `self_update_cli()` runs before the playbook, so it re-execs into released code and runs the released upgrade path |
| Tests after `upgrade` (`version`, `doctor`, `host-management` on `main`) | Yes, but these are light assertions |

So the practical damage on `main` today is three trivial tests plus the upgrade path. The substantive part is the upgrade path: **the `upgrade` leg has never exercised a branch's changes to upgrade** — notable given how many upgrade defects this cycle (#1270, #1275, #1276, #1278) shipped past a green upgrade leg.

For an ordinary merge — the vast majority — `main` is genuinely ahead of the last release tag, so the substitution is unconditional.

A release-bump commit can escape it, but only by winning a race: `docker.yml`'s `tag` job is `needs: [version, build]`, so `vX.Y.Z` lands only after the multi-arch image build, while `tests.yml` runs on the same push in parallel. On the 4.14.0 release the tag appeared 6.4 minutes into a test run that reaches `upgrade` at roughly 8-9 minutes — about two minutes of margin, so that run was unaffected. A slower build or a reordered test list flips it, and if the tag loses, the commit validating a release is tested against the release before it.

Not runtime-specific; it has always been true on Docker. It only becomes visible when released and branch behavior differ — which is how it surfaced, in the Podman lane for #1279, where a test failed against a bug already fixed on the branch.

## Change

`CANASTA_SELF_UPDATED` in the environment the harness passes to the CLI, set in one `cli_env()` builder that `run()` and `run_quiet()` both use — a second hand-rolled env dict is exactly how this pin would get lost again.

`fetch-depth: 0` is not an adequate alternative: it fixes only the shallow case. A branch cut before the latest release tag does not contain it, so the ancestor check legitimately fails and the checkout is still replaced.

No coverage is lost: no integration test depends on self-update running (`test_version` only asserts non-empty output). The self-update path itself is no longer integration-exercised — but it was not being tested before, it was corrupting the run. Unit tests in `test_canasta_cli.py` cover it.

## Verification

2082 unit tests pass, `validate_definitions.py` and `ruff` clean. `tests/unit/test_integration_harness_pins_checkout.py` guards three things: the variable is set, both entry points share the one env builder, and `self_update_cli()` keeps the early return the pin depends on.

Worth merging before #1279's lane opens as a PR — otherwise that lane's first green run would be proving both the lane and this fix at once, and a reviewer could not tell which.

