### PR TITLE
fix(create): decide the runtime from the socket, not from docker info

### DIFF
--- a/roles/orchestrator/tasks/create_preflight.yml
+++ b/roles/orchestrator/tasks/create_preflight.yml
@@ -24,6 +24,30 @@
       ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/detect_docker_socket.yml"
       when: (docker_host | default('')) == ''
 
+    # `docker info` is not evidence of Docker when DOCKER_HOST points at
+    # Podman's socket: the Docker CLI talks to Podman's Docker-compatible
+    # API and reports success, so the probe below concluded Docker and
+    # recorded `docker compose` for an instance that runs under Podman.
+    # The socket already answers the question, so settle it here rather
+    # than asking a command that cannot distinguish the two.
+    #
+    # Mirrors the DOCKER_HOST precedence in canasta.yml, so this reads the
+    # same socket the probes will actually use.
+    - name: Resolve the socket the runtime probes will use
+      ansible.builtin.set_fact:
+        _preflight_docker_host: >-
+          {{ docker_host
+             | default(instance_docker_host | default(''), true)
+             | default(_detected_docker_host | default(''), true) }}
+
+    - name: Use Podman when the socket in use is Podman's
+      ansible.builtin.set_fact:
+        compose_command: podman-compose
+        inspect_command: podman
+      when:
+        - not (compose_command | default('docker compose') is search('podman'))
+        - _preflight_docker_host is search('podman')
+
     # Probe the target's runtime before any state mutation. This is the
     # only place detection happens — the CLI never guesses, so the
     # set_fact below is what makes a Podman-only host work, local or

--- a/tests/unit/test_create_preflight_podman_socket.py
+++ b/tests/unit/test_create_preflight_podman_socket.py
@@ -1,0 +1,103 @@
+"""A Podman socket means Podman, whatever `docker info` says.
+
+On a host that has the Docker CLI installed alongside rootless Podman,
+the socket probe points DOCKER_HOST at
+`unix:///run/user/<uid>/podman/podman.sock`. `docker info` then succeeds
+— the Docker CLI is talking to Podman's Docker-compatible API — so the
+Docker-first probe concluded Docker and recorded:
+
+    "dockerHost":      "unix:///run/user/1000/podman/podman.sock",
+    "composeCommand":  "docker compose",
+    "inspectCommand":  "docker"
+
+The containers run under Podman regardless, so create succeeds and the
+mis-recording only surfaces on a later upgrade, which then runs
+`docker compose` against a host whose Docker daemon is not running.
+
+The socket answers the question on its own, so the decision is made from
+it before any probe runs.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+PREFLIGHT = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "create_preflight.yml")
+
+
+def _block_tasks():
+    with open(PREFLIGHT) as f:
+        doc = yaml.safe_load(f)
+    return doc[0]["block"]
+
+
+def _index_of(name):
+    for i, t in enumerate(_block_tasks()):
+        if t.get("name") == name:
+            return i
+    raise AssertionError("task not found: %s" % name)
+
+
+def _named(name):
+    return _block_tasks()[_index_of(name)]
+
+
+class TestTheSocketDecidesTheRuntime:
+    def test_podman_socket_selects_podman(self):
+        task = _named("Use Podman when the socket in use is Podman's")
+        facts = task["ansible.builtin.set_fact"]
+        assert facts["compose_command"] == "podman-compose"
+        assert facts["inspect_command"] == "podman"
+
+    def test_it_keys_on_the_resolved_socket(self):
+        task = _named("Use Podman when the socket in use is Podman's")
+        conditions = " ".join(task["when"])
+        assert "_preflight_docker_host" in conditions
+        assert "podman" in conditions
+
+    def test_it_does_not_override_an_explicit_podman_command(self):
+        # compose_command already naming podman (registry or .env) is
+        # authoritative; re-setting it would be harmless but the guard
+        # keeps the two sources from fighting.
+        task = _named("Use Podman when the socket in use is Podman's")
+        conditions = " ".join(task["when"])
+        assert "compose_command" in conditions
+
+    def test_the_resolved_socket_mirrors_the_playbook_precedence(self):
+        task = _named("Resolve the socket the runtime probes will use")
+        expr = task["ansible.builtin.set_fact"]["_preflight_docker_host"]
+        # Same order as the DOCKER_HOST expression in canasta.yml, or the
+        # preflight would decide from a different socket than the probes use.
+        assert expr.index("docker_host") < expr.index("instance_docker_host")
+        assert (expr.index("instance_docker_host")
+                < expr.index("_detected_docker_host"))
+
+
+class TestItRunsBeforeTheProbes:
+    def test_decision_precedes_the_docker_probe(self):
+        decision = _index_of("Use Podman when the socket in use is Podman's")
+        probe = _index_of("Probe Docker then Podman for remote/detected runtime")
+        assert decision < probe, (
+            "the socket decision must run before the Docker-first probe, "
+            "or the probe still wins on a Podman host with the Docker CLI"
+        )
+
+    def test_decision_follows_socket_detection(self):
+        detect = _index_of("Detect rootless container socket on target")
+        decision = _index_of("Use Podman when the socket in use is Podman's")
+        assert detect < decision, (
+            "_detected_docker_host is not set until the socket probe runs"
+        )
+
+    def test_the_podman_branch_still_probes_the_runtime(self):
+        # Selecting podman early must land in the branch that registers
+        # _docker_check, or 'Fail if container runtime not available'
+        # fires on a perfectly good Podman host.
+        task = _named("Check container runtime is available")
+        assert "podman" in task["when"]
+        inner = task["block"][0]
+        assert inner["ansible.builtin.command"]["cmd"] == "podman info"
+        assert inner["register"] == "_docker_check"


### PR DESCRIPTION
`docker info` cannot distinguish Docker from Podman once `DOCKER_HOST` points at Podman's socket — the Docker CLI talks to Podman's Docker-compatible API and reports success. The Docker-first probe in `create_preflight.yml` read that as Docker and recorded `composeCommand: "docker compose"` for an instance whose containers run under Podman.

## Fix

Decide from the socket, before any probe runs:

```yaml
- name: Resolve the socket the runtime probes will use
  ansible.builtin.set_fact:
    _preflight_docker_host: >-
      {{ docker_host
         | default(instance_docker_host | default(''), true)
         | default(_detected_docker_host | default(''), true) }}

- name: Use Podman when the socket in use is Podman's
  ansible.builtin.set_fact:
    compose_command: podman-compose
    inspect_command: podman
  when:
    - not (compose_command | default('docker compose') is search('podman'))
    - _preflight_docker_host is search('podman')
```

The precedence mirrors the `DOCKER_HOST` expression in `canasta.yml`, so the preflight decides from the same socket the probes would use rather than a different one.

## Why this does not disturb the rest of the preflight

Selecting `podman-compose` early routes into the existing `Check container runtime is available` branch, which probes `podman info` and registers it as `_docker_check`. That matters twice downstream:

- `Fail if container runtime not available` tests `_docker_check.rc` and `_podman_check.rc`; the podman branch satisfies the first, so a healthy Podman host does not trip it.
- `Resolve container storage root` parses `_docker_check.stdout` for `Docker Root Dir` or `graphRoot` — the podman-docker shim reports the latter, which the existing regex already matches.

An explicit `compose_command` from the registry or `.env` still wins: the guard skips when it already names a podman command.

## Interaction with #1389

This is the source of the wrong records that #1389 is about. #1389 makes `upgrade` re-probe an unusable recorded runtime; this stops the wrong value being written in the first place. Both are worth having — one repairs existing instances, the other stops manufacturing new ones.

## Tests

`tests/unit/test_create_preflight_podman_socket.py` asserts the decision selects `podman-compose`/`podman`, keys on the resolved socket, does not override an explicit podman command, and mirrors `canasta.yml`'s precedence order. Two ordering tests pin it after socket detection and before the Docker-first probe — the ordering is the whole fix, and a later refactor could silently undo it. A final test asserts the podman branch still registers `_docker_check`, which is what keeps the availability check and storage parse working.

## Verified

```
make lint        All checks passed
make validate    87 commands, 69 playbooks, 161 examples
make test-unit   2336 passed
```

Fixes #1390
