### PR TITLE
fix(upgrade): keep an image pin the operator chose

### DIFF
--- a/roles/orchestrator/tasks/upgrade_image_tag.yml
+++ b/roles/orchestrator/tasks/upgrade_image_tag.yml
@@ -90,8 +90,16 @@
       when: _upgrade_k8s_gitops_stat.stat.exists | default(false)
 
 # --- Update Compose CANASTA_IMAGE tag ---
-# Bump the tag if it's the default ghcr.io image,
-# leave it alone if user set a custom/local-build image.
+# Move an instance off the version tag a previous CLI pinned, and leave
+# every other value alone: a custom repository, a local build, or a tag
+# the operator chose.
+#
+# Matching the repository alone was not enough. `:latest` lives under the
+# official repository and never equals the pinned version, so both
+# conditions held on every run and an instance deliberately tracking
+# latest was silently moved back to a fixed version — repeatedly, since
+# the rewrite could never converge. Requiring a version-shaped tag is
+# what separates "the CLI put this here" from "the operator did".
 - name: Update Compose image tag
   when:
     - instance_orchestrator | default('compose') == 'compose'
@@ -99,7 +107,7 @@
     # CANASTA_IMAGE was already read by the migration probe; reuse
     # those values instead of re-reading .env.
     - _mig.env_present.CANASTA_IMAGE
-    - _mig.env.CANASTA_IMAGE is match('^ghcr\\.io/canastawiki/canasta:')
+    - _mig.env.CANASTA_IMAGE is match('^ghcr\\.io/canastawiki/canasta:[0-9]+\\.[0-9]+\\.[0-9]+$')
     - _mig.env.CANASTA_IMAGE != canasta_default_image
   block:
     - name: Update CANASTA_IMAGE to latest default tag
@@ -108,6 +116,14 @@
         state: set
         key: CANASTA_IMAGE
         value: "{{ canasta_default_image }}"
+
+    # The rewrite used to be silent, so an operator who noticed the pin
+    # had moved had nothing to connect it to.
+    - name: Report the image pin change
+      ansible.builtin.debug:
+        msg: >-
+          Updated CANASTA_IMAGE from {{ _mig.env.CANASTA_IMAGE }} to
+          {{ canasta_default_image }}.
 
     # On a gitops instance the .env above is re-rendered from env.template on
     # the next pull, which would revert the tag. CANASTA_IMAGE lives in

--- a/tests/unit/test_upgrade_preserves_image_pin.py
+++ b/tests/unit/test_upgrade_preserves_image_pin.py
@@ -1,0 +1,89 @@
+"""An explicitly chosen image tag is the operator's, not the CLI's.
+
+The rewrite exists to move an instance off the version tag a previous
+CLI pinned. Its guard tested the repository and inequality only:
+
+    CANASTA_IMAGE is match('^ghcr\\.io/canastawiki/canasta:')
+    CANASTA_IMAGE != canasta_default_image
+
+`ghcr.io/canastawiki/canasta:latest` satisfies both — it lives under the
+official repository and never equals a pinned version — so every upgrade
+rewrote it back to a fixed version, and repeating the change never made
+it stick. Nothing reported the change either.
+
+A version-shaped tag is what distinguishes a pin the CLI wrote from one
+the operator chose.
+"""
+
+import os
+import re
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+TASKS = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "upgrade_image_tag.yml")
+
+DEFAULT = "ghcr.io/canastawiki/canasta:3.5.20"
+
+
+def _compose_task():
+    with open(TASKS) as f:
+        for task in yaml.safe_load(f):
+            if task.get("name") == "Update Compose image tag":
+                return task
+    raise AssertionError("Update Compose image tag not found")
+
+
+def _tag_pattern():
+    """The regex the guard uses to recognise a CLI-written pin."""
+    for cond in _compose_task()["when"]:
+        m = re.search(r"match\('(.+?)'\)", str(cond))
+        if m:
+            return m.group(1).replace("\\\\", "\\")
+    raise AssertionError("no match() condition found")
+
+
+def _would_rewrite(value):
+    """Evaluate the guard's two value-dependent conditions."""
+    return bool(re.match(_tag_pattern(), value)) and value != DEFAULT
+
+
+class TestWhatGetsRewritten:
+    def test_an_older_cli_pin_is_bumped(self):
+        assert _would_rewrite("ghcr.io/canastawiki/canasta:3.5.19")
+
+    def test_the_current_pin_is_left_alone(self):
+        assert not _would_rewrite(DEFAULT)
+
+
+class TestWhatIsLeftAlone:
+    def test_latest_survives(self):
+        assert not _would_rewrite("ghcr.io/canastawiki/canasta:latest"), (
+            "an instance deliberately tracking :latest is moved back to a "
+            "fixed version on every upgrade, and never converges"
+        )
+
+    def test_a_named_tag_survives(self):
+        assert not _would_rewrite("ghcr.io/canastawiki/canasta:edge")
+
+    def test_a_dated_build_tag_survives(self):
+        assert not _would_rewrite(
+            "ghcr.io/canastawiki/canasta:1.43.9-20260801-228")
+
+    def test_another_repository_survives(self):
+        assert not _would_rewrite("ghcr.io/example/canasta:3.5.19")
+
+    def test_a_local_build_survives(self):
+        assert not _would_rewrite("canasta:local")
+
+
+class TestTheChangeIsReported:
+    def test_a_message_names_both_values(self):
+        block = _compose_task()["block"]
+        reports = [t for t in block if "ansible.builtin.debug" in t]
+        assert reports, "the pin is rewritten with no output saying so"
+        msg = reports[0]["ansible.builtin.debug"]["msg"]
+        assert "_mig.env.CANASTA_IMAGE" in msg
+        assert "canasta_default_image" in msg


### PR DESCRIPTION
`upgrade` rewrote `CANASTA_IMAGE` on every run for an instance pinned to `:latest`. The guard tested the repository and inequality:

```yaml
- _mig.env.CANASTA_IMAGE is match('^ghcr\.io/canastawiki/canasta:')
- _mig.env.CANASTA_IMAGE != canasta_default_image
```

`:latest` lives under the official repository and never equals the pinned version, so both conditions held every time. The value never converged, repeating the change did not make it stick, and nothing in the output said the pin had moved.

## Fix

Require a version-shaped tag:

```yaml
- _mig.env.CANASTA_IMAGE is match('^ghcr\.io/canastawiki/canasta:[0-9]+\.[0-9]+\.[0-9]+$')
```

That is what distinguishes a pin a previous CLI wrote from one the operator chose. The rewrite still does its job — moving an instance off an older CLI-written version tag — while `:latest`, a named tag, and a dated build tag are all left alone.

The change is also reported now, rather than being silent.

## What changes for whom

| `CANASTA_IMAGE` | Before | After |
| --- | --- | --- |
| `…/canasta:3.5.19` (older CLI pin) | bumped | bumped |
| `…/canasta:3.5.20` (current) | untouched | untouched |
| `…/canasta:latest` | **rewritten every run** | untouched |
| `…/canasta:edge` | **rewritten every run** | untouched |
| `…/canasta:1.43.9-20260801-228` | **rewritten every run** | untouched |
| `ghcr.io/example/canasta:3.5.19` | untouched | untouched |
| `canasta:local` | untouched | untouched |

Only the three middle rows change behavior, and in each the previous behavior discarded an explicit choice.

## Tests

`tests/unit/test_upgrade_preserves_image_pin.py` extracts the regex from the task and evaluates the guard's two value-dependent conditions against each case above, so the table is executable rather than described. It also asserts the change is reported and that the message names both the old and new value.

## Verified

```
make lint        All checks passed
make validate    87 commands, 69 playbooks, 161 examples
make test-unit   2337 passed
```

Fixes #1391
