### PR TITLE
ci(podman): pin podman to an exact version and force it onto PATH

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,16 +123,29 @@ jobs:
   # Docker is taken away rather than left idle: a hardcoded `docker` call has
   # to fail here instead of quietly reaching a live daemon.
   #
-  # Versions under test: Ubuntu's podman package with podman-compose pinned
-  # to 1.3.0 — the pairing the Podman runtime fixes were verified against.
-  # podman-compose 1.6.0 is not covered; the pull step's reliance on
-  # podman-compose skipping buildable services by default is confirmed for
-  # 1.3.0 only.
+  # Both runtimes are pinned to exact versions (see the job's env below):
+  # podman 4.9.3 with podman-compose 1.3.0, the pairing the Podman runtime
+  # fixes were verified against. podman-compose 1.6.0 is not covered; the
+  # pull step's reliance on podman-compose skipping buildable services by
+  # default is confirmed for 1.3.0 only.
+  #
+  # A pin the lane cannot enforce is worse than none, because the workflow
+  # then claims a version it is not running. Runner image
+  # ubuntu24/20260726.254 ships its own podman ahead of /usr/bin on PATH:
+  # apt installed 4.9.3 and `podman --version` reported 5.8.4, which failed
+  # the 4.14.1 release on a commit that touched only VERSION and
+  # RELEASE_NOTES (#1333). So the pinned binary is forced onto PATH and the
+  # result confirmed before any test runs. Whether 5.8.4 breaks create at
+  # all is #1334.
   integration-podman:
     name: "Integration: Podman"
     if: github.event_name != 'pull_request'  # See #67
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    # Job-scoped so the install and the PATH check cannot disagree.
+    env:
+      PODMAN_VERSION: "4.9.3+ds1-1ubuntu0.2"
+      PODMAN_COMPOSE_VERSION: "1.3.0"
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -142,12 +155,65 @@ jobs:
       - name: Install Podman and podman-compose
         run: |
           sudo apt-get update
-          sudo apt-get install -y git-crypt podman uidmap
+          sudo apt-get install -y git-crypt uidmap
+
+          if ! sudo apt-get install -y "podman=$PODMAN_VERSION"; then
+            echo "::error::podman $PODMAN_VERSION is no longer installable" \
+                 "from the archive. Available:"
+            apt-cache madison podman || true
+            echo "Pick a 4.x version from that list, update PODMAN_VERSION," \
+                 "and note the change — this lane's results are only" \
+                 "comparable across runs at a fixed runtime (#1333)."
+            exit 1
+          fi
+
           # Onto PATH, not into the repo venv: the CLI shells out to
           # `podman-compose` by name, so it has to resolve like an
           # operator's install would.
-          python -m pip install --user podman-compose==1.3.0
+          python -m pip install --user "podman-compose==$PODMAN_COMPOSE_VERSION"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # Installing the pinned package is not enough on its own. Runner image
+      # ubuntu24/20260726.254 ships its own podman ahead of /usr/bin on PATH,
+      # so apt installed 4.9.3 while `podman --version` reported 5.8.4 — and
+      # the lane failed the 4.14.1 release on a commit that touched only
+      # VERSION and RELEASE_NOTES (#1333). Move any such binary aside so the
+      # pinned one is what runs, then confirm it.
+      - name: Make the pinned podman the one on PATH
+        run: |
+          apt_podman="$(dpkg -L podman | grep -E '^/usr/bin/podman$' | head -1)"
+          [ -n "$apt_podman" ] || {
+            echo "::error::the podman package does not own /usr/bin/podman"
+            exit 1
+          }
+
+          for p in $(type -a -P podman || true); do
+            if [ "$p" != "$apt_podman" ] && [ -e "$p" ]; then
+              echo "Shadowing $p ($("$p" --version 2>/dev/null || echo unknown))"
+              sudo mv "$p" "$p.shadowed"
+            fi
+          done
+          hash -r
+
+          resolved="$(command -v podman)"
+          version="$(podman --version | awk '{print $3}')"
+          echo "podman under test: $resolved ($version)"
+          echo "podman-compose:    $(podman-compose --version 2>&1 | tail -1)"
+
+          # The pin is the mechanism; this only proves it took effect. It can
+          # still fail if the image overwrites /usr/bin/podman itself, which
+          # leaves nothing to shadow.
+          case "$version" in
+            "${PODMAN_VERSION%%+*}") ;;
+            *)
+              echo "::error::expected podman ${PODMAN_VERSION%%+*} but" \
+                   "$version resolved from $resolved. The pinned package is" \
+                   "installed, so something on PATH is still shadowing it" \
+                   "(#1333). Whether this version works at all is #1334 —" \
+                   "do not read this as a product regression."
+              exit 1
+              ;;
+          esac
 
       # Rootless Podman prerequisites the create pre-flight enforces: without
       # lingering, systemd reaps the containers when the session ends; with


### PR DESCRIPTION
Fixes #1333

The Podman lane failed the 4.14.1 release (`c0a6ece4`) and again on re-run, while every other job passed. That commit changed only `VERSION` and `RELEASE_NOTES.md`, and the lane had passed on its parent 20 minutes earlier.

What differed was the runner image:

| run | runner image | podman |
|---|---|---|
| pass (`30480450316`) | `ubuntu24/20260720.247` | 4.9.3 |
| fail (`30481965489`) | `ubuntu24/20260726.254` | **5.8.4** |

## Two problems, both fixed here

**The version was never pinned.** `apt-get install podman` took whatever the archive offered, while the comment above the job claimed a specific pairing was under test. It is now pinned to an exact version next to the existing podman-compose pin, job-scoped so the install and the check cannot drift apart:

```yaml
env:
  PODMAN_VERSION: "4.9.3+ds1-1ubuntu0.2"
  PODMAN_COMPOSE_VERSION: "1.3.0"
```

If that version ever leaves the archive the lane stops and prints `apt-cache madison podman`, rather than quietly installing something else.

**Pinning the package is not sufficient on its own.** This is the part that made the release look broken. In the failing run apt installed **the same package the passing run used**:

```
Get:7 .../noble-updates/universe amd64 podman amd64 4.9.3+ds1-1ubuntu0.2 [13.4 MB]
```

and `podman --version` still reported `5.8.4`, because the runner image ships its own podman ahead of `/usr/bin` on `PATH`. An exact `apt-get install podman=…` alone would have changed nothing. Any binary resolving ahead of the pinned one is now moved aside, and the resolved path and version are printed and checked before any test runs:

```
podman under test: /usr/bin/podman (4.9.3)
podman-compose:    podman-compose version 1.3.0
```

The check is a confirmation that the pin took effect, not the pin itself. It can still fire if a future image overwrites `/usr/bin/podman` directly, leaving nothing to shadow — in which case it stops with a message naming #1333 and #1334 instead of running an unknown runtime and reporting a product failure.

## Scope

This makes the lane run the runtime it claims to run. It does **not** address whether podman 5.8.4 breaks `canasta create` — that is #1334, which needs a 5.8.4 host to answer.

Ruled out there so far: the release contents, the port preflight (`ss -tlnH` / `lsof -nP`, neither blocks), and podman-compose [#1178](https://github.com/containers/podman-compose/issues/1178) — its `check_dep_conditions()` loop requires `condition: service_healthy`, which this stack never uses; `docker-compose.yml:172` documents choosing `service_started` precisely because podman-compose cannot see image-level healthchecks.

## Verification

`make lint` clean · `make test-unit` 2234 passed · the workflow parses, `PODMAN_VERSION` resolves at job scope, and the new step sits between the install and the Docker-removal steps.

The behavior cannot be verified before merge: the lane only runs post-merge (`if: github.event_name != 'pull_request'`, #67).
