### PR TITLE
fix(delete): probe for a Kubernetes instance without reporting failures

### DIFF
--- a/roles/delete/tasks/main.yml
+++ b/roles/delete/tasks/main.yml
@@ -132,24 +132,28 @@
 - name: Discover unregistered instance
   when: _delete_query is failed
   block:
+    # These three are allowed to miss: the id may name a Compose instance,
+    # or a host with kubectl installed but no cluster reachable. Hence
+    # failed_when over ignore_errors — the latter prints a full failure
+    # block for each probe before carrying on to the right answer.
     - name: Check if kubectl is available
       ansible.builtin.command:
         cmd: "kubectl version --client"
       register: _kubectl_check
       changed_when: false
-      ignore_errors: true  # OK if kubectl not installed
+      failed_when: false
 
     - name: Fail if no kubectl (Compose instance not in registry)
       ansible.builtin.fail:
         msg: "Instance '{{ id }}' not found in the registry."
-      when: _kubectl_check is failed
+      when: _kubectl_check.rc | default(1) != 0
 
     - name: Check for Helm release
       ansible.builtin.command:
         cmd: "helm status canasta-{{ id }} -n canasta-{{ id }}"
       register: _helm_status
       changed_when: false
-      ignore_errors: true  # OK if no Helm release exists
+      failed_when: false
 
     - name: Check for Kubernetes namespace
       kubernetes.core.k8s_info:
@@ -157,7 +161,7 @@
         kind: Namespace
         name: "canasta-{{ id }}"
       register: _ns_check
-      ignore_errors: true  # OK if namespace doesn't exist
+      failed_when: false
 
     - name: Set Kubernetes facts for unregistered instance
       ansible.builtin.set_fact:
@@ -168,14 +172,14 @@
         instance_managed_cluster: false
         _instance_registered: false
       when: >-
-        (_helm_status is succeeded) or
+        (_helm_status.rc | default(1) == 0) or
         (_ns_check.resources | default([]) | length > 0)
 
     - name: Fail if no K8s resources found
       ansible.builtin.fail:
         msg: "Instance '{{ id }}' not found in the registry or Kubernetes."
       when: >-
-        (_helm_status is not succeeded) and
+        (_helm_status.rc | default(1) != 0) and
         (_ns_check.resources | default([]) | length == 0)
 
 - name: Require confirmation for delete


### PR DESCRIPTION
When the id is not in the registry, delete falls back to looking for a Kubernetes instance: kubectl, then `helm status`, then the namespace API. All three are allowed to miss, but `ignore_errors: true` prints a full failure block for each before the play reaches the right conclusion — so a working `canasta delete` on any host with kubectl installed and no cluster reachable looks like three faults.

Switches the probes to `failed_when: false` and moves the conditions from `is failed` / `is succeeded` to `.rc`, the idiom `k8s_preflight.yml` and `create_preflight.yml` already use. Behavior is unchanged; only the reporting of an expected miss.

```
TASK [delete : Check for Helm release] ***
fatal: [localhost]: FAILED! => {"cmd": ["helm", "status", ...],
  "stderr": "Error: Kubernetes cluster unreachable: ... connection refused"}
...ignoring
```

The registry lookups higher in the same file produce similar output and are deliberately left alone — those conditions are threaded through the whole play and are worth their own change.

Closes #1349
