### PR TITLE
Revert "fix(compose): declare web's healthcheck so Podman has a readiness gate"

### DIFF
--- a/roles/orchestrator/files/compose/docker-compose.yml
+++ b/roles/orchestrator/files/compose/docker-compose.yml
@@ -58,22 +58,6 @@ services:
     restart: unless-stopped
     <<: *default-network
     logging: *default-logging
-    # Declared here rather than left to the image's own HEALTHCHECK:
-    # podman ignores that field in an OCI-format image config, so the
-    # container reports no health at all and start.yml's readiness gate
-    # skips both of its arms. Compose passes this one through as
-    # --health-cmd on either runtime.
-    #
-    # 127.0.0.1, not localhost: mediawiki.conf serves /server-status
-    # only when REMOTE_ADDR is exactly '127.0.0.1', and localhost
-    # resolves to ::1 first under rootless podman, which falls through
-    # to MediaWiki as a 404.
-    healthcheck:
-      test: ["CMD-SHELL", "wget -q --method=HEAD 127.0.0.1/server-status"]
-      interval: 10s
-      timeout: 5s
-      retries: 30
-      start_period: 300s
     extra_hosts:
       # "host-gateway" is a magic value resolved by the container engine.
       # Docker and podman >= 4.4 understand it; podman < 4.4 rejects it.


### PR DESCRIPTION
Reverts #1357, which is worse than the bug it fixed.

Declaring the healthcheck makes the container report a status on Podman, so `start.yml` takes the wait-for-healthy arm. Where podman cannot actually run the check, that status stays `starting` until the 60 x 10s budget is spent and `create` fails. #1356 was an intermittent race; this made every Podman create a guaranteed ten-minute failure.

From [run 30590492557](https://github.com/CanastaWiki/Canasta-CLI/actions/runs/30590492557), the Podman lane — all three creates failed and the step hit its 35-minute timeout:

```
fatal: [localhost]: FAILED! => {"attempts": 60,
  "cmd": ["podman", "inspect", "-f", "{{.State.Health.Status}}", "0f4dce34e045"],
  "stdout": "starting"}
```

## Why it passed validation

I verified #1357 on a host running distro podman with a working systemd user session, where the check goes `healthy` in about 22 seconds. The CI lane runs the static bundle from mgoltzsche/podman-static, which upstream documents as built *without systemd support* — and podman schedules healthchecks with systemd transient timers. Nothing runs the check there.

That also vindicates the comment at `start.yml:201`, which says exactly this and which I argued against in #1356 on the strength of a test from the wrong kind of host.

Docker is unaffected either way: the Core Lifecycle failure in that same run was Docker Hub refusing the `library/mariadb:11.4` manifest, and the seven tests that did run showed the gate clearing normally.

## What #1356 needs instead

A readiness signal that does not depend on the runtime executing healthchecks — polling the endpoint from the play rather than asking podman for `.State.Health.Status`. That has to be validated against the static bundle specifically, not only a systemd host.

Reopens #1356.
