### PR TITLE
fix(create): probe the ports the instance will bind, not 80 and 443

### DIFF
--- a/roles/orchestrator/tasks/create_preflight.yml
+++ b/roles/orchestrator/tasks/create_preflight.yml
@@ -128,11 +128,16 @@
             - _podman_rootless.stdout | default('') | trim == 'true'
             - ((_rootless_facts.stdout_lines | default([]))[1] | default('0') | trim | int) > 80
 
-    # Port 80/443 conflict detection for Compose. Compose's caddy
-    # service binds host ports 80 and 443; if anything else is
-    # already serving on them, `docker compose up` will either fail
-    # the bind or — worse — appear to start while external traffic
-    # silently lands on the foreign service.
+    # Port conflict detection for Compose. Compose's caddy service
+    # binds HTTP_PORT and HTTPS_PORT (80 and 443 by default); if
+    # anything else is already serving on them, `docker compose up`
+    # will either fail the bind or — worse — appear to start while
+    # external traffic silently lands on the foreign service.
+    #
+    # A second instance on one host is expected to move off the
+    # defaults, so probe the ports this instance will actually bind.
+    # Its .env does not exist yet, but the -e envfile is a
+    # controller-side path, so the overrides can be read here.
     #
     # Two probes catch the common cases:
     #  1. `ss -tln` for a userspace listener (apache, nginx, haproxy,
@@ -151,13 +156,40 @@
     # on Linux. Try both, and make "no probe available" its own outcome —
     # an unrunnable check must not read as "port is free", which is what
     # `failed_when: false` plus an empty stdout used to produce.
-    - name: Probe for userspace listener on port 80
+    - name: Read the custom env file for port overrides
+      ansible.builtin.slurp:
+        src: "{{ envfile }}"
+      delegate_to: localhost
+      vars:
+        ansible_connection: local
+      register: _preflight_envfile
+      when: envfile is defined and envfile != ''
+
+    # Appending the default keeps [0] defined when the envfile is absent
+    # or sets neither key, so no branch is needed for the common case.
+    - name: Resolve the ports this instance will bind
+      ansible.builtin.set_fact:
+        _preflight_http_port: >-
+          {{ ((_preflight_port_lines | select('match', '^HTTP_PORT=') | list)
+              + ['HTTP_PORT=80'])[0].split('=', 1)[1] }}
+        _preflight_https_port: >-
+          {{ ((_preflight_port_lines | select('match', '^HTTPS_PORT=') | list)
+              + ['HTTPS_PORT=443'])[0].split('=', 1)[1] }}
+      vars:
+        # splitlines(), not split('\n'): a folded scalar hands Jinja a
+        # literal backslash-n, so the split would never match and every
+        # instance would silently fall back to 80/443.
+        _preflight_port_lines: >-
+          {{ (_preflight_envfile.content | default('') | b64decode).splitlines()
+             | map('trim') | select('match', '^HTTPS?_PORT=[0-9]+$') | list }}
+
+    - name: Probe for userspace listener on the HTTP port
       ansible.builtin.shell:
         cmd: |
           if command -v ss >/dev/null 2>&1; then
-            ss -tlnH "sport = :80"
+            ss -tlnH "sport = :{{ _preflight_http_port }}"
           elif command -v lsof >/dev/null 2>&1; then
-            lsof -nP -iTCP:80 -sTCP:LISTEN 2>/dev/null | tail -n +2
+            lsof -nP -iTCP:{{ _preflight_http_port }} -sTCP:LISTEN 2>/dev/null | tail -n +2
           else
             echo "CANASTA_PORT_PROBE_UNAVAILABLE"
           fi
@@ -165,13 +197,13 @@
       changed_when: false
       failed_when: false
 
-    - name: Probe for userspace listener on port 443
+    - name: Probe for userspace listener on the HTTPS port
       ansible.builtin.shell:
         cmd: |
           if command -v ss >/dev/null 2>&1; then
-            ss -tlnH "sport = :443"
+            ss -tlnH "sport = :{{ _preflight_https_port }}"
           elif command -v lsof >/dev/null 2>&1; then
-            lsof -nP -iTCP:443 -sTCP:LISTEN 2>/dev/null | tail -n +2
+            lsof -nP -iTCP:{{ _preflight_https_port }} -sTCP:LISTEN 2>/dev/null | tail -n +2
           else
             echo "CANASTA_PORT_PROBE_UNAVAILABLE"
           fi
@@ -185,34 +217,39 @@
     - name: Warn when the port check could not run
       ansible.builtin.debug:
         msg: >-
-          Could not check whether ports 80 and 443 are free: neither `ss`
-          nor `lsof` is available on this host. If something else is
-          already serving on them, compose will fail to bind (or caddy
-          will start while traffic lands on the other service).
+          Could not check whether ports {{ _preflight_http_port }} and
+          {{ _preflight_https_port }} are free: neither `ss` nor `lsof`
+          is available on this host. If something else is already
+          serving on them, compose will fail to bind (or caddy will
+          start while traffic lands on the other service).
       when: >-
         "CANASTA_PORT_PROBE_UNAVAILABLE" in
         (_port80_listener.stdout | default(''))
 
-    - name: Fail if port 80 is already in use
+    - name: Fail if the HTTP port is already in use
       ansible.builtin.fail:
         msg: >-
-          Port 80 is already in use on this host:
+          Port {{ _preflight_http_port }} is already in use on this host:
           {{ _port80_listener.stdout | trim }}.
-          `canasta create` (Compose) needs ports 80 and 443 free for
-          the caddy service. Stop the conflicting service or use a
-          different host.
+          `canasta create` (Compose) needs ports {{ _preflight_http_port }}
+          and {{ _preflight_https_port }} free for the caddy service.
+          Stop the conflicting service, use a different host, or give
+          this instance its own ports by passing an env file that sets
+          HTTP_PORT and HTTPS_PORT ('canasta create -e <file>').
       when:
         - _port80_listener.stdout | default('') | trim | length > 0
         - '"CANASTA_PORT_PROBE_UNAVAILABLE" not in (_port80_listener.stdout | default(""))'
 
-    - name: Fail if port 443 is already in use
+    - name: Fail if the HTTPS port is already in use
       ansible.builtin.fail:
         msg: >-
-          Port 443 is already in use on this host:
+          Port {{ _preflight_https_port }} is already in use on this host:
           {{ _port443_listener.stdout | trim }}.
-          `canasta create` (Compose) needs ports 80 and 443 free for
-          the caddy service. Stop the conflicting service or use a
-          different host.
+          `canasta create` (Compose) needs ports {{ _preflight_http_port }}
+          and {{ _preflight_https_port }} free for the caddy service.
+          Stop the conflicting service, use a different host, or give
+          this instance its own ports by passing an env file that sets
+          HTTP_PORT and HTTPS_PORT ('canasta create -e <file>').
       when:
         - _port443_listener.stdout | default('') | trim | length > 0
         - '"CANASTA_PORT_PROBE_UNAVAILABLE" not in (_port443_listener.stdout | default(""))'
@@ -230,6 +267,8 @@
 
     # `systemctl is-active` prints one line per service. Treat any
     # 'active' line as a positive — even if only k3s-agent is active.
+    # Traefik claims 80 and 443, so an instance that binds neither is
+    # unaffected and must not be blocked.
     - name: Fail if k3s is running
       ansible.builtin.fail:
         msg: >-
@@ -240,11 +279,16 @@
           to start but external requests will land on Traefik (and
           404). Stop k3s with 'sudo systemctl stop k3s' followed by
           'sudo /usr/local/bin/k3s-killall.sh' (the latter also
-          flushes the lingering iptables rules), or use a different
-          host for Compose installs.
-      when: >-
-        _k3s_active.stdout_lines | default([])
-        | select('eq', 'active') | length > 0
+          flushes the lingering iptables rules), use a different
+          host for Compose installs, or give this instance ports
+          other than 80 and 443 via 'canasta create -e <file>'.
+      when:
+        - >-
+          _k3s_active.stdout_lines | default([])
+          | select('eq', 'active') | length > 0
+        - >-
+          '80' in [_preflight_http_port, _preflight_https_port]
+          or '443' in [_preflight_http_port, _preflight_https_port]
 
     # The host memory floor is profile-aware (~2 GiB base, ~4 GiB with
     # Elasticsearch or observability, ~8 GiB with both), so it can't be checked

--- a/tests/unit/test_create_port_preflight.py
+++ b/tests/unit/test_create_port_preflight.py
@@ -38,12 +38,15 @@ def _fail_tasks():
 class TestPortPreflight:
     def test_fails_when_required_ports_in_use(self):
         fails = _fail_tasks()
-        for port in ("80", "443"):
+        # The ports are resolved from the -e envfile (defaulting to
+        # 80/443), so the messages name the fact rather than a literal.
+        for fact in ("_preflight_http_port", "_preflight_https_port"):
             hits = [t for t in fails
-                    if ("%s is already in use" % port)
-                    in str(t.get("ansible.builtin.fail")
-                           or t.get("fail"))]
-            assert hits, "no hard-fail for port %s already in use" % port
+                    if "is already in use" in str(t.get("ansible.builtin.fail")
+                                                  or t.get("fail"))
+                    and fact in str(t.get("ansible.builtin.fail")
+                                    or t.get("fail"))]
+            assert hits, "no hard-fail for %s already in use" % fact
 
     def test_port_fail_is_gated_on_a_listener_probe(self):
         # Each port fail must be conditional on its probe register having

--- a/tests/unit/test_port_preflight_portable.py
+++ b/tests/unit/test_port_preflight_portable.py
@@ -47,17 +47,31 @@ def _probe_tasks():
     return [
         t for t in _tasks()
         if isinstance(t.get("name"), str)
-        and re.match(r"Probe for userspace listener on port \d+", t["name"])
+        and re.match(
+            r"Probe for userspace listener on the HTTPS? port", t["name"])
     ]
 
 
 class TestProbeIsPortable:
     def test_both_ports_are_probed(self):
-        ports = sorted(
-            re.search(r"port (\d+)", t["name"]).group(1)
-            for t in _probe_tasks()
-        )
-        assert ports == ["443", "80"], "expected probes for 80 and 443, got %s" % ports
+        names = sorted(t["name"] for t in _probe_tasks())
+        assert len(names) == 2, (
+            "expected an HTTP and an HTTPS probe, got %s" % names)
+        assert any("HTTPS port" in n for n in names)
+        assert any(n.endswith("the HTTP port") for n in names)
+
+    def test_probes_use_the_resolved_ports_not_the_defaults(self):
+        # A second Compose instance on one host moves off 80/443 via the
+        # -e envfile. Hardcoding the defaults here rejected that create
+        # before the envfile was ever read.
+        for task in _probe_tasks():
+            cmd = task.get("ansible.builtin.shell", {}).get("cmd", "")
+            assert (
+                "_preflight_http_port" in cmd
+                or "_preflight_https_port" in cmd
+            ), (
+                "%s probes a literal port; it must probe the port this "
+                "instance will actually bind" % task["name"])
 
     def test_probe_falls_back_when_ss_is_absent(self):
         for task in _probe_tasks():
@@ -84,7 +98,8 @@ class TestFailureGateIgnoresTheSentinel:
         return [
             t for t in _tasks()
             if isinstance(t.get("name"), str)
-            and t["name"].startswith("Fail if port")
+            and re.match(r"Fail if the HTTPS? port is already in use",
+                         t["name"])
         ]
 
     def test_both_gates_exist(self):
@@ -105,3 +120,44 @@ class TestFailureGateIgnoresTheSentinel:
             "nothing tells the operator the check was skipped; a guard that "
             "silently does nothing is worse than no guard"
         )
+
+
+class TestPortsComeFromTheEnvFile:
+    """The documented way to run a second Compose instance on one host is
+    `canasta create -e <file>` with HTTP_PORT/HTTPS_PORT. Preflight runs
+    long before the envfile is merged into .env, so it has to read the
+    controller-side file itself or it rejects that create on the ports
+    the instance was never going to bind.
+    """
+
+    def _named(self, needle):
+        return [
+            t for t in _tasks()
+            if isinstance(t.get("name"), str) and needle in t["name"]
+        ]
+
+    def test_envfile_is_read_on_the_controller(self):
+        tasks = self._named("custom env file for port overrides")
+        assert tasks, "preflight never reads the -e envfile"
+        task = tasks[0]
+        assert task.get("delegate_to") == "localhost", (
+            "envfile is a controller-side path; slurping it on the target "
+            "looks for the controller's path on the remote filesystem")
+
+    def test_ports_are_resolved_with_defaults(self):
+        tasks = self._named("Resolve the ports this instance will bind")
+        assert tasks, "preflight never resolves the ports to probe"
+        facts = tasks[0]["ansible.builtin.set_fact"]
+        assert "HTTP_PORT=80" in facts["_preflight_http_port"], (
+            "no default; an absent envfile must still probe 80")
+        assert "HTTPS_PORT=443" in facts["_preflight_https_port"], (
+            "no default; an absent envfile must still probe 443")
+
+    def test_k3s_gate_only_fires_for_the_traefik_ports(self):
+        tasks = self._named("Fail if k3s is running")
+        assert tasks, "k3s gate disappeared"
+        when = tasks[0].get("when")
+        when_text = " ".join(when) if isinstance(when, list) else str(when)
+        assert "_preflight_http_port" in when_text, (
+            "Traefik claims 80 and 443 only; an instance binding neither "
+            "must not be blocked by a running k3s")

--- a/tests/unit/test_preflight_port_resolution.py
+++ b/tests/unit/test_preflight_port_resolution.py
@@ -1,0 +1,106 @@
+"""Evaluate the preflight port-resolution templates, not just their shape.
+
+The structural tests assert create_preflight.yml *mentions* the resolved
+port facts, which a template that always returns the defaults satisfies
+just as well as a working one. That is not hypothetical: written as
+`.split('\\n')` inside a folded scalar, Jinja receives a literal
+backslash-n, the split matches nothing, and every instance silently falls
+back to 80/443 — the exact bug the fix exists to remove, with the
+structural tests green.
+
+So render the real expressions through Ansible's own templar and assert
+on the values that come out.
+"""
+
+import base64
+import os
+
+import pytest
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+PREFLIGHT = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "create_preflight.yml")
+
+RESOLVE_TASK = "Resolve the ports this instance will bind"
+
+
+def _walk(node):
+    if isinstance(node, dict):
+        yield node
+        for v in node.values():
+            yield from _walk(v)
+    elif isinstance(node, list):
+        for i in node:
+            yield from _walk(i)
+
+
+def _resolve_task():
+    with open(PREFLIGHT) as f:
+        for task in _walk(yaml.safe_load(f)):
+            if task.get("name") == RESOLVE_TASK:
+                return task
+    raise AssertionError("%r not found in create_preflight.yml" % RESOLVE_TASK)
+
+
+def _render(envfile_text):
+    """Resolve the HTTP/HTTPS ports the way the playbook does.
+
+    envfile_text of None models "no -e envfile": the slurp is skipped, so
+    the register holds no content at all.
+    """
+    ansible_template = pytest.importorskip("ansible.template")
+    dataloader = pytest.importorskip("ansible.parsing.dataloader")
+
+    task = _resolve_task()
+    facts = task["ansible.builtin.set_fact"]
+    port_lines_expr = task["vars"]["_preflight_port_lines"]
+
+    slurped = {}
+    if envfile_text is not None:
+        slurped = {
+            "content": base64.b64encode(envfile_text.encode()).decode()}
+
+    templar = ansible_template.Templar(
+        loader=dataloader.DataLoader(),
+        variables={"_preflight_envfile": slurped},
+    )
+    trust = ansible_template.trust_as_template
+    port_lines = templar.template(trust(port_lines_expr))
+
+    templar = ansible_template.Templar(
+        loader=dataloader.DataLoader(),
+        variables={"_preflight_port_lines": port_lines},
+    )
+    return (
+        str(templar.template(trust(facts["_preflight_http_port"]))).strip(),
+        str(templar.template(trust(facts["_preflight_https_port"]))).strip(),
+    )
+
+
+class TestPortResolution:
+    def test_envfile_ports_are_honored(self):
+        http, https = _render(
+            "HTTP_PORT=8080\nHTTPS_PORT=8443\nCADDY_AUTO_HTTPS=off\n")
+        assert (http, https) == ("8080", "8443"), (
+            "preflight would probe %s/%s and reject a create on ports the "
+            "instance never binds" % (http, https))
+
+    def test_defaults_apply_without_an_envfile(self):
+        assert _render(None) == ("80", "443")
+
+    def test_defaults_apply_when_the_envfile_sets_no_ports(self):
+        assert _render("CANASTA_ENABLE_CROWDSEC=true\n") == ("80", "443")
+
+    def test_only_one_of_the_two_may_be_overridden(self):
+        assert _render("HTTP_PORT=8080\n") == ("8080", "443")
+        assert _render("HTTPS_PORT=8443\n") == ("80", "8443")
+
+    def test_crlf_and_padding_do_not_defeat_the_match(self):
+        http, https = _render("  HTTP_PORT=8080  \r\n\tHTTPS_PORT=8443\r\n")
+        assert (http, https) == ("8080", "8443")
+
+    def test_a_non_numeric_port_is_ignored_rather_than_probed(self):
+        # A bad value must not become the probed port; fall back instead.
+        assert _render("HTTP_PORT=notaport\n") == ("80", "443")


### PR DESCRIPTION
Preflight hardcoded its port probes to 80 and 443, so a second Compose instance on a host that already had one was rejected before it could say which ports it wanted — even though giving it `HTTP_PORT`/`HTTPS_PORT` via `-e` is the documented way to run two instances on one host.

Preflight cannot read the instance `.env`: it runs at `roles/create/tasks/main.yml` line 12, and `_envfile.yml` merges the envfile at line 116. The `-e` file is a controller-side path, though, so preflight can read it directly. It now does, and probes the ports the instance will actually bind. With no envfile the defaults keep the previous behavior exactly.

The k3s gate gets the same treatment. Traefik's PREROUTING rules intercept 80 and 443 only, so an instance bound to neither is unaffected and should not be blocked.

## `splitlines()`, not `split('\n')`

Worth calling out, because the first version of this fix passed every existing test while changing nothing. In a folded scalar (`>-`) YAML does not process `\n` as an escape, so Jinja receives a literal backslash-n, the split matches nothing, and every instance silently falls back to 80/443. `_envfile.yml` gets away with the same expression only because it sits in a double-quoted scalar, where YAML converts the escape first. `splitlines()` is independent of scalar style.

## Tests

The two existing test files assert that `create_preflight.yml` *mentions* the resolved port facts, which a template that always returns the defaults satisfies just as well as a working one — they stayed green against the bug above. Updated them to the new task names and message text, and added `tests/unit/test_preflight_port_resolution.py`, which renders the real expressions through Ansible's templar and asserts on the values: envfile ports honored, defaults without an envfile, defaults when the envfile sets no ports, one-of-two overridden, CRLF and padding tolerated, and a non-numeric port ignored rather than probed.

Reintroducing `split('\n')` fails two of the new tests and none of the twelve structural ones.

## Verification

`make test-unit` 2234 passed; `make lint` clean.

Verified live on a host running k3s with Traefik on 80/443 — the case that previously failed both gates. `canasta create -e` with `HTTP_PORT=8080`/`HTTPS_PORT=8443` now succeeds: caddy binds 8080/8443, the wiki serves 200, `canasta list` shows `localhost:8080/`, and the k3s cluster is unaffected (both nodes still Ready). A plain `create` with no envfile is still rejected on that host, as it should be.

Closes #1331
