### PR TITLE
fix(create): probe the container runtime without reporting a failure

### DIFF
--- a/roles/orchestrator/tasks/create_preflight.yml
+++ b/roles/orchestrator/tasks/create_preflight.yml
@@ -37,24 +37,27 @@
             cmd: podman info
           register: _docker_check
           changed_when: false
-          ignore_errors: true
+          failed_when: false
 
     - name: Probe Docker then Podman for remote/detected runtime
       when: not (compose_command | default('docker compose') is search('podman'))
       block:
+        # failed_when, not ignore_errors: a Podman-only host is expected
+        # to miss here, and ignore_errors would print a docker failure
+        # block before the fallback below succeeds. Callers read .rc.
         - name: Probe docker info
           ansible.builtin.command:
             cmd: docker info
           register: _docker_check
           changed_when: false
-          ignore_errors: true
+          failed_when: false
 
         - name: Probe podman info (fallback)
           ansible.builtin.command:
             cmd: podman info
           register: _podman_check
           changed_when: false
-          ignore_errors: true
+          failed_when: false
 
         - name: Set compose_command to podman-compose if Docker absent but Podman present
           ansible.builtin.set_fact:


### PR DESCRIPTION
On a Podman-only host the `docker info` probe is expected to miss, but `ignore_errors: true` prints the whole failure block before the podman fallback runs — so every `canasta create` on such a host opens with a red `FAILED!` naming a missing `docker` binary, which then reads as the cause of anything that goes wrong later.

`failed_when: false` continues just as quietly and still registers `.rc`, which is what all three conditions downstream already read (`_docker_check.rc | default(1)`). Two probes further down the same file use `failed_when: false` for the same reason.

Visible in the Podman lane, where Docker is removed on purpose:

```
TASK [orchestrator : Probe docker info] ***
fatal: [localhost]: FAILED! => {"cmd": "docker info", "rc": 2,
  "msg": "Error executing command: [Errno 2] No such file or directory: b'docker'"}
...ignoring
TASK [orchestrator : Probe podman info (fallback)] ***
ok: [localhost]
```

Detection behavior is unchanged — only whether a miss is reported as a failure.

Closes #1350
