### PR TITLE
fix(registry): delegate registry writes to a host that is never rebound

### DIFF
--- a/canasta.yml
+++ b/canasta.yml
@@ -38,6 +38,25 @@
          | default(omit, true) }}
 
   pre_tasks:
+    # Registry operations must reach the controller's conf.json, never a
+    # target's. `delegate_to: localhost` cannot guarantee that: for
+    # commands that loop over instances, switch_connection.yml rebinds
+    # the play host's connection with set_fact, and set_fact outranks
+    # task vars — so a delegated task carrying
+    # `vars: ansible_connection: local` still went out over SSH and wrote
+    # the target's registry.
+    #
+    # add_host rather than an inventory entry because `--host` makes
+    # canasta.py pass `-i <host>,`, which replaces the inventory named in
+    # ansible.cfg. A host added here exists on every path.
+    - name: Add the controller as a delegation target
+      ansible.builtin.add_host:
+        name: canasta_controller
+        ansible_connection: local
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
+      changed_when: false
+      run_once: true
+
     - name: Validate command parameter
       ansible.builtin.assert:
         that: command is defined and command != ''

--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -9,7 +9,7 @@
   canasta_registry:
     id: "{{ id }}"
     state: query
-  delegate_to: localhost
+  delegate_to: canasta_controller
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"
@@ -111,7 +111,7 @@
       canasta_registry:
         id: "{{ id }}"
         state: absent
-      delegate_to: localhost
+      delegate_to: canasta_controller
       vars:
         ansible_connection: local
         ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/playbooks/storage_list.yml
+++ b/playbooks/storage_list.yml
@@ -7,7 +7,7 @@
   canasta_registry:
     state: get_setting
     setting_key: defaultStorageClass
-  delegate_to: localhost
+  delegate_to: canasta_controller
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/playbooks/storage_setup_efs.yml
+++ b/playbooks/storage_setup_efs.yml
@@ -42,7 +42,7 @@
     state: set_setting
     setting_key: defaultStorageClass
     setting_value: "{{ storage_class_name | default('efs') }}"
-  delegate_to: localhost
+  delegate_to: canasta_controller
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/playbooks/storage_setup_nfs.yml
+++ b/playbooks/storage_setup_nfs.yml
@@ -138,7 +138,7 @@
     state: set_setting
     setting_key: defaultStorageClass
     setting_value: "{{ storage_class_name | default('nfs') }}"
-  delegate_to: localhost
+  delegate_to: canasta_controller
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -11,7 +11,7 @@
   canasta_registry:
     state: query_all
     filter_host: "{{ target_host | default(omit) }}"
-  delegate_to: localhost
+  delegate_to: canasta_controller
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/roles/common/tasks/detect_runtime.yml
+++ b/roles/common/tasks/detect_runtime.yml
@@ -50,7 +50,7 @@
         compose_command: podman-compose
         inspect_command: podman
         state: update
-      delegate_to: localhost
+      delegate_to: canasta_controller
       vars:
         ansible_connection: local
         ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/roles/create/tasks/_kubernetes_setup.yml
+++ b/roles/create/tasks/_kubernetes_setup.yml
@@ -24,7 +24,7 @@
   canasta_registry:
     state: get_setting
     setting_key: defaultStorageClass
-  delegate_to: localhost
+  delegate_to: canasta_controller
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/roles/create/tasks/_register.yml
+++ b/roles/create/tasks/_register.yml
@@ -27,7 +27,7 @@
     build_from: "{{ build_from | default(omit) }}"
     build_args: "{{ build_arg | default(omit, true) }}"
     state: present
-  delegate_to: localhost
+  delegate_to: canasta_controller
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/roles/create/tasks/_validate_inputs.yml
+++ b/roles/create/tasks/_validate_inputs.yml
@@ -31,7 +31,7 @@
   canasta_registry:
     id: "{{ id }}"
     state: query
-  delegate_to: localhost
+  delegate_to: canasta_controller
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/roles/delete/tasks/main.yml
+++ b/roles/delete/tasks/main.yml
@@ -16,7 +16,7 @@
       canasta_registry:
         path: "{{ lookup('env', 'CANASTA_HOST_PWD') | default(lookup('env', 'PWD'), true) }}"
         state: query_by_path
-      delegate_to: localhost
+      delegate_to: canasta_controller
       vars:
         ansible_connection: local
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
@@ -40,7 +40,7 @@
   canasta_registry:
     id: "{{ id }}"
     state: query
-  delegate_to: localhost
+  delegate_to: canasta_controller
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"
@@ -106,7 +106,7 @@
       canasta_registry:
         id: "{{ instance_id }}"
         state: absent
-      delegate_to: localhost
+      delegate_to: canasta_controller
       vars:
         ansible_connection: local
         ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/roles/devmode/tasks/disable.yml
+++ b/roles/devmode/tasks/disable.yml
@@ -48,7 +48,7 @@
     id: "{{ instance_id }}"
     dev_mode: false
     state: update
-  delegate_to: localhost
+  delegate_to: canasta_controller
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/roles/devmode/tasks/enable.yml
+++ b/roles/devmode/tasks/enable.yml
@@ -204,7 +204,7 @@
     id: "{{ instance_id }}"
     dev_mode: true
     state: update
-  delegate_to: localhost
+  delegate_to: canasta_controller
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/roles/gitops/tasks/init.yml
+++ b/roles/gitops/tasks/init.yml
@@ -10,7 +10,7 @@
   canasta_registry:
     state: query_all
   register: _gitops_init_registry
-  delegate_to: localhost
+  delegate_to: canasta_controller
 
 - name: Fail with gitops-specific guidance if no instances exist
   ansible.builtin.fail:

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -80,7 +80,7 @@
   canasta_registry:
     id: "{{ instance_id }}"
     state: query
-  delegate_to: localhost
+  delegate_to: canasta_controller
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/tests/unit/test_registry_delegation_target.py
+++ b/tests/unit/test_registry_delegation_target.py
@@ -1,0 +1,119 @@
+"""Registry writes must reach the controller, not whichever host is bound.
+
+`delegate_to: localhost` looks like it pins a task to the controller, but
+it does not. Commands that loop over instances run
+switch_connection.yml, which rebinds the play host's connection with
+set_fact:
+
+    ansible_host: <target>
+    ansible_connection: ssh
+
+set_fact outranks task vars, so a delegated task carrying
+`vars: ansible_connection: local` still connected over SSH and wrote the
+*target's* conf.json. The controller's registry never saw the value, so
+the runtime probe re-ran on every upgrade and the fast-path commands it
+exists to fix kept reading the uncorrected record.
+
+canasta_controller is added by canasta.yml with add_host and is never
+rebound, so delegating there is the only form that holds on every path.
+"""
+
+import os
+import re
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+SEARCH_DIRS = ("roles", "playbooks")
+MAIN_PLAYBOOK = os.path.join(REPO_ROOT, "canasta.yml")
+
+
+def _task_files():
+    for d in SEARCH_DIRS:
+        for root, _dirs, files in os.walk(os.path.join(REPO_ROOT, d)):
+            for name in files:
+                if name.endswith(".yml"):
+                    yield os.path.join(root, name)
+
+
+def _tasks(doc):
+    """Yield every task dict in a loaded YAML doc, including block bodies."""
+    if isinstance(doc, dict):
+        for key in ("block", "rescue", "always", "tasks", "pre_tasks"):
+            for t in doc.get(key) or []:
+                yield from _tasks(t)
+        yield doc
+    elif isinstance(doc, list):
+        for item in doc:
+            yield from _tasks(item)
+
+
+def _registry_tasks():
+    found = []
+    for path in _task_files():
+        with open(path) as f:
+            raw = f.read()
+        if "canasta_registry" not in raw:
+            continue
+        try:
+            doc = yaml.safe_load(raw)
+        except yaml.YAMLError:
+            continue
+        for task in _tasks(doc):
+            if isinstance(task, dict) and "canasta_registry" in task:
+                found.append((os.path.relpath(path, REPO_ROOT), task))
+    return found
+
+
+class TestRegistryTasksDelegateToTheController:
+    def test_there_are_registry_tasks_to_check(self):
+        # Guards the walk itself: a broken traversal would make every
+        # other assertion here vacuously true.
+        assert len(_registry_tasks()) > 10
+
+    def test_no_registry_task_delegates_to_localhost(self):
+        offenders = [
+            path for path, task in _registry_tasks()
+            if task.get("delegate_to") == "localhost"
+        ]
+        assert offenders == [], (
+            "canasta_registry must delegate to canasta_controller, not "
+            "localhost — switch_connection.yml rebinds localhost's "
+            "connection with set_fact, which outranks task vars: %s"
+            % ", ".join(sorted(set(offenders)))
+        )
+
+    def test_every_delegated_registry_task_targets_the_controller(self):
+        wrong = [
+            (path, task.get("delegate_to"))
+            for path, task in _registry_tasks()
+            if "delegate_to" in task
+            and task["delegate_to"] != "canasta_controller"
+        ]
+        assert wrong == [], (
+            "unexpected delegation target for a registry task: %s" % wrong
+        )
+
+
+class TestTheControllerHostExists:
+    def test_canasta_yml_adds_the_controller_host(self):
+        with open(MAIN_PLAYBOOK) as f:
+            play = yaml.safe_load(f)[0]
+        adds = [
+            t for t in (play.get("pre_tasks") or [])
+            if "ansible.builtin.add_host" in t or "add_host" in t
+        ]
+        assert adds, "canasta.yml must add the controller delegation host"
+        spec = adds[0].get("ansible.builtin.add_host") or adds[0]["add_host"]
+        assert spec["name"] == "canasta_controller"
+        assert spec["ansible_connection"] == "local"
+
+    def test_the_controller_host_is_not_rebound(self):
+        # switch_connection.yml may rewrite the play host's connection,
+        # but it must never name the controller host.
+        path = os.path.join(
+            REPO_ROOT, "roles", "common", "tasks", "switch_connection.yml")
+        with open(path) as f:
+            raw = f.read()
+        assert not re.search(r"canasta_controller", raw)

--- a/tests/unit/test_storage_list.py
+++ b/tests/unit/test_storage_list.py
@@ -40,8 +40,8 @@ def test_reads_default_storageclass_from_controller_registry():
         and t["canasta_registry"].get("setting_key") == "defaultStorageClass"
     ]
     assert reads, "must read defaultStorageClass from the registry"
-    assert reads[0].get("delegate_to") == "localhost", (
-        "canasta_registry reads must use delegate_to: localhost"
+    assert reads[0].get("delegate_to") == "canasta_controller", (
+        "canasta_registry reads must delegate to canasta_controller"
     )
 
 

--- a/tests/unit/test_storage_setup_efs.py
+++ b/tests/unit/test_storage_setup_efs.py
@@ -4,7 +4,7 @@ EFS setup needs a live AWS account + Kubernetes cluster, so it can't run in
 CI as an integration test. These assertions lock in the playbook's contract:
 it must validate the cluster up front, install the EFS CSI driver, create a
 StorageClass backed by the EFS provisioner, and persist the chosen default
-StorageClass to the controller registry (with delegate_to: localhost, per
+StorageClass to the controller registry (with delegate_to: canasta_controller, per
 the registry-lives-on-the-controller rule).
 """
 
@@ -74,6 +74,6 @@ def test_persists_default_storageclass_to_controller_registry():
     ]
     assert saves, "must persist defaultStorageClass to the registry"
     # The registry lives on the controller — the write must be delegated.
-    assert saves[0].get("delegate_to") == "localhost", (
-        "canasta_registry writes must use delegate_to: localhost"
+    assert saves[0].get("delegate_to") == "canasta_controller", (
+        "canasta_registry writes must delegate to canasta_controller"
     )

--- a/tests/unit/test_upgrade_detects_legacy_runtime.py
+++ b/tests/unit/test_upgrade_detects_legacy_runtime.py
@@ -153,5 +153,5 @@ class TestTheProbeAsksTheHost:
 
     def test_the_registry_write_runs_on_the_controller(self):
         task = _named(DETECT, "Record the detected runtime")
-        assert task["delegate_to"] == "localhost"
+        assert task["delegate_to"] == "canasta_controller"
         assert task["vars"]["ansible_connection"] == "local"


### PR DESCRIPTION
`delegate_to: localhost` does not pin a task to the controller. Commands that loop over instances run `switch_connection.yml`, which rebinds the play host's connection with `set_fact`:

```yaml
- name: Override connection for remote instance
  ansible.builtin.set_fact:
    ansible_host: "{{ _ssh_host }}"
    ansible_connection: "ssh"
```

`set_fact` outranks task `vars`, so a registry task carrying `delegate_to: localhost` plus `vars: ansible_connection: local` still connected over SSH and wrote the *target's* `conf.json`. The controller's registry never saw the value — which is why the runtime probe re-ran on every upgrade and `list`/`start`/`exec` kept reading the uncorrected record.

## Fix

`canasta.yml` adds a `canasta_controller` host in `pre_tasks`, and all seventeen `canasta_registry` tasks delegate there instead. Nothing rebinds it, so the delegation holds on every path.

`add_host` rather than an inventory entry: `--host` makes `canasta.py` pass `-i <host>,`, which *replaces* the inventory named in `ansible.cfg`. A static entry in `inventory/localhost.yml` would not exist on those invocations, and delegating to a nonexistent host is a hard failure.

## Why the bug was invisible on `create`

`create -H <host>` targets the remote directly via the inline inventory, so `localhost` is still the controller there and the write landed correctly. Only the paths that rebind `localhost` — `upgrade` and the other looping commands — were affected. That asymmetry is why the controller record looked right after a create and wrong after an upgrade.

## Scope

All seventeen call sites, since the pattern is identical everywhere and the issue asked for the audit rather than a point fix:

`playbooks/`: `create.yml` (×2), `storage_list.yml`, `storage_setup_efs.yml`, `storage_setup_nfs.yml`, `upgrade.yml`
`roles/`: `common/detect_runtime`, `create/_kubernetes_setup`, `create/_register`, `create/_validate_inputs`, `delete/main` (×3), `devmode/disable`, `devmode/enable`, `gitops/init`, `upgrade/main`

The now-redundant `vars: ansible_connection: local` blocks are left in place — they are harmless on a host that already connects locally, and removing them would widen the diff without changing behavior.

## Tests

`tests/unit/test_registry_delegation_target.py` walks every task file and asserts no `canasta_registry` task delegates to `localhost`, that every delegated one targets `canasta_controller`, that `canasta.yml` adds the host, and that `switch_connection.yml` never names it. It also asserts the walk finds more than ten registry tasks, so a broken traversal cannot make the rest pass vacuously.

Three existing assertions were updated rather than relaxed — `test_the_registry_write_runs_on_the_controller`, `test_reads_default_storageclass_from_controller_registry`, and `test_persists_default_storageclass_to_controller_registry` all describe the controller in their names and were asserting the value that did not deliver it.

## Verified

```
ansible-playbook canasta.yml --syntax-check   ok
make lint                                     All checks passed
make validate                                 87 commands, 69 playbooks, 161 examples
make test-unit                                2334 passed
```

Fixes #1388
