### PR TITLE
feat(doctor): check the certificate the origin actually serves

### DIFF
--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -1,5 +1,6 @@
 """doctor command — dependency checks."""
 
+import datetime
 import os
 import re
 import subprocess
@@ -461,6 +462,222 @@ def _instance_consistency_lines(inst):
     return lines
 
 
+# --- Origin TLS -------------------------------------------------------------
+#
+# Nothing else looks at the certificate an instance actually serves. Behind a
+# CDN in a non-strict origin mode (Cloudflare "Full", the common setup) the CDN
+# presents its own valid certificate to visitors and does not care what the
+# origin serves, so an origin certificate can expire — or be silently replaced
+# by Caddy's internal CA when ACME breaks — while the site looks perfectly
+# healthy from a browser and from `canasta status`. Switching the CDN to strict
+# origin validation, the recommended posture, then takes the site down
+# instantly.
+
+# Below this, a certificate that should have renewed by now has not: Caddy
+# renews at roughly a third of the remaining lifetime, so a Let's Encrypt
+# certificate inside two weeks of expiry means renewal is failing.
+_TLS_RENEWAL_FLOOR_DAYS = 14
+
+# Caddy falls back to its internal CA when it cannot obtain a public
+# certificate, then reissues from it every 12 hours, logging "certificate
+# renewed successfully" each time. Only the issuer reveals that the domain has
+# not held a publicly trusted certificate in months.
+_TLS_INTERNAL_ISSUER_MARKERS = ("caddy local authority",)
+
+# Names Caddy serves from its internal CA by design — there is no public
+# certificate to fall back from, so an internal issuer is correct there.
+_TLS_LOCAL_NAMES = ("localhost",)
+_TLS_LOCAL_SUFFIXES = (
+    ".localhost", ".local", ".internal", ".test", ".example", ".invalid",
+)
+
+# Ask the origin itself rather than trusting any file on disk: this is the
+# certificate a CDN switched to strict validation would see. SNI is passed per
+# name because a host serving several domains can have one fall back to the
+# internal CA while the others hold valid certificates — the case a
+# whole-instance check that probed a single hostname would pass straight over.
+_ORIGIN_TLS_SCRIPT = r"""
+command -v openssl >/dev/null 2>&1 || { echo NO_OPENSSL; exit 0; }
+for n in %(names)s; do
+  printf '%%sNAME:%%s\n' '%(delim)s' "$n"
+  echo | openssl s_client -connect 127.0.0.1:%(port)s -servername "$n" \
+      2>/dev/null | openssl x509 -noout -issuer -enddate 2>/dev/null
+done
+"""
+
+
+def _is_public_hostname(name):
+    """True when `name` is a publicly resolvable domain, i.e. one that should
+    hold a publicly trusted certificate."""
+    n = (name or "").strip().lower().rstrip(".")
+    if not n or n in _TLS_LOCAL_NAMES or "." not in n:
+        return False
+    if any(n.endswith(suffix) for suffix in _TLS_LOCAL_SUFFIXES):
+        return False
+    if ":" in n or re.match(r"^[0-9.]+$", n):  # IPv6 / IPv4 literal
+        return False
+    return True
+
+
+def _parse_origin_tls(stdout):
+    """[(name, issuer, not_after)] from the probe output, or None when the host
+    has no openssl. issuer/not_after are empty when nothing answered."""
+    segments = stdout.split(_helpers._SENTINEL)
+    if "NO_OPENSSL" in segments[0]:
+        return None
+    entries = []
+    for seg in segments[1:]:
+        header, _, body = seg.partition("\n")
+        if not header.startswith("NAME:"):
+            continue
+        issuer = not_after = ""
+        for line in body.splitlines():
+            line = line.strip()
+            if line.startswith("issuer="):
+                issuer = line[len("issuer="):].strip()
+            elif line.startswith("notAfter="):
+                not_after = line[len("notAfter="):].strip()
+        entries.append((header[len("NAME:"):].strip(), issuer, not_after))
+    return entries
+
+
+def _parse_cert_expiry(text):
+    """openssl's 'Sep 10 12:00:00 2026 GMT' -> aware datetime, or None."""
+    raw = (text or "").strip()
+    if raw.endswith(" GMT"):
+        raw = raw[:-len(" GMT")]
+    try:
+        return datetime.datetime.strptime(
+            raw, "%b %d %H:%M:%S %Y").replace(tzinfo=datetime.timezone.utc)
+    except ValueError:
+        return None
+
+
+def _origin_tls_lines_from_entries(inst_id, entries, now):
+    """doctor lines for the probed certificates (pure — the testable core)."""
+    title = ["", "Origin TLS (%s):" % inst_id]
+    if entries is None:
+        return title + [
+            "  SKIPPED — openssl is not installed on the host, so the served "
+            "certificate cannot be inspected"]
+    if not entries:
+        return []
+    lines = list(title)
+    for name, issuer, not_after in entries:
+        if not issuer and not not_after:
+            lines.append(
+                "  %s: no certificate served on this host — skipped (nothing "
+                "listening on the HTTPS port, or TLS terminates elsewhere)"
+                % name)
+            continue
+        internal = any(
+            m in issuer.lower() for m in _TLS_INTERNAL_ISSUER_MARKERS)
+        if internal and not _is_public_hostname(name):
+            # Expected, and its certificates are short-lived by design (Caddy
+            # reissues every 12 hours), so the expiry checks below would warn
+            # about a local name every single time.
+            lines.append(
+                "  %s: OK (Caddy internal CA — expected for a name with no "
+                "public certificate)" % name)
+            continue
+        if internal:
+            lines.append(
+                "  %s: WARN — served by Caddy's internal CA (%s), not a "
+                "publicly trusted certificate. ACME is failing and Caddy fell "
+                "back to it silently; it reissues every 12 hours and logs "
+                "\"certificate renewed successfully\" each time, so nothing "
+                "else reports this. A CDN in a non-strict origin mode hides "
+                "it from visitors, and switching that CDN to strict origin "
+                "validation would take the site down. Check the caddy "
+                "container's log for the underlying ACME failure."
+                % (name, issuer))
+            continue
+        expiry = _parse_cert_expiry(not_after)
+        if expiry is None:
+            lines.append(
+                "  %s: issuer %s (expiry date unreadable: %r)"
+                % (name, issuer or "unknown", not_after))
+            continue
+        days = (expiry - now).days
+        if days < 0:
+            lines.append(
+                "  %s: WARN — certificate EXPIRED %d day(s) ago (issuer %s). "
+                "Renewal has been failing; a CDN in a non-strict origin mode "
+                "keeps serving visitors its own valid certificate, so nothing "
+                "reports this until the CDN is set to strict origin "
+                "validation, DNS changes, or someone reaches the origin "
+                "directly." % (name, -days, issuer or "unknown"))
+        elif days < _TLS_RENEWAL_FLOOR_DAYS:
+            lines.append(
+                "  %s: WARN — certificate expires in %d day(s) (issuer %s) "
+                "and has not renewed. Renewal should have happened by now, so "
+                "treat this as a broken ACME path rather than a countdown."
+                % (name, days, issuer or "unknown"))
+        else:
+            lines.append(
+                "  %s: OK (expires in %d days, issuer %s)"
+                % (name, days, issuer or "unknown"))
+    return lines
+
+
+def _origin_tls_server_names(path, host):
+    """Unique hostnames the instance serves, from wikis.yaml — the same
+    derivation rewrite_caddy.yml uses to build the Caddy site address."""
+    names = []
+    for wiki in _helpers._read_wikis(path, host):
+        url = (wiki.get("url") or "").strip()
+        if not url:
+            continue
+        name = re.sub(r":[0-9]+$", "", url.split("/")[0])
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
+def _origin_tls_lines(inst):
+    """doctor lines for the certificate the instance actually serves, or []
+    when the check does not apply (no path/names, plain-HTTP Compose)."""
+    path = inst.get("path", "")
+    if not path:
+        return []
+    host = inst.get("host") or "localhost"
+    is_k8s = inst.get("orchestrator", "compose") in ("kubernetes", "k8s")
+    if is_k8s:
+        # Caddy runs http-only behind the ingress on K8s; the ingress
+        # controller is what terminates TLS on the host's 443.
+        port = "443"
+    else:
+        if (_helpers._read_env_for(inst, "CADDY_AUTO_HTTPS") or "on").lower() \
+                == "off":
+            return []
+        port = _helpers._read_env_for(inst, "HTTPS_PORT") or "443"
+    names = _origin_tls_server_names(path, host)
+    if not names:
+        return []
+    script = _ORIGIN_TLS_SCRIPT % {
+        "names": " ".join(_helpers._shell_quote(n) for n in names),
+        "port": _helpers._shell_quote(str(port)),
+        "delim": _helpers._SENTINEL,
+    }
+    try:
+        if _helpers._is_localhost(host):
+            stdout = subprocess.run(
+                ["bash", "-c", script],
+                capture_output=True, text=True, timeout=60,
+            ).stdout
+        else:
+            rc, stdout = _helpers._ssh_run(host, script)
+            if rc != 0 and not stdout.strip():
+                return []
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+    if not stdout.strip():
+        return []
+    return _origin_tls_lines_from_entries(
+        inst.get("id", "?"), _parse_origin_tls(stdout),
+        datetime.datetime.now(datetime.timezone.utc))
+
+
 # --- Kubernetes config drift ------------------------------------------------
 #
 # On K8s, "desired" config is the operator's local files and "actual" is what
@@ -704,6 +921,10 @@ def cmd_doctor(args):
 
     for line in _instance_consistency_lines(inst):
         print(line)
+
+    if inst:
+        for line in _origin_tls_lines(inst):
+            print(line)
 
     parts = stdout.split(_helpers._SENTINEL + "\n")
     docker = parts[1].strip() if len(parts) > 1 else "MISSING"

--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -464,38 +464,25 @@ def _instance_consistency_lines(inst):
 
 # --- Origin TLS -------------------------------------------------------------
 #
-# Nothing else looks at the certificate an instance actually serves. Behind a
-# CDN in a non-strict origin mode (Cloudflare "Full", the common setup) the CDN
-# presents its own valid certificate to visitors and does not care what the
-# origin serves, so an origin certificate can expire — or be silently replaced
-# by Caddy's internal CA when ACME breaks — while the site looks perfectly
-# healthy from a browser and from `canasta status`. Switching the CDN to strict
-# origin validation, the recommended posture, then takes the site down
-# instantly.
+# A CDN in a non-strict origin mode serves visitors its own certificate
+# whatever the origin presents, so an expired or internally-issued origin
+# certificate shows no symptom until the CDN is switched to strict validation.
 
-# Below this, a certificate that should have renewed by now has not: Caddy
-# renews at roughly a third of the remaining lifetime, so a Let's Encrypt
-# certificate inside two weeks of expiry means renewal is failing.
+# Caddy renews well before this, so a certificate still this close to expiry
+# means renewal is failing.
 _TLS_RENEWAL_FLOOR_DAYS = 14
 
-# Caddy falls back to its internal CA when it cannot obtain a public
-# certificate, then reissues from it every 12 hours, logging "certificate
-# renewed successfully" each time. Only the issuer reveals that the domain has
-# not held a publicly trusted certificate in months.
+# Caddy's fallback when it cannot obtain a public certificate.
 _TLS_INTERNAL_ISSUER_MARKERS = ("caddy local authority",)
 
-# Names Caddy serves from its internal CA by design — there is no public
-# certificate to fall back from, so an internal issuer is correct there.
+# Names Caddy serves from its internal CA by design.
 _TLS_LOCAL_NAMES = ("localhost",)
 _TLS_LOCAL_SUFFIXES = (
     ".localhost", ".local", ".internal", ".test", ".example", ".invalid",
 )
 
-# Ask the origin itself rather than trusting any file on disk: this is the
-# certificate a CDN switched to strict validation would see. SNI is passed per
-# name because a host serving several domains can have one fall back to the
-# internal CA while the others hold valid certificates — the case a
-# whole-instance check that probed a single hostname would pass straight over.
+# Probed per SNI name: a host serving several domains can have one fall back
+# while the others hold valid certificates.
 _ORIGIN_TLS_SCRIPT = r"""
 command -v openssl >/dev/null 2>&1 || { echo NO_OPENSSL; exit 0; }
 for n in %(names)s; do
@@ -554,7 +541,7 @@ def _parse_cert_expiry(text):
 
 
 def _origin_tls_lines_from_entries(inst_id, entries, now):
-    """doctor lines for the probed certificates (pure — the testable core)."""
+    """doctor lines for the probed certificates."""
     title = ["", "Origin TLS (%s):" % inst_id]
     if entries is None:
         return title + [
@@ -573,9 +560,8 @@ def _origin_tls_lines_from_entries(inst_id, entries, now):
         internal = any(
             m in issuer.lower() for m in _TLS_INTERNAL_ISSUER_MARKERS)
         if internal and not _is_public_hostname(name):
-            # Expected, and its certificates are short-lived by design (Caddy
-            # reissues every 12 hours), so the expiry checks below would warn
-            # about a local name every single time.
+            # Internal-CA certificates last 12 hours, so the expiry checks
+            # below would warn about a local name on every run.
             lines.append(
                 "  %s: OK (Caddy internal CA — expected for a name with no "
                 "public certificate)" % name)
@@ -621,8 +607,8 @@ def _origin_tls_lines_from_entries(inst_id, entries, now):
 
 
 def _origin_tls_server_names(path, host):
-    """Unique hostnames the instance serves, from wikis.yaml — the same
-    derivation rewrite_caddy.yml uses to build the Caddy site address."""
+    """Unique hostnames the instance serves, derived from wikis.yaml as
+    rewrite_caddy.yml derives the Caddy site address."""
     names = []
     for wiki in _helpers._read_wikis(path, host):
         url = (wiki.get("url") or "").strip()
@@ -643,8 +629,7 @@ def _origin_tls_lines(inst):
     host = inst.get("host") or "localhost"
     is_k8s = inst.get("orchestrator", "compose") in ("kubernetes", "k8s")
     if is_k8s:
-        # Caddy runs http-only behind the ingress on K8s; the ingress
-        # controller is what terminates TLS on the host's 443.
+        # The ingress controller terminates TLS, not Caddy.
         port = "443"
     else:
         if (_helpers._read_env_for(inst, "CADDY_AUTO_HTTPS") or "on").lower() \

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -705,6 +705,12 @@ commands:
       or kubectl + Helm for Kubernetes installs. Also reports
       status of optional tools (git, git-crypt, sops, age, crontab) and
       system resources (memory, disk space).
+
+      When an instance is resolved (from -i, or from the current
+      directory), also checks that instance: config and runtime
+      agreement, whether local config edits have been applied, and the
+      certificate the origin is actually serving (expired, or silently
+      reissued by Caddy's internal CA after ACME failed).
     examples:
       - "canasta doctor"
       - "canasta doctor --host prod1.example.com"

--- a/tests/unit/test_doctor_origin_tls.py
+++ b/tests/unit/test_doctor_origin_tls.py
@@ -1,0 +1,223 @@
+"""Tests for `canasta doctor`'s origin-certificate check.
+
+Behind a CDN in a non-strict origin mode the CDN serves visitors its own valid
+certificate regardless of what the origin presents, so an expired origin
+certificate — or one Caddy silently reissues from its internal CA after ACME
+broke — produces no symptom anywhere until the CDN is switched to strict origin
+validation and the site drops. The check asks the origin directly, per SNI
+name, because one domain on a multi-domain host can fall back while the others
+stay valid.
+"""
+
+import datetime
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from direct_commands import doctor  # noqa: E402
+
+
+NOW = datetime.datetime(2026, 7, 31, tzinfo=datetime.timezone.utc)
+LE = "C = US, O = Let's Encrypt, CN = R11"
+CADDY_LOCAL = "CN = Caddy Local Authority - ECC Intermediate"
+
+
+def _fmt(dt):
+    """openssl's notAfter rendering."""
+    return dt.strftime("%b %e %H:%M:%S %Y GMT").replace("  ", "  ")
+
+
+def _lines(entries, now=NOW):
+    return doctor._origin_tls_lines_from_entries("site", entries, now)
+
+
+class TestPublicHostname:
+    def test_public_domains(self):
+        assert doctor._is_public_hostname("wiki.example.org")
+        assert doctor._is_public_hostname("Example.COM.")
+
+    def test_local_and_reserved_names_are_not_public(self):
+        # Caddy serves these from its internal CA by design, so an internal
+        # issuer there must not be reported as a fallback.
+        for name in ("localhost", "wiki.localhost", "box.local", "svc.internal",
+                     "a.test", "x.example", "y.invalid", "nodots"):
+            assert not doctor._is_public_hostname(name), name
+
+    def test_ip_literals_are_not_public(self):
+        assert not doctor._is_public_hostname("192.0.2.10")
+        assert not doctor._is_public_hostname("2001:db8::1")
+
+    def test_empty(self):
+        assert not doctor._is_public_hostname("")
+        assert not doctor._is_public_hostname(None)
+
+
+class TestParseProbeOutput:
+    def test_missing_openssl_returns_none(self):
+        assert doctor._parse_origin_tls("NO_OPENSSL\n") is None
+
+    def test_parses_issuer_and_expiry_per_name(self):
+        d = doctor._helpers._SENTINEL
+        out = (
+            "%sNAME:a.example.org\nissuer=%s\nnotAfter=Sep 10 12:00:00 2026 GMT\n"
+            "%sNAME:b.example.org\nissuer=%s\nnotAfter=Aug  1 00:00:00 2026 GMT\n"
+            % (d, LE, d, CADDY_LOCAL))
+        assert doctor._parse_origin_tls(out) == [
+            ("a.example.org", LE, "Sep 10 12:00:00 2026 GMT"),
+            ("b.example.org", CADDY_LOCAL, "Aug  1 00:00:00 2026 GMT"),
+        ]
+
+    def test_name_with_no_handshake_yields_empty_fields(self):
+        d = doctor._helpers._SENTINEL
+        assert doctor._parse_origin_tls("%sNAME:a.example.org\n" % d) == [
+            ("a.example.org", "", ""),
+        ]
+
+
+class TestExpiryParsing:
+    def test_openssl_format(self):
+        assert doctor._parse_cert_expiry("Sep 10 12:00:00 2026 GMT") == (
+            datetime.datetime(2026, 9, 10, 12, tzinfo=datetime.timezone.utc))
+
+    def test_day_padded_with_a_space(self):
+        assert doctor._parse_cert_expiry("Aug  1 00:00:00 2026 GMT") == (
+            datetime.datetime(2026, 8, 1, tzinfo=datetime.timezone.utc))
+
+    def test_garbage(self):
+        assert doctor._parse_cert_expiry("not a date") is None
+        assert doctor._parse_cert_expiry("") is None
+
+
+class TestReportedLines:
+    def test_healthy_certificate_is_ok(self):
+        body = " ".join(_lines([
+            ("a.example.org", LE, _fmt(NOW + datetime.timedelta(days=61)))]))
+        assert "WARN" not in body
+        assert "OK (expires in 61 days" in body
+
+    def test_expired_certificate_warns_with_age(self):
+        body = " ".join(_lines([
+            ("a.example.org", LE, _fmt(NOW - datetime.timedelta(days=9)))]))
+        assert "WARN" in body
+        assert "EXPIRED 9 day(s) ago" in body
+
+    def test_long_expired_certificate_warns(self):
+        body = " ".join(_lines([
+            ("a.example.org", LE, _fmt(NOW - datetime.timedelta(days=400)))]))
+        assert "EXPIRED 400 day(s) ago" in body
+
+    def test_unrenewed_inside_the_renewal_window_warns(self):
+        body = " ".join(_lines([
+            ("a.example.org", LE, _fmt(NOW + datetime.timedelta(days=5)))]))
+        assert "WARN" in body
+        assert "expires in 5 day(s)" in body
+        assert "broken ACME path" in body
+
+    def test_internal_ca_on_a_public_domain_warns(self):
+        body = " ".join(_lines([
+            ("a.example.org", CADDY_LOCAL,
+             _fmt(NOW + datetime.timedelta(days=1)))]))
+        assert "WARN" in body
+        assert "internal CA" in body
+        # The 12-hour reissue is why the Caddy log reads as healthy.
+        assert "12 hours" in body
+
+    def test_internal_ca_on_localhost_is_not_a_warning(self):
+        body = " ".join(_lines([
+            ("localhost", CADDY_LOCAL,
+             _fmt(NOW + datetime.timedelta(days=1)))]))
+        assert "WARN" not in body
+
+    def test_per_domain_divergence_on_one_host(self):
+        # The case a single-hostname check would pass straight over: two
+        # domains valid, the primary silently fell back.
+        lines = _lines([
+            ("a.example.org", LE, _fmt(NOW + datetime.timedelta(days=61))),
+            ("b.example.org", LE, _fmt(NOW + datetime.timedelta(days=61))),
+            ("primary.example.org", CADDY_LOCAL,
+             _fmt(NOW + datetime.timedelta(days=1))),
+        ])
+        warns = [ln for ln in lines if "WARN" in ln]
+        assert len(warns) == 1
+        assert "primary.example.org" in warns[0]
+
+    def test_no_listener_is_reported_not_warned(self):
+        body = " ".join(_lines([("a.example.org", "", "")]))
+        assert "WARN" not in body
+        assert "no certificate served" in body
+
+    def test_missing_openssl_is_reported_as_skipped(self):
+        body = " ".join(_lines(None))
+        assert "SKIPPED" in body
+        assert "openssl" in body
+
+    def test_no_names_produces_no_section(self):
+        assert _lines([]) == []
+
+
+class TestServerNameDerivation:
+    def test_strips_path_and_port_and_dedupes(self, monkeypatch):
+        monkeypatch.setattr(
+            doctor._helpers, "_read_wikis",
+            lambda path, host: [
+                {"url": "wiki.example.org/w"},
+                {"url": "wiki.example.org:8443/other"},
+                {"url": "second.example.org"},
+                {"url": ""},
+            ])
+        assert doctor._origin_tls_server_names("/srv/x", "localhost") == [
+            "wiki.example.org", "second.example.org"]
+
+
+class TestOriginTlsGate:
+    def _inst(self, **kw):
+        inst = {"id": "site", "orchestrator": "compose", "path": "/srv/site",
+                "host": "localhost"}
+        inst.update(kw)
+        return inst
+
+    def test_skipped_when_compose_serves_plain_http(self, monkeypatch):
+        monkeypatch.setattr(
+            doctor._helpers, "_read_env_for",
+            lambda inst, key: "off" if key == "CADDY_AUTO_HTTPS" else None)
+        assert doctor._origin_tls_lines(self._inst()) == []
+
+    def test_skipped_without_a_path(self):
+        assert doctor._origin_tls_lines({"id": "site"}) == []
+
+    def test_probes_the_configured_https_port(self, monkeypatch):
+        seen = {}
+
+        class _R:
+            stdout = ""
+
+        monkeypatch.setattr(
+            doctor._helpers, "_read_env_for",
+            lambda inst, key: {"HTTPS_PORT": "8443"}.get(key))
+        monkeypatch.setattr(
+            doctor._helpers, "_read_wikis",
+            lambda path, host: [{"url": "a.example.org"}])
+        monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
+        monkeypatch.setattr(
+            doctor.subprocess, "run",
+            lambda *a, **k: (seen.update(script=a[0][2]) or _R()))
+        doctor._origin_tls_lines(self._inst())
+        assert "127.0.0.1:'8443'" in seen["script"]
+        assert "-servername" in seen["script"]
+
+    def test_kubernetes_probes_the_ingress_on_443(self, monkeypatch):
+        seen = {}
+
+        class _R:
+            stdout = ""
+
+        monkeypatch.setattr(
+            doctor._helpers, "_read_wikis",
+            lambda path, host: [{"url": "a.example.org"}])
+        monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
+        monkeypatch.setattr(
+            doctor.subprocess, "run",
+            lambda *a, **k: (seen.update(script=a[0][2]) or _R()))
+        doctor._origin_tls_lines(self._inst(orchestrator="kubernetes"))
+        assert "127.0.0.1:'443'" in seen["script"]

--- a/tests/unit/test_doctor_origin_tls.py
+++ b/tests/unit/test_doctor_origin_tls.py
@@ -132,15 +132,17 @@ class TestReportedLines:
     def test_per_domain_divergence_on_one_host(self):
         # The case a single-hostname check would pass straight over: two
         # domains valid, the primary silently fell back.
+        primary = "primary.example.org"
         lines = _lines([
             ("a.example.org", LE, _fmt(NOW + datetime.timedelta(days=61))),
             ("b.example.org", LE, _fmt(NOW + datetime.timedelta(days=61))),
-            ("primary.example.org", CADDY_LOCAL,
-             _fmt(NOW + datetime.timedelta(days=1))),
+            (primary, CADDY_LOCAL, _fmt(NOW + datetime.timedelta(days=1))),
         ])
         warns = [ln for ln in lines if "WARN" in ln]
         assert len(warns) == 1
-        assert "primary.example.org" in warns[0]
+        # The warning must be the line reporting that name, not merely mention
+        # it somewhere.
+        assert warns[0].strip().startswith(primary + ":")
 
     def test_no_listener_is_reported_not_warned(self):
         body = " ".join(_lines([("a.example.org", "", "")]))

--- a/tests/unit/test_doctor_origin_tls.py
+++ b/tests/unit/test_doctor_origin_tls.py
@@ -1,13 +1,4 @@
-"""Tests for `canasta doctor`'s origin-certificate check.
-
-Behind a CDN in a non-strict origin mode the CDN serves visitors its own valid
-certificate regardless of what the origin presents, so an expired origin
-certificate — or one Caddy silently reissues from its internal CA after ACME
-broke — produces no symptom anywhere until the CDN is switched to strict origin
-validation and the site drops. The check asks the origin directly, per SNI
-name, because one domain on a multi-domain host can fall back while the others
-stay valid.
-"""
+"""Tests for `canasta doctor`'s origin-certificate check."""
 
 import datetime
 import os
@@ -25,7 +16,7 @@ CADDY_LOCAL = "CN = Caddy Local Authority - ECC Intermediate"
 
 def _fmt(dt):
     """openssl's notAfter rendering."""
-    return dt.strftime("%b %e %H:%M:%S %Y GMT").replace("  ", "  ")
+    return dt.strftime("%b %e %H:%M:%S %Y GMT")
 
 
 def _lines(entries, now=NOW):
@@ -38,8 +29,6 @@ class TestPublicHostname:
         assert doctor._is_public_hostname("Example.COM.")
 
     def test_local_and_reserved_names_are_not_public(self):
-        # Caddy serves these from its internal CA by design, so an internal
-        # issuer there must not be reported as a fallback.
         for name in ("localhost", "wiki.localhost", "box.local", "svc.internal",
                      "a.test", "x.example", "y.invalid", "nodots"):
             assert not doctor._is_public_hostname(name), name
@@ -120,8 +109,6 @@ class TestReportedLines:
              _fmt(NOW + datetime.timedelta(days=1)))]))
         assert "WARN" in body
         assert "internal CA" in body
-        # The 12-hour reissue is why the Caddy log reads as healthy.
-        assert "12 hours" in body
 
     def test_internal_ca_on_localhost_is_not_a_warning(self):
         body = " ".join(_lines([
@@ -130,8 +117,6 @@ class TestReportedLines:
         assert "WARN" not in body
 
     def test_per_domain_divergence_on_one_host(self):
-        # The case a single-hostname check would pass straight over: two
-        # domains valid, the primary silently fell back.
         primary = "primary.example.org"
         lines = _lines([
             ("a.example.org", LE, _fmt(NOW + datetime.timedelta(days=61))),
@@ -140,8 +125,6 @@ class TestReportedLines:
         ])
         warns = [ln for ln in lines if "WARN" in ln]
         assert len(warns) == 1
-        # The warning must be the line reporting that name, not merely mention
-        # it somewhere.
         assert warns[0].strip().startswith(primary + ":")
 
     def test_no_listener_is_reported_not_warned(self):


### PR DESCRIPTION
Closes #1364.

Independent of #1365 and #1366 — no shared code, though it touches the same `doctor` help text as #1366, so whichever merges second needs a trivial rebase of that one paragraph.

## Change

`canasta doctor` probes `127.0.0.1` on the instance's HTTPS port, once **per SNI name** taken from `wikis.yaml`, and reports the issuer and expiry. It warns on:

1. An expired certificate (with how long ago)
2. One inside the renewal window that has not renewed — treated as a broken ACME path, not a countdown
3. The internal-CA fallback: issuer is Caddy's local authority on a domain that should hold a public certificate

Probing per name rather than per instance is what catches the case in the issue where a multi-domain host had two valid Let's Encrypt certificates and the primary domain had silently fallen back — a whole-instance check on one hostname would have passed it.

## One false positive worth flagging

Caddy's internal CA issues **12-hour** certificates, so a naive expiry check warns "expires in 0 days" on every localhost or dev instance, every run. Names Caddy serves from its internal CA by design — `localhost`, `.local`, `.test`, `.internal`, `.example`, `.invalid`, and IP literals — are now reported as expected rather than warned about.

## Verification

Against a live local Compose instance:

```
Origin TLS (dev):
  localhost: OK (Caddy internal CA — expected for a name with no public certificate)
```

Unit tests cover expired, near-expiry, internal-CA-on-a-public-domain, internal-CA-on-localhost, per-domain divergence across one host, no listener, and a host without openssl (reported as skipped, not a failure).

## Not included

The issue also suggests scanning Caddy logs for `tls.renew` failures. The certificate check catches the outcome — expired, or a local issuer — directly, which seemed a better trade than parsing container logs for the same information.
