### PR TITLE
fix(registry): merge partial updates instead of replacing the record

### DIFF
--- a/roles/common/library/canasta_registry.py
+++ b/roles/common/library/canasta_registry.py
@@ -20,15 +20,21 @@ description:
   - Operates on the conf.json registry format.
 options:
   state:
-    description: Desired state of the instance in the registry.
+    description:
+      - Desired state of the instance in the registry.
+      - >-
+        present creates or replaces the whole record from the parameters
+        given, so it must be passed every field the record is to keep.
+        update merges only the parameters supplied onto an existing
+        record and requires the instance to be registered already.
     type: str
     choices:
       - present
+      - update
       - absent
       - query
       - query_all
       - query_by_path
-      - set_runtime
       - set_setting
       - get_setting
     default: query
@@ -121,6 +127,24 @@ __all__ = [
 ]
 
 
+# Registry key -> module parameter, for state=update. `id` and `path`
+# identify a record rather than describe it, so neither is updatable
+# here; a move is a create.
+UPDATABLE_FIELDS = (
+    ("orchestrator", "orchestrator"),
+    ("host", "host"),
+    ("devMode", "dev_mode"),
+    ("managedCluster", "managed_cluster"),
+    ("registry", "registry"),
+    ("kindCluster", "kind_cluster"),
+    ("buildFrom", "build_from"),
+    ("buildArgs", "build_args"),
+    ("dockerHost", "docker_host"),
+    ("composeCommand", "compose_command"),
+    ("inspectCommand", "inspect_command"),
+)
+
+
 def instance_to_dict(instance):
     """Convert an instance dict to the JSON-serializable registry format."""
     result = {
@@ -154,16 +178,20 @@ def instance_to_dict(instance):
 def run_module():
     module_args = dict(
         state=dict(type="str", default="query",
-                   choices=["present", "absent", "query", "query_all",
-                            "query_by_path", "set_runtime",
+                   choices=["present", "update", "absent", "query",
+                            "query_all", "query_by_path",
                             "set_setting", "get_setting"]),
         setting_key=dict(type="str", required=False),
         setting_value=dict(type="str", required=False),
         id=dict(type="str", required=False),
         path=dict(type="str", required=False),
-        orchestrator=dict(type="str", default="compose"),
-        dev_mode=dict(type="bool", default=False),
-        managed_cluster=dict(type="bool", default=False),
+        # No argument defaults on these three: state=update distinguishes
+        # "not supplied" from "supplied false" by testing for None, and a
+        # default makes every field look supplied. state=present applies
+        # the same defaults itself, below.
+        orchestrator=dict(type="str", required=False),
+        dev_mode=dict(type="bool", required=False),
+        managed_cluster=dict(type="bool", required=False),
         registry=dict(type="str", required=False),
         kind_cluster=dict(type="str", required=False),
         build_from=dict(type="str", required=False),
@@ -246,10 +274,10 @@ def run_module():
         new_instance = instance_to_dict({
             "id": inst_id,
             "path": os.path.abspath(inst_path),
-            "orchestrator": module.params["orchestrator"],
+            "orchestrator": module.params["orchestrator"] or "compose",
             "host": module.params.get("host"),
-            "devMode": module.params["dev_mode"],
-            "managedCluster": module.params["managed_cluster"],
+            "devMode": bool(module.params["dev_mode"]),
+            "managedCluster": bool(module.params["managed_cluster"]),
             "registry": module.params.get("registry"),
             "kindCluster": module.params.get("kind_cluster"),
             "buildFrom": module.params.get("build_from"),
@@ -274,23 +302,27 @@ def run_module():
         result["changed"] = changed
         result["instance"] = new_instance
 
-    elif state == "set_runtime":
+    elif state == "update":
         if not inst_id:
-            module.fail_json(msg="id is required when state=set_runtime")
+            module.fail_json(msg="id is required when state=update")
             return
         if inst_id not in instances:
             module.fail_json(
                 msg="Instance '%s' not found in registry" % inst_id)
             return
-        # Field-wise update rather than state=present: present rebuilds
-        # the whole record from module params, so writing one field
-        # through it drops every field the caller did not repeat.
+
         entry = dict(instances[inst_id])
-        for key, param in (("composeCommand", "compose_command"),
-                           ("inspectCommand", "inspect_command")):
+        for key, param in UPDATABLE_FIELDS:
             value = module.params.get(param)
+            if value is None:
+                continue
+            # Mirrors instance_to_dict: the stored format carries a key
+            # only while it holds something, so clearing a field drops
+            # the key rather than recording a false or empty value.
             if value:
                 entry[key] = value
+            else:
+                entry.pop(key, None)
 
         if entry != instances[inst_id]:
             changed = True

--- a/roles/common/tasks/detect_runtime.yml
+++ b/roles/common/tasks/detect_runtime.yml
@@ -49,7 +49,7 @@
         id: "{{ instance_id }}"
         compose_command: podman-compose
         inspect_command: podman
-        state: set_runtime
+        state: update
       delegate_to: localhost
       vars:
         ansible_connection: local

--- a/roles/devmode/tasks/disable.yml
+++ b/roles/devmode/tasks/disable.yml
@@ -46,14 +46,8 @@
 - name: Update registry to non-dev mode
   canasta_registry:
     id: "{{ instance_id }}"
-    path: "{{ instance_path }}"
-    orchestrator: "{{ instance_orchestrator }}"
     dev_mode: false
-    host: "{{ _instance_result.instance.host | default(omit) }}"
-    managed_cluster: "{{ _instance_result.instance.managedCluster | default(false) }}"
-    build_from: "{{ _instance_result.instance.buildFrom | default(omit) }}"
-    docker_host: "{{ _instance_result.instance.dockerHost | default(omit) }}"
-    state: present
+    state: update
   delegate_to: localhost
   vars:
     ansible_connection: local

--- a/roles/devmode/tasks/enable.yml
+++ b/roles/devmode/tasks/enable.yml
@@ -202,14 +202,8 @@
 - name: Update registry to dev mode
   canasta_registry:
     id: "{{ instance_id }}"
-    path: "{{ instance_path }}"
-    orchestrator: "{{ instance_orchestrator }}"
     dev_mode: true
-    host: "{{ _instance_result.instance.host | default(omit) }}"
-    managed_cluster: "{{ _instance_result.instance.managedCluster | default(false) }}"
-    build_from: "{{ _instance_result.instance.buildFrom | default(omit) }}"
-    docker_host: "{{ _instance_result.instance.dockerHost | default(omit) }}"
-    state: present
+    state: update
   delegate_to: localhost
   vars:
     ansible_connection: local

--- a/tests/unit/test_devmode_storage.py
+++ b/tests/unit/test_devmode_storage.py
@@ -61,32 +61,42 @@ class TestDevmodeGuards:
 
 
 class TestDevmodeRegistryUpdate:
-    """canasta_registry state=present rebuilds the whole record from params, so
-    the registry-update in enable/disable must forward every field it wants
-    kept — including dockerHost (set by create --docker-host or rootless
-    auto-detect), or toggling devmode silently drops it."""
+    """Toggling dev mode must touch devMode and nothing else.
+
+    canasta_registry state=present rebuilds the whole record from the
+    params given, so enable/disable used to have to forward every field
+    they wanted kept — and dropped whatever nobody had thought to add
+    yet: dockerHost until it was patched in, then composeCommand,
+    inspectCommand and buildArgs. state=update merges instead, so the
+    fix is to stop repeating fields, not to repeat more of them."""
 
     def _registry_update(self, tasks):
         for t in tasks:
             if isinstance(t, dict) and "canasta_registry" in t:
                 params = t["canasta_registry"]
-                if params.get("state") == "present":
+                if params.get("state") in ("present", "update"):
                     return params
-        raise AssertionError("no canasta_registry state=present task found")
+        raise AssertionError("no canasta_registry write task found")
 
-    def test_enable_forwards_docker_host(self):
+    def _assert_merges_only_dev_mode(self, filename, want):
         params = self._registry_update(
-            _load(os.path.join(DEVMODE_TASKS, "enable.yml")))
-        assert "docker_host" in params
-        assert "dockerHost" in params["docker_host"]
-        assert "default(omit)" in params["docker_host"]
+            _load(os.path.join(DEVMODE_TASKS, filename)))
+        assert params["state"] == "update", (
+            "state=present replaces the record, so every field %s does "
+            "not repeat is dropped" % filename
+        )
+        assert params["dev_mode"] is want
+        assert set(params) == {"id", "dev_mode", "state"}, (
+            "%s passes fields it does not mean to change; with "
+            "state=update they are noise, and each one is a chance to "
+            "write back a stale value" % filename
+        )
 
-    def test_disable_forwards_docker_host(self):
-        params = self._registry_update(
-            _load(os.path.join(DEVMODE_TASKS, "disable.yml")))
-        assert "docker_host" in params
-        assert "dockerHost" in params["docker_host"]
-        assert "default(omit)" in params["docker_host"]
+    def test_enable_merges_only_dev_mode(self):
+        self._assert_merges_only_dev_mode("enable.yml", True)
+
+    def test_disable_merges_only_dev_mode(self):
+        self._assert_merges_only_dev_mode("disable.yml", False)
 
 
 class TestNfsStorageSetup:

--- a/tests/unit/test_registry_partial_update.py
+++ b/tests/unit/test_registry_partial_update.py
@@ -1,0 +1,194 @@
+"""state=present replaces a registry record; state=update merges into it.
+
+`present` rebuilds the record from the module params and assigns it over
+the old one, so every field the caller does not repeat is dropped. That
+reads like an upsert and behaves like a replace, and each caller that
+wanted to change one field had to know it must re-send all the others.
+`canasta devmode enable|disable` did not, and quietly erased dockerHost
+until that was patched in — then composeCommand, inspectCommand and
+buildArgs, which arrived later and nobody went back to add.
+
+Losing composeCommand puts a Podman instance back on the `docker
+compose` default, which is the failure in #1370:
+
+    Error: pull Compose images failed (rc=127): /bin/sh: 1: docker: not found
+
+state=update carries only the params actually supplied, so a caller
+naming one field cannot disturb the rest. `present` keeps its
+create-or-replace meaning for `create`, which owns the whole record.
+"""
+
+import json
+import os
+
+import canasta_registry
+from mock_ansible import run_module_with_params
+
+FULL = {
+    "id": "demo",
+    "path": "/srv/canasta/demo",
+    "orchestrator": "compose",
+    "host": "host1.example.com",
+    "devMode": True,
+    "managedCluster": True,
+    "registry": "localhost:5000",
+    "kindCluster": "kind-demo",
+    "buildFrom": "/src",
+    "buildArgs": ["FOO=1", "BAR=2"],
+    "dockerHost": "unix:///run/user/1001/podman/podman.sock",
+    "composeCommand": "podman-compose",
+    "inspectCommand": "podman",
+}
+
+
+def _params(**kw):
+    params = {
+        "state": "query", "id": None, "path": None, "orchestrator": None,
+        "dev_mode": None, "managed_cluster": None, "registry": None,
+        "kind_cluster": None, "build_from": None, "build_args": None,
+        "host": None, "docker_host": None, "compose_command": None,
+        "inspect_command": None, "filter_host": None, "setting_key": None,
+        "setting_value": None, "config_dir": None,
+    }
+    params.update(kw)
+    return params
+
+
+def _seed(tmp_dir, record=None):
+    record = dict(FULL if record is None else record)
+    with open(os.path.join(tmp_dir, "conf.json"), "w") as f:
+        json.dump({"Instances": {record["id"]: record}}, f)
+    return record
+
+
+def _read_back(tmp_dir, inst_id="demo"):
+    with open(os.path.join(tmp_dir, "conf.json")) as f:
+        return json.load(f)["Instances"][inst_id]
+
+
+def _update(tmp_dir, **kw):
+    kw.setdefault("id", "demo")
+    return run_module_with_params(canasta_registry, _params(
+        state="update", config_dir=tmp_dir, **kw))
+
+
+class TestUpdateTouchesOnlyWhatItIsGiven:
+    def test_it_writes_the_field_it_is_given(self, tmp_dir):
+        _seed(tmp_dir)
+        _, failed, _ = _update(tmp_dir, compose_command="podman-compose",
+                               inspect_command="podman")
+        assert not failed
+        entry = _read_back(tmp_dir)
+        assert entry["composeCommand"] == "podman-compose"
+        assert entry["inspectCommand"] == "podman"
+
+    def test_it_leaves_every_other_field_alone(self, tmp_dir):
+        before = _seed(tmp_dir)
+        _update(tmp_dir, dev_mode=False)
+        entry = _read_back(tmp_dir)
+        for key, value in before.items():
+            if key == "devMode":
+                continue
+            assert entry[key] == value, "update dropped %s" % key
+
+    def test_a_false_boolean_is_a_value_not_a_silence(self, tmp_dir):
+        # The whole bug: with an argument default, "not supplied" and
+        # "supplied false" are the same value, so every unmentioned flag
+        # looks like an explicit false.
+        _seed(tmp_dir)
+        _update(tmp_dir, dev_mode=False)
+        entry = _read_back(tmp_dir)
+        assert "devMode" not in entry
+        assert entry["managedCluster"] is True, (
+            "managed_cluster defaulted to false and was written back over "
+            "a record that had it set"
+        )
+
+    def test_a_true_boolean_is_recorded(self, tmp_dir):
+        _seed(tmp_dir, dict(FULL, devMode=False))
+        _update(tmp_dir, dev_mode=True)
+        assert _read_back(tmp_dir)["devMode"] is True
+
+    def test_an_empty_string_clears_the_field(self, tmp_dir):
+        # Matches instance_to_dict: the stored format carries a key only
+        # while it holds something.
+        _seed(tmp_dir)
+        _update(tmp_dir, host="")
+        assert "host" not in _read_back(tmp_dir)
+
+    def test_it_is_idempotent(self, tmp_dir):
+        _seed(tmp_dir)
+        result, failed, _ = _update(tmp_dir, compose_command="podman-compose")
+        assert not failed
+        assert result["changed"] is False, (
+            "an update that changes nothing reports changed, so every "
+            "playbook run using it looks like it did something"
+        )
+
+    def test_it_reports_a_real_change(self, tmp_dir):
+        _seed(tmp_dir)
+        result, _, _ = _update(tmp_dir, compose_command="docker compose")
+        assert result["changed"] is True
+
+
+class TestUpdateRefusesWhatItCannotMerge:
+    def test_it_requires_an_id(self, tmp_dir):
+        _seed(tmp_dir)
+        _, failed, msg = run_module_with_params(canasta_registry, _params(
+            state="update", dev_mode=True, config_dir=tmp_dir))
+        assert failed
+        assert "id is required" in msg
+
+    def test_it_refuses_an_unregistered_instance(self, tmp_dir):
+        # An update has nothing to merge onto, and creating a partial
+        # record here would produce an instance with no path.
+        _seed(tmp_dir)
+        _, failed, msg = _update(tmp_dir, id="ghost", dev_mode=True)
+        assert failed
+        assert "not found" in msg
+
+    def test_a_refused_update_leaves_the_registry_untouched(self, tmp_dir):
+        before = _seed(tmp_dir)
+        _update(tmp_dir, id="ghost", dev_mode=True)
+        assert _read_back(tmp_dir) == before
+
+
+class TestPresentStillReplaces:
+    """create owns the whole record and relies on this."""
+
+    def test_it_drops_fields_it_was_not_given(self, tmp_dir):
+        _seed(tmp_dir)
+        _, failed, _ = run_module_with_params(canasta_registry, _params(
+            state="present", id="demo", path="/srv/canasta/demo",
+            orchestrator="compose", config_dir=tmp_dir))
+        assert not failed
+        assert "composeCommand" not in _read_back(tmp_dir)
+
+    def test_the_orchestrator_default_survived_losing_its_argspec_default(
+            self, tmp_dir):
+        # The argument default moved into the present branch so update
+        # could tell "not supplied" from "supplied"; present must still
+        # record compose when nothing is passed.
+        _, failed, _ = run_module_with_params(canasta_registry, _params(
+            state="present", id="fresh", path="/srv/canasta/fresh",
+            config_dir=tmp_dir))
+        assert not failed
+        assert _read_back(tmp_dir, "fresh")["orchestrator"] == "compose"
+
+    def test_unset_booleans_are_still_omitted(self, tmp_dir):
+        run_module_with_params(canasta_registry, _params(
+            state="present", id="fresh", path="/srv/canasta/fresh",
+            config_dir=tmp_dir))
+        entry = _read_back(tmp_dir, "fresh")
+        assert "devMode" not in entry
+        assert "managedCluster" not in entry
+
+
+class TestEveryStoredFieldCanBeUpdated:
+    def test_the_map_covers_the_stored_format(self):
+        # instance_to_dict defines what a record may hold; a field
+        # missing from UPDATABLE_FIELDS is one no caller can change
+        # without falling back to a whole-record replace.
+        stored = set(canasta_registry.instance_to_dict(FULL))
+        updatable = {key for key, _param in canasta_registry.UPDATABLE_FIELDS}
+        assert stored - updatable == {"id", "path"}

--- a/tests/unit/test_upgrade_detects_legacy_runtime.py
+++ b/tests/unit/test_upgrade_detects_legacy_runtime.py
@@ -15,13 +15,9 @@ PATH says nothing about it) and the answer has to reach the registry, or
 Docker afterwards.
 """
 
-import json
 import os
 
 import yaml
-
-import canasta_registry
-from mock_ansible import run_module_with_params
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
     os.path.abspath(__file__))))
@@ -56,19 +52,6 @@ def _named(path, needle):
         (t for t in _tasks(path)
          if needle.lower() in str(t.get("name", "")).lower()), None)
 
-
-def _params(**kw):
-    params = {
-        "state": "query", "id": None, "path": None,
-        "orchestrator": "compose", "dev_mode": False,
-        "managed_cluster": False, "registry": None, "kind_cluster": None,
-        "build_from": None, "build_args": None, "host": None,
-        "docker_host": None, "compose_command": None,
-        "inspect_command": None, "filter_host": None,
-        "setting_key": None, "setting_value": None, "config_dir": None,
-    }
-    params.update(kw)
-    return params
 
 
 def _legacy_registry(tmp_dir):
@@ -164,7 +147,7 @@ class TestTheProbeAsksTheHost:
             "without the write-back the probe repeats every upgrade, and "
             "list/start/exec keep resolving the instance to Docker"
         )
-        assert task["canasta_registry"]["state"] == "set_runtime"
+        assert task["canasta_registry"]["state"] == "update"
         assert task["canasta_registry"]["compose_command"] == "podman-compose"
         assert task["canasta_registry"]["inspect_command"] == "podman"
 
@@ -172,55 +155,3 @@ class TestTheProbeAsksTheHost:
         task = _named(DETECT, "Record the detected runtime")
         assert task["delegate_to"] == "localhost"
         assert task["vars"]["ansible_connection"] == "local"
-
-
-class TestSetRuntimeKeepsTheRestOfTheRecord:
-    def test_it_records_the_runtime(self, tmp_dir):
-        _legacy_registry(tmp_dir)
-        _, failed, _ = run_module_with_params(canasta_registry, _params(
-            state="set_runtime", id="legacy",
-            compose_command="podman-compose", inspect_command="podman",
-            config_dir=tmp_dir))
-        assert not failed
-        entry = _read_back(tmp_dir)
-        assert entry["composeCommand"] == "podman-compose"
-        assert entry["inspectCommand"] == "podman"
-
-    def test_it_preserves_fields_it_was_not_given(self, tmp_dir):
-        # state=present rebuilds the record from module params, so
-        # backfilling through it would drop all of these.
-        before = _legacy_registry(tmp_dir)
-        run_module_with_params(canasta_registry, _params(
-            state="set_runtime", id="legacy",
-            compose_command="podman-compose", inspect_command="podman",
-            config_dir=tmp_dir))
-        entry = _read_back(tmp_dir)
-        for key, value in before.items():
-            assert entry[key] == value, "set_runtime dropped %s" % key
-
-    def test_it_is_idempotent(self, tmp_dir):
-        _legacy_registry(tmp_dir)
-        for _ in range(2):
-            result, failed, _ = run_module_with_params(
-                canasta_registry, _params(
-                    state="set_runtime", id="legacy",
-                    compose_command="podman-compose",
-                    inspect_command="podman", config_dir=tmp_dir))
-            assert not failed
-        assert result["changed"] is False
-
-    def test_it_refuses_an_unregistered_instance(self, tmp_dir):
-        _legacy_registry(tmp_dir)
-        _, failed, msg = run_module_with_params(canasta_registry, _params(
-            state="set_runtime", id="ghost",
-            compose_command="podman-compose", config_dir=tmp_dir))
-        assert failed
-        assert "not found" in msg
-
-    def test_it_requires_an_id(self, tmp_dir):
-        _legacy_registry(tmp_dir)
-        _, failed, msg = run_module_with_params(canasta_registry, _params(
-            state="set_runtime", compose_command="podman-compose",
-            config_dir=tmp_dir))
-        assert failed
-        assert "id is required" in msg


### PR DESCRIPTION
Fixes #1372.

Follows #1371, now merged: this folds in the narrow `set_runtime` state that PR introduced.

## Cause

`canasta_registry`'s `state: present` rebuilds an instance record from the module params via `instance_to_dict()` and assigns it over the old one. Every field the caller does not repeat is dropped. It reads like an upsert and behaves like a replace, so each caller has to know it must re-send fields it has no interest in.

`roles/devmode/tasks/enable.yml` and `disable.yml` did not. They lost `dockerHost` until that was patched into the forwarded list, and then silently lost `composeCommand`, `inspectCommand` and `buildArgs`, which were added to the record later and nobody went back to forward.

Losing `composeCommand` puts a Podman instance back on the play-scope `docker compose` default, so toggling dev mode reintroduces #1370 on an instance that had already been repaired:

```
Error: pull Compose images failed (rc=127): /bin/sh: 1: docker: not found
```

The prior `dockerHost` patch is the tell: the field list was treated as the bug twice, and it will be wrong again the next time the record gains a field.

## Fix

- `state: update` merges only the params actually supplied onto an existing record, and fails if the instance is not registered. `UPDATABLE_FIELDS` maps registry key to module parameter; `id` and `path` identify a record rather than describe it, so neither is updatable.
- Both devmode tasks drop to `id` + `dev_mode` + `state: update`.
- `set_runtime` from #1371 is folded into `update`, so there is one partial-update path rather than one per field.

`present` keeps its create-or-replace meaning for `create`, the one caller that legitimately owns the whole record. An audit found no others: the only `state: present` call sites are the two in `roles/create/tasks/_register.yml`.

Not in the proposal on the issue, but required by it: telling "not supplied" from "supplied false" means `orchestrator`, `dev_mode` and `managed_cluster` can no longer carry argument defaults — with a default every field looks supplied, and `update` would write `devMode: false` over every record it touched. `present` now applies the same defaults itself, so its behavior is unchanged, and there are tests pinning that.

## Correction to the issue

`kindCluster` and `registry` are module parameters with no producer — nothing in `roles/` or `playbooks/` writes either — so the issue's claim that a Kubernetes instance loses them does not hold today. The fields actually at risk are `composeCommand`, `inspectCommand` and `buildArgs`. Noted on the issue as well.

## Testing

New `tests/unit/test_registry_partial_update.py` (17 tests): merge behavior, false-vs-unset, clearing a field, idempotence and change reporting, the refusals, and that `present` still replaces and still applies its defaults.

`TestDevmodeRegistryUpdate` in `test_devmode_storage.py` pinned the old workaround ("must forward every field it wants kept"). Inverted: it now asserts devmode passes only `dev_mode`.

The registry-state tests added in #1371 moved out of `test_upgrade_detects_legacy_runtime.py` into the new file, since `update` is no longer upgrade-specific.

`make test-unit` (2329 passed), `make validate` and `make lint` all pass.
