### PR TITLE
refactor(install): dispatch on the CLI's own package names

### DIFF
--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -1,7 +1,11 @@
 ---
 # canasta install - Install dependencies on the target host.
 # Accepts one or more package names: docker, k8s-cp, k8s-worker,
-# git-crypt, sops, canasta.
+# git-crypt, sops, canasta, podman.
+#
+# Package names are the CLI's own, dispatched on as-is. The task files
+# below keep the name of the software they install (k3s), which is not
+# the name the operator asks for (k8s-cp).
 
 # When --id is given without --host, resolve the instance's registered
 # host and switch the connection to it. This lets `canasta install
@@ -13,20 +17,16 @@
     - id is defined and id != ''
     - target_host is not defined or target_host == '' or target_host == 'localhost'
 
-- name: Normalize package names
+- name: Split the requested packages
   ansible.builtin.set_fact:
-    _install_packages: >-
-      {{ packages.split()
-         | map('regex_replace', '^k8s-cp$', 'k3s')
-         | map('regex_replace', '^k8s-worker$', 'k3s-worker')
-         | list }}
+    _install_packages: "{{ packages.split() }}"
 
 - name: Validate packages
   ansible.builtin.fail:
     msg: >-
       Unknown package '{{ item }}'. Supported: docker, k8s-cp,
       k8s-worker, git-crypt, sops, canasta, podman.
-  when: item not in ['docker', 'k3s', 'k3s-worker', 'git-crypt', 'sops', 'canasta', 'podman']
+  when: item not in ['docker', 'k8s-cp', 'k8s-worker', 'git-crypt', 'sops', 'canasta', 'podman']
   loop: "{{ _install_packages }}"
 
 - name: Validate k8s-cp + k8s-worker not requested together
@@ -36,8 +36,8 @@
       A node is either the cluster's control plane or a worker, not
       both.
   when:
-    - "'k3s' in _install_packages"
-    - "'k3s-worker' in _install_packages"
+    - "'k8s-cp' in _install_packages"
+    - "'k8s-worker' in _install_packages"
 
 - name: Validate --cp-host is provided for k8s-worker
   ansible.builtin.fail:
@@ -46,7 +46,7 @@
       control plane host registered via 'canasta host add'. Canasta
       SSHs to that host to fetch the join token and cluster API URL.
   when:
-    - "'k3s-worker' in _install_packages"
+    - "'k8s-worker' in _install_packages"
     - not (cp_host is defined and (cp_host | length > 0))
 
 - name: Install Docker
@@ -59,13 +59,13 @@
   ansible.builtin.include_role:
     name: install
     tasks_from: k3s.yml
-  when: "'k3s' in _install_packages"
+  when: "'k8s-cp' in _install_packages"
 
 - name: Install Kubernetes worker (k3s agent joined to control plane)
   ansible.builtin.include_role:
     name: install
     tasks_from: k3s_worker.yml
-  when: "'k3s-worker' in _install_packages"
+  when: "'k8s-worker' in _install_packages"
 
 - name: Install git-crypt
   ansible.builtin.include_role:

--- a/tests/unit/test_install_podman.py
+++ b/tests/unit/test_install_podman.py
@@ -68,13 +68,12 @@ class TestTheCommandIsReachable:
         )
 
     def test_the_choices_match_what_the_playbook_dispatches_on(self):
+        # The playbook dispatches on the CLI's own package names, so this
+        # is a literal match — no translation table to keep in step.
         with open(INSTALL) as f:
             body = f.read()
         for pkg in _install_param()["choices"]:
-            # k8s-cp/k8s-worker are normalized to k3s names before dispatch.
-            expected = {"k8s-cp": "k3s", "k8s-worker": "k3s-worker"}.get(
-                pkg, pkg)
-            assert "'%s' in _install_packages" % expected in body, (
+            assert "'%s' in _install_packages" % pkg in body, (
                 "'%s' is accepted but nothing dispatches on it" % pkg
             )
 


### PR DESCRIPTION
Closes #1304

## The split

`playbooks/install.yml` rewrote the package names the operator typed before dispatching on them:

```yaml
_install_packages: >-
  {{ packages.split()
     | map('regex_replace', '^k8s-cp$', 'k3s')
     | map('regex_replace', '^k8s-worker$', 'k3s-worker')
     | list }}
```

The CLI accepted `k8s-cp`; every `when:` downstream tested for `k3s`. Two vocabularies, kept in step by hand.

## Why it was vestigial

The translation arrived with #363, which renamed the user-facing `k8s` to `k8s-cp` and mapped it back to the software's own name for dispatch. That was reasonable while the playbook's own `fail` task was the only gate on the package name.

#1289 added `choices:` to the parameter. argparse now rejects anything outside the seven valid values before the playbook runs, so the regex chain can only ever see those seven and renames exactly two of them — a 1:1 substitution with no aliases left to absorb. It could not serve as back-compat for `canasta install k3s` either; that is rejected a step earlier.

## What this buys

`choices:` and dispatch become a literal match. That is exactly what the reachability test added in #1285 wanted — it was carrying the translation table as a hardcoded map that nothing kept honest:

```python
-            # k8s-cp/k8s-worker are normalized to k3s names before dispatch.
-            expected = {"k8s-cp": "k3s", "k8s-worker": "k3s-worker"}.get(pkg, pkg)
-            assert "'%s' in _install_packages" % expected in body
+            assert "'%s' in _install_packages" % pkg in body
```

It also removes the obstacle #1293 ran into: with no per-command translation to model, a generic "every accepted package is dispatched on, and every dispatch branch is reachable" check is a plain string comparison.

## Scope

Only the package token changes. `roles/install/tasks/k3s.yml`, `k3s_worker.yml`, `uninstall_k3s.yml`, `k3s.service` and `/etc/rancher/k3s` name the software actually being installed and are untouched. So `when: "'k8s-cp' in _install_packages"` now includes `tasks_from: k3s.yml` — the condition and the filename no longer share a word, which is accurate rather than confusing: the operator asks for a control plane, the implementation is k3s. A comment at the top of the playbook says so.

`playbooks/uninstall.yml` deliberately keeps its normalization: `^(k8s|kubernetes)$` maps two real aliases onto one token, and that parameter has no `choices:`, so argparse does not gate it.

`packages` is read only by the normalize `set_fact`, and `_install_packages` is referenced nowhere outside this playbook, so the blast radius is the one file. The CLI and playbooks ship from the same checkout, so no older caller can be passing `k3s`.

## Verification

`choices:` and the dispatch branches now agree with no translation table:

```
choices    : ['docker', 'k8s-cp', 'k8s-worker', 'git-crypt', 'sops', 'podman', 'canasta']
dispatched : ['canasta', 'docker', 'git-crypt', 'k8s-cp', 'k8s-worker', 'podman', 'sops']
accepted but never dispatched: none
dispatched but not accepted  : none
```

The `set_fact` was exercised under Ansible to confirm `_install_packages` is still a real list (not a stringified one) and that each path resolves:

| input | result |
|---|---|
| `k8s-cp` | control plane only |
| `k8s-worker docker` | both dispatch |
| `k8s-cp k8s-worker` | mutual-exclusion check fires |
| `podman` | accepted |
| `k3s` | rejected by the validate gate |
| `bogus` | rejected by the validate gate |

`make test-unit` 2143 passed, `make lint` clean, `make validate` clean.