### PR TITLE
fix(create): clear id-mapped files before the rescue removes the directory

### DIFF
--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -57,6 +57,43 @@
         - (orchestrator | default('compose')) in ['kubernetes', 'k8s']
       ignore_errors: true  # Best-effort cleanup on failure
 
+    # Rootless Podman maps the container's root to a subuid, so files the
+    # containers wrote into the instance directory are owned by that
+    # subuid. The `file` module below removes them from this process's
+    # namespace and gets EACCES, leaving a directory the operator cannot
+    # delete either — and a non-empty one blocks the next create. Clear
+    # them from inside the namespace first; `file` then finds only what
+    # it can remove. Same approach delete takes.
+    - name: Detect rootless Podman before cleaning up
+      ansible.builtin.command:
+        cmd: podman info --format {% raw %}{{.Host.Security.Rootless}}{% endraw %}
+      register: _create_podman_rootless
+      changed_when: false
+      failed_when: false
+      when:
+        - instance_path is defined
+        - not (keep_config | default(false) | bool)
+        - instance_dir_was_created | default(false) | bool
+        - inspect_command | default('docker') is search('podman')
+
+    # Guarded like delete's equivalent: an absolute path of non-trivial
+    # length, so a corrupted registry or unset variable cannot turn this
+    # into a destructive `find -delete` near the filesystem root.
+    - name: Clean up on failure (remove id-mapped files)
+      ansible.builtin.command:
+        cmd: >-
+          podman unshare find {{ instance_path | quote }} -mindepth 1 -delete
+        chdir: "/"
+      changed_when: true
+      when:
+        - instance_path is defined
+        - not (keep_config | default(false) | bool)
+        - instance_dir_was_created | default(false) | bool
+        - (_create_podman_rootless.stdout | default('') | trim) == 'true'
+        - instance_path | default('') | length > 5
+        - instance_path | default('') is match('^/')
+      ignore_errors: true  # Best-effort cleanup on failure
+
     # Only remove the directory if this run created it. A pre-existing
     # directory (e.g., the operator was using it as a staging area for
     # an upgrade) belongs to the operator and must not be deleted.

--- a/tests/unit/test_create_rescue_removes_id_mapped_files.py
+++ b/tests/unit/test_create_rescue_removes_id_mapped_files.py
@@ -1,0 +1,93 @@
+"""A failed create must not leave an undeletable instance directory.
+
+Under rootless Podman the containers write through a user-namespace id
+map, so files they create in the instance directory are owned by a
+subuid. `ansible.builtin.file: state: absent` removes from this
+process's namespace and gets EACCES, so the rescue that exists to leave
+no trace instead leaves a directory the operator cannot delete either --
+and a non-empty directory blocks the next create.
+
+`podman unshare` enters the namespace where those ids map back. delete
+already does this (#1267); create's rescue is the counterpart.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+CREATE = os.path.join(REPO_ROOT, "playbooks", "create.yml")
+
+
+def _rescue_tasks():
+    with open(CREATE) as f:
+        doc = yaml.safe_load(f)
+    for play in doc:
+        if isinstance(play, dict) and "rescue" in play:
+            return play["rescue"]
+    raise AssertionError("create.yml has no rescue block")
+
+
+def _task(substring):
+    for t in _rescue_tasks():
+        if substring in str(t.get("name", "")):
+            return t
+    return None
+
+
+class TestRescueClearsIdMappedFiles:
+    def test_it_unshares_before_removing(self):
+        purge = _task("remove id-mapped files")
+        assert purge is not None, (
+            "create's rescue must clear id-mapped files, or a failed "
+            "create on rootless Podman strands an undeletable directory"
+        )
+        assert "podman unshare" in str(purge["ansible.builtin.command"]["cmd"]), (
+            "removal has to happen inside the user namespace"
+        )
+
+    def test_it_runs_before_the_directory_removal(self):
+        names = [str(t.get("name", "")) for t in _rescue_tasks()]
+        purge = next(i for i, n in enumerate(names) if "id-mapped files" in n)
+        remove = next(i for i, n in enumerate(names) if "remove directory" in n)
+        assert purge < remove, (
+            "the id-mapped files must go first; otherwise `file: state: "
+            "absent` still hits EACCES and the directory survives"
+        )
+
+    def test_it_only_fires_for_rootless_podman(self):
+        conditions = [str(c) for c in _task("remove id-mapped files")["when"]]
+        assert any("_create_podman_rootless" in c for c in conditions), (
+            "gated on the rootless probe, so Docker is untouched"
+        )
+
+    def test_the_probe_is_gated_on_a_podman_runtime(self):
+        conditions = [str(c) for c in _task("Detect rootless Podman")["when"]]
+        assert any("inspect_command" in c and "podman" in c
+                   for c in conditions), (
+            "do not shell out to `podman info` on a Docker host"
+        )
+
+
+class TestRescuePurgeIsGuardedLikeDelete:
+    """`find -delete` on a bad path is unrecoverable, so guard it."""
+
+    def test_it_requires_a_nontrivial_absolute_path(self):
+        conditions = [str(c) for c in _task("remove id-mapped files")["when"]]
+        assert any("length > 5" in c for c in conditions), (
+            "a short path could be a corrupted registry or unset variable"
+        )
+        assert any("match('^/')" in c for c in conditions), (
+            "relative paths would resolve against an unexpected cwd"
+        )
+
+    def test_it_still_respects_the_operators_directory(self):
+        conditions = [str(c) for c in _task("remove id-mapped files")["when"]]
+        assert any("instance_dir_was_created" in c for c in conditions), (
+            "a pre-existing directory belongs to the operator; the rescue "
+            "must not empty one this run did not create"
+        )
+        assert any("keep_config" in c for c in conditions), (
+            "--keep-config must suppress the purge as it does the removal"
+        )


### PR DESCRIPTION
Fixes #1282.

A failed `canasta create` on rootless Podman left behind an instance directory the operator could not delete:

```
[ERROR]: Task failed: Module failed: rmtree failed: [Errno 13] Permission denied:
'/tmp/canasta-int-work-gij7xuuf/inttest-lifecycle/config'
Origin: playbooks/create.yml:63:7
```

Under rootless Podman the containers write through a user-namespace id map, so files they create are owned by a subuid. `ansible.builtin.file: state: absent` removes from this process's namespace and gets EACCES. The rescue that exists to leave no trace instead leaves a directory that blocks the next attempt, since `create` refuses to enter a non-empty target.

## Change

Clear the id-mapped files from inside the namespace with `podman unshare` first; the existing `file: state: absent` then finds only what it can remove. That keeps the change additive — the actual removal, and its "only if this run created the directory" rule, are untouched.

`delete` already solves the identical problem this way (#1267), so this is the `create`-rescue counterpart rather than a new approach.

Guarded the same way delete's equivalent is: gated on the rootless probe so Docker never shells out to `podman info`, and requiring a non-trivial absolute path in addition to the existing `keep_config` / `instance_dir_was_created` conditions — `find -delete` on a path from a corrupted registry is unrecoverable.

## Verification and its limits

Worth being straight about this one: it lands with weaker evidence than the other Podman fixes.

It is a failure-path bug — only reachable when a create has *already* failed, which no longer happens on the happy path now that #1283 is in. CI cannot assert it without deliberately breaking a create, and even then only the Podman lane would exercise the branch at all. So there is no green run proving it end to end.

What it does have: 2096 unit tests pass, `ansible-playbook --syntax-check` passes on the create path, yamllint is clean, and `tests/unit/test_create_rescue_removes_id_mapped_files.py` pins the behavior structurally — that the purge exists, uses `podman unshare`, runs *before* the directory removal (otherwise `file` still hits EACCES), fires only for rootless Podman, and keeps every guard.

The strongest argument for correctness is the #1267 precedent: the same problem, the same mechanism, already solved and shipped for `delete`.

## How it was found

The Podman CI lane from #1279, sitting behind #1281 in the first failing run.