### PR TITLE
fix(install): check the target's OS, not the controller's

### DIFF
--- a/roles/install/tasks/docker.yml
+++ b/roles/install/tasks/docker.yml
@@ -18,12 +18,22 @@
     _install_user: >-
       {{ ansible_user | default(_install_user_cmd.stdout, true) }}
 
+# Read the OS from the target. The play runs with gather_facts: false and
+# this role gathers facts further down, so ansible_system is undefined
+# here — and a lookup() fallback would run on the controller, refusing a
+# Linux target whenever the operator drives it from a Mac.
+- name: Determine target OS
+  ansible.builtin.command: uname -s
+  become: false
+  changed_when: false
+  register: _target_uname
+
 - name: Warn on unsupported platforms
   ansible.builtin.fail:
     msg: >-
       'canasta install docker' is for Linux servers only. On macOS or
       Windows, install Docker Desktop from https://www.docker.com/products/docker-desktop/
-  when: ansible_system | default(lookup('pipe', 'uname -s')) not in ['Linux']
+  when: _target_uname.stdout | trim not in ['Linux']
 
 - name: Check if Docker is already installed
   ansible.builtin.command:

--- a/roles/install/tasks/podman.yml
+++ b/roles/install/tasks/podman.yml
@@ -23,11 +23,21 @@
     _install_user: >-
       {{ ansible_user | default(_install_user_cmd.stdout, true) }}
 
+# Read the OS from the target. The play runs with gather_facts: false and
+# this role gathers facts further down, so ansible_system is undefined
+# here — and a lookup() fallback would run on the controller, refusing a
+# Linux target whenever the operator drives it from a Mac.
+- name: Determine target OS
+  ansible.builtin.command: uname -s
+  become: false
+  changed_when: false
+  register: _target_uname
+
 - name: Fail on unsupported platforms
   ansible.builtin.fail:
     msg: >-
       'canasta install podman' is for Linux servers only.
-  when: ansible_system | default(lookup('pipe', 'uname -s')) not in ['Linux']
+  when: _target_uname.stdout | trim not in ['Linux']
 
 - name: Check if podman is already installed
   ansible.builtin.command:

--- a/tests/unit/test_install_platform_guard.py
+++ b/tests/unit/test_install_platform_guard.py
@@ -1,0 +1,95 @@
+"""`canasta install` must judge the target's OS, not the controller's.
+
+The play runs with `gather_facts: false` (canasta.yml) and these roles
+gather facts further down, inside their install blocks — so
+`ansible_system` is undefined where the platform guard sits. The old
+fallback, `lookup('pipe', 'uname -s')`, runs on the *controller*, so
+driving a Linux target from a Mac produced:
+
+    Error: 'canasta install podman' is for Linux servers only.
+
+The failure also inverts the intent: from a Linux controller the guard
+passes no matter what the target runs, which is the case it exists to
+catch.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+TASKS = os.path.join(REPO_ROOT, "roles", "install", "tasks")
+GUARDED = ("docker.yml", "podman.yml")
+
+
+def _tasks(name):
+    with open(os.path.join(TASKS, name)) as f:
+        return [t for t in (yaml.safe_load(f) or []) if isinstance(t, dict)]
+
+
+def _names(name):
+    return [str(t.get("name", "")) for t in _tasks(name)]
+
+
+def _guard(name):
+    return next(
+        (t for t in _tasks(name)
+         if "unsupported platforms" in str(t.get("name", ""))), None)
+
+
+def _probe(name):
+    return next(
+        (t for t in _tasks(name)
+         if "Determine target OS" in str(t.get("name", ""))), None)
+
+
+class TestTheGuardDoesNotConsultTheController:
+    def test_no_lookup_in_the_condition(self):
+        for name in GUARDED:
+            when = str(_guard(name).get("when", ""))
+            assert "lookup(" not in when, (
+                "%s decides on the controller's OS, so a Mac operator "
+                "cannot install to a Linux host" % name
+            )
+
+    def test_it_does_not_rely_on_ungathered_facts(self):
+        # ansible_system is not available at this point in the file.
+        for name in GUARDED:
+            assert "ansible_system" not in str(_guard(name).get("when", ""))
+
+
+class TestTheOSComesFromTheTarget:
+    def test_a_probe_task_exists(self):
+        for name in GUARDED:
+            assert _probe(name), "%s never asks the target its OS" % name
+
+    def test_the_probe_runs_on_the_target(self):
+        # ansible.builtin.command runs on the target; lookup/pipe does not.
+        for name in GUARDED:
+            assert "ansible.builtin.command" in _probe(name)
+            assert "uname" in str(_probe(name)["ansible.builtin.command"])
+
+    def test_the_probe_does_not_escalate(self):
+        for name in GUARDED:
+            assert _probe(name).get("become") is False, (
+                "reading the OS needs no root, and requiring it would fail "
+                "before the guard could give a useful message"
+            )
+
+    def test_the_guard_uses_the_probe(self):
+        for name in GUARDED:
+            assert "_target_uname" in str(_guard(name).get("when", ""))
+
+    def test_the_probe_precedes_the_guard(self):
+        for name in GUARDED:
+            names = _names(name)
+            probe_at = names.index("Determine target OS")
+            guard_at = next(
+                i for i, n in enumerate(names) if "unsupported platforms" in n)
+            assert probe_at < guard_at
+
+    def test_the_comparison_tolerates_whitespace(self):
+        # command stdout carries a trailing newline.
+        for name in GUARDED:
+            assert "trim" in str(_guard(name).get("when", ""))


### PR DESCRIPTION
Fixes #1300

`canasta install` refuses a Linux target when the controller is macOS:

```
$ canasta install -H big.acknowledge.wiki podman
Error: 'canasta install podman' is for Linux servers only.
```

`big` is Debian 13:

```
controller uname: Darwin
big uname:        Linux
```

## Cause

```yaml
when: ansible_system | default(lookup('pipe', 'uname -s')) not in ['Linux']
```

`canasta.yml:12` sets `gather_facts: false`, and both roles gather facts further down — `docker.yml:49`, `podman.yml:53` — inside their install blocks, well after the guard. So `ansible_system` is undefined and the fallback always wins. `lookup()` runs on the **controller**, so a Mac operator is refused regardless of what the target runs.

The logic is also inverted from its intent: from a Linux controller it passes whatever the target is, which is the case it was written to catch.

## Not new, and not limited to podman

`docker.yml` has carried this line since #197, so `canasta install docker` from a macOS controller has never worked either. `podman.yml` inherited the pattern in #1285. Both are fixed here — same defect, same remedy, so one change rather than two.

Fix is to probe `uname -s` on the target, which matches how these files already read `id -un`, and needs no `become`.

## Verified end to end

Against a host with no podman installed, using this branch:

```
Installing Podman + podman-compose...
Enabling lingering and lowering unprivileged port floor...
Podman installed and configured. Rootless prerequisites were configured.
```

```
podman:          absent  ->  5.4.2
podman-compose:  absent  ->  1.3.0
port floor:      1024    ->  80
lingering:       no      ->  yes
persist file:    absent  ->  present
```

That is also the first exercise of `podman.yml`'s apt branch anywhere — every prior test ran against a host that already had podman.

## Tests

`tests/unit/test_install_platform_guard.py` — 8 tests over both files: no `lookup()` in the condition, no reliance on ungathered facts, a probe task that runs on the target, the guard consumes it, ordering, and whitespace tolerance on the command's stdout.

`make test-unit` 2128 passed · `make lint` clean · `make validate` 87 commands, 69 playbooks.

## Incidental

Debian 13 ships podman-compose **1.3.0** — the version 4.14.0's fixes were verified against. Relevant to the version question in #1288 and #1118, though it says nothing about Debian 12.