### PR TITLE
fix(doctor): warn on a staging certificate instead of reporting OK

### DIFF
--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -534,6 +534,12 @@ _TLS_RENEWAL_FLOOR_DAYS = 14
 # Caddy's fallback when it cannot obtain a public certificate.
 _TLS_INTERNAL_ISSUER_MARKERS = ("caddy local authority",)
 
+# Let's Encrypt's staging CA marks every issuer CN this way, e.g.
+# "(STAGING) Artificial Amaranth YE1". Staging certificates are valid and
+# unexpired but chain to an untrusted root, so browsers reject them —
+# the same visible outcome as the internal-CA case above.
+_TLS_STAGING_ISSUER_MARKERS = ("(staging)",)
+
 # Names Caddy serves from its internal CA by design.
 _TLS_LOCAL_NAMES = ("localhost",)
 _TLS_LOCAL_SUFFIXES = (
@@ -658,6 +664,20 @@ def _origin_tls_lines_from_entries(inst_id, entries, now):
                 "and has not renewed. Renewal should have happened by now, so "
                 "treat this as a broken ACME path rather than a countdown."
                 % (name, days, issuer or "unknown"))
+        elif any(m in issuer.lower()
+                 for m in _TLS_STAGING_ISSUER_MARKERS):
+            # Unexpired and correctly issued, so every check above passes
+            # — but it chains to an untrusted root, so browsers reject it
+            # exactly as they do the internal-CA case. Nothing in .env
+            # distinguishes an instance created with --staging-certs from
+            # one promoted afterwards; only the served certificate does.
+            lines.append(
+                "  %s: WARN — staging certificate (issuer %s), valid for %d "
+                "more day(s) but not publicly trusted, so browsers reject "
+                "it. Expected while testing with --staging-certs; on a live "
+                "site, re-issue against the production CA by unsetting "
+                "CANASTA_STAGING_CERTS and restarting."
+                % (name, issuer, days))
         else:
             lines.append(
                 "  %s: OK (expires in %d days, issuer %s)"

--- a/tests/unit/test_doctor_origin_tls.py
+++ b/tests/unit/test_doctor_origin_tls.py
@@ -206,3 +206,51 @@ class TestOriginTlsGate:
             lambda *a, **k: (seen.update(script=a[0][2]) or _R()))
         doctor._origin_tls_lines(self._inst(orchestrator="kubernetes"))
         assert "127.0.0.1:'443'" in seen["script"]
+
+# Real issuer string from a Let's Encrypt staging certificate.
+LE_STAGING = ("C=US, O=(STAGING) Let's Encrypt, "
+              "CN=(STAGING) Artificial Amaranth YE1")
+
+
+class TestStagingCertificates:
+    """A staging certificate passes every other check and still breaks the site.
+
+    It is unexpired and correctly issued, so the expiry branches are
+    happy, but it chains to an untrusted root — browsers reject it just
+    as they reject the internal-CA fallback. Reporting OK meant doctor
+    passed an instance no visitor could load.
+    """
+
+    def test_a_staging_certificate_warns(self):
+        body = " ".join(_lines([
+            ("a.example.org", LE_STAGING,
+             _fmt(NOW + datetime.timedelta(days=89)))]))
+        assert "WARN" in body, (
+            "a browser-untrusted staging certificate is reported as OK"
+        )
+        assert "staging certificate" in body
+
+    def test_it_still_reports_the_remaining_days(self):
+        body = " ".join(_lines([
+            ("a.example.org", LE_STAGING,
+             _fmt(NOW + datetime.timedelta(days=89)))]))
+        assert "89 more day(s)" in body
+
+    def test_it_names_the_way_out(self):
+        body = " ".join(_lines([
+            ("a.example.org", LE_STAGING,
+             _fmt(NOW + datetime.timedelta(days=89)))]))
+        assert "CANASTA_STAGING_CERTS" in body
+
+    def test_an_expired_staging_certificate_still_reports_expiry(self):
+        # Expiry is the more urgent fact; it is checked first.
+        body = " ".join(_lines([
+            ("a.example.org", LE_STAGING,
+             _fmt(NOW - datetime.timedelta(days=3)))]))
+        assert "EXPIRED 3 day(s) ago" in body
+
+    def test_production_letsencrypt_is_unaffected(self):
+        body = " ".join(_lines([
+            ("a.example.org", LE, _fmt(NOW + datetime.timedelta(days=61)))]))
+        assert "staging" not in body.lower()
+        assert "OK (expires in 61 days" in body


### PR DESCRIPTION
A Let's Encrypt staging certificate is unexpired and correctly issued, so every expiry branch was satisfied and the check reported:

```
Origin TLS (e2edocker):
  big.acknowledge.wiki: OK (expires in 89 days, issuer C=US, O=Let's Encrypt,
  CN=(STAGING) Artificial Amaranth YE1)
```

It chains to an untrusted root, so every visitor gets a browser interstitial. That is the same visible outcome as the internal-CA fallback this check already warns about at length.

## Fix

Recognise the staging issuer and warn, keeping the remaining-days figure and naming the way out:

```
big.acknowledge.wiki: WARN — staging certificate (issuer …), valid for 89 more
day(s) but not publicly trusted, so browsers reject it. Expected while testing
with --staging-certs; on a live site, re-issue against the production CA by
unsetting CANASTA_STAGING_CERTS and restarting.
```

Let's Encrypt marks every staging issuer CN `(STAGING)`, which the check already extracts, so no extra probing is needed.

## Why not read the config instead

`CANASTA_STAGING_CERTS` says what was *requested*, not what is being *served*. An instance created with `--staging-certs` and later promoted keeps serving the staging certificate until something re-issues it, and the flag alone cannot tell the two apart. The served certificate can, and this check is already reading it — which is the whole premise of #1367.

## Ordering

The staging branch sits after the expiry branches, so an expired staging certificate still reports as expired. Expiry is the more urgent fact and the remedy differs.

## Noise

This warns on every instance deliberately running `--staging-certs`, which is the intended trade: the alternative is passing an instance no visitor can load. The message says outright that it is expected while testing, so the warning reads as confirmation rather than a defect during a test run.

## Tests

Added to `tests/unit/test_doctor_origin_tls.py` using a real staging issuer string: the warning fires, it still reports remaining days, it names `CANASTA_STAGING_CERTS`, an expired staging certificate still reports expiry first, and production Let's Encrypt is unaffected.

## Verified

```
make lint        All checks passed
make test-unit   2334 passed
```

Found in a hands-on e2e of 4.15.0.

Fixes #1384
