### PR TITLE
fix(upgrade): check the recorded runtime instead of trusting it

### DIFF
--- a/playbooks/_upgrade_single.yml
+++ b/playbooks/_upgrade_single.yml
@@ -22,20 +22,25 @@
     inspect_command: >-
       {{ _inst.value.inspectCommand
          | default(_upgrade_default_inspect_command) }}
+    # Set per instance, not left to whatever the previous iteration used:
+    # canasta.yml's play-level DOCKER_HOST reads this, so an unset value
+    # would leak the last instance's socket into the next one.
+    instance_docker_host: "{{ _inst.value.dockerHost | default('') }}"
     _instance_host: "{{ _inst.value.host | default('localhost') }}"
 
 - name: Switch connection to instance host
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/switch_connection.yml"
 
-# An instance registered before the runtime became a registry field has
-# nothing for the facts above to read, so they fall back to Docker and
-# the whole upgrade runs `docker compose` — rc=127 on a Podman-only
-# host. Silence in the registry is not evidence of Docker; ask the host.
-- name: Detect the runtime for an instance that has none recorded
+# The registry is a claim about the host, not a fact about it, so check
+# it rather than taking it at its word. An instance registered before the
+# runtime became a field has nothing recorded and falls back to Docker;
+# one registered by a create that misread a Podman socket as Docker has
+# `docker compose` recorded outright. Both run the whole upgrade through
+# `docker compose` on a host with no Docker daemon, and gating on "no
+# value recorded" only ever caught the first.
+- name: Confirm the recorded runtime against the instance's host
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/detect_runtime.yml"
-  when:
-    - instance_orchestrator == 'compose'
-    - _inst.value.composeCommand is not defined
+  when: instance_orchestrator == 'compose'
 
 - name: Run upgrade role (migrations + refresh + restart)
   ansible.builtin.include_role:

--- a/roles/common/tasks/detect_runtime.yml
+++ b/roles/common/tasks/detect_runtime.yml
@@ -13,9 +13,18 @@
 # Runs commands on the instance's host, so include this after
 # switch_connection.yml.
 #
-# Input: instance_id
+# Input: instance_id, instance_docker_host (optional)
 # Output: compose_command / inspect_command facts, and the same values
-#   on the registry entry, when the host runs Podman and not Docker.
+#   on the registry entry, when the instance runs under Podman.
+
+# `docker info` succeeds against a Podman socket — the Docker CLI is
+# talking to Podman's Docker-compatible API — so on an instance whose
+# dockerHost is Podman's, the probe below cannot tell the two apart and
+# would confirm a wrong `docker compose` record. The socket settles it
+# without asking.
+- name: Note whether this instance's socket is Podman's
+  ansible.builtin.set_fact:
+    _dr_podman_socket: "{{ instance_docker_host | default('') is search('podman') }}"
 
 - name: Probe docker info
   ansible.builtin.command:
@@ -23,9 +32,11 @@
   register: _dr_docker
   changed_when: false
   failed_when: false
+  when: not _dr_podman_socket
 
-# Only asked when Docker came up short: on a Docker host the answer
-# cannot change the outcome, and this is a round trip to the target.
+# Asked when Docker came up short, and when the socket said Podman so
+# Docker was never asked at all. On a Docker host neither holds and this
+# round trip to the target is skipped.
 - name: Probe podman info
   ansible.builtin.command:
     cmd: podman info

--- a/tests/unit/test_upgrade_detects_legacy_runtime.py
+++ b/tests/unit/test_upgrade_detects_legacy_runtime.py
@@ -75,22 +75,30 @@ def _read_back(tmp_dir):
         return json.load(f)["Instances"]["legacy"]
 
 
-class TestUpgradeProbesWhenTheRegistryIsSilent:
+CONFIRM = "Confirm the recorded runtime against the instance's host"
+
+
+class TestUpgradeChecksTheRecordedRuntime:
     def test_the_detection_is_included(self):
-        task = _named(SINGLE, "Detect the runtime")
+        task = _named(SINGLE, "Confirm the recorded runtime")
         assert task, (
-            "_upgrade_single.yml takes the registry's silence as Docker, "
-            "so an instance registered before composeCommand existed runs "
-            "the whole upgrade with `docker compose`"
+            "_upgrade_single.yml takes the registry at its word, so an "
+            "instance that records nothing — or records `docker compose` "
+            "from a create that misread a Podman socket — runs the whole "
+            "upgrade with `docker compose`"
         )
         assert task["ansible.builtin.include_tasks"].endswith(
             "roles/common/tasks/detect_runtime.yml")
 
-    def test_it_only_runs_when_nothing_is_recorded(self):
-        conds = _named(SINGLE, "Detect the runtime")["when"]
-        assert any("composeCommand is not defined" in str(c) for c in conds), (
-            "the probe runs even for instances that record their runtime, "
-            "spending two round trips per upgrade to relearn it"
+    def test_it_runs_for_every_compose_instance(self):
+        # Gating on "nothing recorded" only caught pre-field instances.
+        # A record holding the wrong runtime is the case that actually
+        # fails today, and it never re-probed.
+        cond = _named(SINGLE, "Confirm the recorded runtime")["when"]
+        conds = cond if isinstance(cond, list) else [cond]
+        assert not any("composeCommand" in str(c) for c in conds), (
+            "re-probing only when composeCommand is absent leaves an "
+            "instance that recorded the wrong runtime unrepairable"
         )
         assert any("compose" in str(c) and "orchestrator" in str(c)
                    for c in conds), (
@@ -101,18 +109,20 @@ class TestUpgradeProbesWhenTheRegistryIsSilent:
         # The controller's PATH is not evidence about the instance's host.
         names = [str(t.get("name", "")) for t in _tasks(SINGLE)]
         assert (names.index("Switch connection to instance host")
-                < names.index(
-                    "Detect the runtime for an instance that has none "
-                    "recorded"))
+                < names.index(CONFIRM))
 
     def test_the_facts_are_reset_before_the_probe(self):
         # set_fact persists across loop iterations, so a podman instance
         # detected in one pass must not leak into the next instance.
         names = [str(t.get("name", "")) for t in _tasks(SINGLE)]
-        assert (names.index("Set instance facts")
-                < names.index(
-                    "Detect the runtime for an instance that has none "
-                    "recorded"))
+        assert (names.index("Set instance facts") < names.index(CONFIRM))
+
+    def test_the_socket_is_bound_per_instance(self):
+        # canasta.yml's play-level DOCKER_HOST reads instance_docker_host;
+        # left unset in the loop it keeps the previous instance's socket.
+        facts = _named(SINGLE, "Set instance facts")["ansible.builtin.set_fact"]
+        assert "instance_docker_host" in facts
+        assert "dockerHost" in facts["instance_docker_host"]
 
 
 class TestTheProbeAsksTheHost:
@@ -155,3 +165,23 @@ class TestTheProbeAsksTheHost:
         task = _named(DETECT, "Record the detected runtime")
         assert task["delegate_to"] == "localhost"
         assert task["vars"]["ansible_connection"] == "local"
+
+class TestAPodmanSocketIsNotAskedAboutDocker:
+    def test_the_socket_is_noted_before_probing(self):
+        names = [str(t.get("name", "")) for t in _tasks(DETECT)]
+        assert (names.index("Note whether this instance's socket is Podman's")
+                < names.index("Probe docker info"))
+
+    def test_docker_is_not_probed_on_a_podman_socket(self):
+        # `docker info` succeeds against Podman's Docker-compatible API,
+        # so asking it would confirm a wrong `docker compose` record
+        # rather than correct it.
+        task = _named(DETECT, "Probe docker info")
+        assert "_dr_podman_socket" in str(task["when"])
+
+    def test_the_podman_probe_still_runs_when_docker_was_skipped(self):
+        # A skipped docker probe leaves _dr_docker undefined; the podman
+        # probe must treat that as "Docker did not answer", or a Podman
+        # socket ends up with no runtime detected at all.
+        task = _named(DETECT, "Probe podman info")
+        assert "default(1)" in str(task["when"])


### PR DESCRIPTION
The runtime probe fired only when `composeCommand` was absent:

```yaml
when:
  - instance_orchestrator == 'compose'
  - _inst.value.composeCommand is not defined
```

That covers instances registered before the field existed, but not one holding the wrong value. As the issue shows, removing `composeCommand` from a record and re-running the same upgrade with the same CLI succeeds — the only difference is whether the key is absent or wrong.

## Fix

Three parts, all needed for a wrong record to actually get repaired.

**Probe every Compose instance.** The registry is a claim about the host, not a fact about it. The gate is now `instance_orchestrator == 'compose'`, and the task is named for what it does — confirm, not fill in.

**Do not ask `docker info` on a Podman socket.** `docker info` succeeds against Podman's Docker-compatible API, so on an instance whose `dockerHost` is Podman's, the probe would have *confirmed* the wrong `docker compose` record instead of correcting it. `detect_runtime.yml` now notes the socket first and skips the Docker probe when it is Podman's; the podman probe already keys on `_dr_docker.rc | default(1)`, so a skipped Docker probe reads as "Docker did not answer" and the Podman branch runs.

This is the case #1390 produces, and the issue's own note calls it out — wrong records are actively being manufactured, not just inherited.

**Bind the socket per instance.** `_upgrade_single.yml` never set `instance_docker_host`, which `canasta.yml`'s play-level `DOCKER_HOST` expression reads. In a loop over instances it therefore carried whatever the previous iteration left behind. It is now set from `_inst.value.dockerHost` alongside the other per-instance facts.

## Cost

One extra probe per Compose instance per upgrade, and only on hosts where Docker does not answer. On a Docker host the first probe succeeds and the Podman round trip is still skipped, as before.

## Tests

The existing class asserted the old contract, including `test_it_only_runs_when_nothing_is_recorded` — the behavior this issue identifies as the bug. It is replaced by `test_it_runs_for_every_compose_instance`, which asserts the gate no longer mentions `composeCommand` at all, with the reason in the failure message. The ordering tests (after the connection switch, after the fact reset) are kept, retargeted at the new task name.

New coverage: the socket is noted before probing, Docker is not probed on a Podman socket, the Podman probe still runs when the Docker probe was skipped, and `instance_docker_host` is bound per instance.

## Verified

```
make lint        All checks passed
make validate    87 commands, 69 playbooks, 161 examples
make test-unit   2333 passed
```

Fixes #1389
