### PR TITLE
fix(caddy): honor trusted proxies on the port-80 redirect

### DIFF
--- a/filter_plugins/canasta_caddy.py
+++ b/filter_plugins/canasta_caddy.py
@@ -190,18 +190,11 @@ def meld_caddy_global_blocks(text):
 
 
 def caddy_explicit_http_hosts(text):
-    """Hostnames the given Caddyfile text already serves with an `http://`
-    site address.
+    """Hostnames the given Caddyfile text serves with an `http://` address.
 
-    Canasta generates its own `http://…` redirect server so the port-80
-    HTTP->HTTPS redirect is a real Caddyfile server (see Caddyfile.j2). Caddy
-    rejects the whole config with "ambiguous site definition" if a hostname is
-    claimed twice, so any name the user's Caddyfile.global already declares
-    that way has to be left alone.
-
-    Matching is on the exact `http://host` token; a bare `host` label is not a
-    clash, because that address only ever produces the https server plus
-    Caddy's own automatic redirect.
+    A bare `host` label is not one of these: it yields the https server plus
+    Caddy's automatic redirect, which the generated redirect server displaces
+    rather than collides with.
     """
     if not isinstance(text, str):
         text = "" if text is None else str(text)

--- a/filter_plugins/canasta_caddy.py
+++ b/filter_plugins/canasta_caddy.py
@@ -189,9 +189,39 @@ def meld_caddy_global_blocks(text):
     return result.strip("\n") + "\n"
 
 
+def caddy_explicit_http_hosts(text):
+    """Hostnames the given Caddyfile text already serves with an `http://`
+    site address.
+
+    Canasta generates its own `http://…` redirect server so the port-80
+    HTTP->HTTPS redirect is a real Caddyfile server (see Caddyfile.j2). Caddy
+    rejects the whole config with "ambiguous site definition" if a hostname is
+    claimed twice, so any name the user's Caddyfile.global already declares
+    that way has to be left alone.
+
+    Matching is on the exact `http://host` token; a bare `host` label is not a
+    clash, because that address only ever produces the https server plus
+    Caddy's own automatic redirect.
+    """
+    if not isinstance(text, str):
+        text = "" if text is None else str(text)
+    hosts = []
+    blocks, _ = _parse_top_level(text.replace("\r\n", "\n"))
+    for block in blocks:
+        if block["is_global"]:
+            continue
+        for addr in block["label"].replace(",", " ").split():
+            if addr.startswith("http://"):
+                host = addr[len("http://"):].split("/")[0].strip()
+                if host and host not in hosts:
+                    hosts.append(host)
+    return hosts
+
+
 class FilterModule(object):
     def filters(self):
         return {
             "meld_caddy_global_blocks": meld_caddy_global_blocks,
             "caddy_unsafe": caddy_unsafe,
+            "caddy_explicit_http_hosts": caddy_explicit_http_hosts,
         }

--- a/roles/orchestrator/tasks/rewrite_caddy.yml
+++ b/roles/orchestrator/tasks/rewrite_caddy.yml
@@ -159,14 +159,9 @@
     # re-evaluated.
     _caddyfile_global_content: "{{ _caddy_global_raw.content | default('') | b64decode | caddy_unsafe }}"
 
-# Names the generated port-80 redirect server takes over from Caddy's
-# automatic redirect, so the global trusted_proxies/client_ip_headers options
-# apply to :80 too (see the comment in Caddyfile.j2). Nothing to take over
-# when Caddy serves plain HTTP (K8s, or CADDY_AUTO_HTTPS=off) — there is no
-# redirect then — or when no trusted proxy is configured, where the built-in
-# redirect already logs the true client IP. Names the user's Caddyfile.global
-# already serves over http:// are left to it; claiming one twice is an
-# "ambiguous site definition" error that stops Caddy from loading at all.
+# Names the generated redirect server claims from Caddy's automatic one (see
+# Caddyfile.j2). Names the user's Caddyfile.global already serves over http://
+# are left to it — Caddy refuses to load a config that claims one twice.
 - name: Determine port-80 redirect server names
   ansible.builtin.set_fact:
     _redirect_server_names: >-

--- a/roles/orchestrator/tasks/rewrite_caddy.yml
+++ b/roles/orchestrator/tasks/rewrite_caddy.yml
@@ -159,6 +159,23 @@
     # re-evaluated.
     _caddyfile_global_content: "{{ _caddy_global_raw.content | default('') | b64decode | caddy_unsafe }}"
 
+# Names the generated port-80 redirect server takes over from Caddy's
+# automatic redirect, so the global trusted_proxies/client_ip_headers options
+# apply to :80 too (see the comment in Caddyfile.j2). Nothing to take over
+# when Caddy serves plain HTTP (K8s, or CADDY_AUTO_HTTPS=off) — there is no
+# redirect then — or when no trusted proxy is configured, where the built-in
+# redirect already logs the true client IP. Names the user's Caddyfile.global
+# already serves over http:// are left to it; claiming one twice is an
+# "ambiguous site definition" error that stops Caddy from loading at all.
+- name: Determine port-80 redirect server names
+  ansible.builtin.set_fact:
+    _redirect_server_names: >-
+      {{ (_server_names
+          | reject('in', _caddyfile_global_content | caddy_explicit_http_hosts)
+          | list)
+         if ((not (_http_only | bool)) and (_trusted_proxies_enabled | bool))
+         else [] }}
+
 # Render the template (CLI global block + inlined Caddyfile.global, which may
 # leave two global blocks) and meld them into one on the way out.
 - name: Write Caddyfile (rendered + global blocks melded)

--- a/roles/orchestrator/templates/Caddyfile.j2
+++ b/roles/orchestrator/templates/Caddyfile.j2
@@ -68,15 +68,9 @@
 {% endif %}
 {{ _caddyfile_global_content | default('') }}
 {#
-  Explicit port-80 redirect server. Caddy's automatic HTTP->HTTPS redirect is
-  synthesized at provision time, after the Caddyfile adapter has applied the
-  global `servers` options, so it inherits neither trusted_proxies nor
-  client_ip_headers: every :80 request is logged with the CDN edge address as
-  client_ip. CrowdSec parses that same access log, so a scenario firing on
-  port-80 traffic bans a CDN edge node and cuts off every visitor behind it.
-  Declaring the redirect server here puts it in the adapter's server map, where
-  the global options do reach it. Only rendered when trusted proxies are in
-  play; otherwise Caddy's built-in redirect is equivalent and stays in charge.
+  Caddy's automatic HTTP->HTTPS redirect server is built after the adapter has
+  applied the global `servers` options, so it honors neither trusted_proxies
+  nor client_ip_headers. Declaring it here puts it where those options reach.
 #}
 {% if (_redirect_server_names | default([]) | length) > 0 %}
 {{ _redirect_server_names | map('regex_replace', '^', 'http://') | join(', ') }} {

--- a/roles/orchestrator/templates/Caddyfile.j2
+++ b/roles/orchestrator/templates/Caddyfile.j2
@@ -67,7 +67,30 @@
 
 {% endif %}
 {{ _caddyfile_global_content | default('') }}
+{#
+  Explicit port-80 redirect server. Caddy's automatic HTTP->HTTPS redirect is
+  synthesized at provision time, after the Caddyfile adapter has applied the
+  global `servers` options, so it inherits neither trusted_proxies nor
+  client_ip_headers: every :80 request is logged with the CDN edge address as
+  client_ip. CrowdSec parses that same access log, so a scenario firing on
+  port-80 traffic bans a CDN edge node and cuts off every visitor behind it.
+  Declaring the redirect server here puts it in the adapter's server map, where
+  the global options do reach it. Only rendered when trusted proxies are in
+  play; otherwise Caddy's built-in redirect is equivalent and stays in charge.
+#}
+{% if (_redirect_server_names | default([]) | length) > 0 %}
+{{ _redirect_server_names | map('regex_replace', '^', 'http://') | join(', ') }} {
+{% if _crowdsec_active | default(false) %}
+    crowdsec
+{% endif %}
+    redir https://{host}{uri} 308
 
+    log {
+        output file /var/log/caddy/access.log
+    }
+}
+
+{% endif %}
 {{ _site_address }} {
     import /etc/caddy/Caddyfile.site
 

--- a/tests/unit/test_caddy_meld.py
+++ b/tests/unit/test_caddy_meld.py
@@ -205,9 +205,6 @@ class TestExplicitHttpHosts:
         assert hosts == ["a.example.com", "b.example.com", "a.example.com:8080"]
 
     def test_bare_and_https_addresses_are_not_clashes(self):
-        # A bare label yields the https server plus Caddy's own automatic
-        # redirect, which our generated http:// server displaces rather than
-        # collides with. An explicit https:// label never touches :80.
         hosts = caddy_explicit_http_hosts(
             "bare.example.com {\n    respond ok\n}\n"
             "https://tls.example.com {\n    respond ok\n}\n"

--- a/tests/unit/test_caddy_meld.py
+++ b/tests/unit/test_caddy_meld.py
@@ -15,6 +15,7 @@ sys.path.insert(
 from canasta_caddy import (  # noqa: E402
     meld_caddy_global_blocks,
     caddy_unsafe,
+    caddy_explicit_http_hosts,
     _parse_top_level,
 )
 
@@ -187,3 +188,33 @@ class TestCaddyUnsafe:
         # are not re-templated). Either way the string value is unchanged.
         s = 'respond "{{ not_evaluated }}"'
         assert str(caddy_unsafe(s)) == s
+
+
+class TestExplicitHttpHosts:
+    def test_finds_http_scheme_addresses(self):
+        hosts = caddy_explicit_http_hosts(
+            "http://a.example.com {\n    redir https://x 308\n}\n"
+        )
+        assert hosts == ["a.example.com"]
+
+    def test_multi_address_label_and_dedupe(self):
+        hosts = caddy_explicit_http_hosts(
+            "http://a.example.com, http://b.example.com {\n    respond ok\n}\n"
+            "http://a.example.com:8080 {\n    respond ok\n}\n"
+        )
+        assert hosts == ["a.example.com", "b.example.com", "a.example.com:8080"]
+
+    def test_bare_and_https_addresses_are_not_clashes(self):
+        # A bare label yields the https server plus Caddy's own automatic
+        # redirect, which our generated http:// server displaces rather than
+        # collides with. An explicit https:// label never touches :80.
+        hosts = caddy_explicit_http_hosts(
+            "bare.example.com {\n    respond ok\n}\n"
+            "https://tls.example.com {\n    respond ok\n}\n"
+        )
+        assert hosts == []
+
+    def test_global_block_and_empty_input_ignored(self):
+        assert caddy_explicit_http_hosts("{\n    debug\n}\n") == []
+        assert caddy_explicit_http_hosts("") == []
+        assert caddy_explicit_http_hosts(None) == []

--- a/tests/unit/test_trusted_proxies.py
+++ b/tests/unit/test_trusted_proxies.py
@@ -9,11 +9,18 @@ Rendering tests evaluate the real Jinja template so a wrong header,
 wrong provider source, or misplaced strict flag is caught.
 """
 
+import ast
 import os
 import re
+import sys
 
 import jinja2
 import yaml
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "..", "..", "filter_plugins")
+)
+from canasta_caddy import caddy_explicit_http_hosts  # noqa: E402
 
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
@@ -61,6 +68,21 @@ def _render_proxy(mode, header, dynamic, cidrs=None, strict=False):
         _trusted_proxies_cidrs=cidrs or [],
         _trusted_proxies_strict=strict,
     )
+
+
+
+def _render_proxy_with(**ctx):
+    """Cloudflare mode plus whatever the caller overrides."""
+    base = dict(
+        _trusted_proxies_enabled=True,
+        _tp_mode="cloudflare",
+        _tp_dynamic=True,
+        _trusted_proxies_headers="Cf-Connecting-Ip",
+        _trusted_proxies_cidrs=[],
+        _trusted_proxies_strict=False,
+    )
+    base.update(ctx)
+    return _render(**base)
 
 
 class TestTrustedProxiesConfigKey:
@@ -161,3 +183,86 @@ class TestCaddyPluginImage:
         assert not os.path.exists(
             os.path.join(REPO_ROOT, "scripts", "update_proxy_ips.py")
         )
+
+
+class TestPortEightyRedirectServer:
+    """Caddy's automatic HTTP->HTTPS redirect server is built after the
+    Caddyfile adapter applies the global `servers` options, so it honors
+    neither trusted_proxies nor client_ip_headers and logs every :80 request
+    with the CDN edge as client_ip. Canasta declares the redirect server
+    explicitly so those options reach it."""
+
+    def _render_redirect(self, names, **ctx):
+        return _render_proxy_with(
+            _redirect_server_names=names, **ctx
+        )
+
+    def test_redirect_server_is_declared_for_each_name(self):
+        out = _render_proxy_with(
+            _redirect_server_names=["a.example.com", "b.example.com"])
+        assert "http://a.example.com, http://b.example.com {" in out
+        assert "redir https://{host}{uri} 308" in out
+        # It must log to the file CrowdSec reads, else the corrected client_ip
+        # never reaches the engine.
+        assert out.count("output file /var/log/caddy/access.log") == 2
+
+    def test_redirect_server_enforces_crowdsec_when_active(self):
+        out = _render_proxy_with(
+            _redirect_server_names=["a.example.com"], _crowdsec_active=True)
+        redirect_block = out[out.index("http://a.example.com {"):]
+        assert "crowdsec" in redirect_block.split("}")[0]
+
+    def test_no_redirect_server_when_no_names(self):
+        out = _render_proxy_with(_redirect_server_names=[])
+        assert "http://" not in out
+        assert "redir " not in out
+
+    def test_absent_variable_renders_nothing(self):
+        # Older instances re-rendered by a task that predates the new fact.
+        out = _render_proxy("cloudflare", "Cf-Connecting-Ip", dynamic=True)
+        assert "redir " not in out
+
+
+def _redirect_names(http_only, trusted, names, user_global=""):
+    """Evaluate rewrite_caddy.yml's real _redirect_server_names expression."""
+    tasks = yaml.safe_load(_read(os.path.join(
+        REPO_ROOT, "roles", "orchestrator", "tasks", "rewrite_caddy.yml",
+    )))
+    expr = next(
+        t["ansible.builtin.set_fact"]["_redirect_server_names"]
+        for t in tasks
+        if "_redirect_server_names" in (t.get("ansible.builtin.set_fact") or {})
+    )
+    env = _ansible_jinja_env()
+    env.filters["caddy_explicit_http_hosts"] = caddy_explicit_http_hosts
+    out = env.from_string(expr).render(
+        _http_only=http_only,
+        _trusted_proxies_enabled=trusted,
+        _server_names=names,
+        _caddyfile_global_content=user_global,
+    )
+    return ast.literal_eval(out.strip())
+
+
+class TestRedirectServerNameSelection:
+    def test_claims_every_wiki_server_name(self):
+        assert _redirect_names(
+            False, True, ["a.example.com", "b.example.com"],
+        ) == ["a.example.com", "b.example.com"]
+
+    def test_empty_without_trusted_proxies(self):
+        # Caddy's built-in redirect already logs the true client IP when
+        # nothing is in front of it.
+        assert _redirect_names(False, False, ["a.example.com"]) == []
+
+    def test_empty_in_plain_http_mode(self):
+        # K8s / CADDY_AUTO_HTTPS=off: there is no redirect to take over.
+        assert _redirect_names(True, True, ["a.example.com"]) == []
+
+    def test_skips_names_the_user_already_serves_over_http(self):
+        # Claiming one twice is "ambiguous site definition" — Caddy refuses to
+        # load the config at all.
+        assert _redirect_names(
+            False, True, ["a.example.com", "b.example.com"],
+            user_global="http://a.example.com {\n    respond ok\n}\n",
+        ) == ["b.example.com"]

--- a/tests/unit/test_trusted_proxies.py
+++ b/tests/unit/test_trusted_proxies.py
@@ -186,24 +186,12 @@ class TestCaddyPluginImage:
 
 
 class TestPortEightyRedirectServer:
-    """Caddy's automatic HTTP->HTTPS redirect server is built after the
-    Caddyfile adapter applies the global `servers` options, so it honors
-    neither trusted_proxies nor client_ip_headers and logs every :80 request
-    with the CDN edge as client_ip. Canasta declares the redirect server
-    explicitly so those options reach it."""
-
-    def _render_redirect(self, names, **ctx):
-        return _render_proxy_with(
-            _redirect_server_names=names, **ctx
-        )
-
     def test_redirect_server_is_declared_for_each_name(self):
         out = _render_proxy_with(
             _redirect_server_names=["a.example.com", "b.example.com"])
         assert "http://a.example.com, http://b.example.com {" in out
         assert "redir https://{host}{uri} 308" in out
-        # It must log to the file CrowdSec reads, else the corrected client_ip
-        # never reaches the engine.
+        # Both servers must log to the file CrowdSec reads.
         assert out.count("output file /var/log/caddy/access.log") == 2
 
     def test_redirect_server_enforces_crowdsec_when_active(self):
@@ -218,7 +206,6 @@ class TestPortEightyRedirectServer:
         assert "redir " not in out
 
     def test_absent_variable_renders_nothing(self):
-        # Older instances re-rendered by a task that predates the new fact.
         out = _render_proxy("cloudflare", "Cf-Connecting-Ip", dynamic=True)
         assert "redir " not in out
 


### PR DESCRIPTION
Closes #1362.

## Cause

Caddy synthesizes its automatic HTTP→HTTPS redirect server at *provision* time, after the Caddyfile adapter has already applied the global `servers` options. The redirect server therefore inherits neither `trusted_proxies` nor `client_ip_headers`, so every `:80` request is logged with the proxy's address as `client_ip` even though `Cf-Connecting-Ip` is present in the same record.

Reproduced against stock Caddy with `trusted_proxies static 0.0.0.0/0`:

| Request | logged `client_ip` |
|---|---|
| HTTPS | `203.0.113.9` (the real client) |
| `:80` auto-redirect | `192.168.65.1` (the peer) |
| `:80` with this change | `203.0.113.9` |

The same run confirmed those `:80` entries are written to `/var/log/caddy/access.log` — the file CrowdSec ingests — so a scenario firing on port-80 traffic bans a shared edge node and cuts off every visitor behind it.

## Change

Declare the redirect server explicitly in `Caddyfile.j2` so it lands in the adapter's server map, where the global options do reach it, and apply the `crowdsec` directive to it so `:80` enforces alongside `:443`. Only rendered when a trusted proxy is configured and Caddy is the TLS edge; elsewhere Caddy's built-in redirect is equivalent and stays in charge.

A hostname the operator's `Caddyfile.global` already serves over `http://` is left alone — claiming one twice is an `ambiguous site definition` error that stops Caddy from loading at all (verified). The new `caddy_explicit_http_hosts` filter detects those.

## Verification

- Rendered the real template through Ansible and validated the output with `ghcr.io/canastawiki/canasta-caddy:2.11.3` → `Valid configuration`.
- Confirmed the explicit block preserves path and query and returns 308, identical to the built-in redirect, and that Caddy's auto-redirect still covers other bare-hostname sites alongside it.
- `caddy fmt` shows no differences beyond the tabs-vs-spaces indentation already present throughout the generated file.
- Unit tests, `make validate`, yamllint all pass.
