### PR TITLE
fix(lifecycle): announce the stop phase and the config-set restart

### DIFF
--- a/roles/config/tasks/set.yml
+++ b/roles/config/tasks/set.yml
@@ -38,6 +38,13 @@
   ansible.builtin.include_tasks: _set_config.yml
   when: not (secret | default(false) | bool)
 
+# The restart is a side effect here, not what the operator asked for, so
+# say it is coming before the instance goes down.
+- name: Report restarting to apply changes
+  when: not (no_restart | default(false) | bool)
+  ansible.builtin.debug:
+    msg: "Restarting instance to apply changes..."
+
 - name: Restart instance to apply changes
   when: not (no_restart | default(false) | bool)
   ansible.builtin.include_role:

--- a/roles/config/tasks/unset.yml
+++ b/roles/config/tasks/unset.yml
@@ -31,6 +31,13 @@
     name: orchestrator
     tasks_from: update_config.yml
 
+# The restart is a side effect here, not what the operator asked for, so
+# say it is coming before the instance goes down.
+- name: Report restarting to apply changes
+  when: not (no_restart | default(false) | bool)
+  ansible.builtin.debug:
+    msg: "Restarting instance to apply changes..."
+
 - name: Restart instance to apply changes
   when: not (no_restart | default(false) | bool)
   ansible.builtin.include_role:

--- a/roles/orchestrator/tasks/stop.yml
+++ b/roles/orchestrator/tasks/stop.yml
@@ -2,6 +2,12 @@
 # Stop containers for an instance.
 # Input: instance_path, instance_devmode (bool), instance_orchestrator
 
+# Announced before the orchestrator dispatch so both Compose and K8s report
+# it, and every caller (stop, restart, config set) gets the message once.
+- name: Report stopping containers
+  ansible.builtin.debug:
+    msg: "Stopping containers..."
+
 - name: Stop (Docker Compose)
   when: instance_orchestrator | default('compose') == 'compose'
   block:


### PR DESCRIPTION
Fixes #1360.

`roles/orchestrator/tasks/stop.yml` had no user-facing output in either the Compose or the Kubernetes branch, so `stop`, `restart`, and `config set` all showed an unexplained silence while containers came down, then reported "Starting containers..." — which reads as a cold start rather than the second half of a restart.

## Changes

- Report "Stopping containers..." above the orchestrator dispatch in `stop.yml`, so both Compose and Kubernetes cover it and every caller (`stop`, `restart`, `config set`, `upgrade`) gets the message once rather than each caller being patched.
- Announce the restart in `roles/config/tasks/set.yml` and `unset.yml`, where it is a side effect rather than the operation the operator requested. Until now nothing indicated the instance would be restarted at all until it was already coming back up.

`config unset` is included because it carried the identical restart block and the identical silence; fixing only `set` would have left the two inconsistent.

## Resulting output

`canasta config set`:

```
Restarting instance to apply changes...
Stopping containers...
Starting containers...
Instance 'foo' restarted.
Settings updated.
```

`canasta restart`:

```
Stopping containers...
Starting containers...
Instance 'foo' restarted.
```

## Notes for review

- `upgrade` now prints both its existing "Restarting containers..." and the new "Stopping containers...". The progression reads naturally, but it is a change to `upgrade` output.
- The `direct_commands/lifecycle.py` fast path is untouched. It streams `docker compose` output directly and was never silent; only the Ansible path had the gap, which is why `config set` was the most confusing case.

## Testing

`make lint`, `make validate` (87 commands, 69 playbooks, 161 examples), and `make test-unit` (2259 passed) all pass.