### PR TITLE
feat(gitops): merge encrypted host vars instead of conflicting on them

### DIFF
--- a/roles/gitops/files/git-crypt-merge
+++ b/roles/gitops/files/git-crypt-merge
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Merge driver for the git-crypt encrypted paths in a Canasta gitops repo.
+#
+# Git hands a merge driver the three stage blobs exactly as stored, which for
+# an encrypted path is ciphertext — and ciphertext never merges, so without
+# this every concurrent edit to hosts/** is a conflict no operator can resolve
+# with ordinary git. Decrypt the stages, merge the plaintext, re-encrypt.
+#
+# The re-encryption is not optional: the clean filter does NOT run on a merge
+# result. Git stages what this script leaves in %A verbatim, so handing back
+# plaintext would commit the secrets in cleartext.
+#
+# Exit non-zero on any decrypt/encrypt failure. Git then keeps the conflict
+# and the three index stages, which is recoverable; staging a guess is not.
+#
+# Args: %O base   %A ours (result goes here)   %B theirs   %L marker size
+set -u
+
+base=$1
+ours=$2
+theirs=$3
+markers=${4:-7}
+
+MAGIC=00474954435259505400
+
+# is_encrypted below cannot tell "plaintext" from "could not look", and a
+# wrong answer skips decryption, merges ciphertext, and re-encrypts the
+# garbage under a zero exit — the one path that corrupts a vars file
+# silently. Refuse to run at all rather than guess.
+for tool in git git-crypt head od tr grep mv rm; do
+    command -v "$tool" >/dev/null 2>&1 || exit 1
+done
+
+is_encrypted() {
+    [ -s "$1" ] || return 1
+    head -c 10 "$1" | od -An -tx1 | tr -d ' \n' | grep -q "^$MAGIC"
+}
+
+# A stage can legitimately arrive as plaintext — an empty ancestor when both
+# sides added the file, or a path committed before it was encrypted — and
+# smudging that would corrupt it. The magic header decides, not the path.
+for stage in "$base" "$ours" "$theirs"; do
+    is_encrypted "$stage" || continue
+    if ! git-crypt smudge < "$stage" > "$stage.plain" 2>/dev/null; then
+        rm -f "$stage.plain"
+        exit 1
+    fi
+    mv "$stage.plain" "$stage"
+done
+
+# Labels describe a rebase, which is how gitops always pulls: the side being
+# replayed onto is the remote's, the commit being replayed is this host's.
+git merge-file --marker-size="$markers" \
+    -L remote -L base -L local "$ours" "$base" "$theirs"
+merged=$?
+
+if ! git-crypt clean < "$ours" > "$ours.enc" 2>/dev/null; then
+    rm -f "$ours.enc"
+    exit 1
+fi
+mv "$ours.enc" "$ours"
+
+exit $merged

--- a/roles/gitops/files/gitattributes.default
+++ b/roles/gitops/files/gitattributes.default
@@ -1,1 +1,1 @@
-hosts/** filter=git-crypt diff=git-crypt
+hosts/** filter=git-crypt diff=git-crypt merge=canasta-gitcrypt

--- a/roles/gitops/tasks/_ensure_merge_driver.yml
+++ b/roles/gitops/tasks/_ensure_merge_driver.yml
@@ -1,0 +1,56 @@
+---
+# Install and register the git-crypt aware merge driver on this host.
+#
+# The driver name in .gitattributes is shared through the repo, but the driver
+# itself is not: git resolves it through merge.<name>.driver in .git/config,
+# which no clone carries. Every host has to register it locally, so this runs
+# from init, join, pull and push — an in-the-wild repo self-heals on its next
+# pull rather than needing an operator to visit each host.
+#
+# Host-local only: nothing here touches a tracked file, so it is safe to run
+# before a pull, which refuses to proceed on a dirty tree.
+#
+# An unregistered driver is not a failure — git falls back to the ordinary
+# binary conflict, which is what these repos do today.
+#
+# Requires: instance_path.
+
+- name: Install the git-crypt merge driver
+  ansible.builtin.copy:
+    src: "{{ role_path }}/files/git-crypt-merge"
+    dest: "{{ instance_path }}/.git/canasta-git-crypt-merge"
+    mode: "0755"
+
+- name: Register the merge driver name
+  ansible.builtin.command:
+    cmd: >-
+      git config merge.{{ gitops_merge_driver }}.name
+      "Canasta git-crypt aware merge"
+    chdir: "{{ instance_path }}"
+  register: _merge_driver_name
+  changed_when: _merge_driver_name.rc == 0
+
+# %L is the conflict marker size; passing it keeps a nested conflict from
+# producing markers git cannot tell apart.
+- name: Register the merge driver command
+  ansible.builtin.command:
+    cmd: >-
+      git config merge.{{ gitops_merge_driver }}.driver
+      "{{ instance_path }}/.git/canasta-git-crypt-merge %O %A %B %L"
+    chdir: "{{ instance_path }}"
+  register: _merge_driver_cmd
+  changed_when: _merge_driver_cmd.rc == 0
+
+# Git only calls the driver if an attribute names it, and the tracked
+# .gitattributes in a repo created before the driver existed does not.
+# .git/info/attributes says it host-locally: not tracked, not cloned, and
+# merged per-attribute with the tracked file, which keeps supplying filter
+# and diff. That closes the window without committing anything — and without
+# two hosts racing to edit the same tracked line.
+- name: Name the merge driver for this checkout
+  ansible.builtin.lineinfile:
+    path: "{{ instance_path }}/.git/info/attributes"
+    regexp: '^hosts/\*\*\s+merge='
+    line: "hosts/** merge={{ gitops_merge_driver }}"
+    create: true
+    mode: "0644"

--- a/roles/gitops/tasks/init_compose.yml
+++ b/roles/gitops/tasks/init_compose.yml
@@ -163,6 +163,11 @@
     dest: "{{ instance_path }}/.gitattributes"
     mode: "0644"
 
+# .gitattributes names the merge driver; .git/config has to resolve it, and
+# no clone carries that, so every host registers it for itself.
+- name: Install and register the git-crypt merge driver
+  ansible.builtin.include_tasks: "_ensure_merge_driver.yml"
+
 # --- Step 8: Initialize git-crypt and export key ---
 - name: Initialize git-crypt
   ansible.builtin.command:

--- a/roles/gitops/tasks/join.yml
+++ b/roles/gitops/tasks/join.yml
@@ -215,6 +215,11 @@
     chdir: "{{ instance_path }}"
   changed_when: true
 
+# The joined repo may already name a merge driver this host cannot resolve
+# yet; register it now so the first pull can merge encrypted paths.
+- name: Install and register the git-crypt merge driver
+  ansible.builtin.include_tasks: "_ensure_merge_driver.yml"
+
 - name: Find tracked files whose content differs from the repo
   ansible.builtin.command:
     cmd: "git diff --name-only HEAD"

--- a/roles/gitops/tasks/pull_compose.yml
+++ b/roles/gitops/tasks/pull_compose.yml
@@ -12,6 +12,12 @@
 - name: Detect a locked git-crypt checkout
   ansible.builtin.include_tasks: "_detect_gitcrypt_lock.yml"
 
+# Host-local, touches no tracked file, so it is safe ahead of the dirty-tree
+# check below. Registering here is what lets a repo created before the driver
+# existed start merging encrypted paths on its next pull.
+- name: Install and register the git-crypt merge driver
+  ansible.builtin.include_tasks: "_ensure_merge_driver.yml"
+
 # --- Step 1: Check for uncommitted changes ---
 # Only tracked files are a hazard: a pull can overwrite a locally modified
 # tracked file. Untracked files cannot be clobbered unless an incoming commit

--- a/roles/gitops/tasks/push_compose.yml
+++ b/roles/gitops/tasks/push_compose.yml
@@ -50,6 +50,9 @@
       does not allow pushing. Only 'source' and 'both' roles can push.
   when: _push_role not in ['source', 'both']
 
+- name: Install and register the git-crypt merge driver
+  ansible.builtin.include_tasks: "_ensure_merge_driver.yml"
+
 # --- Migrate pre-classifier cleartext secret literals into vars.yaml ---
 # Runs before the shared-key migration so a freshly-encrypted secret can still
 # be promoted to _shared if it qualifies.

--- a/roles/gitops/vars/main.yml
+++ b/roles/gitops/vars/main.yml
@@ -24,6 +24,11 @@
 # decrypts the repository named by the per-host restic_repository, so
 # sharing it would hand every host a password for a repository it does
 # not back up to.
+# Name of the merge driver registered in .gitattributes (shared) and in each
+# host's .git/config (local). Encrypted paths are stored as ciphertext, which
+# git cannot merge on its own.
+gitops_merge_driver: canasta-gitcrypt
+
 gitops_shared_keys:
   - aws_access_key_id
   - aws_secret_access_key

--- a/tests/unit/test_gitops_merge_driver.py
+++ b/tests/unit/test_gitops_merge_driver.py
@@ -1,0 +1,135 @@
+"""The git-crypt merge driver must merge encrypted paths without leaking them.
+
+hosts/** is stored as ciphertext, which git cannot merge, so every concurrent
+edit to a shared vars file was an unresolvable binary conflict. A merge driver
+fixes that, but only if it re-encrypts what it hands back: the clean filter
+does NOT run on a merge result, so a driver that returns plaintext commits the
+secrets in cleartext. Everything here guards that one property.
+"""
+import os
+import stat
+
+import yaml
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+GITOPS = os.path.join(REPO_ROOT, "roles", "gitops")
+DRIVER = os.path.join(GITOPS, "files", "git-crypt-merge")
+ENSURE = os.path.join(GITOPS, "tasks", "_ensure_merge_driver.yml")
+ATTRS = os.path.join(GITOPS, "files", "gitattributes.default")
+VARS = os.path.join(GITOPS, "vars", "main.yml")
+
+
+def _read(path):
+    with open(path) as fh:
+        return fh.read()
+
+
+def _driver_name():
+    return yaml.safe_load(_read(VARS))["gitops_merge_driver"]
+
+
+def test_driver_is_executable():
+    assert os.path.isfile(DRIVER)
+    assert os.stat(DRIVER).st_mode & stat.S_IXUSR, (
+        "git invokes the driver directly; a non-executable one fails every merge"
+    )
+
+
+def test_driver_re_encrypts_its_result():
+    body = _read(DRIVER)
+    assert "git-crypt clean" in body, (
+        "the clean filter does not run on a merge result — a driver that "
+        "returns plaintext commits the secrets in cleartext"
+    )
+    # The re-encryption must gate the exit status, not run best-effort.
+    assert "if ! git-crypt clean" in body
+
+
+def test_driver_fails_closed_on_a_decrypt_failure():
+    body = _read(DRIVER)
+    assert "if ! git-crypt smudge" in body
+    assert body.count("exit 1") >= 3, (
+        "a locked checkout, a failed encrypt, and a missing tool must all "
+        "leave the conflict rather than stage a guess"
+    )
+
+
+def test_driver_refuses_to_run_without_its_tools():
+    body = _read(DRIVER)
+    assert "command -v" in body, (
+        "a missing 'head' makes the magic-header test answer 'not encrypted', "
+        "which merges ciphertext and re-encrypts the garbage under exit 0"
+    )
+    for tool in ("git-crypt", "head", "od", "tr", "grep"):
+        assert tool in body
+
+
+def test_driver_only_decrypts_what_is_encrypted():
+    body = _read(DRIVER)
+    assert "is_encrypted" in body, (
+        "an empty ancestor or a pre-encryption commit arrives as plaintext; "
+        "smudging it twice corrupts it"
+    )
+    assert "00474954435259505400" in body, "expected the git-crypt magic header"
+
+
+def test_driver_labels_the_conflict_sides():
+    body = _read(DRIVER)
+    assert "-L remote -L base -L local" in body, (
+        "unlabeled markers name temp files, which tells the operator nothing"
+    )
+    assert "--marker-size" in body
+
+
+def test_attribute_names_the_driver():
+    name = _driver_name()
+    line = _read(ATTRS).strip()
+    assert line.startswith("hosts/**")
+    assert "filter=git-crypt" in line and "merge=%s" % name in line
+
+
+def test_every_host_registers_the_driver_locally():
+    tasks = yaml.safe_load(_read(ENSURE))
+    body = _read(ENSURE)
+    # merge.<name>.driver lives in .git/config, which no clone carries.
+    assert "merge.{{ gitops_merge_driver }}.driver" in body
+    assert "%O %A %B %L" in body, "the driver needs all three stages"
+    copied = [t for t in tasks if "ansible.builtin.copy" in t]
+    assert copied and copied[0]["ansible.builtin.copy"]["mode"] == "0755"
+
+
+def test_the_driver_is_registered_everywhere_it_is_needed():
+    # init and join cover new hosts; pull and push let a repo that predates
+    # the driver self-heal without an operator visiting each host.
+    for flow in ("init_compose.yml", "join.yml", "pull_compose.yml",
+                 "push_compose.yml"):
+        body = _read(os.path.join(GITOPS, "tasks", flow))
+        assert "_ensure_merge_driver.yml" in body, "%s never registers it" % flow
+
+
+def test_registration_precedes_the_pull_and_touches_no_tracked_file():
+    body = _read(os.path.join(GITOPS, "tasks", "pull_compose.yml"))
+    assert body.index("_ensure_merge_driver.yml") < body.index("git -c commit.gpgsign=false pull"), (
+        "registering after the pull would not help that pull"
+    )
+    # pull refuses to run on a dirty tree, so registration must stay local.
+    ensure = _read(ENSURE)
+    assert "git add" not in ensure and "git commit" not in ensure
+
+
+def test_the_attribute_is_named_host_locally_not_committed():
+    body = _read(ENSURE)
+    # Git only calls the driver if an attribute names it. A repo created
+    # before the driver existed has no merge= in its tracked .gitattributes,
+    # so registering the driver alone would leave every existing repo still
+    # conflicting until some host committed that line.
+    assert ".git/info/attributes" in body, (
+        "the attribute has to be supplied host-locally, or existing repos "
+        "stay broken until someone pushes"
+    )
+    assert "merge={{ gitops_merge_driver }}" in body
+    # Committing it instead would have two hosts editing one tracked line
+    # from divergent bases — a conflict over the fix for conflicts.
+    push = _read(os.path.join(GITOPS, "tasks", "push_compose.yml"))
+    assert "git add -- .gitattributes" not in push


### PR DESCRIPTION
`hosts/**` is stored as ciphertext and no merge driver was named, so git compared ciphertext. Every concurrent edit to a shared vars file became a binary conflict no canasta command could resolve — the failure behind #1312, #1313 and #1314.

A driver decrypts the three conflict stages, merges the plaintext with `git merge-file`, and re-encrypts the result.

## What changes for an operator

- **Disjoint edits** — two hosts adding different keys, the common case and the one that actually bit us — merge with no operator involvement. `canasta gitops pull` simply succeeds.
- **A genuine same-key disagreement** still conflicts, but leaves ordinary conflict markers in plaintext in the working tree, labeled `remote` / `base` / `local`. The operator edits the file and continues, as for any other conflict, instead of facing an unmergeable blob.

## The load-bearing detail

**The clean filter does not run on a merge result.** Git stages whatever the driver leaves in `%A` verbatim, so a driver that hands back plaintext commits the secrets in cleartext. I reproduced that with the naive version: the merged blob began `6b 31 3a 20` instead of the `\0GITCRYPT\0` magic, and git-crypt printed `Warning: file not encrypted`. The driver re-encrypts with `git-crypt clean` and gates its exit status on that succeeding.

Every failure path exits non-zero and leaves the conflict with all three index stages intact, because a preserved conflict is recoverable and a staged guess is not. That includes a missing tool: `is_encrypted` cannot tell "plaintext" from "could not look", so a missing `head` would skip decryption, merge ciphertext, and re-encrypt the garbage under a *zero* exit — silently corrupting a vars file. The driver refuses to start unless every tool it needs is present.

## Both halves are host-local, so existing repos need no migration

Git resolves the driver through `merge.<name>.driver` in `.git/config`, and only calls it if an attribute names it. Neither is carried by a clone.

Naming the driver in the tracked `.gitattributes` would have left **every existing repo still conflicting until some host pushed** — and the failure mode is a *pull*, so the first post-upgrade pull would have found the driver registered and inert. It would also have had two hosts editing one tracked line from divergent bases: a conflict over the fix for conflicts.

So `.git/info/attributes` supplies `merge=` host-locally. It is not tracked, not cloned, and merges per-attribute with the tracked file, which keeps supplying `filter` and `diff`:

```
tracked .gitattributes:   hosts/** filter=git-crypt diff=git-crypt
.git/info/attributes:     hosts/** merge=canasta-gitcrypt

git check-attr →  merge: canasta-gitcrypt   filter: git-crypt   diff: git-crypt
```

`init`, `join`, `pull` and `push` all establish both halves, and `pull` does so before pulling, so a repo created long before this change starts merging on its very next pull with nothing committed.

## Verified against a real two-host git-crypt repo

- Disjoint edits: merged unattended, both edits present, blob encrypted at rest, `git-crypt status` clean.
- Same key, different values: conflicts with labeled plaintext markers in the working tree; resolving and continuing commits an encrypted blob.
- Driver's tools unavailable: exits non-zero, all three stages preserved, stage 2 still ciphertext, nothing staged.
- Attribute present but driver unregistered: falls back silently to today's binary conflict, so this cannot break a host that has not upgraded.
- Tracked `.gitattributes` with no `merge=` at all: auto-merges purely via `.git/info/attributes`.

## Not included

The conflict message from #1314 still prints its full decrypt-the-stages recipe. With the driver active that work is already done, so the message should collapse the encrypted case into the ordinary "edit and continue" route when it can see that the driver applies. Kept out of this PR to keep the driver reviewable on its own; worth doing in the same release.

`merge=canasta-gitcrypt` also stays in `gitattributes.default` so new repos carry it in-tree as documentation of intent, even though the host-local file is what drives it.

Fixes #1322
