### PR TITLE
fix(gitops): tell the operator what actually blocked the pull

### DIFF
--- a/roles/gitops/tasks/_explain_pull_failure.yml
+++ b/roles/gitops/tasks/_explain_pull_failure.yml
@@ -18,7 +18,21 @@
       git diff --name-only --diff-filter=U -z \
         | while IFS= read -r -d '' f; do
             attr="$(git check-attr filter -- "$f" 2>/dev/null | sed 's/.*: //')"
-            printf '%s\t%s\n' "$attr" "$f"
+            if [ "$attr" = "git-crypt" ]; then
+              printf 'encrypted\t%s\n' "$f"
+              continue
+            fi
+            # A tracked binary (a public_assets logo) is just as unmergeable as
+            # ciphertext, and needs the same take-one-side advice — minus the
+            # decryption. NUL bytes in the head of the blob are git's own test.
+            raw="$(git cat-file -p ":2:$f" 2>/dev/null | head -c 8000 | wc -c)"
+            txt="$(git cat-file -p ":2:$f" 2>/dev/null | head -c 8000 \
+                   | tr -d '\000' | wc -c)"
+            if [ "$raw" != "$txt" ]; then
+              printf 'binary\t%s\n' "$f"
+            else
+              printf 'text\t%s\n' "$f"
+            fi
           done
   args:
     chdir: "{{ instance_path }}"
@@ -31,11 +45,15 @@
   ansible.builtin.set_fact:
     _pull_conflict_encrypted: >-
       {{ _pull_conflicted.stdout_lines | default([])
-         | select('match', '^git-crypt\t')
+         | select('match', '^encrypted\t')
+         | map('regex_replace', '^[^\t]*\t', '') | list }}
+    _pull_conflict_binary: >-
+      {{ _pull_conflicted.stdout_lines | default([])
+         | select('match', '^binary\t')
          | map('regex_replace', '^[^\t]*\t', '') | list }}
     _pull_conflict_plain: >-
       {{ _pull_conflicted.stdout_lines | default([])
-         | reject('match', '^git-crypt\t')
+         | select('match', '^text\t')
          | map('regex_replace', '^[^\t]*\t', '') | list }}
     _pull_dirty_tree: >-
       {{ 'cannot pull with rebase' in (_pull_failure.stderr | default('')) }}
@@ -58,7 +76,7 @@
       changes cannot be replayed on top of them. Share them with
       'canasta gitops add <file>' then 'canasta gitops push', or discard them
       with 'git checkout -- <file>', then retry.
-      {% elif _pull_conflict_encrypted | length > 0 or _pull_conflict_plain | length > 0 %}
+      {% elif _pull_conflict_encrypted | length > 0 or _pull_conflict_binary | length > 0 or _pull_conflict_plain | length > 0 %}
       Cannot pull: this host's local commit(s) conflict with the remote changes,
       so they could not be replayed on top. The rebase was rolled back — the
       instance is exactly as it was and the local commit(s) are intact.
@@ -77,18 +95,36 @@
 
         d=$(mktemp -d)
         git pull --rebase
-        for s in 1 2 3; do git cat-file -p ":${s}:<file>" | git-crypt smudge > "$d/$s"; done
-        git merge-file -L remote -L base -L local "$d/2" "$d/1" "$d/3"
-        <if it reports a conflict, edit "$d/2" to resolve it>
-        cp "$d/2" <file> && git add -- <file> && git rebase --continue
+        git cat-file -p ':1:<file>' | git-crypt smudge > "$d/base"
+        git cat-file -p ':2:<file>' | git-crypt smudge > "$d/remote"
+        git cat-file -p ':3:<file>' | git-crypt smudge > "$d/local"
+        cp "$d/remote" "$d/merged"
+        git merge-file -L remote -L base -L local "$d/merged" "$d/base" "$d/local"
+        <if it reports a conflict, edit "$d/merged" to resolve it>
+        cp "$d/merged" <file> && git add -- <file> && git rebase --continue
         rm -rf "$d"
 
-      Stage 1 is the common ancestor, 2 the remote's version, 3 this host's.
-      $d holds decrypted secrets until you remove it.
+      base is the common ancestor both versions started from. $d holds
+      decrypted secrets until you remove it.
 
       To take one side whole instead of merging, replace the middle steps with
       'git checkout --ours -- <file>' for the remote's version, or '--theirs'
       for this host's.
+      {% endif %}
+      {% if _pull_conflict_binary | length > 0 %}
+      These conflicting file(s) are binary, so git cannot merge them either:
+      {%- for f in _pull_conflict_binary %}
+        - {{ f }}
+      {%- endfor %}
+
+      Keep one version whole, then continue the rebase:
+
+        cd {{ instance_path }}
+        git pull --rebase
+        git checkout --ours -- <file>
+        git add -- <file> && git rebase --continue
+
+      --ours is the remote's version and --theirs is this host's.
       {% endif %}
       {% if _pull_conflict_plain | length > 0 %}
       Mergeable — resolve these the usual way:

--- a/roles/gitops/tasks/_explain_pull_failure.yml
+++ b/roles/gitops/tasks/_explain_pull_failure.yml
@@ -63,24 +63,32 @@
       so they could not be replayed on top. The rebase was rolled back — the
       instance is exactly as it was and the local commit(s) are intact.
       {% if _pull_conflict_encrypted | length > 0 %}
-      Encrypted (git-crypt) — git compares ciphertext, so there is no
-      line-by-line merge for these:
+      These conflicting file(s) are git-crypt encrypted:
       {%- for f in _pull_conflict_encrypted %}
         - {{ f }}
       {%- endfor %}
 
-      Take one side of each whole file, then continue the rebase:
+      Git compares them as ciphertext, so it cannot merge them and writes no
+      conflict markers. Do not simply edit the file: the working copy holds
+      one side only, and saving it drops the other host's change silently.
 
-        cd {{ instance_path }}
+      To merge the two versions, for each file above, in
+      {{ instance_path }} on a git-crypt unlocked checkout:
+
+        d=$(mktemp -d)
         git pull --rebase
-        git checkout --theirs -- <file>
-        git add -- <file>
-        git rebase --continue
+        for s in 1 2 3; do git cat-file -p ":${s}:<file>" | git-crypt smudge > "$d/$s"; done
+        git merge-file -L remote -L base -L local "$d/2" "$d/1" "$d/3"
+        <if it reports a conflict, edit "$d/2" to resolve it>
+        cp "$d/2" <file> && git add -- <file> && git rebase --continue
+        rm -rf "$d"
 
-      --theirs keeps this host's version and --ours keeps the remote's ('ours'
-      is the remote during a rebase). To read both sides first, on an unlocked
-      checkout: 'git show :2:<file> | git-crypt smudge' for the remote's and
-      ':3:<file>' for this host's.
+      Stage 1 is the common ancestor, 2 the remote's version, 3 this host's.
+      $d holds decrypted secrets until you remove it.
+
+      To take one side whole instead of merging, replace the middle steps with
+      'git checkout --ours -- <file>' for the remote's version, or '--theirs'
+      for this host's.
       {% endif %}
       {% if _pull_conflict_plain | length > 0 %}
       Mergeable — resolve these the usual way:

--- a/roles/gitops/tasks/_explain_pull_failure.yml
+++ b/roles/gitops/tasks/_explain_pull_failure.yml
@@ -1,0 +1,103 @@
+---
+# Turn a failed `git pull --rebase` into a message the operator can act on,
+# then roll the rebase back.
+#
+# Three failures reach here and they need different advice: a dirty working
+# tree (git refused before replaying anything), a conflict in files git can
+# merge, and a conflict in git-crypt paths — where git compares ciphertext, so
+# no line-by-line resolution exists at all.
+#
+# The conflicted paths must be read before the abort clears them.
+#
+# Requires: instance_path, _pull_failure (the registered failed pull result).
+
+- name: Collect conflicted paths before the rebase is rolled back
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      git diff --name-only --diff-filter=U -z \
+        | while IFS= read -r -d '' f; do
+            attr="$(git check-attr filter -- "$f" 2>/dev/null | sed 's/.*: //')"
+            printf '%s\t%s\n' "$attr" "$f"
+          done
+  args:
+    chdir: "{{ instance_path }}"
+    executable: /bin/bash
+  register: _pull_conflicted
+  changed_when: false
+  failed_when: false
+
+- name: Classify the conflicted paths
+  ansible.builtin.set_fact:
+    _pull_conflict_encrypted: >-
+      {{ _pull_conflicted.stdout_lines | default([])
+         | select('match', '^git-crypt\t')
+         | map('regex_replace', '^[^\t]*\t', '') | list }}
+    _pull_conflict_plain: >-
+      {{ _pull_conflicted.stdout_lines | default([])
+         | reject('match', '^git-crypt\t')
+         | map('regex_replace', '^[^\t]*\t', '') | list }}
+    _pull_dirty_tree: >-
+      {{ 'cannot pull with rebase' in (_pull_failure.stderr | default('')) }}
+
+# Never leave the repo mid-rebase: roll back to where the pull started so the
+# operator has one clear problem to solve, with local commits intact.
+- name: Abort an incomplete rebase
+  ansible.builtin.command:
+    cmd: "git rebase --abort"
+    chdir: "{{ instance_path }}"
+  register: _pull_abort
+  changed_when: _pull_abort.rc == 0
+  failed_when: false
+
+- name: Fail with an explanation of what blocked the pull
+  ansible.builtin.fail:
+    msg: |-
+      {% if _pull_dirty_tree | bool %}
+      Cannot pull: this host has local changes to tracked files, so the remote
+      changes cannot be replayed on top of them. Share them with
+      'canasta gitops add <file>' then 'canasta gitops push', or discard them
+      with 'git checkout -- <file>', then retry.
+      {% elif _pull_conflict_encrypted | length > 0 or _pull_conflict_plain | length > 0 %}
+      Cannot pull: this host's local commit(s) conflict with the remote changes,
+      so they could not be replayed on top. The rebase was rolled back — the
+      instance is exactly as it was and the local commit(s) are intact.
+      {% if _pull_conflict_encrypted | length > 0 %}
+      Encrypted (git-crypt) — git compares ciphertext, so there is no
+      line-by-line merge for these:
+      {%- for f in _pull_conflict_encrypted %}
+        - {{ f }}
+      {%- endfor %}
+
+      Take one side of each whole file, then continue the rebase:
+
+        cd {{ instance_path }}
+        git pull --rebase
+        git checkout --theirs -- <file>
+        git add -- <file>
+        git rebase --continue
+
+      --theirs keeps this host's version and --ours keeps the remote's ('ours'
+      is the remote during a rebase). To read both sides first, on an unlocked
+      checkout: 'git show :2:<file> | git-crypt smudge' for the remote's and
+      ':3:<file>' for this host's.
+      {% endif %}
+      {% if _pull_conflict_plain | length > 0 %}
+      Mergeable — resolve these the usual way:
+      {%- for f in _pull_conflict_plain %}
+        - {{ f }}
+      {%- endfor %}
+
+        cd {{ instance_path }}
+        git pull --rebase
+        (edit each file, then 'git add' it)
+        git rebase --continue
+      {% endif %}
+      To throw this host's local commit(s) away instead:
+      'git reset --hard origin/main'.
+      {% else %}
+      Cannot pull: the rebase could not be completed and was rolled back — the
+      instance is exactly as it was and the local commit(s) are intact.
+      git said: {{ (_pull_failure.stdout | default('') ~ ' '
+                    ~ _pull_failure.stderr | default('')) | trim }}
+      {% endif %}

--- a/roles/gitops/tasks/pull_compose.yml
+++ b/roles/gitops/tasks/pull_compose.yml
@@ -73,30 +73,17 @@
   failed_when: false
 
 # A conflicting replay stops mid-rebase, which strands the instance in a state
-# no canasta command understands. Roll back to exactly where the pull started —
-# local commits intact — so the operator has one clear problem to solve.
-- name: Abort an incomplete rebase
-  ansible.builtin.command:
-    cmd: "git rebase --abort"
-    chdir: "{{ instance_path }}"
-  register: _pull_abort
-  changed_when: _pull_abort.rc == 0
-  failed_when: false
+# no canasta command understands. Name what conflicted, roll back to exactly
+# where the pull started — local commits intact — and fail.
+- name: Explain and roll back a failed pull
   when: _pull_result.rc != 0
+  block:
+    - name: Hand the failure to the shared explainer
+      ansible.builtin.set_fact:
+        _pull_failure: "{{ _pull_result }}"
 
-- name: Fail if the pull could not be replayed
-  ansible.builtin.fail:
-    msg: >-
-      Cannot pull: this host's local commit(s) conflict with the remote
-      changes, so they could not be replayed on top. The rebase was rolled
-      back — the instance is exactly as it was and the local commit(s) are
-      intact. Resolve the conflict in the file(s) named below, either by
-      re-applying this host's change on top of the remote version, or by
-      discarding the local commit(s) with
-      'git reset --hard origin/main' (this throws them away).
-      git said: {{ (_pull_result.stdout | default('') ~ ' '
-                    ~ _pull_result.stderr | default('')) | trim }}
-  when: _pull_result.rc != 0
+    - name: Report why the pull could not be replayed
+      ansible.builtin.include_tasks: "_explain_pull_failure.yml"
 
 - name: Update submodules
   ansible.builtin.command:

--- a/roles/gitops/tasks/pull_kubernetes.yml
+++ b/roles/gitops/tasks/pull_kubernetes.yml
@@ -14,30 +14,17 @@
   changed_when: "'Already up to date' not in _git_pull.stdout"
   failed_when: false
 
-# Never leave the repo mid-rebase: roll back to where the pull started so the
-# operator has one clear problem to solve, with local commits intact.
-- name: Abort an incomplete rebase
-  ansible.builtin.command:
-    cmd: "git rebase --abort"
-    chdir: "{{ instance_path }}"
-  register: _git_pull_abort
-  changed_when: _git_pull_abort.rc == 0
-  failed_when: false
+# Never leave the repo mid-rebase: name what conflicted, roll back to where the
+# pull started, and fail with local commits intact.
+- name: Explain and roll back a failed pull
   when: _git_pull.rc != 0
+  block:
+    - name: Hand the failure to the shared explainer
+      ansible.builtin.set_fact:
+        _pull_failure: "{{ _git_pull }}"
 
-- name: Fail if the pull could not be replayed
-  ansible.builtin.fail:
-    msg: >-
-      Cannot pull: this host's local commit(s) conflict with the remote
-      changes, so they could not be replayed on top. The rebase was rolled
-      back — the instance is exactly as it was and the local commit(s) are
-      intact. Resolve the conflict in the file(s) named below, either by
-      re-applying this host's change on top of the remote version, or by
-      discarding the local commit(s) with
-      'git reset --hard origin/main' (this throws them away).
-      git said: {{ (_git_pull.stdout | default('') ~ ' '
-                    ~ _git_pull.stderr | default('')) | trim }}
-  when: _git_pull.rc != 0
+    - name: Report why the pull could not be replayed
+      ansible.builtin.include_tasks: "_explain_pull_failure.yml"
 
 # Keep extensions/skins submodules in sync with the pulled pointers.
 - name: Update submodules

--- a/tests/unit/test_gitops_pull_conflict_message.py
+++ b/tests/unit/test_gitops_pull_conflict_message.py
@@ -1,0 +1,130 @@
+"""A failed `gitops pull` must say what blocked it, in terms that apply.
+
+Three different failures reached one message that fit none of them: it told the
+operator to resolve a conflict after the rebase had already been rolled back,
+it named no files (it pasted git's raw output instead), and it offered a
+line-by-line resolution for git-crypt paths, where git compares ciphertext and
+no such resolution exists. On Kubernetes the same text also answered a plain
+dirty working tree, which is not a conflict at all.
+"""
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+TASKS = os.path.join(REPO_ROOT, "roles", "gitops", "tasks")
+EXPLAINER = os.path.join(TASKS, "_explain_pull_failure.yml")
+PULLS = ("pull_compose.yml", "pull_kubernetes.yml")
+
+
+def _tasks(path):
+    with open(path) as fh:
+        return yaml.safe_load(fh) or []
+
+
+def _explainer():
+    return _tasks(EXPLAINER)
+
+
+def _named(tasks, name):
+    for task in tasks:
+        if (task.get("name") or "") == name:
+            return task
+    return None
+
+
+def _fail_msg():
+    for task in _explainer():
+        if "ansible.builtin.fail" in task:
+            return task["ansible.builtin.fail"]["msg"]
+    raise AssertionError("expected a fail task in the explainer")
+
+
+def test_both_pull_variants_share_the_explainer():
+    for name in PULLS:
+        raw = open(os.path.join(TASKS, name)).read()
+        assert "_explain_pull_failure.yml" in raw, (
+            "%s: must route its pull failure through the shared explainer" % name
+        )
+        assert "_pull_failure" in raw, (
+            "%s: must hand the failed result to the explainer" % name
+        )
+
+
+def test_conflicts_are_read_before_the_abort_clears_them():
+    tasks = _explainer()
+    names = [t.get("name") or "" for t in tasks]
+    collect = "Collect conflicted paths before the rebase is rolled back"
+    abort = "Abort an incomplete rebase"
+    assert collect in names and abort in names
+    assert names.index(collect) < names.index(abort), (
+        "aborting first would leave nothing to report"
+    )
+
+
+def test_conflicted_paths_are_collected_with_their_filter():
+    task = _named(_explainer(), "Collect conflicted paths before the rebase is rolled back")
+    cmd = task["ansible.builtin.shell"]["cmd"]
+    assert "--diff-filter=U" in cmd, "only unmerged paths are conflicts"
+    assert "check-attr filter" in cmd, (
+        "the git-crypt attribute decides which advice applies"
+    )
+    assert task.get("failed_when") is False, (
+        "a failure here must not replace the real error"
+    )
+
+
+def test_encrypted_and_plain_conflicts_are_split():
+    task = _named(_explainer(), "Classify the conflicted paths")
+    facts = task["ansible.builtin.set_fact"]
+    assert "git-crypt" in str(facts["_pull_conflict_encrypted"])
+    assert "_pull_conflict_plain" in facts
+    assert "cannot pull with rebase" in str(facts["_pull_dirty_tree"]), (
+        "the dirty-tree refusal must be told apart from a real conflict"
+    )
+
+
+def test_the_abort_still_cannot_fail_the_play():
+    task = _named(_explainer(), "Abort an incomplete rebase")
+    assert task.get("failed_when") is False, (
+        "'no rebase in progress' must not itself fail the play"
+    )
+
+
+def test_dirty_tree_gets_the_add_and_push_route():
+    msg = _fail_msg()
+    assert "_pull_dirty_tree" in msg
+    assert "canasta gitops add" in msg and "canasta gitops push" in msg, (
+        "a dirty tree is fixed by sharing or discarding the changes, "
+        "not by resolving a conflict"
+    )
+
+
+def test_encrypted_conflicts_get_whole_file_advice():
+    msg = _fail_msg()
+    assert "_pull_conflict_encrypted" in msg
+    assert "ciphertext" in msg, "say why no line-by-line merge exists"
+    assert "--theirs" in msg and "--ours" in msg, (
+        "taking one side wholesale is the only resolution available"
+    )
+    assert "is the remote during a rebase" in msg, (
+        "ours/theirs invert under rebase; an operator who gets it backwards "
+        "silently keeps the wrong credentials"
+    )
+
+
+def test_conflicted_files_are_named():
+    msg = _fail_msg()
+    assert "for f in _pull_conflict_encrypted" in msg
+    assert "for f in _pull_conflict_plain" in msg, (
+        "the old message promised files 'named below' and named none"
+    )
+
+
+def test_local_commits_are_still_reported_safe():
+    msg = " ".join(_fail_msg().split())
+    assert "rolled back" in msg and "intact" in msg
+    assert "git reset --hard origin/main" in msg, (
+        "the escape hatch must stay documented"
+    )

--- a/tests/unit/test_gitops_pull_conflict_message.py
+++ b/tests/unit/test_gitops_pull_conflict_message.py
@@ -75,11 +75,12 @@ def test_conflicted_paths_are_collected_with_their_filter():
     )
 
 
-def test_encrypted_and_plain_conflicts_are_split():
+def test_conflicts_are_split_three_ways():
     task = _named(_explainer(), "Classify the conflicted paths")
     facts = task["ansible.builtin.set_fact"]
-    assert "git-crypt" in str(facts["_pull_conflict_encrypted"])
-    assert "_pull_conflict_plain" in facts
+    for fact in ("_pull_conflict_encrypted", "_pull_conflict_binary",
+                 "_pull_conflict_plain"):
+        assert fact in facts, "missing bucket: %s" % fact
     assert "cannot pull with rebase" in str(facts["_pull_dirty_tree"]), (
         "the dirty-tree refusal must be told apart from a real conflict"
     )
@@ -118,11 +119,12 @@ def test_encrypted_conflicts_offer_a_real_three_way_merge():
     # side wholesale would be data loss, so a real merge has to come first.
     assert "git merge-file" in msg, "a true merge must be the primary route"
     assert "git-crypt smudge" in msg, "the stages have to be decrypted first"
-    for stage in (":${s}:", '"$d/1"', '"$d/2"', '"$d/3"'):
+    for stage in (":1:", ":2:", ":3:", '"$d/base"', '"$d/remote"', '"$d/local"'):
         assert stage in msg, "missing stage handling: %s" % stage
-    assert "Stage 1 is the common ancestor" in msg, (
-        "an operator who mixes up the stages merges the wrong pair"
-    )
+    # Named scratch files, not :1:/:2:/:3: positional temp names — an operator
+    # who mixes up the stages merges the wrong pair.
+    assert '"$d/merged"' in msg, "the file to edit and install must be named"
+    assert "base is the common ancestor" in msg
 
 
 def test_decrypted_scratch_copies_are_flagged():
@@ -154,3 +156,15 @@ def test_local_commits_are_still_reported_safe():
     assert "git reset --hard origin/main" in msg, (
         "the escape hatch must stay documented"
     )
+
+
+def test_tracked_binaries_are_not_called_mergeable():
+    # A public_assets logo is as unmergeable as ciphertext but has nothing to
+    # decrypt; calling it "resolve the usual way" sends the operator to edit a
+    # PNG in a text editor.
+    task = _named(_explainer(), "Collect conflicted paths before the rebase is rolled back")
+    cmd = task["ansible.builtin.shell"]["cmd"]
+    assert "tr -d '\\000'" in cmd, "expected a NUL-byte test to spot binaries"
+    msg = _fail_msg()
+    assert "_pull_conflict_binary" in msg
+    assert "are binary, so git cannot merge them either" in msg

--- a/tests/unit/test_gitops_pull_conflict_message.py
+++ b/tests/unit/test_gitops_pull_conflict_message.py
@@ -101,16 +101,42 @@ def test_dirty_tree_gets_the_add_and_push_route():
     )
 
 
-def test_encrypted_conflicts_get_whole_file_advice():
+def test_encrypted_conflicts_warn_against_editing_in_place():
     msg = _fail_msg()
     assert "_pull_conflict_encrypted" in msg
-    assert "ciphertext" in msg, "say why no line-by-line merge exists"
-    assert "--theirs" in msg and "--ours" in msg, (
-        "taking one side wholesale is the only resolution available"
+    assert "ciphertext" in msg, "say why git cannot merge them"
+    # git leaves no markers and checks out one side decrypted, so the file
+    # looks resolvable and editing it drops the other host's change.
+    flat = " ".join(msg.split())
+    assert "writes no conflict markers" in flat
+    assert "one side only" in flat
+
+
+def test_encrypted_conflicts_offer_a_real_three_way_merge():
+    msg = _fail_msg()
+    # Both hosts may have edited different parts of the same file; taking one
+    # side wholesale would be data loss, so a real merge has to come first.
+    assert "git merge-file" in msg, "a true merge must be the primary route"
+    assert "git-crypt smudge" in msg, "the stages have to be decrypted first"
+    for stage in (":${s}:", '"$d/1"', '"$d/2"', '"$d/3"'):
+        assert stage in msg, "missing stage handling: %s" % stage
+    assert "Stage 1 is the common ancestor" in msg, (
+        "an operator who mixes up the stages merges the wrong pair"
     )
-    assert "is the remote during a rebase" in msg, (
-        "ours/theirs invert under rebase; an operator who gets it backwards "
-        "silently keeps the wrong credentials"
+
+
+def test_decrypted_scratch_copies_are_flagged():
+    msg = _fail_msg()
+    assert "rm -rf" in msg and "decrypted secrets" in msg, (
+        "the recipe writes cleartext credentials to disk; say so and clean up"
+    )
+
+
+def test_taking_one_side_stays_available_as_the_shortcut():
+    msg = _fail_msg()
+    assert "--ours" in msg and "--theirs" in msg
+    assert "remote's version" in msg, (
+        "ours/theirs invert under rebase; label them rather than assume"
     )
 
 

--- a/tests/unit/test_gitops_pull_rebase.py
+++ b/tests/unit/test_gitops_pull_rebase.py
@@ -20,9 +20,40 @@ TASKS = os.path.join(REPO_ROOT, "roles", "gitops", "tasks")
 PULLS = ("pull_compose.yml", "pull_kubernetes.yml")
 
 
-def _tasks(name):
+def _load(name):
     with open(os.path.join(TASKS, name)) as fh:
-        return yaml.safe_load(fh)
+        return yaml.safe_load(fh) or []
+
+
+def _tasks(name, _seen=None):
+    """Every task the file runs, following blocks and same-role includes.
+
+    The rollback and its explanation live in _explain_pull_failure.yml, shared
+    by both pull variants, so the assertions below have to look through the
+    include rather than only at the top level.
+    """
+    seen = set() if _seen is None else _seen
+    if name in seen:
+        return []
+    seen.add(name)
+
+    def walk(tasks):
+        out = []
+        for task in tasks or []:
+            out.append(task)
+            for key in ("block", "rescue", "always"):
+                out.extend(walk(task.get(key)))
+            inc = (task.get("ansible.builtin.include_tasks")
+                   or task.get("include_tasks"))
+            target = inc if isinstance(inc, str) else (inc or {}).get("file", "")
+            target = os.path.basename(str(target).strip())
+            if target.endswith(".yml") and os.path.isfile(
+                os.path.join(TASKS, target)
+            ):
+                out.extend(_tasks(target, seen))
+        return out
+
+    return walk(_load(name))
 
 
 def _cmds(tasks):


### PR DESCRIPTION
One message answered three different failures and fit none of them. It told the operator to resolve a conflict after the rebase had already been rolled back, named no files despite promising them (it interpolated raw git output), and offered a line-by-line resolution for git-crypt paths, where git compares ciphertext and no such resolution exists. On Kubernetes the same text also answered a plain dirty working tree, which is not a conflict at all.

Both pull variants now route through one `_explain_pull_failure.yml`, which reads the conflicted paths before the abort clears them, sorts them into three kinds, and gives each the advice that applies.

## Conflicts get a real merge, not a coin flip

Taking one side wholesale is data loss whenever both hosts edited different parts of the same file — the normal case for a vars file several hosts contribute to. The three conflict stages decrypt through `git-crypt smudge`, so a genuine three-way merge on the plaintext works, and re-staging re-encrypts.

```
These conflicting file(s) are git-crypt encrypted:
  - hosts/_shared/vars.yaml

Git compares them as ciphertext, so it cannot merge them and writes no
conflict markers. Do not simply edit the file: the working copy holds
one side only, and saving it drops the other host's change silently.

To merge the two versions, for each file above, in
/opt/canasta/mysite on a git-crypt unlocked checkout:

  d=$(mktemp -d)
  git pull --rebase
  git cat-file -p ':1:<file>' | git-crypt smudge > "$d/base"
  git cat-file -p ':2:<file>' | git-crypt smudge > "$d/remote"
  git cat-file -p ':3:<file>' | git-crypt smudge > "$d/local"
  cp "$d/remote" "$d/merged"
  git merge-file -L remote -L base -L local "$d/merged" "$d/base" "$d/local"
  <if it reports a conflict, edit "$d/merged" to resolve it>
  cp "$d/merged" <file> && git add -- <file> && git rebase --continue
  rm -rf "$d"

base is the common ancestor both versions started from. $d holds
decrypted secrets until you remove it.

To take one side whole instead of merging, replace the middle steps with
'git checkout --ours -- <file>' for the remote's version, or '--theirs'
for this host's.
```

The extra `cp` earns its keep: `git merge-file` writes its result into its *first* argument, so without it `remote` would silently become the merged file. `base` / `remote` / `local` / `merged` say which file is which — positional `:1:` `:2:` `:3:` scratch names left the operator to remember an ordering, and merging the wrong pair fails silently.

## Do not edit the working copy

Worth calling out because it is the trap that loses data: after a git-crypt conflict, `git status` reports `UU`, but the working-tree file holds the **decrypted "ours" side only, with no conflict markers**. It looks like an ordinary resolvable file. Editing and saving it discards the other host's change without a word.

## Three kinds of conflict, three routes

- **git-crypt encrypted** (`hosts/**` — `_shared/vars.yaml`, `hosts.yaml`, `<host>/vars.yaml`): the merge recipe above.
- **Binary but not encrypted** (a tracked `public_assets` logo): equally unmergeable, nothing to decrypt, so take one side. These were previously landing in the "resolve the usual way" list, which sends an operator to edit a PNG in a text editor. Classified by NUL bytes in the blob.
- **Text**: the normal edit-and-continue route.

A dirty working tree — not a conflict at all — gets its own add-and-push-or-discard message instead.

## Verification

Rendered every branch of the template through Jinja rather than trusting it, then ran the printed recipe verbatim against a real two-host git-crypt repo: `merge-file rc=0`, both hosts' edits present in the result, blob encrypted at rest (`\0GITCRYPT\0`), `git-crypt status` clean. Also confirmed the classifier sorts a conflicted `logo.png` and `hosts/_shared/vars.yaml` in the same pull into the binary and encrypted buckets respectively.

## Follow-up

#1322 would register a git-crypt aware merge driver, which makes most of these conflicts resolve automatically and leaves the rest editable in place with ordinary markers. This message stays as the fallback for hosts where that driver is not registered — it lives in `.git/config`, which is not cloned, so every un-migrated repo and every fresh clone is in that state.

Fixes #1314
