### PR TITLE
fix(caddy): bump the CrowdSec bouncer to v0.14.0

### DIFF
--- a/images/caddy/Dockerfile
+++ b/images/caddy/Dockerfile
@@ -25,11 +25,11 @@
 #
 # CADDY_VERSION is set by what the bundled plugins require, so it can lead
 # the stock default caddy:<ver>-alpine in docker-compose.yml — the
-# crowdsec bouncer v0.13.1 pins Caddy v2.11.3. Keep the published image
+# crowdsec bouncer v0.14.0 pins Caddy v2.11.3. Keep the published image
 # tag in lockstep with _CADDY_PLUGIN_IMAGE / the sync_compose_profiles
 # literal.
 ARG CADDY_VERSION=2.11.3
-ARG CROWDSEC_BOUNCER_VERSION=v0.13.1
+ARG CROWDSEC_BOUNCER_VERSION=v0.14.0
 ARG CDN_RANGES_VERSION=v2.1.0
 ARG COMBINE_IP_RANGES_VERSION=v0.0.1
 


### PR DESCRIPTION
`images/caddy/Dockerfile` pins `CROWDSEC_BOUNCER_VERSION=v0.13.1`. Upstream released [v0.14.0](https://github.com/hslatman/caddy-crowdsec-bouncer/releases/tag/v0.14.0) on 29 July 2026.

## The fix that matters

`StreamBouncer.Run` sent fetched decisions on `b.Stream` with an unguarded send. On shutdown the consumer (`Core.startProcessingDecisions`) returns on `ctx.Done()`, so a send racing cancellation blocks forever on a channel nobody reads — deadlocking `Core.Shutdown`'s `wg.Wait()`. Both sends are now wrapped in a `select` on `ctx.Done()`.

Upstream describes the severe symptom as Caddy's admin API hanging during `changeConfig`, which does not apply here: Canasta has no `caddy reload` or admin-API call anywhere, and Caddy config changes go through a container or pod restart. What remains reachable is the SIGTERM path — a deadlocked shutdown means Caddy does not exit, so the runtime waits out its stop timeout and then SIGKILLs. On Kubernetes that is more exposed, since the CrowdSec engine is a sidecar in the caddy pod and the whole pod rolls.

The rendered Caddyfile sets `ticker_interval 15s`, four times more often than the 60s default, so this stack races shutdown more often than most deployments.

## Risk

Low, and lower than it first appears:

- `go.mod` is byte-identical between v0.13.1 and v0.14.0 — Caddy stays at `v2.11.3` and the crowdsec lib at `v1.6.3`. No `CADDY_VERSION` bump, so the published image tag is unchanged.
- No Caddyfile directive changes, so `Caddyfile.j2` needs no edit.
- The one new validation rejects a non-positive `ticker_interval`. The template hardcodes `15s`, so it is a no-op here.
- The remaining changes are an internal init refactor and README churn.

The real caveat is freshness: `stream.go` was rewritten shortly before release, and that is the path that enforces bans.

## Note on delivery

The image is versioned by the bundled Caddy release, not by the bouncer, so this republishes `ghcr.io/canastawiki/canasta-caddy:2.11.3` with different contents rather than producing a new tag. Instances already running that tag pick up v0.14.0 only when they re-pull.

Fixes #1375
