### PR TITLE
fix(gitops): keep restic_password per-host alongside its repository

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -2366,6 +2366,15 @@ commands:
       The instance must already exist and have a working `.env`
       file. Use `canasta gitops init` to bootstrap a new gitops
       repository instead.
+
+      Account-wide credentials (the AWS keys, SMTP) are shared across
+      every host in the repo. Backup credentials are not: a password
+      that unlocks one specific repository belongs with the per-host
+      `RESTIC_REPOSITORY` it opens, so `RESTIC_PASSWORD` stays on the
+      host that generated it. If the hosts in this repo all back up to
+      one restic repository, set the joining host's password to match
+      it — `canasta config set -i <id> RESTIC_PASSWORD=<password>` —
+      or its backups will fail against a repository it cannot open.
     examples:
       - "canasta gitops join -n staging --repo git@github.com:org/config.git --key /tmp/gc.key"
     playbook: gitops_join.yml

--- a/roles/gitops/vars/main.yml
+++ b/roles/gitops/vars/main.yml
@@ -18,10 +18,15 @@
 # Environment-identifying values — bucket names, repository URLs,
 # regions, endpoints, hostnames — stay per-host so dev / staging /
 # prod can address different infrastructure under one gitops repo.
+#
+# A credential that unlocks one specific store counts as
+# environment-identifying too, however secret it looks: restic_password
+# decrypts the repository named by the per-host restic_repository, so
+# sharing it would hand every host a password for a repository it does
+# not back up to.
 gitops_shared_keys:
   - aws_access_key_id
   - aws_secret_access_key
-  - restic_password
   - smtp_password
   - smtp_user
 

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -2571,10 +2571,11 @@ def test_gitops_push_shared_vars(inst):
     with open(vars_file) as f:
         vars_data = yaml.safe_load(f) or {}
     # Should migrate to shared (in gitops_shared_keys):
-    vars_data["restic_password"] = "test-password"
     vars_data["aws_access_key_id"] = "AKIATEST"
     vars_data["aws_secret_access_key"] = "secrettest"
-    # Should stay per-host (environment-specific identifiers):
+    # Should stay per-host (environment-specific identifiers, plus the
+    # password that unlocks the per-host restic repository):
+    vars_data["restic_password"] = "test-password"
     vars_data["restic_repository"] = "s3:s3.example.com/test-backup"
     vars_data["aws_bucket_name"] = "test-bucket"
     with open(vars_file, "w") as f:
@@ -2593,9 +2594,6 @@ def test_gitops_push_shared_vars(inst):
     )
     with open(shared_file) as f:
         shared_data = yaml.safe_load(f) or {}
-    assert shared_data.get("restic_password") == "test-password", (
-        "restic_password not in shared vars: %s" % shared_data
-    )
     assert shared_data.get("aws_access_key_id") == "AKIATEST", (
         "aws_access_key_id not in shared vars: %s" % shared_data
     )
@@ -2604,6 +2602,10 @@ def test_gitops_push_shared_vars(inst):
     )
 
     print("Checking environment-specific keys stayed per-host...")
+    assert "restic_password" not in shared_data, (
+        "restic_password should NOT be in shared (unlocks the per-host "
+        "restic_repository): %s" % shared_data
+    )
     assert "restic_repository" not in shared_data, (
         "restic_repository should NOT be in shared (per-host): %s"
         % shared_data
@@ -2616,13 +2618,12 @@ def test_gitops_push_shared_vars(inst):
     print("Checking host vars: shared-list keys removed, host-specific kept...")
     with open(vars_file) as f:
         host_data = yaml.safe_load(f) or {}
-    assert "restic_password" not in host_data, (
-        "restic_password should have moved to shared, still in host: %s"
-        % host_data
-    )
     assert "aws_access_key_id" not in host_data, (
         "aws_access_key_id should have moved to shared, still in host: %s"
         % host_data
+    )
+    assert host_data.get("restic_password") == "test-password", (
+        "restic_password should remain per-host: %s" % host_data
     )
     assert host_data.get("restic_repository") == "s3:s3.example.com/test-backup", (
         "restic_repository should remain per-host: %s" % host_data

--- a/tests/unit/test_gitops_shared_keys.py
+++ b/tests/unit/test_gitops_shared_keys.py
@@ -1,0 +1,47 @@
+"""`gitops_shared_keys` must not contain a credential that unlocks one
+specific per-host store.
+
+`gitops push` moves every listed key out of the pushing host's vars.yaml into
+hosts/_shared/vars.yaml, where the pushing host's value wins and every other
+host then renders it into .env. That is right for an account credential which
+is the same everywhere, and wrong for a key that pairs with a per-host
+resource: restic_password decrypts the repository named by restic_repository,
+which is deliberately per-host, so sharing it hands each host a password for a
+repository it does not back up to.
+"""
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+GITOPS_VARS = os.path.join(REPO_ROOT, "roles", "gitops", "vars", "main.yml")
+
+
+def _shared_keys():
+    with open(GITOPS_VARS) as fh:
+        return yaml.safe_load(fh)["gitops_shared_keys"]
+
+
+def test_restic_password_is_not_shared():
+    assert "restic_password" not in _shared_keys()
+
+
+def test_restic_repository_is_not_shared():
+    # The pair must stay together: sharing either half without the other
+    # leaves a host addressing one repository with another's credentials.
+    assert "restic_repository" not in _shared_keys()
+
+
+def test_account_wide_credentials_are_still_shared():
+    keys = _shared_keys()
+    for key in ("aws_access_key_id", "aws_secret_access_key"):
+        assert key in keys, "%s should stay shared" % key
+
+
+def test_no_bucket_or_endpoint_identifiers_are_shared():
+    for key in _shared_keys():
+        for token in ("repository", "bucket", "region", "endpoint", "host"):
+            assert token not in key, (
+                "%s looks environment-identifying and should stay per-host" % key
+            )


### PR DESCRIPTION
`restic_password` unlocks the repository named by `restic_repository`, which is deliberately per-host so dev / staging / prod can back up to different infrastructure. Sharing only the password left every host but the last pusher holding a credential for a repository it does not write to, and its backups failing.

Drops it from `gitops_shared_keys` so the pair stays together.

## Scope

This stops *new* migrations. Repos that already moved the key keep working off the existing `_shared` value — no reverse migration, since that would itself rewrite an unmergeable encrypted file on every host (see #1312).

## Tests

The existing integration assertion that `restic_password` migrates to `_shared` now asserts it stays per-host, alongside `restic_repository`. A new unit test pins the rule and rejects any future key containing `repository`, `bucket`, `region`, `endpoint`, or `host`.

Fixes #1313
