### PR TITLE
test(validate): hold every documented example to the CLI's own parser

### DIFF
--- a/scripts/cli_examples.py
+++ b/scripts/cli_examples.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Parse `canasta ...` example invocations against the command definitions.
+
+Two checkers read examples and hold them to the same CLI:
+validate_definitions.py for the `examples:` in command_definitions.yml,
+and validate_wiki_examples.py for the fenced shell blocks on
+canasta.wiki. Both have to tokenize an invocation the same way, so the
+tokenizer lives here rather than in two copies that drift.
+"""
+
+import re
+import shlex
+
+# Positionals that swallow everything after them: whatever follows is
+# passed to another program (php, a maintenance script), so its flags
+# are not ours to validate.
+PASSTHROUGH_POSITIONALS = ("exec_args", "script_args")
+
+# What `tokenize` substitutes for <domain>, <NODE1_IP> and friends. A
+# caller checking values has to let it through — it stands in for a
+# value the author deliberately left for the reader to fill in.
+PLACEHOLDER = "PLACEHOLDER"
+
+INVOCATION = re.compile(r"^(?:sudo\s+)?canasta(?:-native|-docker)?(?:\s|$)")
+
+
+def canasta_segment(text):
+    """The `canasta ...` part of a shell line, or None.
+
+    Handles a `$ ` prompt and compound lines: the invocation is not
+    always the first thing on the line (`cd /path && canasta delete`),
+    and anything downstream of a pipe is another program.
+    """
+    text = re.sub(r"^\s*\$\s+", "", text.strip())
+    for segment in re.split(r"\|\||&&|[|;]", text):
+        segment = segment.strip()
+        if INVOCATION.match(segment):
+            return segment
+    return None
+
+
+def tokenize(line):
+    """Split a shell example into argv, or None if it cannot be parsed.
+
+    Placeholders (<domain>, <NODE1_IP>) become a literal so shlex does
+    not choke, and only the first command of a pipeline is ours.
+    """
+    text = canasta_segment(line)
+    if text is None:
+        return None
+    text = re.sub(r"<[^>\s]*>", PLACEHOLDER, text)
+    text = re.sub(r"\s+#.*$", "", text)
+    try:
+        tokens = shlex.split(text)
+    except ValueError:
+        return None
+    tokens = [t for t in tokens if t != "sudo"]
+    return tokens[1:] if tokens else None  # drop the `canasta` itself
+
+
+def build_command_table(definitions):
+    """Map a tuple of CLI tokens -> command definition.
+
+    Group commands are stored as `group_sub`, and a group name may
+    itself contain an underscore (`storage_setup`), so the group has to
+    be matched longest-first before the remainder is treated as the
+    subcommand.
+    """
+    groups = sorted(
+        (g["name"] for g in definitions.get("command_groups", [])),
+        key=len, reverse=True,
+    )
+    table = {}
+    for command in definitions["commands"]:
+        name = command["name"]
+        for group in groups:
+            if name.startswith(group + "_"):
+                sub = name[len(group) + 1:].replace("_", "-")
+                table[tuple(group.split("_") + [sub])] = command
+                break
+        else:
+            table[(name.replace("_", "-"),)] = command
+    return table
+
+
+def resolve_command(tokens, table):
+    """Return (command, remaining tokens), or (None, None) if unknown.
+
+    Longest match first: `storage setup s3` has to win over any shorter
+    prefix that also names a command.
+    """
+    for width in (3, 2, 1):
+        if tuple(tokens[:width]) in table:
+            return table[tuple(tokens[:width])], tokens[width:]
+    return None, None

--- a/scripts/validate_definitions.py
+++ b/scripts/validate_definitions.py
@@ -6,23 +6,117 @@ Checks:
 2. Every playbook file in playbooks/ has a corresponding command definition
 3. All required fields are present in each command definition
 4. Parameter types are valid
+5. Every `examples:` entry is an invocation the CLI would accept
 
 Usage:
     python scripts/validate_definitions.py
 """
 
 import os
+import re
 import sys
 
 import yaml
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import cli_examples  # noqa: E402
+
 
 VALID_TYPES = {"string", "path", "bool", "choice", "integer"}
+SHORT_FLAG = re.compile(r"^-[A-Za-z]$")
 # A command must have either a playbook or direct_only: true — not both,
 # not neither. 'playbook' is conditional, so it's not in the unconditional
 # required-fields set; its presence is enforced separately below.
 REQUIRED_CMD_FIELDS = {"name", "description", "parameters"}
 REQUIRED_PARAM_FIELDS = {"name", "type", "description"}
+
+
+def flag_table(command, definitions):
+    """Map flag spelling -> parameter, plus the positionals in order."""
+    longs, shorts, positionals = {}, {}, []
+    for param in command.get("parameters") or []:
+        if param.get("positional"):
+            positionals.append(param)
+            continue
+        # `long:` overrides the flag spelling (host_name -> --name).
+        longs["--" + (param.get("long") or param["name"]).replace("_", "-")] = param
+        if param.get("short"):
+            shorts["-" + param["short"]] = param
+    for param in definitions.get("global_flags") or []:
+        longs["--" + param["name"].replace("_", "-")] = param
+        if param.get("short"):
+            shorts["-" + param["short"]] = param
+    return longs, shorts, positionals
+
+
+def check_choices(param, value, label):
+    """Errors if `value` is one a `choices:` list would reject."""
+    choices = param.get("choices")
+    if not choices or value is None or value == cli_examples.PLACEHOLDER:
+        return []
+    if value in choices:
+        return []
+    return ["%s: '%s' is not one of %s" % (label, value, ", ".join(choices))]
+
+
+def check_example(command, example, table, definitions):
+    """Errors for one `examples:` entry the CLI would refuse to parse.
+
+    The examples also feed the generated command reference, so an
+    invocation that argparse rejects ships as published documentation.
+    Walking the tokens has to track which flags take a value, because
+    otherwise a flag's value is indistinguishable from a positional.
+    """
+    tokens = cli_examples.tokenize(example)
+    if not tokens:
+        if cli_examples.canasta_segment(example) is None:
+            return ["not a canasta invocation"]
+        return ["cannot be parsed as a shell command line"]
+
+    invoked, rest = cli_examples.resolve_command(tokens, table)
+    if invoked is None:
+        return ["unknown command: %s" % " ".join(tokens[:3])]
+    if invoked is not command:
+        return ["invokes '%s'" % invoked["name"]]
+
+    longs, shorts, positionals = flag_table(command, definitions)
+    errors = []
+    index, next_positional = 0, 0
+    while index < len(rest):
+        token = rest[index]
+        index += 1
+        if token == "--":
+            break  # everything after is passed through verbatim
+
+        if token.startswith("--") or SHORT_FLAG.match(token):
+            flag, sep, inline = token.partition("=")
+            param = longs.get(flag) if flag.startswith("--") else shorts.get(flag)
+            if param is None:
+                # Without the parameter there is no telling whether the
+                # next token is its value, so stop rather than guess.
+                errors.append("unknown flag: %s" % flag)
+                break
+            if param.get("type") == "bool":
+                continue
+            value = inline if sep else None
+            if value is None and index < len(rest):
+                value = rest[index]
+                index += 1
+            errors.extend(check_choices(param, value, flag))
+            continue
+
+        if next_positional >= len(positionals):
+            errors.append("extra argument: %s" % token)
+            break
+        param = positionals[next_positional]
+        if param["name"] in cli_examples.PASSTHROUGH_POSITIONALS:
+            break  # the rest is another program's command line
+        errors.extend(check_choices(param, token, param["name"]))
+        # A multi positional keeps consuming; a single one is now filled.
+        if not param.get("multi"):
+            next_positional += 1
+
+    return errors
 
 
 def main():
@@ -39,6 +133,8 @@ def main():
 
     # Collect defined playbook names
     defined_playbooks = set()
+    table = cli_examples.build_command_table(data)
+    example_count = 0
 
     for i, cmd in enumerate(commands):
         prefix = "commands[%d] (%s)" % (i, cmd.get("name", "?"))
@@ -86,6 +182,12 @@ def main():
             if ptype == "choice" and not param.get("choices"):
                 errors.append("%s: type 'choice' requires 'choices' list" % ppfx)
 
+        # Check the documented examples actually parse
+        for example in cmd.get("examples") or []:
+            example_count += 1
+            for problem in check_example(cmd, example, table, data):
+                errors.append("%s: example '%s': %s" % (prefix, example, problem))
+
     # Check for orphan playbooks (files with no matching definition)
     if os.path.isdir(playbooks_dir):
         for fname in sorted(os.listdir(playbooks_dir)):
@@ -106,8 +208,8 @@ def main():
             print("  - %s" % e, file=sys.stderr)
         sys.exit(1)
     else:
-        print("Validation passed: %d commands, %d playbooks" % (
-            len(commands), len(defined_playbooks)))
+        print("Validation passed: %d commands, %d playbooks, %d examples" % (
+            len(commands), len(defined_playbooks), example_count))
 
 
 if __name__ == "__main__":

--- a/scripts/validate_wiki_examples.py
+++ b/scripts/validate_wiki_examples.py
@@ -25,7 +25,6 @@ exist.
 import argparse
 import os
 import re
-import shlex
 import sys
 import urllib.error
 import urllib.parse
@@ -35,6 +34,13 @@ import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import wiki_http  # noqa: E402
+
+# The tokenizer is shared with validate_definitions.py, which holds the
+# `examples:` in command_definitions.yml to the same CLI.
+from cli_examples import (  # noqa: E402
+    PASSTHROUGH_POSITIONALS, build_command_table, canasta_segment,
+    resolve_command, tokenize,
+)
 
 DEFAULT_API = "https://canasta.wiki/w/api.php"
 HELP_NAMESPACE = 12
@@ -50,33 +56,11 @@ DEFINITIONS_PATH = os.path.join(
     "meta", "command_definitions.yml",
 )
 
-# Positionals that swallow everything after them: whatever follows is
-# passed to another program (php, a maintenance script), so its flags
-# are not ours to validate.
-PASSTHROUGH_POSITIONALS = ("exec_args", "script_args")
-
 SHELL_BLOCK = re.compile(
     r"<syntaxhighlight\b[^>]*\blang=\"(?:bash|sh|shell|console)\"[^>]*>"
     r"(.*?)</syntaxhighlight>",
     re.DOTALL | re.IGNORECASE,
 )
-
-INVOCATION = re.compile(r"^(?:sudo\s+)?canasta(?:-native|-docker)?(?:\s|$)")
-
-
-def canasta_segment(text):
-    """The `canasta ...` part of a shell line, or None.
-
-    Handles a `$ ` prompt and compound lines: the invocation is not
-    always the first thing on the line (`cd /path && canasta delete`),
-    and anything downstream of a pipe is another program.
-    """
-    text = re.sub(r"^\s*\$\s+", "", text.strip())
-    for segment in re.split(r"\|\||&&|[|;]", text):
-        segment = segment.strip()
-        if INVOCATION.match(segment):
-            return segment
-    return None
 
 
 # --- Command table -----------------------------------------------------
@@ -85,31 +69,6 @@ def canasta_segment(text):
 def load_definitions(path=DEFINITIONS_PATH):
     with open(path) as f:
         return yaml.safe_load(f)
-
-
-def build_command_table(definitions):
-    """Map a tuple of CLI tokens -> command definition.
-
-    Group commands are stored as `group_sub`, and a group name may
-    itself contain an underscore (`storage_setup`), so the group has to
-    be matched longest-first before the remainder is treated as the
-    subcommand.
-    """
-    groups = sorted(
-        (g["name"] for g in definitions.get("command_groups", [])),
-        key=len, reverse=True,
-    )
-    table = {}
-    for command in definitions["commands"]:
-        name = command["name"]
-        for group in groups:
-            if name.startswith(group + "_"):
-                sub = name[len(group) + 1:].replace("_", "-")
-                table[tuple(group.split("_") + [sub])] = command
-                break
-        else:
-            table[(name.replace("_", "-"),)] = command
-    return table
 
 
 def flag_spec(command, definitions):
@@ -166,25 +125,6 @@ def iter_shell_lines(wikitext):
                 yield first_line + offset, text
 
 
-def tokenize(line):
-    """Split a shell example into argv, or None if it cannot be parsed.
-
-    Placeholders (<domain>, <NODE1_IP>) become a literal so shlex does
-    not choke, and only the first command of a pipeline is ours.
-    """
-    text = canasta_segment(line)
-    if text is None:
-        return None
-    text = re.sub(r"<[^>\s]*>", "PLACEHOLDER", text)
-    text = re.sub(r"\s+#.*$", "", text)
-    try:
-        tokens = shlex.split(text)
-    except ValueError:
-        return None
-    tokens = [t for t in tokens if t != "sudo"]
-    return tokens[1:] if tokens else None  # drop the `canasta` itself
-
-
 # --- Validation --------------------------------------------------------
 
 
@@ -204,12 +144,7 @@ class Finding:
 
 def validate_example(tokens, table, definitions):
     """Return (kind, detail) for the first problem found, else None."""
-    command = rest = None
-    for width in (3, 2, 1):
-        if tuple(tokens[:width]) in table:
-            command = table[tuple(tokens[:width])]
-            rest = tokens[width:]
-            break
+    command, rest = resolve_command(tokens, table)
     if command is None:
         return "unknown command:", " ".join(tokens[:2]) or "(empty)"
 

--- a/tests/unit/test_validate_definitions.py
+++ b/tests/unit/test_validate_definitions.py
@@ -22,6 +22,124 @@ class TestValidateMain:
             )
 
 
+class TestExampleChecks:
+    """A documented example has to be an invocation the CLI accepts.
+
+    The examples feed the generated command reference, so one that
+    argparse rejects ships as published documentation. The case that
+    got through: `install` gained a `podman` example and a `podman`
+    mention in three descriptions, but not in the `choices:` list that
+    is actually enforced.
+    """
+
+    INSTALL = {
+        "name": "install",
+        "description": "Install dependencies",
+        "playbook": "install.yml",
+        "parameters": [
+            {"name": "host", "type": "string", "short": "H",
+             "description": "Target host"},
+            {"name": "verbose_output", "type": "bool", "long": "loud",
+             "description": "Chatter"},
+            {"name": "packages", "type": "string", "description": "Packages",
+             "positional": True, "multi": True,
+             "choices": ["docker", "sops", "canasta"]},
+        ],
+    }
+    CREATE = {
+        "name": "create",
+        "description": "Create an instance",
+        "playbook": "create.yml",
+        "parameters": [
+            {"name": "id", "type": "string", "short": "i", "description": "ID"},
+            {"name": "orchestrator", "type": "choice",
+             "choices": ["compose", "k8s"], "description": "Orchestrator"},
+        ],
+    }
+
+    def _defs(self):
+        return {"commands": [self.INSTALL, self.CREATE], "command_groups": [],
+                "global_flags": [{"name": "verbose", "short": "v",
+                                  "type": "bool", "description": "Verbose"}]}
+
+    def _check(self, command, example):
+        import cli_examples
+        data = self._defs()
+        table = cli_examples.build_command_table(data)
+        return validate_definitions.check_example(command, example, table, data)
+
+    def test_positional_outside_choices_is_rejected(self):
+        errors = self._check(self.INSTALL, "canasta install podman")
+        assert errors and "'podman' is not one of" in errors[0]
+
+    def test_positional_in_choices_passes(self):
+        assert self._check(self.INSTALL, "canasta install docker") == []
+
+    def test_every_value_of_a_multi_positional_is_checked(self):
+        errors = self._check(self.INSTALL, "canasta install docker podman")
+        assert len(errors) == 1 and "'podman'" in errors[0]
+
+    def test_choice_flag_outside_choices_is_rejected(self):
+        errors = self._check(self.CREATE, "canasta create -i x --orchestrator nomad")
+        assert errors and "--orchestrator: 'nomad' is not one of" in errors[0]
+
+    def test_choice_flag_accepts_inline_value_form(self):
+        assert self._check(self.CREATE, "canasta create --orchestrator=k8s") == []
+
+    def test_flag_value_is_not_mistaken_for_a_positional(self):
+        # -H takes a value; 'prod1' must not be checked against packages.
+        assert self._check(self.INSTALL, "canasta install -H prod1 docker") == []
+
+    def test_bool_flag_does_not_consume_the_next_token(self):
+        errors = self._check(self.INSTALL, "canasta install --loud podman")
+        assert errors and "'podman' is not one of" in errors[0]
+
+    def test_global_flags_are_accepted(self):
+        assert self._check(self.INSTALL, "canasta install -v docker") == []
+
+    def test_unknown_flag_is_reported(self):
+        assert self._check(self.INSTALL, "canasta install --nope docker") == [
+            "unknown flag: --nope"
+        ]
+
+    def test_unknown_command_is_reported(self):
+        errors = self._check(self.INSTALL, "canasta instal docker")
+        assert errors and errors[0].startswith("unknown command:")
+
+    def test_example_listed_under_the_wrong_command_is_reported(self):
+        assert self._check(self.INSTALL, "canasta create -i x") == [
+            "invokes 'create'"
+        ]
+
+    def test_placeholder_values_are_not_checked(self):
+        # <package> is the author deferring to the reader, not a value.
+        assert self._check(self.INSTALL, "canasta install <package>") == []
+
+    def test_compound_line_is_unwrapped_before_checking(self):
+        errors = self._check(self.INSTALL, "cd /tmp && canasta install podman")
+        assert errors and "'podman' is not one of" in errors[0]
+
+    def test_real_examples_all_parse(self):
+        """Every example in the real definitions is a valid invocation."""
+        import cli_examples
+        repo_root = os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.abspath(__file__))
+        ))
+        with open(os.path.join(repo_root, "meta",
+                               "command_definitions.yml")) as f:
+            data = yaml.safe_load(f)
+        table = cli_examples.build_command_table(data)
+        offenders = []
+        for cmd in data["commands"]:
+            for example in cmd.get("examples") or []:
+                for problem in validate_definitions.check_example(
+                    cmd, example, table, data
+                ):
+                    offenders.append("%s: %s -- %s"
+                                     % (cmd["name"], example, problem))
+        assert not offenders, "\n  ".join([""] + offenders)
+
+
 class TestDirectOnlyInvariants:
     """Invariants that have to hold for 'direct_only: true' commands.
 


### PR DESCRIPTION
Closes #1293

## The gap

`make validate` never read the `examples:` in `meta/command_definitions.yml`. The only `choices`-related check was "`type: choice` requires a `choices:` list" — nothing compared a documented invocation against what argparse would actually accept.

That is how `canasta install podman` shipped as an example while `podman` was missing from the `choices:` list:

```
$ canasta install podman
canasta install: error: argument packages: invalid choice: 'podman'

$ make validate
Validation passed: 87 commands, 69 playbooks   # rc=0
```

Three of the four places naming the package agreed; the one that was enforced did not. The examples also feed the generated command reference, so the published docs carried invocations that could not work.

## The check

`check_example()` tokenizes each example and walks it against its own command:

- the invocation must resolve to the command it is listed under — catches typos and misfiled examples
- flags must exist, drawn from the command's parameters plus `global_flags`, honoring `long:` and `short:`
- any value supplied for a parameter carrying `choices:` must be a member of that list — both `type: choice` flags and positionals, single or `multi`

The walk has to track which flags take a value, or a flag's value is indistinguishable from a positional and `-H prod1 docker` would check `prod1` against the package list. `bool` params consume nothing, `--flag=value` is handled, `--` and the `exec_args`/`script_args` passthrough positionals stop the walk, and `<placeholder>` values are let through.

## Shared tokenizer

The tokenizer moves to `scripts/cli_examples.py` — `canasta_segment`, `tokenize`, `build_command_table`, `resolve_command` — shared with `validate_wiki_examples.py` rather than copied. Both hold examples to the same CLI, and two copies would drift. Same pattern as the existing `scripts/wiki_http.py`. `validate_wiki_examples.py` loses ~60 duplicated lines; its behavior is unchanged.

## Verification

Current definitions pass, and the summary line now reports the examples so it is visible the check ran:

```
Validation passed: 87 commands, 69 playbooks, 161 examples
```

Reproducing the reported scenario — dropping `podman` from `choices:` while leaving the examples in place — fails with rc=1:

```
Validation FAILED with 2 error(s):
  - commands[11] (install): example 'canasta install podman': packages: 'podman' is not one of docker, k8s-cp, k8s-worker, git-crypt, sops, canasta
  - commands[11] (install): example 'canasta install --host prod1.example.com podman': packages: 'podman' is not one of docker, k8s-cp, k8s-worker, git-crypt, sops, canasta
```

14 new tests cover each rejection mode plus the false-positive traps (flag values, bool flags, placeholders, compound `cd … && canasta …` lines), and one asserts every example in the real definitions parses. Full suite 2134 passed, up from 2120. `make lint` clean.

## Not included

The issue's adjacent suggestion — checking that `choices:` agrees with the package names the playbook dispatches on — is deliberately left out. `playbooks/install.yml` normalizes `k8s-cp` to `k3s` and `k8s-worker` to `k3s-worker` before any `when:` sees them, so a literal comparison would flag two valid choices as unhandled. Modeling that `regex_replace` chain is more machinery than one command justifies; happy to split it into its own issue.