### PR TITLE
fix: resolve the container runtime from the registry, not just .env

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -1481,12 +1481,24 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
             inst = resolve_instance(
                 getattr(args, "id", None)
             ) if os.path.isfile(get_config_file_path()) else {}
+            # The registry is on the controller, so it reads the same
+            # whatever host the instance runs on — unlike the .env below,
+            # and it is where create records the runtime it probed.
+            for _key, _field in (("compose_command", "composeCommand"),
+                                 ("inspect_command", "inspectCommand")):
+                reg_val = inst.get(_field)
+                if reg_val:
+                    extra_vars[_key] = reg_val
             path = inst.get("path", "")
             # The .env sits on the instance's host, so it is only
-            # readable from here when that host is this machine.
+            # readable from here when that host is this machine. Kept as
+            # a fallback for instances created before the registry
+            # carried the runtime fields.
             is_local = (inst.get("host") or "localhost") in ("localhost", "")
             if path and is_local and not host_value:
                 for _key in ("compose_command", "inspect_command"):
+                    if _key in extra_vars:
+                        continue
                     env_val = _read_env(path, _key)
                     if env_val:
                         extra_vars[_key] = env_val

--- a/tests/unit/test_registry_runtime_resolution.py
+++ b/tests/unit/test_registry_runtime_resolution.py
@@ -1,0 +1,154 @@
+"""The registry is where an instance's runtime is recorded — read it.
+
+build_ansible_args documented "a registry entry (composeCommand /
+inspectCommand) wins, then the instance's .env", but only ever read the
+.env. create records the probed runtime in the registry and does not
+write it to .env, so no extra-var was set and every Ansible task fell
+back to the play-scope default of `docker compose`:
+
+    $ canasta config set -i podtest RESTIC_REPOSITORY=...
+    Cannot connect to the Docker daemon at unix:///var/run/docker.sock.
+    (cmd: docker compose -f docker-compose.yml down)
+
+against a healthy rootless-Podman instance. Two paths had already been
+patched one at a time for the same reason — _upgrade_single.yml and
+roles/delete/tasks/main.yml — while 16 other task files using
+compose_command still inherited the default.
+
+The registry lives on the controller, so unlike the .env it reads the
+same for a remote instance.
+"""
+
+import json
+import os
+import sys
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+sys.path.insert(0, REPO_ROOT)
+
+import canasta  # noqa: E402
+
+PODMAN = {"composeCommand": "podman-compose", "inspectCommand": "podman"}
+
+
+def _registry(tmp_path, monkeypatch, **fields):
+    cfg = tmp_path / "cfg"
+    inst = tmp_path / "inst"
+    cfg.mkdir()
+    inst.mkdir()
+    record = {"path": str(inst), "orchestrator": "compose", "host": "localhost"}
+    record.update(fields)
+    (cfg / "conf.json").write_text(json.dumps({"Instances": {"demo": record}}))
+    monkeypatch.setenv("CANASTA_CONFIG_DIR", str(cfg))
+    return inst
+
+
+def _args(**kw):
+    class _A:
+        def __getattr__(self, name):
+            return None
+    a = _A()
+    a.verbose = False
+    for k, v in kw.items():
+        setattr(a, k, v)
+    return a
+
+
+def _definitions():
+    with open(os.path.join(REPO_ROOT, "meta", "command_definitions.yml")) as f:
+        return yaml.safe_load(f)
+
+
+def _extra_vars(argv):
+    path = argv[argv.index("-e") + 1].lstrip("@")
+    with open(path) as f:
+        return json.load(f)
+
+
+def _run(command="config_set", **kw):
+    return _extra_vars(canasta.build_ansible_args(
+        "ansible-playbook", command, _args(id="demo", **kw), _definitions()))
+
+
+class TestTheRegistryIsRead:
+    def test_compose_command_comes_from_the_registry(self, tmp_path,
+                                                     monkeypatch):
+        _registry(tmp_path, monkeypatch, **PODMAN)
+        assert _run()["compose_command"] == "podman-compose", (
+            "without this every Ansible task runs `docker compose` against "
+            "a podman instance"
+        )
+
+    def test_inspect_command_too(self, tmp_path, monkeypatch):
+        _registry(tmp_path, monkeypatch, **PODMAN)
+        assert _run()["inspect_command"] == "podman"
+
+    def test_it_applies_to_any_command(self, tmp_path, monkeypatch):
+        # The point of fixing this centrally: playbooks that never read
+        # the registry themselves still get the right runtime.
+        _registry(tmp_path, monkeypatch, **PODMAN)
+        for cmd in ("config_set", "reconcile", "backup_create"):
+            assert _run(cmd)["compose_command"] == "podman-compose", (
+                "%s still inherits the default runtime" % cmd
+            )
+
+
+class TestRemoteInstances:
+    def test_the_registry_is_read_for_a_remote_instance(self, tmp_path,
+                                                        monkeypatch):
+        # The .env fallback is local-only by necessity — it sits on the
+        # instance's host. The registry does not have that limitation.
+        _registry(tmp_path, monkeypatch, host="prod1.example.com", **PODMAN)
+        assert _run()["compose_command"] == "podman-compose"
+
+
+class TestPrecedence:
+    def test_the_registry_wins_over_env(self, tmp_path, monkeypatch):
+        inst = _registry(tmp_path, monkeypatch, **PODMAN)
+        (inst / ".env").write_text("compose_command=docker compose\n")
+        assert _run()["compose_command"] == "podman-compose", (
+            "the registry records what create actually probed; a stale "
+            ".env must not override it"
+        )
+
+    def test_env_still_covers_older_instances(self, tmp_path, monkeypatch):
+        # Instances created before the registry carried these fields.
+        inst = _registry(tmp_path, monkeypatch)
+        (inst / ".env").write_text("compose_command=podman-compose\n")
+        assert _run()["compose_command"] == "podman-compose"
+
+    def test_the_runtime_is_not_settable_from_the_cli(self):
+        # Which is why the registry can be read unconditionally: there is
+        # no operator-supplied value for it to trample. The guard in
+        # build_ansible_args is defensive only.
+        defs = _definitions()
+        declared = [
+            p["name"] for c in defs["commands"]
+            for p in c.get("parameters", [])
+            if p["name"] in ("compose_command", "inspect_command")
+        ]
+        assert declared == [], (
+            "a CLI flag for the runtime would outrank the registry and the "
+            "create_preflight probe both; resolution would need reordering"
+        )
+
+
+class TestNothingIsInventedWhenUnknown:
+    def test_no_runtime_recorded_injects_nothing(self, tmp_path, monkeypatch):
+        # The default belongs in vars/compose_runtime.yml, at a precedence
+        # create_preflight.yml's probe can still override — an extra-var
+        # here would silently outrank a probe that asked the target.
+        _registry(tmp_path, monkeypatch)
+        vars_ = _run()
+        assert "compose_command" not in vars_
+        assert "inspect_command" not in vars_
+
+    def test_a_partial_record_only_sets_what_it_has(self, tmp_path,
+                                                    monkeypatch):
+        _registry(tmp_path, monkeypatch, composeCommand="podman-compose")
+        vars_ = _run()
+        assert vars_["compose_command"] == "podman-compose"
+        assert "inspect_command" not in vars_


### PR DESCRIPTION
Fixes #1299

`canasta config set` fails on a healthy rootless-Podman instance:

```
$ canasta config set -i podtest RESTIC_REPOSITORY=/home/cicalese/podtest-backups
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
Error: The command exited with a non-zero return code. (cmd: docker compose -f docker-compose.yml down)
```

`build_ansible_args` documents its own intent at `canasta.py:1469`:

> Runtime resolution: a registry entry (composeCommand / inspectCommand) wins, then the instance's .env

The code only ever did the second half. `create` records the probed runtime in the registry and never writes it to `.env`, so on the affected instance:

```
.env compose_command/inspect_command:  absent
registry composeCommand:               podman-compose
```

No extra-var was set, and every Ansible task inherited the play-scope default from `vars/compose_runtime.yml` — `docker compose`. `roles/orchestrator/tasks/stop.yml:58` is correctly parameterized; it just never received the right value.

## This is the general form of two fixes already made

18 task files under `roles/` read `compose_command`. Exactly two resolved it from the registry, both patched individually after this same symptom — `playbooks/_upgrade_single.yml` (#1270) and `roles/delete/tasks/main.yml` (#1269). The remaining 16 inherited the default, which is why `config set` broke next.

Reading the registry here fixes `config`, `backup`, `devmode`, `maintenance`, `extension`/`skin`, `sitemap`, `reconcile` and `rebuild` at once, and would have pre-empted both earlier issues.

## Two properties worth noting

**Remote instances.** The registry is on the controller, so it resolves for a remote instance. The `.env` fallback cannot — that file sits on the instance's host — and stays gated to local instances, covering instances created before the registry carried these fields.

**Nothing is invented.** When the registry has no runtime recorded and there is no `.env` value, no extra-var is emitted. An extra-var outranks everything including `create_preflight.yml`'s runtime probe, so guessing here would silently override a probe that actually asked the target.

## Tests

`tests/unit/test_registry_runtime_resolution.py` — 9 tests exercising the real function against a temporary registry: the registry is read, it applies to any command (not just the two previously patched), it works for a remote instance, it wins over a stale `.env`, `.env` still covers older instances, and an unknown runtime injects nothing.

One test asserts that `compose_command` is **not** a declared CLI parameter. That is what makes it safe to read the registry unconditionally — there is no operator-supplied value to trample. If a flag were ever added, resolution would need reordering, and that test would say so.

`make test-unit` 2129 passed · `make lint` clean · `make validate` 87 commands, 69 playbooks.

## Verification

Unit-tested only so far — found during a Podman e2e on `main` at `45569f8` (podman 5.4.2 / podman-compose 1.3.0). Re-running `config set` against a live Podman instance is the real check; doing that next.