### PR TITLE
ci(podman): compare canonical paths when shadowing podman

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -187,15 +187,28 @@ jobs:
             exit 1
           }
 
+          # Compare canonical paths, not strings: /bin is a symlink to
+          # /usr/bin, so `type -a -P` lists the pinned binary twice and a
+          # string compare moves it aside as if it were a foreign one —
+          # which is what broke this step on its first run. The Docker
+          # removal below hits the same symlink and handles it by checking
+          # `-e` after each move.
+          pinned="$(readlink -f "$apt_podman")"
           for p in $(type -a -P podman || true); do
-            if [ "$p" != "$apt_podman" ] && [ -e "$p" ]; then
+            [ -e "$p" ] || continue
+            if [ "$(readlink -f "$p")" != "$pinned" ]; then
               echo "Shadowing $p ($("$p" --version 2>/dev/null || echo unknown))"
               sudo mv "$p" "$p.shadowed"
             fi
           done
           hash -r
 
-          resolved="$(command -v podman)"
+          resolved="$(command -v podman || true)"
+          [ -n "$resolved" ] || {
+            echo "::error::no podman on PATH after shadowing — the pinned" \
+                 "binary at $apt_podman was moved aside by mistake (#1333)."
+            exit 1
+          }
           version="$(podman --version | awk '{print $3}')"
           echo "podman under test: $resolved ($version)"
           echo "podman-compose:    $(podman-compose --version 2>&1 | tail -1)"


### PR DESCRIPTION
Follow-up to #1335, which broke the lane it was fixing. My bug.

The Podman lane now fails in 23 seconds at "Make the pinned podman the one on PATH":

```
Shadowing /bin/podman (podman version 4.9.3)
##[error]Process completed with exit code 1.
```

It shadowed the **pinned** binary, not a foreign one, and then nothing resolved.

## Cause

`/bin` is a symlink to `/usr/bin`, so `type -a -P podman` lists the same file twice:

```
/bin/podman
/usr/bin/podman
```

`dpkg -L` reports `/usr/bin/podman`. The loop saw `/bin/podman` first, compared the two as **strings**, concluded it was a different binary, and moved the pinned podman away.

The Docker-removal step three lines below hits the identical symlink and already guards against it:

> `# /bin is a symlink to /usr/bin, so type -a -P reports the same binary twice; the second path is already gone once the first is moved.`

I wrote the podman loop without that guard.

Worth noting from the same run: podman resolved to **4.9.3** before the loop touched anything, so the exact-version pin from #1335 is working — there was no foreign binary to shadow on this runner image at all.

## Fix

Compare `readlink -f` output rather than path strings, and fail with a specific message if nothing resolves after the loop instead of reporting a version mismatch for a binary that is no longer present.

## Verified

Both failure modes, against the real step body:

```
$ # /bin -> /usr/bin symlink, plus a foreign podman earlier on PATH
Shadowing /tmp/symtest2/opt/podman (podman version 5.8.4)
podman under test: /tmp/symtest2/bin/podman (4.9.3)
```

The foreign binary is shadowed; the pinned one, listed twice via the symlink, is left alone. Under the old comparison the same simulation moved the pinned binary and left nothing on PATH.

`make lint` clean · `make test-unit` 2234 passed.

The lane itself only runs post-merge (#67), so this cannot be confirmed green until it lands — but the failure it addresses is deterministic, not environmental, and the simulation above exercises the same code path.
