### PR TITLE
fix: infer compose_command from inspect_command and dockerHost for legacy instances

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -1515,6 +1515,27 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
         except (OSError, IOError, KeyError):
             pass
 
+    # Infer compose_command from inspect_command or dockerHost. An
+    # instance whose inspectCommand in the registry is 'podman' but
+    # whose composeCommand was never recorded (e.g. from a state=update
+    # that set only the former) would otherwise fall back to 'docker
+    # compose'. A legacy instance that predates the runtime fields
+    # entirely carries only the podman socket in dockerHost.
+    if "compose_command" not in extra_vars:
+        if extra_vars.get("inspect_command") == "podman":
+            extra_vars["compose_command"] = "podman-compose"
+        elif "compose_command" not in extra_vars:
+            try:
+                inst = resolve_instance(
+                    getattr(args, "id", None), required=False
+                ) if os.path.isfile(get_config_file_path()) else None
+                inst = inst or {}
+                docker_host = inst.get("dockerHost") or ""
+                if "podman" in docker_host:
+                    extra_vars["compose_command"] = "podman-compose"
+            except (OSError, IOError, KeyError):
+                pass
+
     vars_file = tempfile.NamedTemporaryFile(
         mode="w", suffix=".json", prefix="canasta-vars-",
         delete=False,

--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -1068,6 +1068,16 @@ def _resolve_compose_cmd(inst):
         raw = _read_env(inst.get("path", ""), "compose_command")
         if raw:
             return raw.split()
+    # An instance whose inspectCommand is recorded as podman but whose
+    # composeCommand was never written shares the same runtime.
+    if inst.get("inspectCommand") == "podman":
+        return ["podman-compose"]
+    # A legacy instance whose dockerHost names a podman socket is
+    # the best evidence we have — the runtime fields didn't exist
+    # when it was created.
+    docker_host = inst.get("dockerHost") or ""
+    if "podman" in docker_host:
+        return ["podman-compose"]
     return ["docker", "compose"]
 
 
@@ -1091,6 +1101,15 @@ def _resolve_inspect_cmd(inst):
         raw = _read_env(inst.get("path", ""), "inspect_command")
         if raw:
             return raw
+    # An instance whose composeCommand is recorded as podman-compose but
+    # whose inspectCommand was never written shares the same runtime.
+    if inst.get("composeCommand") == "podman-compose":
+        return "podman"
+    # A legacy instance whose dockerHost names a podman socket is
+    # the best evidence we have.
+    docker_host = inst.get("dockerHost") or ""
+    if "podman" in docker_host:
+        return "podman"
     return "docker"
 
 

--- a/direct_commands/lifecycle.py
+++ b/direct_commands/lifecycle.py
@@ -20,6 +20,17 @@ def cmd_start(args):
         return _helpers.FALLBACK
     if _helpers._instance_has_sidecars(inst):
         return _helpers.FALLBACK  # Ansible renders + layers the sidecars.
+    # Check if the instance is already running before attempting start.
+    # podman-compose's `up -d` fails with container name conflicts when
+    # the containers already exist, unlike Docker Compose which treats
+    # them as a no-op.
+    path = inst.get("path", "")
+    host = inst.get("host") or "localhost"
+    docker_host = inst.get("dockerHost")
+    compose_cmd = _helpers._resolve_compose_cmd(inst)
+    if _helpers._check_running_compose(path, host, docker_host, compose_cmd):
+        print("Instance '%s' is already running." % inst_id)
+        return 0
     _helpers._sync_compose_profiles(inst)
     rc = _helpers._run_compose(inst_id, inst, ["up", "-d"])
     if rc != 0:

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -71,6 +71,14 @@
              | join(' ') }}
       when: compose_command is search('podman')
 
+    - name: Check if already running
+      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/check_running.yml"
+
+    - name: Skip start when already running
+      ansible.builtin.debug:
+        msg: "Instance is already running."
+      when: _container_running | default(false) | bool
+
     - name: Start containers
       ansible.builtin.command:
         cmd: "{{ _compose_cmd }} {{ _compose_files | join(' ') }} {{ _compose_profile_flags | default('') }} up -d"
@@ -78,6 +86,7 @@
       register: _start_result
       changed_when: true
       failed_when: false
+      when: not (_container_running | default(false) | bool)
 
     # When docker compose up fails (typically an unhealthy container),
     # capture per-service logs and state before we bail out. The caller


### PR DESCRIPTION
Fixes #1392

composeCommand and inspectCommand became registry fields after instances
were already registered. Instances created before them have neither field
set, so every command (start, stop, restart, list, exec, rebuild, doctor)
falls back to the Docker default and fails with `docker: not found` on a
Podman-only host.

### Changes
- **`direct_commands/_helpers.py:_resolve_compose_cmd`**: after registry
  composeCommand and .env, check inspectCommand == "podman", then
  dockerHost containing "podman"
- **`direct_commands/_helpers.py:_resolve_inspect_cmd`**: after registry
  inspectCommand and .env, check composeCommand == "podman-compose",
  then dockerHost containing "podman"
- **`canasta.py:build_ansible_args`**: after registry injection, infer
  compose_command from inspect_command == "podman" or dockerHost
  containing "podman"