### PR TITLE
fix(crowdsec): report console blocklists instead of claiming enrollment

### DIFF
--- a/roles/crowdsec/tasks/status.yml
+++ b/roles/crowdsec/tasks/status.yml
@@ -40,14 +40,6 @@
   changed_when: false
   failed_when: false
 
-- name: Get console enrollment status
-  ansible.builtin.command:
-    cmd: "{{ _cscli_prefix }} cscli console status -o raw"
-    chdir: "{{ _cscli_chdir | default(omit) }}"
-  register: _crowdsec_console
-  changed_when: false
-  failed_when: false
-
 # `cscli decisions list` excludes CAPI blocklist decisions, so count them by
 # origin. -o raw keeps the payload to one integer; tail drops the CSV header.
 - name: Count community-blocklist (CAPI) decisions
@@ -86,16 +78,20 @@
              if (_crowdsec_capi_count.stdout | trim | int) > 0 else ''))
          if _crowdsec_capi.rc == 0
          else 'not registered (no community blocklist; auto-registers on the next start)' }}
-    # `cscli console status -o raw` is CSV (option,enabled); an enrolled engine
-    # has at least one forward option set to true. This is the engine's local
-    # view — it cannot confirm the Console still recognizes the engine (that
-    # needs PAPI, a paid feature), so we say "per local config" rather than
-    # imply a verified live link. The breakdown filter returns a ready-to-append
-    # block (real newlines) or '' when no lists are pulled.
+    # Report the console blocklists the engine is actually pulling, not whether
+    # it is enrolled. Enrollment cannot be confirmed locally (that needs PAPI, a
+    # paid feature) and the share options in console.yaml are no proxy for it —
+    # share_custom and share_tainted default to true, so any check for an
+    # enabled option matches a never-enrolled engine. Console blocklists carry
+    # origin 'lists', which is observable. These are *additional* to the CAPI
+    # community blocklist reported above, which needs no console account and is
+    # unaffected by this line — say so, or "none" reads as "unprotected". The
+    # breakdown filter returns a ready-to-append block (real newlines) or ''.
     _crowdsec_console_line: >-
-      {{ ('enrolled (per local config)' ~ _crowdsec_blocklist_lines)
-         if (_crowdsec_console.rc == 0 and ',true' in (_crowdsec_console.stdout | default('')))
-         else 'not enrolled — run: canasta crowdsec console-enroll <key> (optional, for the full blocklist)' }}
+      {{ ('active' ~ _crowdsec_blocklist_lines)
+         if (_crowdsec_blocklist_lines | trim) != ''
+         else 'none (optional; the community blocklist above is unaffected) —
+               add more with: canasta crowdsec console-enroll <key>' }}
 
 - name: Show CrowdSec status
   ansible.builtin.debug:
@@ -106,7 +102,7 @@
       {{ _crowdsec_bouncer_list | canasta_crowdsec_status_bouncers }}
 
       Central API (community blocklist): {{ _crowdsec_capi_line }}
-      Console: {{ _crowdsec_console_line }}
+      Console blocklists: {{ _crowdsec_console_line }}
 
       Local decisions (manual bans + scenario detections):
       {{ _crowdsec_decisions.stdout | default('(none)') }}

--- a/roles/crowdsec/tasks/status.yml
+++ b/roles/crowdsec/tasks/status.yml
@@ -78,15 +78,9 @@
              if (_crowdsec_capi_count.stdout | trim | int) > 0 else ''))
          if _crowdsec_capi.rc == 0
          else 'not registered (no community blocklist; auto-registers on the next start)' }}
-    # Report the console blocklists the engine is actually pulling, not whether
-    # it is enrolled. Enrollment cannot be confirmed locally (that needs PAPI, a
-    # paid feature) and the share options in console.yaml are no proxy for it —
-    # share_custom and share_tainted default to true, so any check for an
-    # enabled option matches a never-enrolled engine. Console blocklists carry
-    # origin 'lists', which is observable. These are *additional* to the CAPI
-    # community blocklist reported above, which needs no console account and is
-    # unaffected by this line — say so, or "none" reads as "unprotected". The
-    # breakdown filter returns a ready-to-append block (real newlines) or ''.
+    # Console blocklists (origin 'lists') are observable; enrollment is not —
+    # confirming it needs PAPI. They are additional to the CAPI community
+    # blocklist above, so say that is unaffected or "none" reads as unprotected.
     _crowdsec_console_line: >-
       {{ ('active' ~ _crowdsec_blocklist_lines)
          if (_crowdsec_blocklist_lines | trim) != ''

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -868,16 +868,18 @@ class TestCrowdsecStatusWiring:
 
     def test_status_reports_capi_and_console(self):
         """status must surface Central API registration (the community
-        blocklist) and console enrollment, so an un-registered engine is no
-        longer a silent failure."""
+        blocklist) so an un-registered engine is no longer a silent failure,
+        and must report the console blocklists actually pulled. Console
+        enrollment itself cannot be confirmed locally, so it is not claimed."""
         content = _read(os.path.join(
             REPO_ROOT, "roles", "crowdsec", "tasks", "status.yml",
         ))
         assert "cscli capi status" in content, (
             "status must probe Central API registration (community blocklist)"
         )
-        assert "cscli console status" in content, (
-            "status must probe console enrollment state"
+        assert "--origin lists" in content, (
+            "status must report the console blocklists actually pulled, "
+            "rather than inferring enrollment from local share options"
         )
 
     def test_status_counts_blocklist_decisions(self):
@@ -906,24 +908,50 @@ class TestCrowdsecStatusWiring:
         assert "_crowdsec_console_line" in content, (
             "status must derive a one-line console summary"
         )
-        assert "Console: {{ _crowdsec_console_line }}" in content, (
+        assert "Console blocklists: {{ _crowdsec_console_line }}" in content, (
             "status must display the one-line console summary, not dump the "
             "raw cscli console table (which shows the misleading "
             "console_management row)"
         )
 
-    def test_console_enrolled_detection_is_glyph_free(self):
-        """Enrolled-detection must read the stable `-o raw` CSV (option,enabled)
-        rather than scraping the human table's ✅ glyph, which is fragile to
-        cscli formatting/locale/color changes."""
+    def test_console_summary_does_not_imply_community_blocklist_is_absent(self):
+        """The console line reports *additional* blocklists layered on the CAPI
+        community blocklist, which needs no console account. Saying only "none"
+        would read as "unprotected" on an engine already enforcing tens of
+        thousands of CAPI IPs, so the empty case must say the community
+        blocklist is unaffected."""
         content = _read(os.path.join(
             REPO_ROOT, "roles", "crowdsec", "tasks", "status.yml",
         ))
-        assert "cscli console status -o raw" in content, (
-            "console status must be read as raw CSV, not the human table"
+        assert "community blocklist above is unaffected" in content, (
+            "the no-console-blocklists message must make clear the CAPI "
+            "community blocklist is still active"
+        )
+        assert "Console blocklists:" in content, (
+            "the label must scope the line to console blocklists so it is not "
+            "read as overall CrowdSec status"
+        )
+
+    def test_console_summary_not_derived_from_share_options(self):
+        """`cscli console status` lists share options, two of which
+        (share_custom, share_tainted) CrowdSec enables by default. Keying the
+        summary on "any option is true" therefore reports every engine as
+        enrolled, including one that never was. Enrollment cannot be confirmed
+        locally at all, so the summary must report the blocklists actually
+        pulled (origin `lists`) instead."""
+        content = _read(os.path.join(
+            REPO_ROOT, "roles", "crowdsec", "tasks", "status.yml",
+        ))
+        assert "cscli console status" not in content, (
+            "console summary must not be derived from share options, which "
+            "default to true on a never-enrolled engine"
+        )
+        assert "--origin lists" in content, (
+            "console summary must be derived from the blocklists actually "
+            "pulled, which is observable locally"
         )
         assert "✅" not in content, (
-            "enrolled-detection must not depend on the ✅ glyph"
+            "summary must not depend on cscli's human-table glyphs"
         )
 
 


### PR DESCRIPTION
Fixes #1368.

`canasta crowdsec status` reported `Console: enrolled (per local config)` on every instance, including ones that had never been enrolled.

## The defect

The check keyed on any option in `cscli console status -o raw` being true:

```yaml
if (_crowdsec_console.rc == 0 and ',true' in (_crowdsec_console.stdout | default('')))
```

`share_custom` and `share_tainted` default to true in a stock `console.yaml`, so the condition always held. The `else` branch — the one telling the operator how to enrol — was unreachable.

Verified on instances with no console enrollment: no enrollment token under `/etc/crowdsec/`, the only credential being `online_api_credentials.yaml` (plain CAPI registration, whose `login` is a generated machine ID rather than an account), and `cscli decisions list --origin lists` returning only its CSV header. All reported `enrolled`.

## The fix

Enrollment cannot be confirmed locally — that needs PAPI, a paid feature — so this stops claiming it and reports what is observable: the console blocklists actually being pulled, which carry origin `lists`. The `cscli console status` probe that fed the unsound inference is dropped, as it had no other consumer.

The line is also relabelled `Console blocklists:` and, in the empty case, states that the CAPI community blocklist reported on the line above is unaffected. That blocklist needs no console account, so an unqualified "none" would read as no protection on an engine already enforcing tens of thousands of community-blocklist IPs — see the [correction comment](https://github.com/CanastaWiki/Canasta-CLI/issues/1368#issuecomment-5148921946) on the issue.

## Resulting output

Before, on a never-enrolled instance:

```
Central API (community blocklist): registered — community blocklist active (26917 IPs loaded)
Console: enrolled (per local config)
```

After:

```
Central API (community blocklist): registered — community blocklist active (26917 IPs loaded)
Console blocklists: none (optional; the community blocklist above is unaffected) — add more with: canasta crowdsec console-enroll <key>
```

With console blocklists present, the line reads `Console blocklists: active` followed by the existing per-list breakdown.

Instances where CrowdSec is not enabled are unaffected: preflight fails before any status output is produced.

## Testing

`make test-unit` (2260 passed), `make lint`, `make validate` all pass.

Two existing tests asserted the old invariant and were updated rather than removed, so they now encode why it was wrong: one asserts `cscli console status` is absent, the other that the summary derives from `--origin lists`. A new test covers the wording regression — that the empty case must state the community blocklist is unaffected, and that the label is scoped — since the logic was already correct there and only the phrasing misled.
