### PR TITLE
fix(start): drive the healthcheck on Podman instead of skipping the gate

### DIFF
--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -198,6 +198,53 @@
         - _start_web_cid.stdout | trim != ''
         - _start_web_has_health.stdout | default('') | trim != ''
 
+    # Podman inherits the image's healthcheck but never runs it under
+    # podman-compose: it schedules checks with systemd transient timers
+    # that compose does not create, so .State.Health.Status stays empty
+    # and the wait above is skipped for every container. Skipping it is
+    # right for a custom image that declares no healthcheck, and wrong
+    # here — it restores the composer race the gate exists to prevent.
+    # `podman healthcheck run` executes the configured check on demand,
+    # so poll that instead of a status nothing updates.
+    - name: Probe whether web defines a healthcheck (Podman)
+      ansible.builtin.command:
+        argv:
+          - "{{ _inspect_cmd }}"
+          - healthcheck
+          - run
+          - "{{ _start_web_cid.stdout | trim }}"
+      register: _start_web_hc_probe
+      changed_when: false
+      failed_when: false
+      when:
+        - _start_web_cid.stdout | trim != ''
+        - (_start_web_has_health.stdout | default('') | trim) == ''
+        - _inspect_cmd | default('docker') is search('podman')
+
+    # Same budget as the Docker path: 60 × 10s, over the healthcheck's
+    # 5 min start period plus a slow first composer install. A container
+    # with no healthcheck at all must skip rather than spend that budget
+    # failing, and podman distinguishes the two cases in its message.
+    - name: Wait for web to pass its healthcheck (Podman)
+      ansible.builtin.command:
+        argv:
+          - "{{ _inspect_cmd }}"
+          - healthcheck
+          - run
+          - "{{ _start_web_cid.stdout | trim }}"
+      register: _start_web_podman_health
+      changed_when: false
+      retries: 60
+      delay: 10
+      until: _start_web_podman_health.rc == 0
+      when:
+        - _start_web_cid.stdout | trim != ''
+        - (_start_web_has_health.stdout | default('') | trim) == ''
+        - _inspect_cmd | default('docker') is search('podman')
+        - >-
+          'no defined healthcheck'
+          not in (_start_web_hc_probe.stderr | default(''))
+
     # Register CAPI + auto-enroll the bouncer when CrowdSec is on. Shared
     # with the K8s start path and create. crowdsec_autoenroll is false only
     # for create's first start, which defers enrollment until after the

--- a/tests/unit/test_start_health_gate_probe.py
+++ b/tests/unit/test_start_health_gate_probe.py
@@ -96,3 +96,68 @@ class TestHealthWaitIsGatedOnANonEmptyStatus:
             "the gate must still wait for 'healthy' — it exists to stop "
             "install.php racing composer"
         )
+
+
+class TestPodmanDrivesTheHealthcheck:
+    """Skipping the gate on Podman is not an option -- it must be driven.
+
+    Podman inherits the image's healthcheck but never runs it under
+    podman-compose: checks are scheduled with systemd transient timers
+    that compose does not create, so `.State.Health.Status` stays empty
+    for every container and the Docker-shaped wait is always skipped.
+
+    That left Podman with no readiness gate at all, and `create` raced
+    composer -- install.php crashing on a half-written vendor/ is the
+    exact failure the gate exists to prevent. `podman healthcheck run`
+    executes the check on demand, so the loop polls that instead.
+    """
+
+    def test_a_podman_wait_exists(self):
+        wait = _task("Wait for web to pass its healthcheck (Podman)")
+        assert wait is not None, (
+            "Podman needs its own readiness wait; without one the gate is "
+            "skipped for every container and create races composer"
+        )
+        argv = " ".join(str(a) for a in wait["ansible.builtin.command"]["argv"])
+        assert "healthcheck" in argv and "run" in argv, (
+            "poll `podman healthcheck run`, which executes the check, "
+            "rather than a status field nothing updates"
+        )
+
+    def test_it_waits_for_success_not_a_status_string(self):
+        wait = _task("Wait for web to pass its healthcheck (Podman)")
+        assert "rc == 0" in str(wait.get("until", "")), (
+            "healthcheck run signals health through its exit code"
+        )
+
+    def test_it_gets_the_same_budget_as_the_docker_path(self):
+        wait = _task("Wait for web to pass its healthcheck (Podman)")
+        docker = _task("Wait for web container to report healthy")
+        assert wait.get("retries") == docker.get("retries")
+        assert wait.get("delay") == docker.get("delay"), (
+            "the healthcheck's 5 min start period applies on both runtimes"
+        )
+
+    def test_it_only_runs_when_no_status_is_reported(self):
+        conditions = [
+            str(c) for c
+            in _task("Wait for web to pass its healthcheck (Podman)")["when"]
+        ]
+        assert any("_start_web_has_health" in c and "== ''" in c
+                   for c in conditions), (
+            "when the runtime does report a status, the existing wait "
+            "handles it -- do not run the check twice"
+        )
+        assert any("podman" in c for c in conditions), (
+            "Docker reports a real status and must keep its own path"
+        )
+
+    def test_a_custom_image_without_a_healthcheck_still_skips(self):
+        conditions = [
+            str(c) for c
+            in _task("Wait for web to pass its healthcheck (Podman)")["when"]
+        ]
+        assert any("no defined healthcheck" in c for c in conditions), (
+            "an image that declares no HEALTHCHECK must skip rather than "
+            "burn the full 10-minute budget failing a check that cannot pass"
+        )


### PR DESCRIPTION
Fixes #1296.

The post-merge run of #1292 on `main` failed with:

```
PHP Fatal error: Uncaught Error: Failed opening required
'/var/www/mediawiki/w/vendor/composer/../aws/aws-sdk-php/src/functions.php'
```

`install.php` ran while composer was still writing `vendor/` — the exact race the web health gate exists to prevent, which the comment above the gate names by symptom. In that job the gate was **skipped 7 times out of 7**: on Podman it was never entered at all.

## Cause

#1283 fixed the gate hanging for its full 60 × 10s on Podman 4.9.3, where `.State.Health` exists but `.Status` renders empty, by treating an empty render as "no health signal to wait on".

That is right for a custom image with no `HEALTHCHECK`. It is wrong for Podman, where the healthcheck *is* defined and simply never runs — Podman schedules checks with systemd transient timers that podman-compose does not create. So the signal was not missing, it was never triggered, and the fix skipped a gate that should have been driven.

The risk was written down in #1281 and left unresolved; this is that risk landing. It is intermittent — in the same job `lifecycle` and `upgrade-rebuilds-buildable` both created instances fine and only `upgrade` lost the race.

## Change

Poll `podman healthcheck run <container>`, which executes the configured check on demand, and gate on its exit code. Same 60 × 10s budget as the Docker path, covering the healthcheck's 5-minute start period plus a slow first composer install.

A container that genuinely declares no healthcheck still skips, keyed on podman's own "no defined healthcheck" message — without that, the custom-image case regains exactly the ten-minute hang #1283 removed.

## Verification

Docker is untouched: both new tasks are gated on a podman inspect command. Confirmed by a local `lifecycle` run against Docker, where the log shows the original gate doing real work and the new task skipped —

```
TASK [orchestrator : Wait for web container to report healthy]
FAILED - RETRYING: ... (59 retries left).
TASK [orchestrator : Wait for web to pass its healthcheck (Podman)]
skipping: [localhost]
```

`PASSED: lifecycle`. 2099 unit tests pass, yamllint and `validate_definitions.py` clean. `tests/unit/test_start_health_gate_probe.py` gains five guards: the Podman wait exists, it polls `healthcheck run`, it keys on the exit code, it gets the same retry budget as Docker, it only fires when no status is reported, and a healthcheck-less image still skips.

The Podman half needs the lane to confirm — and the honest test is repeated runs, since the bug it fixes is a race that passed three creates out of four.