### PR TITLE
fix(podman): hand the backup repo back to the operator, not a subuid

### DIFF
--- a/roles/orchestrator/tasks/run_backup.yml
+++ b/roles/orchestrator/tasks/run_backup.yml
@@ -158,6 +158,33 @@
               stdout: "{{ _compose_restic_result.stdout }}"
               rc: "{{ _compose_restic_result.rc }}"
       always:
+        # The chown below runs inside the container, so its uid is read
+        # through the runtime's user namespace. Rootless Podman maps
+        # container uid 0 to the operator and container uid N to
+        # subuid_base + N - 1 — so passing the host uid straight through
+        # hands the repo to a subuid nobody can use. Docker has no such
+        # mapping and wants the host uid.
+        - name: Detect rootless Podman for the ownership handback
+          ansible.builtin.command:
+            cmd: podman info --format {% raw %}{{.Host.Security.Rootless}}{% endraw %}
+          register: _backup_podman_rootless
+          changed_when: false
+          failed_when: false
+          when:
+            - _backup_local_repo | length > 0
+            - inspect_command | default('docker') is search('podman')
+
+        - name: Choose the in-container ownership target
+          ansible.builtin.set_fact:
+            _backup_chown_target: >-
+              {{ '0:0'
+                 if (_backup_podman_rootless.stdout | default('') | trim) == 'true'
+                 else (_backup_repo_parent.stat.uid | string) + ':'
+                      + (_backup_repo_parent.stat.gid | string) }}
+          when:
+            - _backup_local_repo | length > 0
+            - _backup_repo_parent.stat.exists | default(false)
+
         # `always`, not a following task: restic failing aborts the block,
         # and a repo left root-owned after a failed run is exactly when the
         # operator needs to inspect it. Mirrors the K8s path (#1205).
@@ -172,10 +199,27 @@
               - docker.io/library/alpine
               - chown
               - -R
-              - "{{ _backup_repo_parent.stat.uid }}:{{ _backup_repo_parent.stat.gid }}"
+              - "{{ _backup_chown_target }}"
               - "{{ _backup_local_repo }}"
+          register: _backup_reclaim
           changed_when: true
           failed_when: false
           when:
             - _backup_local_repo | length > 0
             - _backup_repo_parent.stat.exists | default(false)
+
+        # The reclaim is best-effort by design — it must not turn a good
+        # backup into a failure — but a silent one leaves the operator
+        # locked out of their own repo with nothing to go on.
+        - name: Warn when repo ownership was not restored
+          ansible.builtin.debug:
+            msg: >-
+              WARNING: could not restore ownership of {{ _backup_local_repo }}.
+              The backup itself is unaffected, but pruning or removing it may
+              need elevated access
+              {{ "(on rootless Podman: 'podman unshare rm -rf " ~ _backup_local_repo ~ "')"
+                 if (_backup_podman_rootless.stdout | default('') | trim) == 'true'
+                 else "(try sudo)" }}.
+          when:
+            - _backup_reclaim is defined
+            - _backup_reclaim.rc | default(0) != 0

--- a/tests/unit/test_backup_ownership_reclaim_namespace.py
+++ b/tests/unit/test_backup_ownership_reclaim_namespace.py
@@ -1,0 +1,138 @@
+"""The ownership reclaim runs inside a container — mind the namespace.
+
+restic runs as root in its container, so a local-path repo comes back
+root-owned and the operator cannot prune or remove their own backups.
+The reclaim exists to hand it back, and it chowns from inside a
+container.
+
+That uid is read through the runtime's user namespace. Rootless Podman
+maps container uid 0 to the operator and container uid N to
+subuid_base + N - 1, so passing the host uid straight through inverts
+the intent:
+
+    $ grep ^cicalese: /etc/subuid
+    cicalese:100000:65536
+    100000 + 1000 - 1 = 100999
+
+    $ ls -ld ~/podtest-backups
+    drwxr-xr-x 7 100999 100999 ... podtest-backups
+
+The operator was locked out of the repository the step was supposed to
+give back, and `failed_when: false` reported success. Docker has no such
+mapping and still wants the host uid.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+RUN_BACKUP = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "run_backup.yml")
+
+
+def _tasks():
+    out = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            out.append(node)
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for i in node:
+                walk(i)
+
+    with open(RUN_BACKUP) as f:
+        walk(yaml.safe_load(f))
+    return out
+
+
+def _names():
+    return [str(t.get("name", "")) for t in _tasks() if isinstance(t, dict)]
+
+
+def _named(needle):
+    return next(
+        (t for t in _tasks()
+         if needle.lower() in str(t.get("name", "")).lower()), None)
+
+
+class TestTheTargetIsChosenByNamespace:
+    def test_the_chown_is_not_hardcoded_to_the_host_uid(self):
+        argv = str(_named("Reclaim local-path repo ownership")
+                   ["ansible.builtin.command"]["argv"])
+        assert "_backup_repo_parent.stat.uid" not in argv, (
+            "passing the host uid into the container hands a rootless "
+            "Podman repo to a subuid the operator cannot use"
+        )
+        assert "_backup_chown_target" in argv
+
+    def test_rootless_podman_targets_container_root(self):
+        expr = str(_named("Choose the in-container ownership target")
+                   ["ansible.builtin.set_fact"]["_backup_chown_target"])
+        assert "'0:0'" in expr, (
+            "container uid 0 is what maps back to the operator under "
+            "rootless Podman"
+        )
+        assert expr.index("'0:0'") < expr.index("else"), (
+            "inverted, this sends 0:0 to Docker and the host uid to podman "
+            "— exactly backwards"
+        )
+
+    def test_docker_still_gets_the_host_uid(self):
+        expr = str(_named("Choose the in-container ownership target")
+                   ["ansible.builtin.set_fact"]["_backup_chown_target"])
+        assert "_backup_repo_parent.stat.uid" in expr
+        assert "_backup_repo_parent.stat.gid" in expr
+
+    def test_the_choice_keys_on_the_rootless_probe(self):
+        expr = str(_named("Choose the in-container ownership target")
+                   ["ansible.builtin.set_fact"]["_backup_chown_target"])
+        assert "_backup_podman_rootless" in expr
+
+
+class TestTheProbe:
+    def test_it_only_runs_for_podman(self):
+        when = str(_named("Detect rootless Podman for the ownership handback").get(
+            "when", ""))
+        assert "podman" in when.lower()
+
+    def test_a_failed_probe_is_not_fatal(self):
+        # An unreachable runtime must not fail a completed backup; the
+        # expression then falls through to the Docker branch.
+        assert _named("Detect rootless Podman for the ownership handback").get(
+            "failed_when") is False
+
+    def test_it_precedes_the_choice_and_the_chown(self):
+        names = _names()
+        probe_at = next(
+            i for i, n in enumerate(names) if "Detect rootless Podman for the ownership handback" in n)
+        choose_at = next(
+            i for i, n in enumerate(names) if "Choose the in-container" in n)
+        chown_at = next(
+            i for i, n in enumerate(names) if "Reclaim local-path repo" in n)
+        assert probe_at < choose_at < chown_at
+
+
+class TestFailureIsSurfaced:
+    def test_the_reclaim_is_still_best_effort(self):
+        # It must not turn a good backup into a failed run.
+        assert _named("Reclaim local-path repo ownership").get(
+            "failed_when") is False
+
+    def test_but_a_failure_warns(self):
+        warn = _named("Warn when repo ownership was not restored")
+        assert warn, (
+            "failed_when: false with no warning is how this stayed invisible"
+        )
+        assert "_backup_reclaim.rc" in str(warn.get("when", ""))
+
+    def test_the_warning_names_the_recovery(self):
+        msg = str(_named("Warn when repo ownership was not restored")
+                  ["ansible.builtin.debug"]["msg"])
+        assert "podman unshare" in msg, (
+            "a subuid-owned repo cannot be removed without entering the "
+            "user namespace; say so"
+        )

--- a/tests/unit/test_backup_repo_ownership.py
+++ b/tests/unit/test_backup_repo_ownership.py
@@ -66,10 +66,24 @@ class TestComposeReclaimsOwnership:
             "ansible.builtin.command", {}).get("argv", [])]
         assert "chown" in argv, "the reclaim task does not chown"
         joined = " ".join(argv)
-        assert "_backup_repo_parent.stat.uid" in joined, (
+        # The target is computed per runtime rather than interpolated here.
+        # The chown runs inside a container, and rootless Podman maps
+        # container uid N to subuid_base + N - 1, so passing the host uid
+        # through hands the repo to a subuid nobody can use. The Docker
+        # branch still derives from the parent directory, asserted below;
+        # both branches are covered in
+        # test_backup_ownership_reclaim_namespace.py.
+        assert "_backup_chown_target" in joined, (
             "ownership must come from the repo's parent directory, not a "
             "guess at who ran the command"
         )
+        chooser = next(
+            t for t in _tasks(COMPOSE_BACKUP)
+            if "Choose the in-container ownership target"
+            in str(t.get("name", ""))
+        )
+        assert "_backup_repo_parent.stat.uid" in str(
+            chooser["ansible.builtin.set_fact"]["_backup_chown_target"])
         assert "-R" in argv, "the whole repo tree needs chowning, not just its root"
 
     def test_it_runs_even_when_restic_fails(self):


### PR DESCRIPTION
Fixes #1323

After a backup on rootless Podman, the operator could not touch their own repository:

```
$ ls -ld ~/podtest-backups
drwxr-xr-x 7 100999 100999 4096 ... podtest-backups

$ rm -rf ~/podtest-backups
(fails — 7 entries not owned by the operator)
```

That is precisely what the reclaim step exists to prevent. Its own comment says so: *"restic runs as root in the container, so a local-path repo ends up root-owned and the operator cannot prune or remove their own backups."*

## Cause

The reclaim chowns from **inside a container**, using a uid read from a host `stat`. Rootless Podman maps container uid 0 to the operator and container uid N to `subuid_base + N - 1`:

```
$ grep ^cicalese: /etc/subuid
cicalese:100000:65536

100000 + 1000 - 1 = 100999      # exactly the observed owner
```

So passing the host uid straight through inverts the intent — on Docker it hands the repo back, on rootless Podman it hands it to a subuid nobody can use. `failed_when: false` meant it reported success either way.

## Fix

Choose the in-container target by runtime: `0:0` under rootless Podman, host `uid:gid` otherwise. Docker has no user-namespace mapping and is unchanged.

The reclaim stays best-effort — it must not turn a good backup into a failed run — but a failure now warns and names the recovery command instead of passing silently. Silence is how this stayed invisible.

## Verified live

Rootless Podman (podman 5.4.2, Debian 13), operator uid 1000, subuid base 100000:

| | before | after |
|---|---|---|
| repo owner | `100999` | `cicalese` (1000) |
| entries not owned by operator | 7 | 0 |
| plain `rm -rf` | failed | works |

No `podman unshare` needed afterwards, which is the practical outcome the step is for.

## Please look at this in review

This touched an existing test twice.

`test_backup_repo_ownership.py::_reclaim_task()` returns the **first** task whose name contains "reclaim". My probe was called "…before reclaim*ing* ownership" and silently became the match, so the test asserted against the wrong task. I renamed my tasks rather than change their helper — but that first-match-on-substring lookup is fragile and will do this again.

It then failed on its real assertion, which pinned `_backup_repo_parent.stat.uid` appearing literally in the chown argv — the value this fix moves into a fact. Its stated intent (*"ownership must come from the repo's parent directory, not a guess at who ran the command"*) is unchanged and still asserted, now against the expression that computes the target.

## Tests

`tests/unit/test_backup_ownership_reclaim_namespace.py` — 10 tests: the chown is not hardcoded to the host uid, rootless Podman targets `0:0` (and is not inverted), Docker keeps the host uid, the probe is podman-only and non-fatal, ordering, and a failed reclaim warns and names `podman unshare`.

`make test-unit` 2197 passed · `make lint` clean · `make validate` 87 commands, 69 playbooks, 161 examples.