### PR TITLE
feat(doctor): warn when CrowdSec runs behind a CDN with no trusted proxy

### DIFF
--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -317,20 +317,15 @@ _SERVICE_PROFILE = {
 _SERVICE_PROFILE["db"] = "internal-db"
 
 
-# Headers that mark a request as having passed through a proxy. The two
-# vendor headers are conclusive; X-Forwarded-For is not, since any client can
-# send it, so the check below asks for it on most of the sample rather than on
-# a single request.
 _PROXIED_REQUEST_HEADERS = ("Cf-Connecting-Ip", "Cdn-Loop", "X-Forwarded-For")
 
 
 def _looks_proxied(cdn_evidence):
-    """True when the sampled Caddy access log says something is in front.
+    """True when the sampled access log says something is proxying in front.
 
-    cdn_evidence is (sampled, hits) from the tail of the access log. A forged
-    X-Forwarded-For on one request must not be enough, so require the headers
-    on more than half the sample — a real CDN sets them on everything it
-    forwards, and a client cannot forge its way to a majority of the traffic.
+    cdn_evidence is (sampled, hits). A majority rather than a single hit: any
+    client can forge X-Forwarded-For, but a proxy sets these on everything it
+    forwards.
     """
     if not cdn_evidence:
         return False
@@ -346,7 +341,7 @@ def _consistency_warnings(env, current_profiles, running_services, uses_cirrus,
       flags + DB mode.
     - A container running under a profile that isn't active (unmanaged — a
       stop/start won't restore it).
-    - CrowdSec enabled behind a CDN with no CADDY_TRUSTED_PROXIES.
+    - CrowdSec enabled behind a proxy with no CADDY_TRUSTED_PROXIES.
     - CirrusSearch configured in settings while Elasticsearch is disabled.
     - any env.template literal that differs from .env (the durable gitops
       source and the live config have diverged; a pull would reset .env to it).
@@ -381,14 +376,6 @@ def _consistency_warnings(env, current_profiles, running_services, uses_cirrus,
             "'elasticsearch' profile is inactive — search depends on an "
             "unmanaged Elasticsearch; set CANASTA_ENABLE_ELASTICSEARCH=true")
 
-    # CrowdSec behind a CDN with nothing telling Caddy to trust it. Caddy then
-    # reports the CDN edge address as the client IP, so the engine attributes
-    # all traffic to a handful of edge nodes: per-IP scenarios can never
-    # identify a real attacker, and a scenario that does fire bans an edge node
-    # and blackholes every visitor behind it. Nothing surfaces this on its own
-    # — `canasta crowdsec status` reports the bouncer active and the community
-    # blocklist loaded, and its "No active decisions" reads as "nothing
-    # malicious detected" when it means "nothing is distinguishable".
     crowdsec_on = env.get("CANASTA_ENABLE_CROWDSEC", "").strip().lower() == "true"
     if (crowdsec_on and not env.get("CADDY_TRUSTED_PROXIES", "").strip()
             and _looks_proxied(cdn_evidence)):
@@ -423,9 +410,7 @@ def _consistency_warnings(env, current_profiles, running_services, uses_cirrus,
     return warns
 
 
-# How many access-log lines to sample when deciding whether something is
-# proxying in front of Caddy. The log is JSON, one request per line, and lives
-# in a named volume, so it is read through the caddy container.
+# Read through the caddy container: the access log lives in a named volume.
 _ACCESS_LOG_SAMPLE = 200
 
 
@@ -434,8 +419,8 @@ def _gather_runtime(path, host, inst=None):
     an instance, localhost or remote. env_template_literals maps each KEY to the
     literal value pinned in env.template, excluding placeholder (KEY={{...}})
     lines and comments; empty when not gitops / no env.template. cdn_evidence is
-    (sampled, hits) over the tail of the Caddy access log, (0, 0) when the log
-    can't be read (caddy down, no log yet)."""
+    (sampled, hits) over the tail of the Caddy access log, (0, 0) when it can't
+    be read."""
     d = _helpers._SENTINEL
     qpath = _helpers._shell_quote(path)
     compose_cmd = _helpers._resolve_compose_cmd(inst or {"path": path})

--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -317,14 +317,36 @@ _SERVICE_PROFILE = {
 _SERVICE_PROFILE["db"] = "internal-db"
 
 
+# Headers that mark a request as having passed through a proxy. The two
+# vendor headers are conclusive; X-Forwarded-For is not, since any client can
+# send it, so the check below asks for it on most of the sample rather than on
+# a single request.
+_PROXIED_REQUEST_HEADERS = ("Cf-Connecting-Ip", "Cdn-Loop", "X-Forwarded-For")
+
+
+def _looks_proxied(cdn_evidence):
+    """True when the sampled Caddy access log says something is in front.
+
+    cdn_evidence is (sampled, hits) from the tail of the access log. A forged
+    X-Forwarded-For on one request must not be enough, so require the headers
+    on more than half the sample — a real CDN sets them on everything it
+    forwards, and a client cannot forge its way to a majority of the traffic.
+    """
+    if not cdn_evidence:
+        return False
+    sampled, hits = cdn_evidence
+    return sampled > 0 and hits * 2 > sampled
+
+
 def _consistency_warnings(env, current_profiles, running_services, uses_cirrus,
-                          template_literals=None):
+                          template_literals=None, cdn_evidence=None):
     """Pure: warnings about config/runtime drift for a Compose instance.
 
     - COMPOSE_PROFILES that disagrees with what sync would derive from the
       flags + DB mode.
     - A container running under a profile that isn't active (unmanaged — a
       stop/start won't restore it).
+    - CrowdSec enabled behind a CDN with no CADDY_TRUSTED_PROXIES.
     - CirrusSearch configured in settings while Elasticsearch is disabled.
     - any env.template literal that differs from .env (the durable gitops
       source and the live config have diverged; a pull would reset .env to it).
@@ -359,6 +381,31 @@ def _consistency_warnings(env, current_profiles, running_services, uses_cirrus,
             "'elasticsearch' profile is inactive — search depends on an "
             "unmanaged Elasticsearch; set CANASTA_ENABLE_ELASTICSEARCH=true")
 
+    # CrowdSec behind a CDN with nothing telling Caddy to trust it. Caddy then
+    # reports the CDN edge address as the client IP, so the engine attributes
+    # all traffic to a handful of edge nodes: per-IP scenarios can never
+    # identify a real attacker, and a scenario that does fire bans an edge node
+    # and blackholes every visitor behind it. Nothing surfaces this on its own
+    # — `canasta crowdsec status` reports the bouncer active and the community
+    # blocklist loaded, and its "No active decisions" reads as "nothing
+    # malicious detected" when it means "nothing is distinguishable".
+    crowdsec_on = env.get("CANASTA_ENABLE_CROWDSEC", "").strip().lower() == "true"
+    if (crowdsec_on and not env.get("CADDY_TRUSTED_PROXIES", "").strip()
+            and _looks_proxied(cdn_evidence)):
+        sampled, hits = cdn_evidence
+        warns.append(
+            "CrowdSec is enabled and %d of the last %d Caddy access-log "
+            "entries carry proxy headers (%s), but CADDY_TRUSTED_PROXIES is "
+            "unset — CrowdSec sees only the proxy's addresses, so its "
+            "scenarios cannot identify a real client and any ban it issues "
+            "lands on a shared edge node and blocks every visitor behind it. "
+            "Set it to the provider in front of this instance: 'canasta "
+            "config set CADDY_TRUSTED_PROXIES=cloudflare' (or imperva, or a "
+            "comma-separated CIDR list for any other proxy). Leave it unset "
+            "if Caddy really is the edge — trusting the header "
+            "unconditionally would let any client forge its own source IP"
+            % (hits, sampled, ", ".join(_PROXIED_REQUEST_HEADERS)))
+
     drifted = sorted(
         k for k, tv in (template_literals or {}).items()
         if k in env and env[k] != tv)
@@ -376,11 +423,19 @@ def _consistency_warnings(env, current_profiles, running_services, uses_cirrus,
     return warns
 
 
+# How many access-log lines to sample when deciding whether something is
+# proxying in front of Caddy. The log is JSON, one request per line, and lives
+# in a named volume, so it is read through the caddy container.
+_ACCESS_LOG_SAMPLE = 200
+
+
 def _gather_runtime(path, host, inst=None):
-    """(running_services, uses_cirrus, env_template_literals) for an instance,
-    localhost or remote. env_template_literals maps each KEY to the literal
-    value pinned in env.template, excluding placeholder (KEY={{...}}) lines and
-    comments; empty when not gitops / no env.template."""
+    """(running_services, uses_cirrus, env_template_literals, cdn_evidence) for
+    an instance, localhost or remote. env_template_literals maps each KEY to the
+    literal value pinned in env.template, excluding placeholder (KEY={{...}})
+    lines and comments; empty when not gitops / no env.template. cdn_evidence is
+    (sampled, hits) over the tail of the Caddy access log, (0, 0) when the log
+    can't be read (caddy down, no log yet)."""
     d = _helpers._SENTINEL
     qpath = _helpers._shell_quote(path)
     compose_cmd = _helpers._resolve_compose_cmd(inst or {"path": path})
@@ -393,8 +448,18 @@ def _gather_runtime(path, host, inst=None):
         "&& echo USES_CIRRUS || echo NO_CIRRUS; "
         "echo '%(d)s'; "
         "grep -E '^[A-Za-z_][A-Za-z0-9_]*=' %(p)s/env.template 2>/dev/null "
-        "| grep -v '={{'"
-    ) % {"p": qpath, "d": d, "c": compose_str}
+        "| grep -v '={{'; "
+        "echo '%(d)s'; "
+        "_al=$(%(c)s exec -T caddy tail -n %(n)d /var/log/caddy/access.log "
+        "2>/dev/null); "
+        "printf '%%s %%s\\n' "
+        "\"$(printf '%%s' \"$_al\" | grep -c . )\" "
+        "\"$(printf '%%s' \"$_al\" | grep -Ec '%(h)s')\""
+    ) % {
+        "p": qpath, "d": d, "c": compose_str,
+        "n": _ACCESS_LOG_SAMPLE,
+        "h": "|".join(_PROXIED_REQUEST_HEADERS),
+    }
     if _helpers._is_localhost(host):
         try:
             out = subprocess.run(
@@ -402,11 +467,11 @@ def _gather_runtime(path, host, inst=None):
                 capture_output=True, text=True, timeout=30,
             ).stdout
         except (subprocess.TimeoutExpired, OSError):
-            return [], False, {}
+            return [], False, {}, (0, 0)
     else:
         rc, out = _helpers._ssh_run(host, script)
         if rc != 0 and not out.strip():
-            return [], False, {}
+            return [], False, {}, (0, 0)
     parts = out.split(d + "\n")
     head = parts[0].strip() if parts else ""
     running = [s for s in head.split("\n") if s.strip()]
@@ -422,7 +487,15 @@ def _gather_runtime(path, host, inst=None):
             if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
                 val = val[1:-1]
             template_literals[key.strip()] = val
-    return running, uses_cirrus, template_literals
+    cdn_evidence = (0, 0)
+    if len(parts) > 3:
+        fields = parts[3].strip().split()
+        if len(fields) == 2:
+            try:
+                cdn_evidence = (int(fields[0]), int(fields[1]))
+            except ValueError:
+                pass
+    return running, uses_cirrus, template_literals, cdn_evidence
 
 
 def _instance_consistency_lines(inst):
@@ -446,9 +519,10 @@ def _instance_consistency_lines(inst):
         p.strip() for p in env.get("COMPOSE_PROFILES", "").split(",")
         if p.strip()
     ]
-    running, uses_cirrus, template_literals = _gather_runtime(path, host, inst)
+    running, uses_cirrus, template_literals, cdn_evidence = _gather_runtime(
+        path, host, inst)
     warns = _consistency_warnings(
-        env, current, running, uses_cirrus, template_literals)
+        env, current, running, uses_cirrus, template_literals, cdn_evidence)
     lines = ["", "Instance consistency (%s):" % inst.get("id", "?")]
     if warns:
         lines += ["  WARN: %s" % w for w in warns]

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -705,6 +705,12 @@ commands:
       or kubectl + Helm for Kubernetes installs. Also reports
       status of optional tools (git, git-crypt, sops, age, crontab) and
       system resources (memory, disk space).
+
+      When an instance is resolved (from -i, or from the current
+      directory), also checks that instance: config and runtime
+      agreement, whether local config edits have been applied, and
+      whether CrowdSec is enabled behind a proxy with no
+      CADDY_TRUSTED_PROXIES.
     examples:
       - "canasta doctor"
       - "canasta doctor --host prod1.example.com"

--- a/tests/unit/test_doctor_consistency.py
+++ b/tests/unit/test_doctor_consistency.py
@@ -224,12 +224,6 @@ class TestInstanceConsistencyLines:
 
 
 class TestCrowdSecBehindCdn:
-    """CrowdSec enabled behind a CDN with CADDY_TRUSTED_PROXIES unset enforces
-    nothing: every source IP Caddy reports is a CDN edge address, so per-IP
-    scenarios cannot fire on a real client, and one that does fire bans an edge
-    node and blackholes every visitor behind it. `canasta crowdsec status`
-    looks healthy throughout."""
-
     ENV = {
         "CANASTA_ENABLE_CROWDSEC": "true",
         "COMPOSE_PROFILES": "internal-db,varnish,crowdsec",
@@ -254,8 +248,6 @@ class TestCrowdSecBehindCdn:
         assert self._warns(env, cdn_evidence=(200, 200)) == []
 
     def test_quiet_on_a_direct_edge_facing_instance(self):
-        # Caddy really is the edge: nothing forwards, nothing to trust. This
-        # is the case the fix must not be "always set it" for.
         assert self._warns(cdn_evidence=(200, 0)) == []
 
     def test_quiet_when_crowdsec_is_disabled(self):
@@ -267,14 +259,11 @@ class TestCrowdSecBehindCdn:
         assert out == []
 
     def test_a_forged_header_on_one_request_is_not_enough(self):
-        # Any client can send X-Forwarded-For; a real CDN sets it on
-        # everything it forwards.
         assert self._warns(cdn_evidence=(200, 1)) == []
         assert self._warns(cdn_evidence=(200, 100)) == []   # exactly half
         assert self._warns(cdn_evidence=(200, 101)) != []   # a majority
 
     def test_quiet_when_the_access_log_is_unreadable(self):
-        # caddy down, or no traffic yet — no evidence either way.
         assert self._warns(cdn_evidence=(0, 0)) == []
         assert self._warns(cdn_evidence=None) == []
 

--- a/tests/unit/test_doctor_consistency.py
+++ b/tests/unit/test_doctor_consistency.py
@@ -125,7 +125,7 @@ class TestGatherRuntime:
 
         monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
         monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _R())
-        running, cirrus, lits = doctor._gather_runtime("/srv/x", "localhost")
+        running, cirrus, lits, cdn = doctor._gather_runtime("/srv/x", "localhost")
         assert running == ["web", "varnish", "db"]
         assert cirrus is True
         assert lits["CANASTA_IMAGE"] == "ghcr.io/canastawiki/canasta:3.5.1"
@@ -140,7 +140,7 @@ class TestGatherRuntime:
 
         monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
         monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _R())
-        running, cirrus, lits = doctor._gather_runtime("/srv/x", "localhost")
+        running, cirrus, lits, cdn = doctor._gather_runtime("/srv/x", "localhost")
         assert running == ["web"]
         assert cirrus is False
         assert lits == {}
@@ -161,7 +161,7 @@ class TestInstanceConsistencyLines:
                                "COMPOSE_PROFILES=varnish\n")
         monkeypatch.setattr(
             doctor, "_gather_runtime",
-            lambda path, host, inst=None: (["web", "varnish", "db"], True, {}))
+            lambda path, host, inst=None: (["web", "varnish", "db"], True, {}, (0, 0)))
         lines = doctor._instance_consistency_lines(inst)
         assert lines[1] == "Instance consistency (site):"
         body = " ".join(lines)
@@ -179,7 +179,8 @@ class TestInstanceConsistencyLines:
                                "COMPOSE_PROFILES=internal-db,varnish,crowdsec\n")
         monkeypatch.setattr(
             doctor, "_gather_runtime",
-            lambda path, host, inst=None: (["web", "varnish", "crowdsec", "db"], False, {}))
+            lambda path, host, inst=None: (
+                ["web", "varnish", "crowdsec", "db"], False, {}, (0, 0)))
         lines = doctor._instance_consistency_lines(inst)
         assert any("OK (" in line for line in lines)
 
@@ -195,7 +196,8 @@ class TestInstanceConsistencyLines:
             doctor, "_gather_runtime",
             lambda path, host, inst=None: (["web", "varnish", "db"], False,
                                 {"CANASTA_IMAGE":
-                                 "ghcr.io/canastawiki/canasta:3.5.1"}))
+                                 "ghcr.io/canastawiki/canasta:3.5.1"},
+                                (0, 0)))
         body = " ".join(doctor._instance_consistency_lines(inst))
         assert "env.template disagrees with .env" in body
         assert "3.5.1" in body and "3.5.12" in body
@@ -213,8 +215,102 @@ class TestInstanceConsistencyLines:
                                "HTTP_PORT=8090\n")
         monkeypatch.setattr(
             doctor, "_gather_runtime",
-            lambda path, host, inst=None: (["web", "db"], False, {"HTTP_PORT": "80"}))
+            lambda path, host, inst=None: (
+                ["web", "db"], False, {"HTTP_PORT": "80"}, (0, 0)))
         body = " ".join(doctor._instance_consistency_lines(inst))
         assert "env.template disagrees with .env" in body
         assert "canasta reconcile" in body
         assert "names its own fix" in body
+
+
+class TestCrowdSecBehindCdn:
+    """CrowdSec enabled behind a CDN with CADDY_TRUSTED_PROXIES unset enforces
+    nothing: every source IP Caddy reports is a CDN edge address, so per-IP
+    scenarios cannot fire on a real client, and one that does fire bans an edge
+    node and blackholes every visitor behind it. `canasta crowdsec status`
+    looks healthy throughout."""
+
+    ENV = {
+        "CANASTA_ENABLE_CROWDSEC": "true",
+        "COMPOSE_PROFILES": "internal-db,varnish,crowdsec",
+    }
+    PROFILES = ["internal-db", "varnish", "crowdsec"]
+    RUNNING = ["web", "caddy", "varnish", "crowdsec", "db"]
+
+    def _warns(self, env=None, cdn_evidence=None):
+        return doctor._consistency_warnings(
+            env or dict(self.ENV), self.PROFILES, self.RUNNING, False,
+            None, cdn_evidence)
+
+    def test_warns_when_proxied_and_unset(self):
+        out = self._warns(cdn_evidence=(200, 200))
+        assert len(out) == 1
+        assert "CADDY_TRUSTED_PROXIES is unset" in out[0]
+        assert "200 of the last 200" in out[0]
+        assert "canasta config set CADDY_TRUSTED_PROXIES=cloudflare" in out[0]
+
+    def test_quiet_when_trusted_proxies_is_set(self):
+        env = dict(self.ENV, CADDY_TRUSTED_PROXIES="cloudflare")
+        assert self._warns(env, cdn_evidence=(200, 200)) == []
+
+    def test_quiet_on_a_direct_edge_facing_instance(self):
+        # Caddy really is the edge: nothing forwards, nothing to trust. This
+        # is the case the fix must not be "always set it" for.
+        assert self._warns(cdn_evidence=(200, 0)) == []
+
+    def test_quiet_when_crowdsec_is_disabled(self):
+        env = {"CANASTA_ENABLE_CROWDSEC": "false",
+               "COMPOSE_PROFILES": "internal-db,varnish"}
+        out = doctor._consistency_warnings(
+            env, ["internal-db", "varnish"], ["web", "caddy", "varnish", "db"],
+            False, None, (200, 200))
+        assert out == []
+
+    def test_a_forged_header_on_one_request_is_not_enough(self):
+        # Any client can send X-Forwarded-For; a real CDN sets it on
+        # everything it forwards.
+        assert self._warns(cdn_evidence=(200, 1)) == []
+        assert self._warns(cdn_evidence=(200, 100)) == []   # exactly half
+        assert self._warns(cdn_evidence=(200, 101)) != []   # a majority
+
+    def test_quiet_when_the_access_log_is_unreadable(self):
+        # caddy down, or no traffic yet — no evidence either way.
+        assert self._warns(cdn_evidence=(0, 0)) == []
+        assert self._warns(cdn_evidence=None) == []
+
+
+class TestGatherRuntimeCdnEvidence:
+    def test_parses_the_sampled_counts(self, monkeypatch):
+        d = doctor._helpers._SENTINEL
+        out = "web\n%s\nNO_CIRRUS\n%s\n\n%s\n200 187\n" % (d, d, d)
+
+        class _R:
+            stdout = out
+
+        monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
+        monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _R())
+        assert doctor._gather_runtime("/srv/x", "localhost")[3] == (200, 187)
+
+    def test_missing_or_malformed_counts_are_no_evidence(self, monkeypatch):
+        d = doctor._helpers._SENTINEL
+
+        class _R:
+            stdout = "web\n%s\nNO_CIRRUS\n%s\n\n%s\nnope\n" % (d, d, d)
+
+        monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
+        monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _R())
+        assert doctor._gather_runtime("/srv/x", "localhost")[3] == (0, 0)
+
+    def test_samples_the_caddy_access_log(self, monkeypatch):
+        seen = {}
+
+        class _R:
+            stdout = ""
+
+        monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
+        monkeypatch.setattr(
+            doctor.subprocess, "run",
+            lambda *a, **k: (seen.update(script=a[0][2]) or _R()))
+        doctor._gather_runtime("/srv/x", "localhost")
+        assert "exec -T caddy tail -n 200 /var/log/caddy/access.log" in seen["script"]
+        assert "Cf-Connecting-Ip|Cdn-Loop|X-Forwarded-For" in seen["script"]


### PR DESCRIPTION
Closes #1363.

Depends on #1365 — please merge that one first. This check tells operators to set `CADDY_TRUSTED_PROXIES=cloudflare`, and until #1362 is fixed that remedy still mis-attributes the port-80 traffic. Merging the detector ahead of the fix hands people a half-working answer.

## Change

`canasta doctor` samples the tail of the Caddy access log and warns when all three hold:

1. `CANASTA_ENABLE_CROWDSEC=true`
2. `CADDY_TRUSTED_PROXIES` is unset
3. Most sampled requests carry `Cf-Connecting-Ip`, `Cdn-Loop`, or `X-Forwarded-For`

The **majority** threshold on (3) is deliberate rather than "any hit": any client can forge `X-Forwarded-For` on a single request, but a real CDN sets these on everything it forwards, so a forger cannot reach a majority of the traffic. That keeps the check quiet on a genuinely edge-facing instance, which matters because the fix cannot be "always set it" — trusting the header unconditionally on a direct instance would let any client forge its own source IP.

The warning names its own fix and states the counts it saw, so the operator can judge it.

## Verification

Against a live local Compose instance the sampler returns `(200 sampled, 0 hits)` — correct for a direct instance, no warning raised. Unit tests cover the proxied case, the direct case, CrowdSec disabled, the single forged header, the exact-half boundary, and an unreadable log (caddy down / no traffic).

## Not included

The issue also floats surfacing this in `canasta crowdsec status`, where "No active decisions" is currently the misleading line. That needs orchestrator-specific log access inside the Ansible role, so I left it out of this change — worth a separate issue if wanted.
