### PR TITLE
fix(gitops): defer the shared-key migration while the host is behind

### DIFF
--- a/roles/gitops/tasks/push_compose.yml
+++ b/roles/gitops/tasks/push_compose.yml
@@ -57,6 +57,39 @@
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/gitops/tasks/_migrate_reclassified_secrets.yml
 
+# --- Is this host up to date with the remote? ---
+# The migration below rewrites hosts/_shared/vars.yaml, which .gitattributes
+# encrypts with git-crypt. Git merges the stored ciphertext, so a rewrite made
+# from a stale base can never be replayed on top of another host's version and
+# leaves a conflict no canasta command resolves. Defer the migration instead —
+# the keys move on the next push, once the operator has pulled.
+#
+# A fetch that fails (no network, no credentials) leaves the host treated as up
+# to date: the push that follows reports the real problem.
+- name: Fetch the remote to compare against
+  ansible.builtin.command:
+    cmd: "git fetch origin main"
+    chdir: "{{ instance_path }}"
+  environment: "{{ gitops_git_env }}"
+  register: _push_fetch
+  changed_when: false
+  failed_when: false
+
+- name: Count commits this host is missing
+  ansible.builtin.command:
+    cmd: "git rev-list --count HEAD..@{upstream}"
+    chdir: "{{ instance_path }}"
+  register: _push_behind
+  changed_when: false
+  failed_when: false
+
+- name: Record whether this host is behind the remote
+  ansible.builtin.set_fact:
+    _push_is_behind: >-
+      {{ (_push_fetch.rc | default(1)) == 0
+         and (_push_behind.rc | default(1)) == 0
+         and (_push_behind.stdout | default('0', true) | trim | int) > 0 }}
+
 # --- Auto-migrate shared-category keys to _shared/vars.yaml ---
 # Keys named in gitops_shared_keys (vars/main.yml) belong in the
 # shared file so all hosts inherit them. On every push, any such key
@@ -95,8 +128,21 @@
          | selectattr('key', 'in', gitops_shared_keys)
          | list }}
 
+- name: Defer the migration while this host is behind
+  ansible.builtin.debug:
+    msg: >-
+      Holding back {{ _push_keys_to_migrate | length }} shared credential
+      key(s) from hosts/_shared/vars.yaml: this host is behind the remote,
+      and that file is encrypted, so a rewrite from a stale base could not
+      be merged. Run 'canasta gitops pull', then push again.
+  when:
+    - _push_keys_to_migrate | length > 0
+    - _push_is_behind | bool
+
 - name: Write migrated shared vars
-  when: _push_keys_to_migrate | length > 0
+  when:
+    - _push_keys_to_migrate | length > 0
+    - not (_push_is_behind | bool)
   block:
     - name: Create _shared directory
       ansible.builtin.file:

--- a/tests/unit/test_gitops_shared_vars_stale_base.py
+++ b/tests/unit/test_gitops_shared_vars_stale_base.py
@@ -1,0 +1,103 @@
+"""`gitops push` must not rewrite hosts/_shared/vars.yaml from a stale base.
+
+.gitattributes encrypts hosts/** with git-crypt and declares no merge driver,
+so git merges the stored ciphertext. A shared-key migration performed while the
+host is behind the remote therefore produces a commit that can never be
+replayed on top of another host's version of the same file, and `gitops pull`
+aborts with a binary conflict the CLI offers no way through.
+
+Deferring the migration — rather than failing the push — is what keeps the
+operator unstuck: push is the only command that commits, and pull refuses to
+run on a dirty tree, so failing here would strand local edits.
+"""
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+PUSH_COMPOSE = os.path.join(
+    REPO_ROOT, "roles", "gitops", "tasks", "push_compose.yml",
+)
+
+
+def _read():
+    with open(PUSH_COMPOSE) as fh:
+        return fh.read()
+
+
+def _tasks():
+    return yaml.safe_load(_read())
+
+
+def _walk(tasks):
+    for task in tasks or []:
+        yield task
+        for key in ("block", "rescue", "always"):
+            for nested in _walk(task.get(key)):
+                yield nested
+
+
+def _named(name):
+    for task in _walk(_tasks()):
+        if (task.get("name") or "") == name:
+            return task
+    return None
+
+
+def test_push_fetches_before_deciding():
+    task = _named("Fetch the remote to compare against")
+    assert task, "expected a fetch before the shared-key migration"
+    cmd = task["ansible.builtin.command"]["cmd"]
+    assert "git fetch" in cmd
+    # Must not fail the push when the remote is unreachable.
+    assert task.get("failed_when") is False
+    assert task.get("changed_when") is False
+
+
+def test_behind_count_is_measured_against_the_upstream():
+    task = _named("Count commits this host is missing")
+    assert task, "expected a behind-count task"
+    cmd = task["ansible.builtin.command"]["cmd"]
+    assert "rev-list --count HEAD..@{upstream}" in cmd
+    assert task.get("failed_when") is False
+
+
+def test_unreachable_remote_is_treated_as_up_to_date():
+    task = _named("Record whether this host is behind the remote")
+    assert task, "expected the behind fact to be set"
+    expr = str(task["ansible.builtin.set_fact"]["_push_is_behind"])
+    # Both the fetch and the count must have succeeded before a non-zero
+    # count is believed, so an offline host keeps the old behavior.
+    assert "_push_fetch.rc" in expr
+    assert "_push_behind.rc" in expr
+    assert "int) > 0" in expr
+
+
+def test_migration_is_skipped_while_behind():
+    task = _named("Write migrated shared vars")
+    assert task, "expected the shared-vars migration block"
+    when = task.get("when")
+    assert isinstance(when, list), "expected the guard to be a condition list"
+    assert any("_push_keys_to_migrate" in str(c) for c in when)
+    assert any(
+        "not" in str(c) and "_push_is_behind" in str(c) for c in when
+    ), "migration must not run while the host is behind the remote"
+
+
+def test_skipping_is_reported_to_the_operator():
+    task = _named("Defer the migration while this host is behind")
+    assert task, "a silently skipped migration would look like a no-op"
+    msg = task["ansible.builtin.debug"]["msg"]
+    assert "gitops pull" in msg, "the message must name the way forward"
+
+
+def test_push_itself_is_not_blocked_by_being_behind():
+    # The commit and push must stay reachable so staged work still lands
+    # locally; the remote's own rejection routes the operator to pull.
+    for name in ("Commit staged changes", "Push to main"):
+        task = _named(name)
+        assert task, "expected a '%s' task" % name
+        assert "_push_is_behind" not in str(task.get("when", "")), (
+            "%s must not be gated on being behind" % name
+        )


### PR DESCRIPTION
`hosts/**` is git-crypt encrypted and `.gitattributes` declares no merge driver, so git merges the stored ciphertext. The shared-key migration rewrote `hosts/_shared/vars.yaml` from whatever base the host happened to be on, so a host that was behind committed an encrypted file derived from a stale base — a commit that can never be replayed on top of another host's version. `gitops pull` then aborts on a binary conflict the CLI offers no way through.

Fetch before the migration and skip it while the host is behind its upstream. The keys migrate on the next push, after the operator has pulled.

## Why skip rather than fail

`gitops push` is the only command that commits, and `gitops pull` refuses to run on a dirty tree. Failing here would leave an operator with local edits unable to do either. The push itself still proceeds: it commits staged work and is then rejected as non-fast-forward, which already routes the operator to `gitops pull`.

An unreachable remote is treated as up to date, so an offline host keeps today's behavior rather than gaining a new failure mode.

Fixes #1312
