### PR TITLE
fix(start): drive Podman's readiness gate from the play

### DIFF
--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -198,52 +198,59 @@
         - _start_web_cid.stdout | trim != ''
         - _start_web_has_health.stdout | default('') | trim != ''
 
-    # Podman inherits the image's healthcheck but never runs it under
-    # podman-compose: it schedules checks with systemd transient timers
-    # that compose does not create, so .State.Health.Status stays empty
-    # and the wait above is skipped for every container. Skipping it is
-    # right for a custom image that declares no healthcheck, and wrong
-    # here — it restores the composer race the gate exists to prevent.
-    # `podman healthcheck run` executes the configured check on demand,
-    # so poll that instead of a status nothing updates.
-    - name: Probe whether web defines a healthcheck (Podman)
+    # Podman renders an empty status for the stock image, so the wait
+    # above skips and the composer race comes back. Two reasons, both
+    # outside our control: the published image is OCI-format and podman
+    # ignores Healthcheck in an OCI config, and podman runs healthchecks
+    # from systemd transient timers that compose never creates — the
+    # static builds used in CI have no systemd at all.
+    #
+    # So ask the container the question the healthcheck would ask,
+    # rather than asking the runtime for an answer it cannot produce.
+    # This depends on nothing but `exec`.
+    #
+    # 127.0.0.1, not localhost: mediawiki.conf serves /server-status
+    # only when REMOTE_ADDR is exactly '127.0.0.1', and localhost
+    # resolves to ::1 first under rootless podman, which falls through
+    # to MediaWiki as a 404.
+    #
+    # Best-effort on purpose. A custom image that never serves
+    # /server-status must not turn a missing signal into a failed
+    # create — the gate did not run on Podman at all before this, so
+    # warning and continuing is never worse than the old behavior,
+    # while a wait that cannot pass would be far worse. 30 × 10s
+    # matches the image healthcheck's 5 min --start-period.
+    - name: Wait for web to answer on Podman
       ansible.builtin.command:
         argv:
           - "{{ _inspect_cmd }}"
-          - healthcheck
-          - run
+          - exec
           - "{{ _start_web_cid.stdout | trim }}"
-      register: _start_web_hc_probe
+          - wget
+          - "-q"
+          - "--method=HEAD"
+          - "127.0.0.1/server-status"
+      register: _start_web_podman_ready
       changed_when: false
       failed_when: false
+      retries: 30
+      delay: 10
+      until: _start_web_podman_ready.rc == 0
       when:
         - _start_web_cid.stdout | trim != ''
         - (_start_web_has_health.stdout | default('') | trim) == ''
         - _inspect_cmd | default('docker') is search('podman')
 
-    # Same budget as the Docker path: 60 × 10s, over the healthcheck's
-    # 5 min start period plus a slow first composer install. A container
-    # with no healthcheck at all must skip rather than spend that budget
-    # failing, and podman distinguishes the two cases in its message.
-    - name: Wait for web to pass its healthcheck (Podman)
-      ansible.builtin.command:
-        argv:
-          - "{{ _inspect_cmd }}"
-          - healthcheck
-          - run
-          - "{{ _start_web_cid.stdout | trim }}"
-      register: _start_web_podman_health
-      changed_when: false
-      retries: 60
-      delay: 10
-      until: _start_web_podman_health.rc == 0
-      when:
-        - _start_web_cid.stdout | trim != ''
-        - (_start_web_has_health.stdout | default('') | trim) == ''
-        - _inspect_cmd | default('docker') is search('podman')
-        - >-
-          'no defined healthcheck'
-          not in (_start_web_hc_probe.stderr | default(''))
+    - name: Report that web never answered on Podman
+      ansible.builtin.debug:
+        msg: >-
+          web did not answer /server-status within 5 minutes, so the
+          readiness gate is being skipped. A custom image that does not
+          serve /server-status is expected here. On the stock image this
+          means web is still starting, and the MediaWiki installer may
+          race composer — check the container logs if create then fails
+          on a missing vendor/ file.
+      when: (_start_web_podman_ready.rc | default(0)) != 0
 
     # Register CAPI + auto-enroll the bouncer when CrowdSec is on. Shared
     # with the K8s start path and create. crowdsec_autoenroll is false only

--- a/tests/unit/test_start_health_gate_probe.py
+++ b/tests/unit/test_start_health_gate_probe.py
@@ -99,49 +99,78 @@ class TestHealthWaitIsGatedOnANonEmptyStatus:
 
 
 class TestPodmanDrivesTheHealthcheck:
-    """Skipping the gate on Podman is not an option -- it must be driven.
+    """Skipping the gate on Podman is not an option -- it must be driven,
+    and it must never be able to fail the create.
 
-    Podman inherits the image's healthcheck but never runs it under
-    podman-compose: checks are scheduled with systemd transient timers
-    that compose does not create, so `.State.Health.Status` stays empty
-    for every container and the Docker-shaped wait is always skipped.
+    Podman renders an empty status for the stock image, so the
+    Docker-shaped wait is always skipped and `create` races composer --
+    install.php crashing on a half-written vendor/ is the exact failure
+    the gate exists to prevent. Two independent reasons, both outside
+    this repo: the published image is OCI-format and podman ignores
+    `Healthcheck` in an OCI config, and podman runs healthchecks from
+    systemd transient timers that compose never creates.
 
-    That left Podman with no readiness gate at all, and `create` raced
-    composer -- install.php crashing on a half-written vendor/ is the
-    exact failure the gate exists to prevent. `podman healthcheck run`
-    executes the check on demand, so the loop polls that instead.
+    Asking the runtime to run the check therefore cannot work. An
+    earlier attempt declared the healthcheck in the compose file so a
+    status would render; podman then reported `starting` forever
+    wherever it could not run the check, the wait spent its whole
+    budget, and every create failed. That is worse than the race it
+    replaced, and it is why the wait below is best-effort: the play
+    makes the request itself, and a signal that never arrives costs a
+    warning rather than a failure.
     """
 
     def test_a_podman_wait_exists(self):
-        wait = _task("Wait for web to pass its healthcheck (Podman)")
+        wait = _task("Wait for web to answer on Podman")
         assert wait is not None, (
             "Podman needs its own readiness wait; without one the gate is "
             "skipped for every container and create races composer"
         )
         argv = " ".join(str(a) for a in wait["ansible.builtin.command"]["argv"])
-        assert "healthcheck" in argv and "run" in argv, (
-            "poll `podman healthcheck run`, which executes the check, "
-            "rather than a status field nothing updates"
+        assert "exec" in argv and "server-status" in argv, (
+            "make the request from the play; podman cannot be asked to run "
+            "the image's healthcheck"
+        )
+
+    def test_it_addresses_loopback_numerically(self):
+        wait = _task("Wait for web to answer on Podman")
+        argv = " ".join(str(a) for a in wait["ansible.builtin.command"]["argv"])
+        assert "127.0.0.1/server-status" in argv, (
+            "mediawiki.conf serves /server-status only when REMOTE_ADDR is "
+            "exactly '127.0.0.1'; localhost resolves to ::1 first under "
+            "rootless podman and falls through to MediaWiki as a 404"
+        )
+        assert "localhost" not in argv, (
+            "a name here reintroduces the ::1 404"
         )
 
     def test_it_waits_for_success_not_a_status_string(self):
-        wait = _task("Wait for web to pass its healthcheck (Podman)")
+        wait = _task("Wait for web to answer on Podman")
         assert "rc == 0" in str(wait.get("until", "")), (
-            "healthcheck run signals health through its exit code"
+            "the request signals readiness through its exit code"
         )
 
-    def test_it_gets_the_same_budget_as_the_docker_path(self):
-        wait = _task("Wait for web to pass its healthcheck (Podman)")
-        docker = _task("Wait for web container to report healthy")
-        assert wait.get("retries") == docker.get("retries")
-        assert wait.get("delay") == docker.get("delay"), (
-            "the healthcheck's 5 min start period applies on both runtimes"
+    def test_it_cannot_fail_the_create(self):
+        wait = _task("Wait for web to answer on Podman")
+        assert wait.get("failed_when") is False, (
+            "a readiness signal that never arrives -- a custom image that "
+            "does not serve /server-status, or a runtime quirk -- must cost "
+            "a warning, not a failed create. Making this wait fatal is what "
+            "broke every Podman create once before"
+        )
+
+    def test_its_budget_is_bounded(self):
+        wait = _task("Wait for web to answer on Podman")
+        budget = wait.get("retries", 0) * wait.get("delay", 0)
+        assert 0 < budget <= 300, (
+            "bound the wait to the image healthcheck's 5 min --start-period: "
+            "past that the signal is not coming, and since overrunning only "
+            "warns, waiting longer just delays the real error"
         )
 
     def test_it_only_runs_when_no_status_is_reported(self):
         conditions = [
-            str(c) for c
-            in _task("Wait for web to pass its healthcheck (Podman)")["when"]
+            str(c) for c in _task("Wait for web to answer on Podman")["when"]
         ]
         assert any("_start_web_has_health" in c and "== ''" in c
                    for c in conditions), (
@@ -152,12 +181,8 @@ class TestPodmanDrivesTheHealthcheck:
             "Docker reports a real status and must keep its own path"
         )
 
-    def test_a_custom_image_without_a_healthcheck_still_skips(self):
-        conditions = [
-            str(c) for c
-            in _task("Wait for web to pass its healthcheck (Podman)")["when"]
-        ]
-        assert any("no defined healthcheck" in c for c in conditions), (
-            "an image that declares no HEALTHCHECK must skip rather than "
-            "burn the full 10-minute budget failing a check that cannot pass"
+    def test_a_silent_skip_is_reported(self):
+        assert _task("Report that web never answered on Podman") is not None, (
+            "continuing without the gate is a real loss of protection; say so "
+            "rather than proceeding silently"
         )


### PR DESCRIPTION
Podman renders an empty health status for the stock image, so the Docker-shaped wait skips and `create` races composer — `install.php` crashing on a half-written `vendor/` is the failure the gate exists to prevent (#1296, and again on `main` in [run 30564941145](https://github.com/CanastaWiki/Canasta-CLI/actions/runs/30564941145)).

Two independent causes, both outside this repo: the published image is OCI-format and podman ignores `Healthcheck` in an OCI config, and podman runs healthchecks from systemd transient timers that compose never creates — the static builds used in CI have no systemd at all.

So the runtime cannot be asked to run the check. Make the request from the play instead, over `exec`, which depends on nothing but the container being up.

## Why not the compose-level healthcheck

That was #1357, and it is reverted in #1358. Declaring the healthcheck does make a status render — and wherever podman cannot run the check, that status stays `starting` until the 60 x 10s budget is spent and `create` fails. It turned an intermittent race into a guaranteed failure on every Podman create.

The lesson is in the design here: this wait is **best-effort**. `failed_when: false` with `until` retries the full budget and then continues. A custom image that never serves `/server-status`, or a runtime quirk nobody has seen yet, costs a warning rather than a create. The gate did not run on Podman at all before, so continuing is never worse than the old behavior.

`127.0.0.1`, not `localhost`: `mediawiki.conf` serves `/server-status` only when `REMOTE_ADDR` is exactly `'127.0.0.1'`, and `localhost` resolves to `::1` first under rootless podman, which falls through to MediaWiki as a 404 (CanastaWiki/CanastaBase#226).

## Verified in both configurations

The two environments whose difference caused #1357 to pass review and then break `main`.

**Static bundle, no systemd** — [dispatch on this branch](https://github.com/CanastaWiki/Canasta-CLI/actions/runs/30597149829), all four podman legs plus Docker and K8s green. From the 4.9.5 and 5.8.4/1.6.0 legs:

```
TASK [orchestrator : Wait for web to answer on Podman]
FAILED - RETRYING: ... (29 retries left).
FAILED - RETRYING: ... (28 retries left).
FAILED - RETRYING: ... (27 retries left).
ok: [localhost]
TASK [orchestrator : Report that web never answered on Podman]
skipping: [localhost]

=== Results: 5 passed, 0 failed, 0 skipped ===
```

Zero warnings emitted across every start in both legs, so the gate genuinely engaged rather than falling back to warn-and-continue. Worth stating explicitly: because the wait is best-effort, a green lane alone would not have proved this — the logs had to be read.

**Distro podman 5.4.2 with systemd, Debian 13** — two retries then `ok`, `create_rc=0` in 151s, `/server-status` reachable.

## Guards

The Podman unit tests keep every original intent and gain one that would have caught #1357 at commit time:

```python
def test_it_cannot_fail_the_create(self):
    assert wait.get("failed_when") is False, (
        "…Making this wait fatal is what broke every Podman create once before")
```

Also pinned: the request must address `127.0.0.1` and must not contain `localhost`; the budget must stay bounded; a skipped gate must be reported rather than silent.

`make test-unit` (2259 passed), `make lint`, `validate_definitions` pass.

Closes #1356
