### PR TITLE
test(ci): add a Podman integration lane and assert the buildable rebuild

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
     # See #67.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -112,8 +112,98 @@ jobs:
       - name: Run core tests
         run: >-
           .venv/bin/python tests/integration/run_tests.py
-          lifecycle import upgrade version doctor host-management
-        timeout-minutes: 20
+          lifecycle import upgrade upgrade-rebuilds-buildable
+          version doctor host-management
+        timeout-minutes: 25
+
+  # Podman is a supported container runtime, but every other integration job
+  # runs on Docker — so a Podman-only regression ships with a green suite.
+  # This lane mirrors integration-core's compose legs on podman-compose.
+  #
+  # Docker is taken away rather than left idle: a hardcoded `docker` call has
+  # to fail here instead of quietly reaching a live daemon.
+  #
+  # Versions under test: Ubuntu's podman package with podman-compose pinned
+  # to 1.3.0 — the pairing the Podman runtime fixes were verified against.
+  # podman-compose 1.6.0 is not covered; the pull step's reliance on
+  # podman-compose skipping buildable services by default is confirmed for
+  # 1.3.0 only.
+  integration-podman:
+    name: "Integration: Podman"
+    if: github.event_name != 'pull_request'  # See #67
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install Podman and podman-compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git-crypt podman uidmap
+          # Onto PATH, not into the repo venv: the CLI shells out to
+          # `podman-compose` by name, so it has to resolve like an
+          # operator's install would.
+          python -m pip install --user podman-compose==1.3.0
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # Rootless Podman prerequisites the create pre-flight enforces: without
+      # lingering, systemd reaps the containers when the session ends; with
+      # the unprivileged port floor above 80, the pre-flight refuses to run
+      # at all (it cannot see the instance's HTTP_PORT that early).
+      - name: Satisfy rootless Podman prerequisites
+        run: |
+          sudo loginctl enable-linger "$(id -un)"
+          sudo sysctl -w net.ipv4.ip_unprivileged_port_start=80
+          grep -q "^$(id -un):" /etc/subuid || sudo usermod \
+            --add-subuids 100000-165535 --add-subgids 100000-165535 \
+            "$(id -un)"
+          echo "XDG_RUNTIME_DIR=/run/user/$(id -u)" >> "$GITHUB_ENV"
+
+      - name: Remove Docker so only Podman is reachable
+        run: |
+          sudo systemctl stop docker.socket docker.service || true
+          sudo systemctl mask docker.socket docker.service || true
+          for d in $(type -a -P docker || true); do
+            sudo mv "$d" "$d.disabled"
+          done
+          hash -r
+          if command -v docker; then
+            echo "docker is still on PATH" >&2
+            exit 1
+          fi
+
+      - name: Show runtime versions
+        run: |
+          podman --version
+          podman-compose --version
+          podman info >/dev/null
+
+      - name: Install Python dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install -r requirements.txt
+          .venv/bin/pip install kubernetes
+          # Retry to ride out transient Ansible Galaxy CDN timeouts.
+          for attempt in 1 2 3 4; do
+            .venv/bin/ansible-galaxy collection install kubernetes.core && break
+            if [ "$attempt" -eq 4 ]; then
+              echo "ansible-galaxy install failed after 4 attempts" >&2
+              exit 1
+            fi
+            echo "ansible-galaxy install attempt $attempt failed; retrying in $((attempt * 10))s..." >&2
+            sleep $((attempt * 10))
+          done
+          git config --global user.name "CI"
+          git config --global user.email "ci@canasta.wiki"
+
+      - name: Run Podman tests
+        run: >-
+          .venv/bin/python tests/integration/run_tests.py
+          lifecycle upgrade upgrade-rebuilds-buildable doctor
+        timeout-minutes: 35
 
   integration-features:
     name: "Integration: Features"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,8 +166,13 @@ jobs:
         run: |
           sudo systemctl stop docker.socket docker.service || true
           sudo systemctl mask docker.socket docker.service || true
+          # /bin is a symlink to /usr/bin, so `type -a -P` reports the
+          # same binary twice; the second path is already gone once the
+          # first is moved.
           for d in $(type -a -P docker || true); do
-            sudo mv "$d" "$d.disabled"
+            if [ -e "$d" ]; then
+              sudo mv "$d" "$d.disabled"
+            fi
           done
           hash -r
           if command -v docker; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,27 @@ Run `make help` to see the available targets.
 
 ```bash
 make test-unit            # Unit tests
-make test-integration     # Integration tests (requires Docker)
+make test-integration     # Integration tests (requires Docker or Podman)
 make lint                 # ansible-lint + yamllint
 make validate             # Validate command_definitions.yml structure
 make docs                 # Regenerate docs/commands/*.md
 ```
+
+### Container runtimes in CI
+
+The integration suite runs against whichever runtime the host provides.
+The `Integration: Podman` job runs the create/start/stop and upgrade legs
+under rootless `podman` with `podman-compose` 1.3.0 and Docker removed
+from the runner; every other integration job runs on Docker. A few tests
+reach past the CLI with Docker-specific invocations and report SKIPPED
+under Podman.
+
+`podman-compose` 1.6.0 is not covered yet. It differs from 1.3.0 in ways
+the CLI depends on — notably whether `pull` skips services with a
+`build:` section by default.
+
+Integration jobs are skipped on pull requests (cost, secrets); run the
+workflow manually against a branch to exercise them before merging.
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ test-unit: venv
 	$(PYTEST) tests/unit/ -v
 
 # Integration tests call ./canasta commands as subprocesses. Requires
-# Docker and git-crypt. Pass a test name to run a single test, e.g.
+# git-crypt and a container runtime (Docker or Podman). Pass a test name
+# to run a single test, e.g.
 # 'python tests/integration/run_tests.py lifecycle'.
 test-integration: venv
 	$(PYTHON) tests/integration/run_tests.py

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -11,7 +11,7 @@ Usage:
     python tests/integration/run_tests.py --list        # list tests
 
 Requirements:
-    - Docker running
+    - A container runtime running (Docker or Podman)
     - Canasta CLI installed (.venv with ansible)
     - Run from repo root or set CANASTA_ROOT
 """
@@ -45,6 +45,47 @@ def next_port():
     global _port_counter
     _port_counter += 10
     return str(_port_counter), str(_port_counter + 1)
+
+
+_runtime = None
+
+
+def container_runtime():
+    """Return the runtime serving this host: 'docker', 'podman', or ''.
+
+    Probed in the same order the CLI's own create pre-flight uses, so a
+    test run resolves to whatever the CLI will resolve to. Cached — the
+    answer cannot change mid-run.
+    """
+    global _runtime
+    if _runtime is None:
+        _runtime = ""
+        for candidate in ("docker", "podman"):
+            try:
+                probe = subprocess.run(
+                    [candidate, "info"], capture_output=True,
+                )
+            except OSError:
+                continue
+            if probe.returncode == 0:
+                _runtime = candidate
+                break
+    return _runtime
+
+
+def require_docker():
+    """Skip a test that drives `docker` directly on a non-Docker host.
+
+    Most tests only call the CLI and are runtime-agnostic. A few reach
+    past it to seed volumes or exec into containers with Docker-specific
+    invocations; those report SKIPPED under Podman rather than failing on
+    a missing binary.
+    """
+    if container_runtime() != "docker":
+        raise SkipTest(
+            "test drives `docker` directly; this host runs %s"
+            % (container_runtime() or "no container runtime")
+        )
 
 
 class TestInstance:
@@ -177,7 +218,8 @@ def wait_for_wiki_at_path(http_port, api_path="/w/api.php", timeout=300):
         time.sleep(5)
     # Dump diagnostics
     print("  TIMEOUT waiting for wiki (last: %s)" % last_err)
-    subprocess.run(["docker", "ps", "-a"], capture_output=False)
+    if container_runtime():
+        subprocess.run([container_runtime(), "ps", "-a"], capture_output=False)
     raise AssertionError(
         "Wiki did not become ready at port %s within %ds" % (http_port, timeout)
     )
@@ -316,6 +358,98 @@ def test_upgrade(inst):
     wait_for_wiki(inst.http_port)
 
 
+def test_upgrade_rebuilds_buildable(inst):
+    """Upgrade must actually rebuild services carrying a `build:` directive.
+
+    The rebuild step enumerates buildable services out of the merged
+    compose config. When that render fails, an empty service list is
+    indistinguishable from "nothing to rebuild": the loop runs over
+    nothing and the upgrade reports success while the custom image stays
+    stale. That silent skip is invisible to a hand-run, so assert it —
+    the Dockerfile's canary label is changed between the two builds and
+    read back off the image after the upgrade.
+    """
+    runtime = container_runtime()
+    inst_path = inst.instance_path()
+    custom_image = "%s:custom" % inst.id
+
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir,
+        "-e", inst.env_file,
+    )
+    wait_for_wiki(inst.http_port)
+
+    base_image = read_env(inst.env_path())["CANASTA_IMAGE"]
+
+    def write_dockerfile(canary):
+        # One LABEL over the instance's own base image: the build is a
+        # single metadata layer, so it needs no network and finishes
+        # instantly, while still producing a distinct image ID.
+        with open(os.path.join(inst_path, "Dockerfile.custom"), "w") as f:
+            f.write(
+                "FROM %s\nLABEL canasta.canary=%s\n" % (base_image, canary)
+            )
+
+    def image_canary():
+        result = subprocess.run(
+            [runtime, "image", "inspect", custom_image, "--format",
+             '{{ index .Config.Labels "canasta.canary" }}'],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, (
+            "could not inspect %s: %s" % (custom_image, result.stderr)
+        )
+        return result.stdout.strip()
+
+    print("Layering a custom web build over the instance image...")
+    override_path = os.path.join(inst_path, "docker-compose.override.yml")
+    with open(override_path, "w") as f:
+        f.write(
+            "services:\n"
+            "  web:\n"
+            "    image: %s\n"
+            "    build:\n"
+            "      context: .\n"
+            "      dockerfile: Dockerfile.custom\n" % custom_image
+        )
+    write_dockerfile("before")
+
+    # Build the first image directly rather than leaning on compose's
+    # implicit build-on-up: the point under test is the *rebuild* the CLI
+    # performs during upgrade, so the starting state should not depend on
+    # another compose behavior.
+    print("Building the custom image...")
+    build = subprocess.run(
+        [runtime, "build", "-t", custom_image, "-f", "Dockerfile.custom", "."],
+        cwd=inst_path, capture_output=True, text=True,
+    )
+    assert build.returncode == 0, (
+        "could not build %s:\n%s" % (custom_image, build.stderr)
+    )
+    assert image_canary() == "before", "precondition: canary label not set"
+
+    print("Restarting onto the custom image...")
+    inst.run_ok("restart", "-i", inst.id)
+    wait_for_wiki(inst.http_port)
+
+    print("Editing the Dockerfile so a rebuild is observable...")
+    write_dockerfile("after")
+
+    print("Running upgrade...")
+    inst.run_ok("upgrade")
+
+    print("Verifying the buildable service was rebuilt...")
+    assert image_canary() == "after", (
+        "upgrade did not rebuild the buildable web service — %s still "
+        "carries the pre-upgrade canary label" % custom_image
+    )
+
+    print("Verifying wiki still accessible...")
+    wait_for_wiki(inst.http_port)
+
+
 def _mysql_data_volume(inst):
     """Name of the instance's MySQL data volume, as Compose derives it."""
     return "%s_mysql-data-volume" % re.sub(
@@ -433,6 +567,9 @@ def test_upgrade_mysql_to_mariadb(inst):
     must then be idempotent: the datadir is already MariaDB, so detection does
     not fire and no re-migration touches the data.
     """
+    # Seeds a genuine MySQL 8 datadir with throwaway `docker run`
+    # containers.
+    require_docker()
     volume = _mysql_data_volume(inst)
 
     print("Creating instance...")
@@ -498,6 +635,9 @@ def test_upgrade_mysql_to_mariadb_recovery(inst):
     still detect and migrate here. A successful MariaDB query afterward proves
     the recovery path fired (MariaDB physically cannot boot on MySQL 8 data).
     """
+    # Seeds a genuine MySQL 8 datadir with throwaway `docker run`
+    # containers.
+    require_docker()
     volume = _mysql_data_volume(inst)
 
     print("Creating instance (compose already pins MariaDB)...")
@@ -656,6 +796,8 @@ def test_upgrade_backfill_hosts_yaml(inst):
 
 def test_backup(inst):
     """Init repo, create snapshot, drop DB, restore, verify."""
+    # Drops the database through `docker compose exec`.
+    require_docker()
     print("Creating instance...")
     inst.run_ok(
         "create", "-i", inst.id, "-w", "main",
@@ -2447,6 +2589,8 @@ def test_gitops_push_reporting(inst):
 
 def test_backup_restore_excludes_safety(inst):
     """Verify --snapshot latest skips safety-before-restore snapshots (#147)."""
+    # Stages a fake safety snapshot with `docker run`.
+    require_docker()
     print("Creating instance...")
     inst.run_ok(
         "create", "-i", inst.id, "-w", "main",
@@ -2736,6 +2880,8 @@ def test_crowdsec(inst):
     sees the Docker bridge gateway as the client, which makes a 403 assertion
     environment-fragile. This pins the deterministic behavior (backfill +
     command/decision plumbing)."""
+    # Drives cscli through `docker compose exec`.
+    require_docker()
     print("Creating instance...")
     inst.run_ok(
         "create", "-i", inst.id, "-w", "main",
@@ -3421,6 +3567,8 @@ def test_sidecar_lifecycle(inst):
     manual e2e: the orphan container left behind after removal, and the
     stop/restart wedge from k8s-notation resources.
     """
+    # Queries sidecar containers and volumes through the Docker CLI.
+    require_docker()
     print("Creating instance...")
     inst.run_ok(
         "create", "-i", inst.id, "-w", "main",
@@ -3490,6 +3638,8 @@ def test_sidecar_migrate(inst):
     docker-compose.override.yml (a left-behind override entry would shadow
     the migrated sidecar). --dry-run must change nothing.
     """
+    # Queries sidecar containers and volumes through the Docker CLI.
+    require_docker()
     print("Creating instance...")
     inst.run_ok(
         "create", "-i", inst.id, "-w", "main",
@@ -3572,6 +3722,7 @@ ALL_TESTS = {
     "lifecycle": test_lifecycle,
     "import": test_import_export,
     "upgrade": test_upgrade,
+    "upgrade-rebuilds-buildable": test_upgrade_rebuilds_buildable,
     "upgrade-mysql-to-mariadb": test_upgrade_mysql_to_mariadb,
     "upgrade-mysql-to-mariadb-recovery": test_upgrade_mysql_to_mariadb_recovery,
     "reconcile": test_reconcile,
@@ -3620,13 +3771,13 @@ def main():
     requested = [a for a in sys.argv[1:] if not a.startswith("-")]
     tests = {n: ALL_TESTS[n] for n in requested} if requested else ALL_TESTS
 
-    # Check Docker
-    result = subprocess.run(
-        ["docker", "info"], capture_output=True
-    )
-    if result.returncode != 0:
-        print("ERROR: Docker not available")
+    # Check a container runtime is reachable. Podman is a supported
+    # runtime, so requiring Docker here would make the suite unrunnable
+    # on exactly the hosts that need the most coverage.
+    if not container_runtime():
+        print("ERROR: no container runtime available (tried docker, podman)")
         sys.exit(1)
+    print("Container runtime: %s" % container_runtime())
 
     passed = 0
     failed = 0

--- a/tests/unit/test_ci_podman_lane.py
+++ b/tests/unit/test_ci_podman_lane.py
@@ -1,0 +1,90 @@
+"""CI has to exercise Podman, not just Docker.
+
+Podman is a supported container runtime, but for a long time every
+integration job ran on Docker. A Podman-only regression therefore
+produced two green signals -- the PR checks and the post-merge run --
+and shipped anyway; five such defects were found by hand instead.
+
+These guards are deliberately structural rather than behavioral: what
+the lane proves can only be proven by running it, but its *existence*
+and its shape are cheap to pin so the coverage cannot quietly go away
+again.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+WORKFLOW = os.path.join(REPO_ROOT, ".github", "workflows", "tests.yml")
+
+
+def _jobs():
+    with open(WORKFLOW) as f:
+        return yaml.safe_load(f)["jobs"]
+
+
+def _run_steps(job):
+    return [s.get("run", "") for s in job.get("steps", [])]
+
+
+class TestPodmanLane:
+    def test_a_podman_integration_job_exists(self):
+        assert "integration-podman" in _jobs(), (
+            "tests.yml must carry an integration job that runs against "
+            "Podman; without one, a Podman-only regression ships green"
+        )
+
+    def test_podman_lane_installs_podman_compose(self):
+        runs = " ".join(_run_steps(_jobs()["integration-podman"]))
+        assert "podman-compose==" in runs, (
+            "the Podman lane must install a pinned podman-compose -- the "
+            "runtime's behavior differs enough between versions that an "
+            "unpinned install makes the result unattributable"
+        )
+
+    def test_podman_lane_removes_docker(self):
+        runs = " ".join(_run_steps(_jobs()["integration-podman"]))
+        assert "docker" in runs and "mv" in runs, (
+            "the Podman lane must take Docker off the runner, so a "
+            "hardcoded `docker` call fails instead of quietly reaching a "
+            "live daemon"
+        )
+
+    def test_podman_lane_runs_lifecycle_and_upgrade(self):
+        runs = " ".join(_run_steps(_jobs()["integration-podman"]))
+        assert "run_tests.py" in runs, (
+            "the Podman lane must run the integration suite"
+        )
+        for test in ("lifecycle", "upgrade"):
+            assert test in runs, (
+                "the Podman lane must cover the %s leg -- it is where the "
+                "known Podman defects surfaced" % test
+            )
+
+    def test_podman_lane_is_gated_like_the_other_integration_jobs(self):
+        jobs = _jobs()
+        assert (jobs["integration-podman"].get("if")
+                == jobs["integration-core"].get("if")), (
+            "the Podman lane must carry the same event gate as the other "
+            "integration jobs (see #67), so it is not accidentally the "
+            "only one running on pull requests"
+        )
+
+
+class TestBuildableRebuildIsAsserted:
+    """The rebuild skip that broke on Podman was silent, so pin the assertion.
+
+    `upgrade` reported success while buildable services were never
+    rebuilt. Only a test that reads the rebuilt image back catches that,
+    and it has to run on both runtimes.
+    """
+
+    def test_rebuild_assertion_runs_on_both_runtimes(self):
+        jobs = _jobs()
+        for job in ("integration-core", "integration-podman"):
+            runs = " ".join(_run_steps(jobs[job]))
+            assert "upgrade-rebuilds-buildable" in runs, (
+                "%s must run the buildable-rebuild assertion" % job
+            )


### PR DESCRIPTION
Fixes #1279.

Podman is a supported container runtime and no CI job exercised it, so a Podman-only regression produced two green signals — the PR checks and the post-merge run — and shipped anyway. Five such defects were found by hand instead, over three merge cycles.

## The lane

`integration-podman` runs `lifecycle`, `upgrade`, `upgrade-rebuilds-buildable`, and `doctor` under rootless podman with `podman-compose` pinned to 1.3.0, gated to non-`pull_request` events like the other integration jobs (#67).

Docker is taken off the runner rather than left idle — its units are masked and the binary moved aside — so a hardcoded `docker` call fails loudly here instead of quietly reaching a live daemon. The rootless prerequisites the create pre-flight enforces are satisfied explicitly: lingering, subuid/subgid, and the unprivileged port floor.

## The assertion for the silent skip

#1276 is the one worth caring about: an unrenderable compose config became an empty service list, so buildable services were never rebuilt while the upgrade reported success. No amount of hand-testing catches a silent skip.

`upgrade-rebuilds-buildable` catches it. It layers a custom `build:` over the web service, changes a canary label between builds, and reads the label back off the image after `canasta upgrade`. It runs on **both** lanes, so it guards Docker too.

It also settles the open question in #1279 empirically: the upgrade's `pull` did not choke on a buildable service under podman-compose 1.3.0, which is what #1277 assumed but could not confirm.

## Runtime-agnostic suite

`container_runtime()` probes docker then podman in the same order the create pre-flight uses, `main()` accepts either, and the diagnostic dump follows the resolved runtime. The seven tests that reach past the CLI with Docker-specific invocations call `require_docker()` and report SKIPPED under Podman rather than failing on a missing binary.

## What the lane found on its way to green

Both were pre-existing defects on `main`, neither Podman-specific in its consequences:

- **#1281** (fixed in #1283) — the web health gate waited out its full 60 x 10s on Podman 4.9.3, because the guard tested `.State.Health` for presence while its `Status` was empty. `create` was unusable.
- **#1290** (fixed in #1291) — `canasta upgrade` self-updated the checkout mid-run, so every test after it ran the released CLI. This affected Docker equally and had been true all along.

#1282 (rescue cleanup hitting EACCES under rootless Podman) and #1280 (`canasta rebuild` silently no-oping on Podman) are filed and unclaimed. The lane deliberately omits a `rebuild` leg until #1280 is fixed.

## Verification

[Run 30415798394](https://github.com/CanastaWiki/Canasta-CLI/actions/runs/30415798394) — **12/12 jobs green**, including `Integration: Podman` (4 passed, 0 failed, 0 skipped) and `Integration: Core Lifecycle`.

The prediction that the #1291 fix would let the new test reach branch code held exactly: the branch's health-probe task name appears 7 times in the Podman log and the v4.14.0 name 0 times.

`upgrade-rebuilds-buildable` was also verified locally against Docker end to end before this ever reached CI, and the assertion confirmed load-bearing — the canary label held at `before` right up to the upgrade and flipped to `after` only once it ran.

`tests/unit/test_ci_podman_lane.py` pins the lane's existence, its pinned podman-compose version, the Docker removal, its event gate matching the other integration jobs, and that the rebuild assertion runs on both lanes.

## Version coverage

Targeted: Ubuntu 24.04's podman (4.9.3) with podman-compose 1.3.0 — the pairing the Podman runtime fixes were verified against. podman-compose 1.6.0 is not covered; adding it as a matrix leg is the obvious follow-up, kept out of this PR so a brand-new lane does not land red on an unverified combination. `CONTRIBUTING.md` states what each lane covers.