### PR TITLE
test(integration): make teardown failures fail the run

### DIFF
--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -171,15 +171,39 @@ class TestInstance:
     def env_path(self):
         return os.path.join(self.instance_path(), ".env")
 
+    def is_registered(self):
+        """True when this test's registry still lists the instance."""
+        path = os.path.join(self.config_dir, "conf.json")
+        try:
+            with open(path) as f:
+                return self.id in (json.load(f).get("Instances") or {})
+        except (OSError, ValueError):
+            return False
+
     def cleanup(self):
-        """Delete the instance and remove work directory."""
-        print("  Cleanup: deleting instance %s" % self.id)
-        self.run("delete", "-i", self.id, "--yes")
+        """Delete the instance and remove work directory.
+
+        Returns False when teardown failed. Tests that never create an
+        instance, or that delete it themselves, leave nothing to remove:
+        deleting anyway fails and fills a passing run's log with the
+        failure. A delete that fails for an instance still in the
+        registry is a real leak — containers, volumes and the entry
+        itself outlive the test, and the next one inherits them.
+        """
+        ok = True
+        if self.is_registered():
+            print("  Cleanup: deleting instance %s" % self.id)
+            _, rc = self.run("delete", "-i", self.id, "--yes")
+            if rc != 0:
+                print("  CLEANUP FAILED: canasta delete -i %s exited %d"
+                      % (self.id, rc))
+                ok = False
         subprocess.run(
             ["sudo", "rm", "-rf", self.work_dir],
             capture_output=True,
         )
         shutil.rmtree(self.config_dir, ignore_errors=True)
+        return ok
 
 
 def wait_for_wiki(http_port, timeout=300):
@@ -3887,6 +3911,7 @@ def main():
     passed = 0
     failed = 0
     skipped = 0
+    teardown_failed = []
 
     for name, test_fn in tests.items():
         inst = TestInstance("inttest-%s" % name)
@@ -3905,12 +3930,15 @@ def main():
             print("ERROR: %s: %s" % (name, e))
             failed += 1
         finally:
-            inst.cleanup()
+            if not inst.cleanup():
+                teardown_failed.append(name)
 
     print("\n=== Results: %d passed, %d failed, %d skipped ===" % (
         passed, failed, skipped,
     ))
-    sys.exit(1 if failed else 0)
+    if teardown_failed:
+        print("=== Teardown failed: %s ===" % ", ".join(teardown_failed))
+    sys.exit(1 if failed or teardown_failed else 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two problems in `TestInstance.cleanup()`, one hiding the other.

**Teardown could not fail the run.** `PASSED` prints before the `finally:` block, and cleanup called `self.run("delete", ...)` while dropping the returned `rc`. A `canasta delete` that broke outright would still produce `Results: N passed, 0 failed`, with containers, volumes and registry entries left for the next test to inherit.

**Cleanup deleted instances that were never created.** Tests that create nothing, or that delete the instance as part of what they exercise, still got a `canasta delete` — which fails, and prints its failure into the log of a passing run. That is most of the red text in a green integration lane today: 24 such blocks in a Core Lifecycle run reporting 8 passed, 0 failed.

The fix reads the test's own `conf.json` and skips the delete when the instance is no longer listed, then reports the deletes that do fail:

```
=== Results: 8 passed, 0 failed, 0 skipped ===
=== Teardown failed: lifecycle ===
```

Worth being explicit: this can turn a currently-green lane red, because a delete that fails for a registered instance is now a failure rather than silence. That is the point of the change.

Verified `is_registered()` against a populated registry, an empty one, a missing file and truncated JSON.

Closes #1348
