### PR TITLE
fix(upgrade): detect the runtime of an instance that records none

### DIFF
--- a/playbooks/_upgrade_single.yml
+++ b/playbooks/_upgrade_single.yml
@@ -27,6 +27,16 @@
 - name: Switch connection to instance host
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/switch_connection.yml"
 
+# An instance registered before the runtime became a registry field has
+# nothing for the facts above to read, so they fall back to Docker and
+# the whole upgrade runs `docker compose` — rc=127 on a Podman-only
+# host. Silence in the registry is not evidence of Docker; ask the host.
+- name: Detect the runtime for an instance that has none recorded
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/detect_runtime.yml"
+  when:
+    - instance_orchestrator == 'compose'
+    - _inst.value.composeCommand is not defined
+
 - name: Run upgrade role (migrations + refresh + restart)
   ansible.builtin.include_role:
     name: upgrade

--- a/roles/common/library/canasta_registry.py
+++ b/roles/common/library/canasta_registry.py
@@ -28,6 +28,7 @@ options:
       - query
       - query_all
       - query_by_path
+      - set_runtime
       - set_setting
       - get_setting
     default: query
@@ -154,7 +155,7 @@ def run_module():
     module_args = dict(
         state=dict(type="str", default="query",
                    choices=["present", "absent", "query", "query_all",
-                            "query_by_path",
+                            "query_by_path", "set_runtime",
                             "set_setting", "get_setting"]),
         setting_key=dict(type="str", required=False),
         setting_value=dict(type="str", required=False),
@@ -272,6 +273,34 @@ def run_module():
 
         result["changed"] = changed
         result["instance"] = new_instance
+
+    elif state == "set_runtime":
+        if not inst_id:
+            module.fail_json(msg="id is required when state=set_runtime")
+            return
+        if inst_id not in instances:
+            module.fail_json(
+                msg="Instance '%s' not found in registry" % inst_id)
+            return
+        # Field-wise update rather than state=present: present rebuilds
+        # the whole record from module params, so writing one field
+        # through it drops every field the caller did not repeat.
+        entry = dict(instances[inst_id])
+        for key, param in (("composeCommand", "compose_command"),
+                           ("inspectCommand", "inspect_command")):
+            value = module.params.get(param)
+            if value:
+                entry[key] = value
+
+        if entry != instances[inst_id]:
+            changed = True
+            instances[inst_id] = entry
+            if not module.check_mode:
+                data["Instances"] = instances
+                write_config(config_dir, data)
+
+        result["changed"] = changed
+        result["instance"] = entry
 
     elif state == "absent":
         if not inst_id:

--- a/roles/common/tasks/detect_runtime.yml
+++ b/roles/common/tasks/detect_runtime.yml
@@ -1,0 +1,56 @@
+---
+# Ask an instance's own host which container runtime it has, and record
+# the answer in the registry.
+#
+# The write-back is what lets the fast-path commands that read the
+# registry (list, start, exec) resolve the instance correctly too, so
+# the probe is not repeated per command.
+#
+# Only the Podman case is recorded. A working Docker host already
+# matches the default, and a Docker daemon that happens to be down
+# during this run is not evidence worth persisting.
+#
+# Runs commands on the instance's host, so include this after
+# switch_connection.yml.
+#
+# Input: instance_id
+# Output: compose_command / inspect_command facts, and the same values
+#   on the registry entry, when the host runs Podman and not Docker.
+
+- name: Probe docker info
+  ansible.builtin.command:
+    cmd: docker info
+  register: _dr_docker
+  changed_when: false
+  failed_when: false
+
+# Only asked when Docker came up short: on a Docker host the answer
+# cannot change the outcome, and this is a round trip to the target.
+- name: Probe podman info
+  ansible.builtin.command:
+    cmd: podman info
+  register: _dr_podman
+  changed_when: false
+  failed_when: false
+  when: _dr_docker.rc | default(1) != 0
+
+- name: Use Podman when Docker is absent
+  when:
+    - _dr_docker.rc | default(1) != 0
+    - _dr_podman.rc | default(1) == 0
+  block:
+    - name: Set the Podman runtime for this instance
+      ansible.builtin.set_fact:
+        compose_command: podman-compose
+        inspect_command: podman
+
+    - name: Record the detected runtime in the registry
+      canasta_registry:
+        id: "{{ instance_id }}"
+        compose_command: podman-compose
+        inspect_command: podman
+        state: set_runtime
+      delegate_to: localhost
+      vars:
+        ansible_connection: local
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/tests/unit/test_upgrade_detects_legacy_runtime.py
+++ b/tests/unit/test_upgrade_detects_legacy_runtime.py
@@ -1,0 +1,226 @@
+"""An instance with no recorded runtime must be asked, not assumed.
+
+composeCommand/inspectCommand became registry fields after instances
+were already registered, so every instance created before them reads
+back as Docker. _upgrade_single.yml takes the registry at its word, and
+on a Podman-only host the whole upgrade runs `docker compose`:
+
+    Pulling Canasta container images...
+    Error: pull Compose images failed (rc=127): /bin/sh: 1: docker: not found
+
+with `canasta doctor` on the same host reporting Docker MISSING and
+Podman OK. The probe has to run on the instance's host (the controller's
+PATH says nothing about it) and the answer has to reach the registry, or
+`canasta list` and `canasta start` keep resolving that instance to
+Docker afterwards.
+"""
+
+import json
+import os
+
+import yaml
+
+import canasta_registry
+from mock_ansible import run_module_with_params
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+SINGLE = os.path.join(REPO_ROOT, "playbooks", "_upgrade_single.yml")
+DETECT = os.path.join(
+    REPO_ROOT, "roles", "common", "tasks", "detect_runtime.yml")
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _tasks(path):
+    out = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            out.append(node)
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for i in node:
+                walk(i)
+
+    walk(_load(path))
+    return out
+
+
+def _named(path, needle):
+    return next(
+        (t for t in _tasks(path)
+         if needle.lower() in str(t.get("name", "")).lower()), None)
+
+
+def _params(**kw):
+    params = {
+        "state": "query", "id": None, "path": None,
+        "orchestrator": "compose", "dev_mode": False,
+        "managed_cluster": False, "registry": None, "kind_cluster": None,
+        "build_from": None, "build_args": None, "host": None,
+        "docker_host": None, "compose_command": None,
+        "inspect_command": None, "filter_host": None,
+        "setting_key": None, "setting_value": None, "config_dir": None,
+    }
+    params.update(kw)
+    return params
+
+
+def _legacy_registry(tmp_dir):
+    """An instance recorded before the runtime fields existed."""
+    data = {"Instances": {"legacy": {
+        "id": "legacy",
+        "path": "/srv/canasta/legacy",
+        "orchestrator": "compose",
+        "host": "host1.example.com",
+        "devMode": True,
+        "buildFrom": "/src",
+        "dockerHost": "unix:///run/user/1001/podman/podman.sock",
+    }}}
+    with open(os.path.join(tmp_dir, "conf.json"), "w") as f:
+        json.dump(data, f)
+    return data["Instances"]["legacy"]
+
+
+def _read_back(tmp_dir):
+    with open(os.path.join(tmp_dir, "conf.json")) as f:
+        return json.load(f)["Instances"]["legacy"]
+
+
+class TestUpgradeProbesWhenTheRegistryIsSilent:
+    def test_the_detection_is_included(self):
+        task = _named(SINGLE, "Detect the runtime")
+        assert task, (
+            "_upgrade_single.yml takes the registry's silence as Docker, "
+            "so an instance registered before composeCommand existed runs "
+            "the whole upgrade with `docker compose`"
+        )
+        assert task["ansible.builtin.include_tasks"].endswith(
+            "roles/common/tasks/detect_runtime.yml")
+
+    def test_it_only_runs_when_nothing_is_recorded(self):
+        conds = _named(SINGLE, "Detect the runtime")["when"]
+        assert any("composeCommand is not defined" in str(c) for c in conds), (
+            "the probe runs even for instances that record their runtime, "
+            "spending two round trips per upgrade to relearn it"
+        )
+        assert any("compose" in str(c) and "orchestrator" in str(c)
+                   for c in conds), (
+            "Kubernetes instances have no compose runtime to probe"
+        )
+
+    def test_it_runs_after_the_connection_switch(self):
+        # The controller's PATH is not evidence about the instance's host.
+        names = [str(t.get("name", "")) for t in _tasks(SINGLE)]
+        assert (names.index("Switch connection to instance host")
+                < names.index(
+                    "Detect the runtime for an instance that has none "
+                    "recorded"))
+
+    def test_the_facts_are_reset_before_the_probe(self):
+        # set_fact persists across loop iterations, so a podman instance
+        # detected in one pass must not leak into the next instance.
+        names = [str(t.get("name", "")) for t in _tasks(SINGLE)]
+        assert (names.index("Set instance facts")
+                < names.index(
+                    "Detect the runtime for an instance that has none "
+                    "recorded"))
+
+
+class TestTheProbeAsksTheHost:
+    def test_it_probes_both_runtimes(self):
+        cmds = [t["ansible.builtin.command"]["cmd"] for t in _tasks(DETECT)
+                if "ansible.builtin.command" in t]
+        assert "docker info" in cmds
+        assert "podman info" in cmds
+
+    def test_a_missing_binary_does_not_abort_the_upgrade(self):
+        # `docker info` where docker is absent leaves no rc at all.
+        for t in _tasks(DETECT):
+            if "ansible.builtin.command" not in t:
+                continue
+            assert t["failed_when"] is False
+            assert t["changed_when"] is False
+        block = _named(DETECT, "Use Podman when Docker is absent")
+        assert all("default(1)" in str(c) for c in block["when"]), (
+            "the conditions read .rc directly, which is undefined when the "
+            "binary is missing — the case this exists to handle"
+        )
+
+    def test_podman_wins_only_when_docker_is_unavailable(self):
+        conds = [str(c) for c
+                 in _named(DETECT, "Use Podman when Docker is absent")["when"]]
+        assert any("_dr_docker" in c and "!= 0" in c for c in conds)
+        assert any("_dr_podman" in c and "== 0" in c for c in conds)
+
+    def test_the_result_is_written_back_to_the_registry(self):
+        task = _named(DETECT, "Record the detected runtime")
+        assert task, (
+            "without the write-back the probe repeats every upgrade, and "
+            "list/start/exec keep resolving the instance to Docker"
+        )
+        assert task["canasta_registry"]["state"] == "set_runtime"
+        assert task["canasta_registry"]["compose_command"] == "podman-compose"
+        assert task["canasta_registry"]["inspect_command"] == "podman"
+
+    def test_the_registry_write_runs_on_the_controller(self):
+        task = _named(DETECT, "Record the detected runtime")
+        assert task["delegate_to"] == "localhost"
+        assert task["vars"]["ansible_connection"] == "local"
+
+
+class TestSetRuntimeKeepsTheRestOfTheRecord:
+    def test_it_records_the_runtime(self, tmp_dir):
+        _legacy_registry(tmp_dir)
+        _, failed, _ = run_module_with_params(canasta_registry, _params(
+            state="set_runtime", id="legacy",
+            compose_command="podman-compose", inspect_command="podman",
+            config_dir=tmp_dir))
+        assert not failed
+        entry = _read_back(tmp_dir)
+        assert entry["composeCommand"] == "podman-compose"
+        assert entry["inspectCommand"] == "podman"
+
+    def test_it_preserves_fields_it_was_not_given(self, tmp_dir):
+        # state=present rebuilds the record from module params, so
+        # backfilling through it would drop all of these.
+        before = _legacy_registry(tmp_dir)
+        run_module_with_params(canasta_registry, _params(
+            state="set_runtime", id="legacy",
+            compose_command="podman-compose", inspect_command="podman",
+            config_dir=tmp_dir))
+        entry = _read_back(tmp_dir)
+        for key, value in before.items():
+            assert entry[key] == value, "set_runtime dropped %s" % key
+
+    def test_it_is_idempotent(self, tmp_dir):
+        _legacy_registry(tmp_dir)
+        for _ in range(2):
+            result, failed, _ = run_module_with_params(
+                canasta_registry, _params(
+                    state="set_runtime", id="legacy",
+                    compose_command="podman-compose",
+                    inspect_command="podman", config_dir=tmp_dir))
+            assert not failed
+        assert result["changed"] is False
+
+    def test_it_refuses_an_unregistered_instance(self, tmp_dir):
+        _legacy_registry(tmp_dir)
+        _, failed, msg = run_module_with_params(canasta_registry, _params(
+            state="set_runtime", id="ghost",
+            compose_command="podman-compose", config_dir=tmp_dir))
+        assert failed
+        assert "not found" in msg
+
+    def test_it_requires_an_id(self, tmp_dir):
+        _legacy_registry(tmp_dir)
+        _, failed, msg = run_module_with_params(canasta_registry, _params(
+            state="set_runtime", compose_command="podman-compose",
+            config_dir=tmp_dir))
+        assert failed
+        assert "id is required" in msg


### PR DESCRIPTION
Fixes #1370.

## Cause

`composeCommand` / `inspectCommand` only became registry fields in #1224, so any instance registered before that carries neither. `_upgrade_single.yml` reads the runtime off the registry record and falls back to the play-scope `docker compose` default when it is absent — the registry's silence is indistinguishable from a recorded Docker instance. On a Podman-only host the whole upgrade then runs Docker commands, and `pull` is the first step that cannot tolerate it:

```
Pulling Canasta container images...
Error: pull Compose images failed (rc=127): /bin/sh: 1: docker: not found
```

`canasta doctor` on the same host reports Docker MISSING and Podman OK, which is what makes the failure confusing.

#1272 fixed the read-the-runtime-from-the-registry half of this. The remaining hole is the instances that have nothing recorded.

The same gap makes such an instance read as STOPPED in `canasta list`: the direct-command fast path resolves it to `["docker", "compose"]` too, and for a remote instance the `.env` fallback never applies.

## Fix

- `roles/common/tasks/detect_runtime.yml` (new): probes `docker info` then `podman info` on the instance's own host and, when Docker is absent and Podman is present, sets the runtime facts and writes them back to the registry. The write-back is what repairs `list` / `start` / `exec` as well, so the probe is not repeated per command.
- `playbooks/_upgrade_single.yml`: includes it after the connection switch, only for compose instances whose registry entry records no runtime.
- `roles/common/library/canasta_registry.py`: new `state: set_runtime`. `state: present` rebuilds the record from module params, so backfilling one field through it would silently drop `devMode`, `buildFrom`, `dockerHost` and the rest.

Only the Podman case is persisted. A working Docker host already matches the default, and a Docker daemon that merely happens to be down during the run is not evidence worth writing to the registry — so Docker hosts re-probe on each upgrade, at the cost of one command.

## Testing

New `tests/unit/test_upgrade_detects_legacy_runtime.py` (14 tests) covers the include and its guards, the probe's tolerance of a missing binary (`docker info` leaves no `rc` at all when Docker is not installed), the write-back, and `set_runtime`'s field preservation and idempotence.

`make test-unit` (2320 passed), `make validate` and `make lint` all pass.
