### PR TITLE
fix(gitops): stop printing the manual recipe for an already-merged conflict

### DIFF
--- a/roles/gitops/tasks/_explain_pull_failure.yml
+++ b/roles/gitops/tasks/_explain_pull_failure.yml
@@ -19,13 +19,12 @@
         | while IFS= read -r -d '' f; do
             attr="$(git check-attr filter -- "$f" 2>/dev/null | sed 's/.*: //')"
             if [ "$attr" = "git-crypt" ]; then
-              # A registered merge driver has already decrypted, merged and
-              # re-encrypted this path, so what is left in the working tree is
-              # an ordinary marker conflict. Telling the operator to redo that
-              # by hand is the confusion this message exists to remove.
-              m="$(git check-attr merge -- "$f" 2>/dev/null | sed 's/.*: //')"
-              if [ -n "$m" ] && [ "$m" != "unspecified" ] \
-                 && git config --get "merge.$m.driver" >/dev/null 2>&1; then
+              # A merge driver leaves an editable marker conflict here, so the
+              # decrypt-by-hand recipe would be busywork. Decide on the file
+              # itself rather than on whether a driver is registered: a
+              # registered driver that failed closed leaves no markers and one
+              # side only, and calling that editable loses the other side.
+              if grep -q '^<<<<<<< ' "$f" 2>/dev/null; then
                 printf 'text\t%s\n' "$f"
               else
                 printf 'encrypted\t%s\n' "$f"

--- a/roles/gitops/tasks/_explain_pull_failure.yml
+++ b/roles/gitops/tasks/_explain_pull_failure.yml
@@ -19,7 +19,17 @@
         | while IFS= read -r -d '' f; do
             attr="$(git check-attr filter -- "$f" 2>/dev/null | sed 's/.*: //')"
             if [ "$attr" = "git-crypt" ]; then
-              printf 'encrypted\t%s\n' "$f"
+              # A registered merge driver has already decrypted, merged and
+              # re-encrypted this path, so what is left in the working tree is
+              # an ordinary marker conflict. Telling the operator to redo that
+              # by hand is the confusion this message exists to remove.
+              m="$(git check-attr merge -- "$f" 2>/dev/null | sed 's/.*: //')"
+              if [ -n "$m" ] && [ "$m" != "unspecified" ] \
+                 && git config --get "merge.$m.driver" >/dev/null 2>&1; then
+                printf 'text\t%s\n' "$f"
+              else
+                printf 'encrypted\t%s\n' "$f"
+              fi
               continue
             fi
             # A tracked binary (a public_assets logo) is just as unmergeable as

--- a/tests/unit/test_gitops_pull_conflict_message.py
+++ b/tests/unit/test_gitops_pull_conflict_message.py
@@ -168,3 +168,30 @@ def test_tracked_binaries_are_not_called_mergeable():
     msg = _fail_msg()
     assert "_pull_conflict_binary" in msg
     assert "are binary, so git cannot merge them either" in msg
+
+
+def test_encrypted_paths_the_merge_driver_handled_are_not_given_the_long_recipe():
+    # With a merge driver registered, the driver has already decrypted,
+    # merged and re-encrypted the path, so the working tree holds an ordinary
+    # marker conflict. Printing the decrypt-the-stages recipe for it tells the
+    # operator to redo work that is done.
+    task = _named(_explainer(), "Collect conflicted paths before the rebase is rolled back")
+    cmd = task["ansible.builtin.shell"]["cmd"]
+    assert "check-attr merge" in cmd, (
+        "encryption alone does not decide the advice; whether a driver ran does"
+    )
+    assert 'git config --get "merge.$m.driver"' in cmd, (
+        "the attribute can name a driver this host has not registered, and "
+        "then git falls back to the binary conflict the long recipe is for"
+    )
+    # Both conditions, not either: named AND registered.
+    assert '[ "$m" != "unspecified" ]' in cmd
+
+
+def test_the_long_recipe_survives_for_hosts_without_the_driver():
+    cmd = _named(_explainer(), "Collect conflicted paths before the rebase is rolled back")["ansible.builtin.shell"]["cmd"]
+    assert "printf 'encrypted" in cmd, (
+        "a host on an older CLI, or one where git-crypt is unavailable and "
+        "the driver failed closed, still needs the full recipe"
+    )
+    assert "git merge-file" in _fail_msg()

--- a/tests/unit/test_gitops_pull_conflict_message.py
+++ b/tests/unit/test_gitops_pull_conflict_message.py
@@ -170,28 +170,31 @@ def test_tracked_binaries_are_not_called_mergeable():
     assert "are binary, so git cannot merge them either" in msg
 
 
-def test_encrypted_paths_the_merge_driver_handled_are_not_given_the_long_recipe():
-    # With a merge driver registered, the driver has already decrypted,
-    # merged and re-encrypted the path, so the working tree holds an ordinary
-    # marker conflict. Printing the decrypt-the-stages recipe for it tells the
-    # operator to redo work that is done.
+def test_an_editable_conflict_is_not_given_the_long_recipe():
+    # A merge driver leaves ordinary markers in the working tree, so the
+    # decrypt-by-hand recipe would be busywork.
     task = _named(_explainer(), "Collect conflicted paths before the rebase is rolled back")
     cmd = task["ansible.builtin.shell"]["cmd"]
-    assert "check-attr merge" in cmd, (
-        "encryption alone does not decide the advice; whether a driver ran does"
+    assert "grep -q '^<<<<<<< '" in cmd, (
+        "the file itself says whether it can be edited in place"
     )
-    assert 'git config --get "merge.$m.driver"' in cmd, (
-        "the attribute can name a driver this host has not registered, and "
-        "then git falls back to the binary conflict the long recipe is for"
-    )
-    # Both conditions, not either: named AND registered.
-    assert '[ "$m" != "unspecified" ]' in cmd
 
 
-def test_the_long_recipe_survives_for_hosts_without_the_driver():
+def test_classification_is_on_the_file_not_on_what_is_registered():
+    cmd = _named(_explainer(), "Collect conflicted paths before the rebase is rolled back")["ansible.builtin.shell"]["cmd"]
+    # A registered driver that failed closed leaves no markers and one side
+    # only. Trusting the registration would call that editable, and the
+    # operator would save it and silently drop the other host's change.
+    assert "git config --get" not in cmd, (
+        "a driver can be registered and still not have run"
+    )
+    assert "check-attr merge" not in cmd
+
+
+def test_the_long_recipe_survives_for_conflicts_with_no_markers():
     cmd = _named(_explainer(), "Collect conflicted paths before the rebase is rolled back")["ansible.builtin.shell"]["cmd"]
     assert "printf 'encrypted" in cmd, (
-        "a host on an older CLI, or one where git-crypt is unavailable and "
-        "the driver failed closed, still needs the full recipe"
+        "an older CLI, or a driver that failed closed, still needs the full "
+        "recipe — the file holds one side and no markers"
     )
     assert "git merge-file" in _fail_msg()


### PR DESCRIPTION
With the merge driver from #1322 registered, a conflict git cannot auto-resolve still fails the pull, so the explainer runs. It classified the path by its `filter` attribute, saw `git-crypt`, and printed the full decrypt-the-three-stages recipe from #1314 — for a file the driver had already decrypted, merged and re-encrypted, whose working copy already held ordinary conflict markers. A page of raw git telling the operator to redo work that was done.

## Classify on the file, not on what is registered

The obvious implementation — check that the `merge` attribute names a driver and that this host has it registered — is wrong, and wrong in the dangerous direction.

A driver can be registered and still not have run. If it fails closed (a locked git-crypt checkout, a missing tool) git falls back to the binary conflict, and the working tree ends up holding one side of the file with no markers at all:

```
k1: REMOTE
k2: b
```

The local host's `k2: LOCAL` is nowhere in it. Trusting the registration classifies that as an ordinary text conflict, so the message says "resolve these the usual way" — the operator edits, stages, continues, and silently drops the other host's change. That is the exact trap #1314 exists to warn about.

So the test is whether the working copy actually contains conflict markers. Their presence is what decides whether the file can be edited in place, whether they came from a merge driver or from a plain text file, and it needs no knowledge of drivers at all.

| state | classified |
| --- | --- |
| driver worked, genuine conflict | `text` — edit in place |
| driver registered but failed closed | `encrypted` — full recipe |
| no driver at all (older CLI) | `encrypted` — full recipe |

Verified against a real two-host git-crypt repo in each state.

## No message rewrite

The three buckets already exist. A path with markers is reclassified as text and picks up the existing "resolve these the usual way" route. The long recipe stays for the cases above, where the file genuinely holds one side and cannot be edited in place.

## Ordering

Independent of #1326 — it reads the file rather than this repo's driver by name, so it merges cleanly either before or after, and simply has no effect until a driver is actually merging things.

Fixes #1327
