### PR TITLE
fix(install): enable the rootless Podman socket

### DIFF
--- a/roles/install/tasks/podman.yml
+++ b/roles/install/tasks/podman.yml
@@ -18,6 +18,14 @@
   changed_when: false
   register: _install_user_cmd
 
+# become: false — the operator's uid, not root's, is the one whose
+# /run/user/<uid> holds the rootless socket.
+- name: Determine operator uid
+  ansible.builtin.command: id -u
+  become: false
+  changed_when: false
+  register: _install_uid
+
 - name: Set install user fact
   ansible.builtin.set_fact:
     _install_user: >-
@@ -150,6 +158,34 @@
           echo 'net.ipv4.ip_unprivileged_port_start=80' |
           sudo tee /etc/sysctl.d/canasta-privport.conf
       when: _persist_result is failed
+
+    # The third prerequisite, and the one an operator is most likely to
+    # need explicitly: --docker-host on `create` and `install` documents
+    # unix:///run/user/<uid>/podman/podman.sock, and nothing created it.
+    #
+    # become: false because this is a user unit — as root it would enable
+    # root's socket, not the operator's. systemctl --user needs
+    # XDG_RUNTIME_DIR, which a non-interactive SSH session does not set.
+    - name: Enable the rootless Podman socket for the operator
+      ansible.builtin.command:
+        cmd: systemctl --user enable --now podman.socket
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ _install_uid.stdout | trim }}"
+      become: false
+      changed_when: true
+      register: _podman_socket_result
+      failed_when: false
+
+    - name: Warn if the Podman socket could not be enabled
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: Could not enable podman.socket for
+          '{{ _install_user }}'. Rootless Podman still works through the
+          podman CLI, but --docker-host
+          unix:///run/user/{{ _install_uid.stdout | trim }}/podman/podman.sock
+          has nothing listening. Enable it manually:
+          systemctl --user enable --now podman.socket
+      when: _podman_socket_result.rc | default(1) != 0
 
 - name: Report Podman installed
   ansible.builtin.debug:

--- a/tests/unit/test_install_podman_socket.py
+++ b/tests/unit/test_install_podman_socket.py
@@ -1,0 +1,87 @@
+"""`install podman` must provision the socket --docker-host points at.
+
+The task file configured two rootless prerequisites — lingering and the
+unprivileged port floor — and reported "Rootless prerequisites were
+configured". The socket was not one of them, so:
+
+    $ canasta install -H host podman
+    Podman already available. Rootless prerequisites were configured.
+    $ ssh host 'systemctl --user is-active podman.socket'
+    inactive
+
+while --docker-host on both `create` and `install` documents
+`unix:///run/user/<uid>/podman/podman.sock`. The normal podman path never
+touches the socket — it shells out to podman-compose and podman — so this
+only bites the operator who follows that documented route.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+PODMAN = os.path.join(REPO_ROOT, "roles", "install", "tasks", "podman.yml")
+
+
+def _all_tasks():
+    with open(PODMAN) as f:
+        doc = yaml.safe_load(f)
+    out = []
+    for task in doc:
+        out.append(task)
+        out.extend(task.get("block") or [])
+    return out
+
+
+def _named(name):
+    for t in _all_tasks():
+        if t.get("name") == name:
+            return t
+    raise AssertionError("task not found: %s" % name)
+
+
+class TestTheSocketIsEnabled:
+    def test_the_socket_task_exists(self):
+        task = _named("Enable the rootless Podman socket for the operator")
+        cmd = task["ansible.builtin.command"]["cmd"]
+        assert "systemctl --user" in cmd
+        assert "podman.socket" in cmd
+        assert "--now" in cmd, (
+            "enable without --now leaves the socket inactive until reboot"
+        )
+
+    def test_it_runs_as_the_operator_not_root(self):
+        # A user unit: as root this would enable root's socket, which is
+        # not the one --docker-host names.
+        task = _named("Enable the rootless Podman socket for the operator")
+        assert task["become"] is False
+
+    def test_it_supplies_the_runtime_dir(self):
+        # systemctl --user needs XDG_RUNTIME_DIR, which a non-interactive
+        # SSH session does not set.
+        task = _named("Enable the rootless Podman socket for the operator")
+        env = task["environment"]
+        assert "XDG_RUNTIME_DIR" in env
+        assert "_install_uid" in env["XDG_RUNTIME_DIR"]
+
+    def test_failure_is_not_fatal(self):
+        # Rootless podman works through the CLI without the socket, so a
+        # host that cannot enable it must still finish the install.
+        task = _named("Enable the rootless Podman socket for the operator")
+        assert task["failed_when"] is False
+
+    def test_a_failure_is_reported(self):
+        task = _named("Warn if the Podman socket could not be enabled")
+        msg = task["ansible.builtin.debug"]["msg"]
+        assert "podman.socket" in msg
+        assert "docker-host" in msg
+
+
+class TestTheOperatorUidIsResolved:
+    def test_uid_is_read_as_the_operator(self):
+        task = _named("Determine operator uid")
+        assert task["ansible.builtin.command"] == "id -u"
+        assert task["become"] is False, (
+            "root's uid would point XDG_RUNTIME_DIR at the wrong directory"
+        )


### PR DESCRIPTION
`canasta install podman` reports that rootless prerequisites are configured, but leaves `podman.socket` inactive:

```
$ canasta install -H big podman
Podman already available. Rootless prerequisites were configured.

$ ssh big 'systemctl --user is-active podman.socket'
inactive
$ ssh big 'ls /run/user/1000/podman/podman.sock'
ls: cannot access '/run/user/1000/podman/podman.sock': No such file or directory
```

`roles/install/tasks/podman.yml` handled exactly two prerequisites — `loginctl enable-linger` and `net.ipv4.ip_unprivileged_port_start=80`. Both worked. The socket was not among them, while `--docker-host` on both `create` and `install` documents:

> Set this when the target uses rootless podman (typically `unix:///run/user/<uid>/podman/podman.sock`)

So the documented sequence points at a socket the install step does not provision.

## Fix

Enable it as the third rootless prerequisite. Three details matter:

- **`become: false`.** It is a user unit. Enabling it as root enables *root's* socket, which is not the one `--docker-host` names.
- **`XDG_RUNTIME_DIR` is supplied explicitly.** `systemctl --user` needs it and a non-interactive SSH session does not set it. The uid comes from a new `id -u` probe, also run as the operator.
- **Best-effort.** Rootless Podman works fine through the CLI without the socket, so a host that cannot enable it still completes the install, with a warning naming the manual command.

## Scope

This does not affect the normal Podman path, which is why a full lifecycle passed without it. `detect_runtime.yml` selects `podman-compose`/`podman` and everything downstream shells out to those binaries — no socket involved. A complete create/stop/start/delete on podman 5.4.2 ran with the socket inactive throughout. The gap is only on the `--docker-host` route.

## Tests

`tests/unit/test_install_podman_socket.py` asserts the task enables *and starts* the socket (`--now`, or it stays inactive until reboot), runs as the operator rather than root, supplies `XDG_RUNTIME_DIR` from the operator's uid, does not fail the install, and warns with the manual command when it cannot. A final test pins the uid probe to `become: false`, since root's uid would point `XDG_RUNTIME_DIR` at the wrong directory.

## Verified

```
make lint        All checks passed
make validate    87 commands, 69 playbooks, 161 examples
make test-unit   2335 passed
```

Found in a hands-on e2e of 4.15.0.

Fixes #1385
