### PR TITLE
fix(compose): declare web's healthcheck so Podman has a readiness gate

### DIFF
--- a/roles/orchestrator/files/compose/docker-compose.yml
+++ b/roles/orchestrator/files/compose/docker-compose.yml
@@ -58,6 +58,22 @@ services:
     restart: unless-stopped
     <<: *default-network
     logging: *default-logging
+    # Declared here rather than left to the image's own HEALTHCHECK:
+    # podman ignores that field in an OCI-format image config, so the
+    # container reports no health at all and start.yml's readiness gate
+    # skips both of its arms. Compose passes this one through as
+    # --health-cmd on either runtime.
+    #
+    # 127.0.0.1, not localhost: mediawiki.conf serves /server-status
+    # only when REMOTE_ADDR is exactly '127.0.0.1', and localhost
+    # resolves to ::1 first under rootless podman, which falls through
+    # to MediaWiki as a 404.
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --method=HEAD 127.0.0.1/server-status"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 300s
     extra_hosts:
       # "host-gateway" is a magic value resolved by the container engine.
       # Docker and podman >= 4.4 understand it; podman < 4.4 rejects it.


### PR DESCRIPTION
Podman gets no readiness gate today. The check lives in the image, and podman ignores `Healthcheck` in an OCI-format image config, so the web container reports no health at all — both arms of `start.yml`'s gate skip and `create` races composer. `install.php` then runs against a half-written `vendor/`, which is the intermittent failure in #1296 and again on `main` today in [run 30564941145](https://github.com/CanastaWiki/Canasta-CLI/actions/runs/30564941145).

Declaring the check in the compose file gets it to either runtime as `--health-cmd`, the same way `db` and `elasticsearch` already report health on Podman. Docker is unaffected — a compose-level check overrides an identical image-level one.

## Why `127.0.0.1` and not `localhost`

`mediawiki.conf` serves `/server-status` only inside

```apache
<If "%{REMOTE_ADDR} == '127.0.0.1' && %{REQUEST_URI} == '/server-status'">
```

Under rootless podman `localhost` resolves to `::1` first, so `REMOTE_ADDR` never matches and the request falls through to MediaWiki. Measured inside a running web container on Debian 13 / podman 5.4.2:

```
localhost/server-status:  HTTP/1.1 404 Not Found
127.0.0.1/server-status:  HTTP/1.1 200 OK      (~22s after start)
```

Spelling it `localhost` would have turned a missing gate into a ten-minute wait on a check that cannot pass.

## Verified

Patched compose on a Podman host, `canasta create`:

```
TASK [orchestrator : Wait for web container to report healthy]
FAILED - RETRYING: ... (59 retries left).
FAILED - RETRYING: ... (58 retries left).
ok: [localhost]

Probe whether web defines a healthcheck (Podman): skipping
Wait for web to pass its healthcheck (Podman):    skipping

health=[healthy]  hc=[CMD-SHELL wget -q --method=HEAD 127.0.0.1/server-status]
gatetest_web_1 | Up 26 seconds (healthy)
create_rc=0  elapsed=148s
```

The gate engages and clears in the same two-retries shape the Docker lane has always had, and the Podman fallback correctly stops being needed. Create went 128s → 148s; that difference is the wait doing its job.

`make test-unit` (2257 passed), `make lint` and `validate_definitions` all pass.

## Not in scope

The image's own `HEALTHCHECK` in CanastaBase has the same `localhost` bug. It is invisible on Docker and moot here once compose overrides it, but any IPv6-preferring runtime reading that image directly gets a permanently failing healthcheck. That belongs in the CanastaBase repo.

This does not re-open #484 — that was `depends_on: condition: service_healthy`, which stays `service_started`.

Closes #1356
