### PR TITLE
fix(rebuild): enumerate buildable services on Podman, and fail loudly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Run core tests
         run: >-
           .venv/bin/python tests/integration/run_tests.py
-          lifecycle import upgrade upgrade-rebuilds-buildable
+          lifecycle import upgrade upgrade-rebuilds-buildable rebuild
           version doctor host-management
         timeout-minutes: 25
 
@@ -207,7 +207,7 @@ jobs:
       - name: Run Podman tests
         run: >-
           .venv/bin/python tests/integration/run_tests.py
-          lifecycle upgrade upgrade-rebuilds-buildable doctor
+          lifecycle upgrade upgrade-rebuilds-buildable rebuild doctor
         timeout-minutes: 35
 
   integration-features:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,11 +28,11 @@ make docs                 # Regenerate docs/commands/*.md
 ### Container runtimes in CI
 
 The integration suite runs against whichever runtime the host provides.
-The `Integration: Podman` job runs the create/start/stop and upgrade legs
-under rootless `podman` with `podman-compose` 1.3.0 and Docker removed
-from the runner; every other integration job runs on Docker. A few tests
-reach past the CLI with Docker-specific invocations and report SKIPPED
-under Podman.
+The `Integration: Podman` job runs the create/start/stop, upgrade, and
+rebuild legs under rootless `podman` with `podman-compose` 1.3.0 and
+Docker removed from the runner; every other integration job runs on
+Docker. A few tests reach past the CLI with Docker-specific invocations
+and report SKIPPED under Podman.
 
 `podman-compose` 1.6.0 is not covered yet. It differs from 1.3.0 in ways
 the CLI depends on — notably whether `pull` skips services with a

--- a/direct_commands/rebuild.py
+++ b/direct_commands/rebuild.py
@@ -1,60 +1,82 @@
 """rebuild — rebuild buildable services and restart."""
 
-import json
 import subprocess
 import sys
+
+import yaml
 
 from . import _helpers
 from ._helpers import register
 
 
 def _list_buildable_services(inst, include_sidecars=False):
-    """Return service names with a build: directive in the merged compose config.
+    """Service names with a build: directive in the merged compose config.
 
-    Uses compose config --format json so the compose tool itself
-    handles the main + override + dev file merging — no need to
-    parse YAML ourselves.
+    Returns None when the config could not be rendered or parsed -- an
+    empty list then means only "this instance has no buildable service".
+
+    Asking the compose tool to render the merged model keeps the main +
+    override + dev file precedence out of here. Two runtime differences
+    have to be respected, the same two the Ansible path handles:
+
+    `--format json` is Docker Compose v2 only — podman-compose has no
+    such option and exits 2 — and podman-compose ignores COMPOSE_PROFILES
+    from .env, so profiled services are absent unless --profile is passed
+    explicitly. Either one alone yields an empty service list, which is
+    indistinguishable from "nothing to rebuild".
+
+    podman-compose renders YAML, and YAML is a superset of JSON, so one
+    parser reads both runtimes' output.
     """
     host = inst.get("host") or "localhost"
     path = inst.get("path", "")
     devmode = inst.get("devMode", False)
     file_args = _helpers._compose_file_args(path, host, devmode, include_sidecars)
     compose_cmd = _helpers._resolve_compose_cmd(inst)
+    profile_args = _helpers._compose_profile_args(inst)
+    fmt_args = [] if _helpers._is_podman_compose(inst) else ["--format", "json"]
 
     if _helpers._is_localhost(host):
         try:
             result = subprocess.run(
-                compose_cmd + file_args + ["config", "--format", "json"],
+                compose_cmd + file_args + profile_args + ["config"] + fmt_args,
                 cwd=path, capture_output=True, text=True, timeout=30,
             )
         except (subprocess.TimeoutExpired, OSError) as e:
             print("Error querying compose config: %s" % e, file=sys.stderr)
-            return []
+            return None
         if result.returncode != 0:
             print(
                 "Error: compose config failed: %s"
                 % (result.stderr or "").strip(),
                 file=sys.stderr,
             )
-            return []
+            return None
         stdout = result.stdout
     else:
         compose_str = " ".join(compose_cmd)
         rc, stdout = _helpers._ssh_run(
             host,
-            "cd %s && %s %s config --format json" % (
-                _helpers._shell_quote(path), compose_str, " ".join(file_args),
+            "cd %s && %s %s config%s" % (
+                _helpers._shell_quote(path), compose_str,
+                " ".join(file_args + profile_args),
+                (" " + " ".join(fmt_args)) if fmt_args else "",
             ),
         )
         if rc != 0:
             print("Error: compose config failed on %s" % host, file=sys.stderr)
-            return []
+            return None
 
     try:
-        data = json.loads(stdout)
-    except (ValueError, TypeError):
-        print("Error: docker compose config returned invalid JSON", file=sys.stderr)
-        return []
+        data = yaml.safe_load(stdout)
+    except yaml.YAMLError:
+        data = None
+    if not isinstance(data, dict):
+        print(
+            "Error: compose config returned no usable service list",
+            file=sys.stderr,
+        )
+        return None
 
     services = data.get("services", {}) or {}
     return [
@@ -84,6 +106,16 @@ def cmd_rebuild(args):
     has_sidecars = _helpers._instance_has_sidecars(inst)
 
     services = _list_buildable_services(inst, include_sidecars=has_sidecars)
+    # None means the enumeration itself failed. Reporting that as
+    # "nothing to rebuild" and exiting 0 is how a broken rebuild passes
+    # for a successful one.
+    if services is None:
+        print(
+            "Error: could not determine which services are buildable, so "
+            "nothing was rebuilt.",
+            file=sys.stderr,
+        )
+        return 1
     if not services:
         print(
             "No services have a build: directive — nothing to rebuild. "

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -463,6 +463,96 @@ def test_upgrade_rebuilds_buildable(inst):
     wait_for_wiki(inst.http_port)
 
 
+def test_rebuild(inst):
+    """`canasta rebuild` must actually rebuild, and fail loudly if it can't.
+
+    The standalone rebuild enumerates buildable services with its own
+    compose invocation rather than the upgrade path's. When that
+    enumeration broke, it returned an empty list, printed "nothing to
+    rebuild", and exited 0 — a no-op reported as a success. Assert the
+    rebuild by changing the Dockerfile's canary label and reading it back
+    off the image, the same way the upgrade path is asserted.
+    """
+    runtime = container_runtime()
+    inst_path = inst.instance_path()
+    custom_image = "%s:custom" % inst.id
+
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir,
+        "-e", inst.env_file,
+    )
+    wait_for_wiki(inst.http_port)
+
+    base_image = read_env(inst.env_path())["CANASTA_IMAGE"]
+
+    def write_dockerfile(canary):
+        with open(os.path.join(inst_path, "Dockerfile.custom"), "w") as f:
+            f.write(
+                "FROM %s\nLABEL canasta.canary=%s\n" % (base_image, canary)
+            )
+
+    def image_canary():
+        result = subprocess.run(
+            [runtime, "image", "inspect", custom_image, "--format",
+             '{{ index .Config.Labels "canasta.canary" }}'],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, (
+            "could not inspect %s: %s" % (custom_image, result.stderr)
+        )
+        return result.stdout.strip()
+
+    print("Layering a custom web build over the instance image...")
+    with open(os.path.join(inst_path, "docker-compose.override.yml"), "w") as f:
+        f.write(
+            "services:\n"
+            "  web:\n"
+            "    image: %s\n"
+            "    build:\n"
+            "      context: .\n"
+            "      dockerfile: Dockerfile.custom\n" % custom_image
+        )
+    write_dockerfile("before")
+
+    print("Building the custom image...")
+    build = subprocess.run(
+        [runtime, "build", "-t", custom_image, "-f", "Dockerfile.custom", "."],
+        cwd=inst_path, capture_output=True, text=True,
+    )
+    assert build.returncode == 0, (
+        "could not build %s:\n%s" % (custom_image, build.stderr)
+    )
+    assert image_canary() == "before", "precondition: canary label not set"
+
+    print("Restarting onto the custom image...")
+    inst.run_ok("restart", "-i", inst.id)
+    wait_for_wiki(inst.http_port)
+
+    print("Editing the Dockerfile so a rebuild is observable...")
+    write_dockerfile("after")
+
+    print("Running rebuild...")
+    output = inst.run_ok("rebuild", "-i", inst.id)
+
+    # The failure mode was a success report over skipped work, so the
+    # claim itself is worth asserting, not just the exit code.
+    assert "nothing to rebuild" not in output, (
+        "rebuild found no buildable services on an instance that has one:\n%s"
+        % output
+    )
+
+    print("Verifying the buildable service was rebuilt...")
+    assert image_canary() == "after", (
+        "rebuild did not rebuild the buildable web service — %s still "
+        "carries the pre-rebuild canary label" % custom_image
+    )
+
+    print("Verifying wiki still accessible...")
+    wait_for_wiki(inst.http_port)
+
+
 def _mysql_data_volume(inst):
     """Name of the instance's MySQL data volume, as Compose derives it."""
     return "%s_mysql-data-volume" % re.sub(
@@ -3736,6 +3826,7 @@ ALL_TESTS = {
     "import": test_import_export,
     "upgrade": test_upgrade,
     "upgrade-rebuilds-buildable": test_upgrade_rebuilds_buildable,
+    "rebuild": test_rebuild,
     "upgrade-mysql-to-mariadb": test_upgrade_mysql_to_mariadb,
     "upgrade-mysql-to-mariadb-recovery": test_upgrade_mysql_to_mariadb_recovery,
     "reconcile": test_reconcile,

--- a/tests/unit/test_ci_podman_lane.py
+++ b/tests/unit/test_ci_podman_lane.py
@@ -57,7 +57,7 @@ class TestPodmanLane:
         assert "run_tests.py" in runs, (
             "the Podman lane must run the integration suite"
         )
-        for test in ("lifecycle", "upgrade"):
+        for test in ("lifecycle", "upgrade", "rebuild"):
             assert test in runs, (
                 "the Podman lane must cover the %s leg -- it is where the "
                 "known Podman defects surfaced" % test

--- a/tests/unit/test_rebuild.py
+++ b/tests/unit/test_rebuild.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+import types
 
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
@@ -258,11 +259,11 @@ class TestListBuildableServices:
         })
         assert sorted(result) == ["extra", "web"]
 
-    def test_returns_empty_on_invalid_json(self, monkeypatch):
+    def test_returns_none_on_unparseable_output(self, monkeypatch):
         def fake_subprocess_run(cmd, **kw):
             class R:
                 returncode = 0
-                stdout = "not json"
+                stdout = "\t- not: [valid"
                 stderr = ""
             return R()
 
@@ -277,9 +278,11 @@ class TestListBuildableServices:
             "host": "localhost",
             "devMode": False,
         })
-        assert result == []
+        # None, not []: a failed render must stay distinguishable from an
+        # instance that genuinely has no buildable service.
+        assert result is None
 
-    def test_returns_empty_on_compose_config_failure(self, monkeypatch, capsys):
+    def test_returns_none_on_compose_config_failure(self, monkeypatch, capsys):
         def fake_subprocess_run(cmd, **kw):
             class R:
                 returncode = 1
@@ -298,6 +301,92 @@ class TestListBuildableServices:
             "host": "localhost",
             "devMode": False,
         })
-        assert result == []
+        # None, not []: a failed render must stay distinguishable from an
+        # instance that genuinely has no buildable service.
+        assert result is None
         err = capsys.readouterr().err
         assert "compose config failed" in err
+
+
+class TestListBuildableServicesOnPodman:
+    """The enumeration has to work on podman-compose, not just Docker.
+
+    `--format json` is Docker Compose v2 only — podman-compose has no
+    such option and exits 2 — and podman-compose ignores
+    COMPOSE_PROFILES from .env. Either one alone produced an empty
+    service list, which `canasta rebuild` reported as "nothing to
+    rebuild" while exiting 0.
+    """
+
+    def _capture(self, monkeypatch, podman, profiles=None):
+        seen = {}
+
+        def fake_run(cmd, **kw):
+            seen["cmd"] = cmd
+
+            class R:
+                returncode = 0
+                stdout = (
+                    "services:\n"
+                    "  web:\n"
+                    "    build:\n"
+                    "      context: .\n"
+                    "  db:\n"
+                    "    image: mariadb:11.4\n"
+                )
+                stderr = ""
+            return R()
+
+        monkeypatch.setattr(direct_commands._helpers, "_is_localhost", lambda h: True)
+        monkeypatch.setattr(
+            direct_commands._helpers, "_compose_file_args", lambda *a, **kw: [])
+        monkeypatch.setattr(
+            direct_commands._helpers, "_is_podman_compose", lambda i: podman)
+        monkeypatch.setattr(
+            direct_commands._helpers, "_compose_profile_args",
+            lambda i: list(profiles or []))
+        monkeypatch.setattr(direct_commands.rebuild.subprocess, "run", fake_run)
+
+        result = direct_commands._list_buildable_services(
+            {"path": "/srv/test", "host": "localhost", "devMode": False})
+        return result, seen["cmd"]
+
+    def test_podman_gets_no_format_flag(self, monkeypatch):
+        result, cmd = self._capture(monkeypatch, podman=True)
+        assert "--format" not in cmd, (
+            "podman-compose has no --format option and exits 2 on it"
+        )
+        assert result == ["web"], (
+            "podman-compose renders YAML; the parser must read it"
+        )
+
+    def test_docker_keeps_the_format_flag(self, monkeypatch):
+        _, cmd = self._capture(monkeypatch, podman=False)
+        assert "--format" in cmd and "json" in cmd
+
+    def test_podman_profiles_are_passed_explicitly(self, monkeypatch):
+        _, cmd = self._capture(
+            monkeypatch, podman=True, profiles=["--profile", "internal-db"])
+        assert "--profile" in cmd and "internal-db" in cmd, (
+            "podman-compose ignores COMPOSE_PROFILES from .env, so profiled "
+            "services vanish from the rendered config without these flags"
+        )
+
+
+class TestRebuildFailsLoudlyWhenEnumerationBreaks:
+    def test_enumeration_failure_is_not_reported_as_nothing_to_rebuild(
+        self, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(
+            direct_commands.rebuild, "_list_buildable_services",
+            lambda *a, **kw: None)
+        monkeypatch.setattr(
+            direct_commands._helpers, "_resolve_instance",
+            lambda a: ("mysite", {"path": "/srv/mysite", "orchestrator": "compose"}))
+        monkeypatch.setattr(
+            direct_commands._helpers, "_instance_has_sidecars", lambda i: False)
+
+        rc = direct_commands.rebuild.cmd_rebuild(
+            types.SimpleNamespace(id="mysite", no_cache=False, no_restart=False))
+        assert rc == 1, "a failed enumeration must not exit 0"
+        assert "nothing was rebuilt" in capsys.readouterr().err


### PR DESCRIPTION
Fixes #1280.

`canasta rebuild` was a no-op on Podman that reported success:

```
$ canasta rebuild -i mysite
No services have a build: directive — nothing to rebuild. Add a
docker-compose.override.yml with a build: section to layer a custom image.
$ echo $?
0
```

...on an instance that does have one. Same silent-skip class as #1276, in the Python fast path rather than the Ansible one.

## Three defects, one function

`_list_buildable_services()` built its own compose invocation instead of reusing the shared helpers, and that invocation was Docker-only:

1. **`--format json`** — Compose v2 only. podman-compose has no such option and exits 2, so the enumeration failed outright. #1278 fixed exactly this flag in the Ansible path but not here.
2. **`json.loads`** — even with the flag dropped, podman-compose renders YAML. Verified: `json.loads` on podman-compose output raises, `yaml.safe_load` returns `['web']`. YAML is a superset of JSON, so one parser covers both runtimes.
3. **No `--profile` args** — podman-compose ignores `COMPOSE_PROFILES` from `.env`. `_helpers._compose_profile_args()` already exists for this and `_run_compose` uses it; this function hand-rolled its call and skipped it. This one silently narrows the result rather than failing outright.

`_run_compose` — which performs the actual `build`/`down`/`up` — was already correct. Only the enumeration was broken.

## The exit code

An empty list meant both "no buildable services" and "the enumeration broke", and `cmd_rebuild` turned both into exit 0. The enumeration now returns `None` on failure and rebuild exits 1 with a message saying nothing was rebuilt; an empty list keeps its plain meaning.

## Test coverage

There was no integration test for `canasta rebuild` at all — only unit tests, which mocked the very call that was wrong. That is why a Docker-passing suite never noticed.

The new `rebuild` integration test changes a canary label between builds and reads it back off the image, the same assertion shape `upgrade-rebuilds-buildable` uses, and additionally asserts the command does not claim "nothing to rebuild" — the failure mode was a success report over skipped work, so the claim itself is worth asserting.

It runs on **both** lanes. The Podman lane had no rebuild leg precisely because of this bug; #1279's PR said as much.

## Verification

Ran locally against Docker end to end — `PASSED: rebuild`, with `Rebuilding: web` in the output confirming the enumeration found the service rather than silently finding nothing.

2094 unit tests pass, including new coverage for the podman format flag, the YAML parse, the profile args, and the non-zero exit on a failed enumeration. Two existing tests asserting `[]` on failure were updated to `None` — that contract change is deliberate. yamllint, ruff, and `validate_definitions.py` clean.

Timeouts unchanged: Core ran 14m35s against a 25-minute step budget and Podman 10m21s against 35, so one more test fits comfortably in both.