### PR TITLE
fix(podman): tolerate an existing backup volume

### DIFF
--- a/roles/orchestrator/tasks/run_backup.yml
+++ b/roles/orchestrator/tasks/run_backup.yml
@@ -20,10 +20,18 @@
       ansible.builtin.set_fact:
         _bvol: "canasta-backup-{{ instance_path | basename }}"
 
+    # `docker volume create` is idempotent; `podman volume create` exits
+    # 125 when the volume is already there. Tolerate only that, so a real
+    # failure — bad name, no space — still stops the backup rather than
+    # letting it run against a volume that was never created.
     - name: Ensure backup volume exists
       ansible.builtin.command:
         cmd: "{{ inspect_command }} volume create {{ _bvol }}"
-      changed_when: true
+      register: _bvol_create
+      changed_when: _bvol_create.rc == 0
+      failed_when:
+        - _bvol_create.rc != 0
+        - "'already exists' not in (_bvol_create.stderr | default(''))"
 
     - name: Stage files into backup volume
       when: >-

--- a/tests/unit/test_backup_volume_idempotent.py
+++ b/tests/unit/test_backup_volume_idempotent.py
@@ -1,0 +1,90 @@
+"""Creating the backup volume must tolerate it already existing.
+
+`docker volume create` succeeds on an existing volume. `podman volume
+create` does not:
+
+    $ podman volume create zzz-test    # second time
+    Error: volume with name zzz-test already exists: volume already exists
+    rc=125
+
+The task is named "Ensure backup volume exists" but ran the command
+bare, so on Podman the first backup succeeded and every later one
+failed.
+
+The tolerance has to be narrow. Blanket-ignoring the failure would let
+the backup proceed against a volume that was never created — a bad name
+or a full disk would then surface much later, or not at all.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+RUN_BACKUP = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "run_backup.yml")
+
+
+def _tasks():
+    out = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            out.append(node)
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for i in node:
+                walk(i)
+
+    with open(RUN_BACKUP) as f:
+        walk(yaml.safe_load(f))
+    return out
+
+
+def _task():
+    return next(
+        (t for t in _tasks()
+         if "Ensure backup volume exists" in str(t.get("name", ""))), None)
+
+
+class TestAnExistingVolumeIsNotAFailure:
+    def test_the_task_exists(self):
+        assert _task()
+
+    def test_it_registers_the_result(self):
+        assert _task().get("register") == "_bvol_create", (
+            "without registering, the failure cannot be inspected and the "
+            "task fails the whole backup on podman"
+        )
+
+    def test_already_exists_is_tolerated(self):
+        cond = _task().get("failed_when")
+        assert cond, "a bare command fails on podman's exit 125"
+        body = " ".join(cond) if isinstance(cond, list) else str(cond)
+        assert "already exists" in body
+
+
+class TestRealFailuresStillStop:
+    def test_it_does_not_ignore_every_error(self):
+        # `failed_when: false` or `ignore_errors: true` would let the
+        # backup continue against a volume that does not exist.
+        task = _task()
+        assert task.get("ignore_errors") is not True
+        assert task.get("failed_when") is not False
+
+    def test_the_condition_keeps_the_nonzero_check(self):
+        cond = _task().get("failed_when")
+        body = " ".join(cond) if isinstance(cond, list) else str(cond)
+        assert "rc != 0" in body, (
+            "the tolerance must be scoped to the already-exists case, not "
+            "applied to any exit status"
+        )
+
+
+class TestChangedReporting:
+    def test_it_is_not_unconditionally_changed(self):
+        # A volume that already existed was not created by this run.
+        assert _task().get("changed_when") is not True
+        assert "rc" in str(_task().get("changed_when"))


### PR DESCRIPTION
Fixes #1307

```
Error: The command exited with a non-zero return code.
  (cmd: podman volume create canasta-backup-podtest)
Error: volume with name canasta-backup-podtest already exists
```

`docker volume create` succeeds on an existing volume; `podman volume create` exits 125. Measured on the same host:

```
$ podman volume create zzz-test    # second time
Error: volume with name zzz-test already exists: volume already exists
rc=125
```

The task is named "Ensure backup volume exists" but ran the command bare, so on Podman the **first** backup succeeded and every later one failed. That is why it surfaced on a retry rather than a first run.

## The tolerance is deliberately narrow

`failed_when: false` or `ignore_errors: true` would let the backup proceed against a volume that was never created — a bad name or a full disk would then surface much later, or not at all. Only the already-exists case is accepted; every other non-zero exit still stops the backup.

`changed_when` now reflects whether the volume was actually created, rather than always reporting changed.

## Only the Ansible path was affected

`direct_commands/backup.py:33` runs the same command as `%(rt)s volume create %(vol)s >/dev/null 2>&1;`, swallowing the error. Unchanged here.

## Verified live

Against a rootless-Podman instance with the volume already present — the exact failing state:

```
backup create  rc=0  -> snapshot 0d819855
backup create  rc=0  -> snapshot 22212733    # the repeat that used to fail
```

The second run is the one that matters; #1307 never affected the first.

## Tests

`tests/unit/test_backup_volume_idempotent.py` — 6 tests: the result is registered, already-exists is tolerated, real failures still stop the run (no `ignore_errors`, no `failed_when: false`, and the `rc != 0` clause is retained), and `changed_when` is no longer unconditional.

`make test-unit` 2157 passed · `make lint` clean · `make validate` 87 commands, 69 playbooks.

Related: #1306 and #1315 block the same command earlier for different reasons; all three were needed to get a backup through on Podman.