### PR TITLE
test(integration): stream CLI output instead of buffering it

### DIFF
--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -119,20 +119,34 @@ class TestInstance:
         return env
 
     def run(self, *args):
-        """Run a canasta command in verbose mode. Returns (stdout, returncode)."""
+        """Run a canasta command in verbose mode. Returns (stdout, returncode).
+
+        Streams each line as it arrives instead of collecting the whole
+        run and printing it at the end. A command that outlives the CI
+        step timeout is killed outright, and buffered output dies with
+        it — a create that stalled produced 35 minutes of nothing, while
+        Ansible had been printing a retry line every 10 seconds naming
+        the task it was stuck on.
+        """
         env = self.cli_env()
         # Run in verbose mode for CI feedback
         cmd = [CANASTA_BIN, "--verbose"] + list(args)
         print("  $ canasta %s" % " ".join(args), flush=True)
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, cwd=self.work_dir, env=env,
+        # stderr folded into stdout so the two stay in order; they were
+        # concatenated before, which put every warning after the run.
+        proc = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, bufsize=1, cwd=self.work_dir, env=env,
         )
-        output = result.stdout + result.stderr
-        if output.strip():
-            for line in output.strip().split("\n"):
-                print("    %s" % line)
+        lines = []
+        for line in proc.stdout:
+            line = line.rstrip("\n")
+            lines.append(line)
+            print("    %s" % line, flush=True)
+        proc.stdout.close()
+        returncode = proc.wait()
         sys.stdout.flush()
-        return output, result.returncode
+        return "\n".join(lines), returncode
 
     def run_quiet(self, *args):
         """Run without --verbose for parseable output."""


### PR DESCRIPTION
`TestInstance.run()` buffered a command's whole output and printed it after the process exited, so a command killed by the CI step timeout logged nothing at all. #1334 reads as 35 minutes of silence for that reason alone — Ansible was printing a retry line every ten seconds naming the wait it was stuck on, into a buffer the harness never got to flush.

Reads the child's output line by line and prints as it arrives. The accumulated text is still the return value, so callers are unchanged; `.split("\n")` on it now yields no trailing empty element, since the joined string has no trailing newline.

stderr folds into stdout rather than being concatenated after it, so warnings appear where they happened instead of after the run.

Verified against a stub that writes to both streams with a pause in the middle:

```
[t+0.0s]   $ canasta whatever
[t+0.2s]     line one to stdout
[t+0.2s]     line two to stderr
[t+1.2s]     line three after a pause
rc = 7
```

The third line arrives at t+1.2s rather than all three landing together at the end, and the exit code survives.

`run_quiet()` is left alone: short commands whose output is parsed, not where a stall shows up.

Closes #1354
