### PR TITLE
fix(podman): fully qualify every container image reference

### DIFF
--- a/direct_commands/backup.py
+++ b/direct_commands/backup.py
@@ -35,7 +35,7 @@ def cmd_backup_list(args):
         "--env-file %(path)s/.env "
         "-v %(vol)s:/currentsnapshot "
         "%(local_mount)s "
-        "restic/restic "
+        "docker.io/restic/restic "
         "--cache-dir /tmp/restic-cache "
         "snapshots"
     ) % {"vol": _helpers._shell_quote(bvol), "path": qpath,

--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -140,7 +140,7 @@
         nodeSelector: "{{ _restore_node_selector }}"
         containers:
           - name: restic
-            image: restic/restic:latest
+            image: docker.io/restic/restic:latest
             command:
               - sh
               - -c

--- a/roles/orchestrator/tasks/k8s_run_backup.yml
+++ b/roles/orchestrator/tasks/k8s_run_backup.yml
@@ -285,7 +285,7 @@
             initContainers: "{{ _backup_init_containers }}"
             containers:
               - name: restic
-                image: restic/restic:latest
+                image: docker.io/restic/restic:latest
                 command:
                   - sh
                   - -c

--- a/roles/orchestrator/tasks/restore_instance.yml
+++ b/roles/orchestrator/tasks/restore_instance.yml
@@ -144,7 +144,7 @@
         cmd: >-
           {{ inspect_command }} run --rm
           -v "canasta-backup-{{ instance_path | basename }}:/currentsnapshot"
-          alpine sh -c 'rm -rf /currentsnapshot/* /currentsnapshot/.[!.]* 2>/dev/null || true'
+          docker.io/library/alpine sh -c 'rm -rf /currentsnapshot/* /currentsnapshot/.[!.]* 2>/dev/null || true'
       changed_when: true
 
     - name: Restore snapshot into backup volume
@@ -177,7 +177,7 @@
           {{ inspect_command }} run --rm \
             -v "canasta-backup-{{ instance_path | basename }}:/currentsnapshot:ro" \
             -v "{{ instance_path }}:/install" \
-            alpine sh -c '
+            docker.io/library/alpine sh -c '
             std="config extensions images skins public_assets";
             for d in $std; do
               if [ -d /currentsnapshot/$d ]; then
@@ -213,7 +213,7 @@
           {{ inspect_command }} run --rm
           -e W={{ wiki | quote }}
           -v "canasta-backup-{{ instance_path | basename }}:/currentsnapshot:ro"
-          alpine sh -c 'test -f "/currentsnapshot/config/backup/db_$W.sql"'
+          docker.io/library/alpine sh -c 'test -f "/currentsnapshot/config/backup/db_$W.sql"'
       register: _restore_wiki_in_snapshot
       changed_when: false
       failed_when: false
@@ -235,7 +235,7 @@
             -e W={{ wiki | quote }} \
             -v "canasta-backup-{{ instance_path | basename }}:/currentsnapshot:ro" \
             -v "{{ instance_path }}:/install" \
-            alpine sh -c '
+            docker.io/library/alpine sh -c '
             for rel in "config/settings/wikis/$W" "images/$W" "public_assets/$W"; do
               if [ -d "/currentsnapshot/$rel" ]; then
                 mkdir -p "/install/$rel";

--- a/roles/orchestrator/tasks/run_backup.yml
+++ b/roles/orchestrator/tasks/run_backup.yml
@@ -38,7 +38,7 @@
               {% for src, dst in backup_volumes.items() %}
                 -v {{ src }}:/src{{ loop.index0 }}:ro \
               {% endfor %}
-                alpine sh -c \
+                docker.io/library/alpine sh -c \
                 "rm -rf /currentsnapshot/* && \
               {% for src, dst in backup_volumes.items() %}
                 cp -a /src{{ loop.index0 }} {{ dst }}{{ ' && ' if not loop.last else '' }} \
@@ -126,7 +126,7 @@
               {% if _backup_local_repo %}
                 -v {{ _backup_local_repo }}:{{ _backup_local_repo }} \
               {% endif %}
-                restic/restic \
+                docker.io/restic/restic \
                 --cache-dir /tmp/restic-cache \
                 {{ backup_args | join(' ') }}
             chdir: "{{ instance_path }}"
@@ -150,7 +150,7 @@
               - --rm
               - -v
               - "{{ _backup_local_repo }}:{{ _backup_local_repo }}"
-              - alpine
+              - docker.io/library/alpine
               - chown
               - -R
               - "{{ _backup_repo_parent.stat.uid }}:{{ _backup_repo_parent.stat.gid }}"

--- a/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
+++ b/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
@@ -52,7 +52,7 @@
       ansible.builtin.command:
         cmd: >-
           {{ inspect_command }} run --rm -v {{ _mig_volume }}:/data
-          alpine test -f /data/mysql.ibd
+          docker.io/library/alpine test -f /data/mysql.ibd
       register: _mig_detect
       changed_when: false
       failed_when: false
@@ -169,7 +169,7 @@
               ansible.builtin.command:
                 cmd: >-
                   {{ inspect_command }} run --rm -v {{ _mig_volume }}:/data
-                  alpine sh -c 'rm -rf /data/* /data/..?* /data/.[!.]*'
+                  docker.io/library/alpine sh -c 'rm -rf /data/* /data/..?* /data/.[!.]*'
               changed_when: true
 
             # The managed-compose refresh that pins the MariaDB image runs

--- a/tests/unit/test_restic_image_is_qualified.py
+++ b/tests/unit/test_restic_image_is_qualified.py
@@ -1,0 +1,95 @@
+"""Container images must carry their registry.
+
+Podman does not assume docker.io for a short name. With no
+`unqualified-search-registries` configured — the state of a stock
+install — `restic/restic` is refused outright:
+
+    Error: short-name "restic/restic" did not resolve to an alias and no
+    unqualified-search registries are defined in
+    "/etc/containers/registries.conf"
+
+so `canasta backup` could not run at all on Podman.
+
+The Canasta stack itself was never affected because every image in the
+rendered compose file is already fully qualified (docker.io/library/...,
+ghcr.io/..., docker.elastic.co/...). restic was the one that was missed.
+
+The K8s references matter for the same reason on a CRI-O cluster;
+containerd assumes docker.io, so they happen to work under k3s today.
+"""
+
+import os
+import re
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+
+SITES = (
+    os.path.join("roles", "orchestrator", "tasks", "run_backup.yml"),
+    os.path.join("direct_commands", "backup.py"),
+    os.path.join("roles", "backup", "tasks", "restore_k8s.yml"),
+    os.path.join("roles", "orchestrator", "tasks", "k8s_run_backup.yml"),
+)
+
+# `restic/restic` not preceded by a registry host.
+UNQUALIFIED = re.compile(r"(?<![\w./-])restic/restic")
+
+
+def _read(rel):
+    with open(os.path.join(REPO_ROOT, rel)) as f:
+        return f.read()
+
+
+class TestEveryResticReferenceIsQualified:
+    def test_no_bare_short_name(self):
+        for rel in SITES:
+            body = _read(rel)
+            assert not UNQUALIFIED.search(body), (
+                "%s uses the short name; podman refuses it with no "
+                "unqualified-search registry configured" % rel
+            )
+
+    def test_the_image_is_still_referenced(self):
+        # Guard against the regex passing because the reference was
+        # deleted rather than qualified.
+        for rel in SITES:
+            assert "restic/restic" in _read(rel)
+
+    def test_it_is_qualified_to_docker_io(self):
+        for rel in SITES:
+            assert "docker.io/restic/restic" in _read(rel)
+
+
+# The helper container is run in more places than restic, and it runs
+# FIRST during a backup — the staging step. Qualifying restic alone would
+# still have left `canasta backup` broken on Podman.
+ALPINE_SITES = (
+    os.path.join("roles", "orchestrator", "tasks", "run_backup.yml"),
+    os.path.join("roles", "orchestrator", "tasks", "restore_instance.yml"),
+    os.path.join("roles", "upgrade", "tasks", "migrations",
+                 "mysql_to_mariadb.yml"),
+)
+
+# `alpine` used as an image argument, not inside a tag like
+# caddy:2.10.2-alpine or in prose.
+BARE_ALPINE = re.compile(r"(?<![\w./:-])alpine(?=\s+(sh|test)\b|\s*$)",
+                         re.MULTILINE)
+
+
+class TestTheHelperImageIsQualifiedToo:
+    def test_no_bare_alpine_invocation(self):
+        for rel in ALPINE_SITES:
+            body = _read(rel)
+            hits = [m.group(0) for m in BARE_ALPINE.finditer(body)]
+            assert not hits, (
+                "%s runs the short name `alpine`; podman refuses it the "
+                "same way it refuses restic/restic" % rel
+            )
+
+    def test_the_helper_is_still_used(self):
+        for rel in ALPINE_SITES:
+            assert "alpine" in _read(rel)
+
+    def test_it_is_qualified_to_the_library_namespace(self):
+        for rel in ALPINE_SITES:
+            assert "docker.io/library/alpine" in _read(rel)


### PR DESCRIPTION
Fixes #1306

`canasta backup init` on a rootless-Podman instance:

```
Error: short-name "restic/restic" did not resolve to an alias and no
unqualified-search registries are defined in "/etc/containers/registries.conf"
```

Podman does not assume `docker.io` for a short name, and a stock install configures no `unqualified-search-registries`.

## restic was not the only one

`restic/restic` is what the error names, but it is not the first short name a backup reaches — `alpine` is used as a helper container in six more places, and the **staging step runs it before restic**. Qualifying restic alone would have moved the failure, not removed it. I found this while setting up the live check, after the issue was already filed; #1306's description is updated to match.

Also covers `restore_instance.yml` and the MySQL-to-MariaDB migration, which run the same helper.

The Canasta stack itself was never affected: every image in the rendered compose file already names its registry (`docker.io/library/mariadb`, `ghcr.io/canastawiki/canasta`, `docker.elastic.co/...`). These helpers are the references that missed that convention.

The two K8s restic references are qualified for the same reason. They resolve today because k3s uses containerd, which does assume docker.io; a CRI-O cluster would refuse them.

## Verified live

Against a rootless-Podman instance (podman 5.4.2 / podman-compose 1.3.0, Debian 13), driven remotely:

```
backup init rc=0
backup create rc=0 -> snapshot 0d819855
  Files: 26 new ... processed 26 files, 87.680 KiB
```

and the snapshot carries real data, not just a zero exit:

```
/currentsnapshot/config/backup/db_main.sql
```

That run also needed #1307 and #1315, which are the next two Docker-isms in the same path — all three are cases where Docker is permissive and podman is strict.

## Tests

`tests/unit/test_restic_image_is_qualified.py` — 6 tests: no bare short name at any site, the images are still actually referenced (so the check cannot pass by deletion), and both are qualified. The `alpine` matcher is anchored to invocation position so it does not trip on tags like `caddy:2.10.2-alpine` or on prose.

`make test-unit` 2157 passed · `make lint` clean · `make validate` 87 commands, 69 playbooks.