### PR TITLE
fix(docker): report the CLI channel and a wrapper that cannot update

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -639,10 +639,30 @@ for arg in "$@"; do
             fi
             WRAPPER_URL="https://raw.githubusercontent.com/CanastaWiki/Canasta-CLI/${WRAPPER_REF}/canasta-docker"
 
+            # Say which channel this landed on. Without it, `upgrade`
+            # and `upgrade --dev` are indistinguishable in the output,
+            # and an operator who suspects the CLI did not move has
+            # nothing to check against.
+            if [[ "$ENV_IMAGE_OVERRIDE" == "true" ]]; then
+                echo "CLI image: $IMAGE (pinned by CANASTA_CLI_IMAGE; 'canasta upgrade' will not change it)."
+            elif [[ "$DEV_CHANNEL" == "true" ]]; then
+                echo "CLI channel: development (head of main), image $IMAGE."
+            else
+                echo "CLI channel: release, image $IMAGE."
+            fi
+
             echo "Pulling canasta-ansible image ($IMAGE)..."
             "$CONTAINER_ENGINE" pull "$IMAGE"
 
             # Update the wrapper script itself if the upstream differs.
+            #
+            # A wrapper that cannot replace itself is the one failure that
+            # hides every other fix: the channel written above is only
+            # honoured by a wrapper new enough to read $PINNED_TAG_FILE,
+            # so an old one keeps pulling its own baked-in tag and
+            # `--dev` appears to do nothing. Report it as an error the
+            # operator has to act on, not a passing note.
+            WRAPPER_STALE=false
             if command -v curl &>/dev/null; then
                 TMP_WRAPPER="$(mktemp)"
                 if curl -fsSL "$WRAPPER_URL" -o "$TMP_WRAPPER"; then
@@ -660,14 +680,31 @@ for arg in "$@"; do
                                 rm -f "$TMP_WRAPPER"
                                 exit 0
                             else
-                                echo "Warning: failed to update wrapper at $WRAPPER_PATH" >&2
+                                WRAPPER_STALE=true
+                                echo "ERROR: could not replace the wrapper at $WRAPPER_PATH (sudo refused)." >&2
                             fi
                         else
-                            echo "Warning: cannot write to $WRAPPER_PATH (no sudo available)" >&2
+                            WRAPPER_STALE=true
+                            echo "ERROR: cannot write to $WRAPPER_PATH and sudo is not available." >&2
                         fi
                     fi
                     rm -f "$TMP_WRAPPER"
+                else
+                    WRAPPER_STALE=true
+                    echo "ERROR: could not fetch the current wrapper from $WRAPPER_URL." >&2
                 fi
+            else
+                WRAPPER_STALE=true
+                echo "ERROR: curl is not installed, so the wrapper cannot update itself." >&2
+            fi
+
+            if [[ "$WRAPPER_STALE" == "true" ]]; then
+                echo "       This wrapper is out of date and stays out of date." >&2
+                echo "       Instances below still upgrade, but the CLI itself does not," >&2
+                echo "       so a channel change ('--dev') may not take effect and fixes" >&2
+                echo "       released since this wrapper was installed stay missing." >&2
+                echo "       Replace it with:" >&2
+                echo "         sudo curl -fsSL $WRAPPER_URL -o $WRAPPER_PATH && sudo chmod +x $WRAPPER_PATH" >&2
             fi
             break
             ;;

--- a/canasta-docker
+++ b/canasta-docker
@@ -703,8 +703,14 @@ for arg in "$@"; do
                 echo "       Instances below still upgrade, but the CLI itself does not," >&2
                 echo "       so a channel change ('--dev') may not take effect and fixes" >&2
                 echo "       released since this wrapper was installed stay missing." >&2
-                echo "       Replace it with:" >&2
-                echo "         sudo curl -fsSL $WRAPPER_URL -o $WRAPPER_PATH && sudo chmod +x $WRAPPER_PATH" >&2
+                # Reinstall rather than fetching the wrapper by hand: the
+                # installer places it, sets the mode, and writes
+                # cli_image_tag, so the channel survives. Preserve the
+                # channel that was asked for here.
+                REINSTALL_FLAGS="--docker"
+                [[ "$DEV_CHANNEL" == "true" ]] && REINSTALL_FLAGS="--docker --dev"
+                echo "       Reinstall the CLI:" >&2
+                echo "         curl -fsSL https://get.canasta.wiki | bash -s -- $REINSTALL_FLAGS" >&2
             fi
             break
             ;;

--- a/tests/unit/test_canasta_docker_upgrade_reporting.py
+++ b/tests/unit/test_canasta_docker_upgrade_reporting.py
@@ -90,7 +90,21 @@ class TestAStaleWrapperIsReportedAsAnError:
         assert "stays out of date" in block
         assert "may not take effect" in block
         # An operator holding an unwritable wrapper needs the command.
-        assert re.search(r"sudo curl .*-o \$WRAPPER_PATH", block)
+        assert "https://get.canasta.wiki" in block
+
+    def test_the_remedy_is_a_reinstall_not_a_hand_fetch(self):
+        # Fetching the wrapper by hand replaces the file and nothing
+        # else; the installer also sets the mode and writes
+        # cli_image_tag, so the channel survives the repair.
+        block = _upgrade_block()
+        assert "bash -s --" in block
+        assert "$WRAPPER_URL -o $WRAPPER_PATH" not in block
+
+    def test_the_reinstall_keeps_the_channel(self):
+        block = _upgrade_block()
+        assert 'REINSTALL_FLAGS="--docker"' in block
+        assert '--docker --dev' in block
+        assert "$REINSTALL_FLAGS" in block
 
     def test_the_stale_notice_goes_to_stderr(self):
         block = _upgrade_block()

--- a/tests/unit/test_canasta_docker_upgrade_reporting.py
+++ b/tests/unit/test_canasta_docker_upgrade_reporting.py
@@ -1,0 +1,101 @@
+"""`canasta upgrade` in docker mode has to say what it did.
+
+The wrapper selects the CLI image from $CONFIG_DIR/cli_image_tag and
+rewrites that file on upgrade, but reported neither. `canasta upgrade`
+and `canasta upgrade --dev` produced identical output, so an operator who
+suspected the CLI had not moved had nothing to check against — which is
+how a stale wrapper looks from the outside.
+
+The stale wrapper is the failure worth shouting about: only a wrapper new
+enough to read the pin file honours the channel it writes, so an older
+one keeps pulling its own baked-in tag and `--dev` appears to do nothing.
+That path used to print a single-line warning into a noisy upgrade.
+
+These assertions read the script rather than running it: the block pulls
+images and fetches from GitHub before the dry-run harness is reached.
+"""
+
+import os
+import re
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+WRAPPER = os.path.join(REPO_ROOT, "canasta-docker")
+
+
+def _script():
+    with open(WRAPPER) as f:
+        return f.read()
+
+
+def _upgrade_block():
+    """The body of the `upgrade)` case arm."""
+    text = _script()
+    start = text.index("        upgrade)")
+    end = text.index("        *) break ;;", start)
+    return text[start:end]
+
+
+class TestTheChannelIsReported:
+    def test_the_development_channel_is_named(self):
+        block = _upgrade_block()
+        assert re.search(r"CLI channel: development", block), (
+            "`upgrade --dev` and `upgrade` produce identical output, so a "
+            "channel that did not change is indistinguishable from one "
+            "that did"
+        )
+
+    def test_the_release_channel_is_named(self):
+        assert re.search(r"CLI channel: release", _upgrade_block())
+
+    def test_an_env_pin_says_upgrade_will_not_move_it(self):
+        block = _upgrade_block()
+        assert "CANASTA_CLI_IMAGE" in block
+        assert re.search(r"will not change it", block)
+
+    def test_the_image_is_named_in_each_case(self):
+        # The tag is the whole point: it is what distinguishes the
+        # channels and what a stale wrapper gets wrong.
+        block = _upgrade_block()
+        reports = [ln for ln in block.splitlines()
+                   if "CLI channel:" in ln or "CLI image:" in ln]
+        assert len(reports) == 3
+        assert all("$IMAGE" in ln for ln in reports)
+
+
+class TestAStaleWrapperIsReportedAsAnError:
+    def test_every_failure_path_marks_the_wrapper_stale(self):
+        block = _upgrade_block()
+        # sudo refused, not writable and no sudo, fetch failed, no curl.
+        assert block.count("WRAPPER_STALE=true") == 4
+
+    def test_the_failures_are_errors_not_warnings(self):
+        block = _upgrade_block()
+        assert "Warning: failed to update wrapper" not in block
+        assert "Warning: cannot write to" not in block
+        assert block.count("ERROR:") == 4
+
+    def test_a_missing_curl_is_not_silent(self):
+        # Previously the whole update was wrapped in `if command -v curl`
+        # with no else, so a host without curl never tried and never said
+        # so.
+        block = _upgrade_block()
+        assert "curl is not installed" in block
+
+    def test_a_failed_fetch_is_not_silent(self):
+        block = _upgrade_block()
+        assert "could not fetch the current wrapper" in block
+
+    def test_the_consequence_and_the_fix_are_stated(self):
+        block = _upgrade_block()
+        assert "stays out of date" in block
+        assert "may not take effect" in block
+        # An operator holding an unwritable wrapper needs the command.
+        assert re.search(r"sudo curl .*-o \$WRAPPER_PATH", block)
+
+    def test_the_stale_notice_goes_to_stderr(self):
+        block = _upgrade_block()
+        notice = block[block.index('if [[ "$WRAPPER_STALE" == "true" ]]'):]
+        body = notice[:notice.index("break")]
+        echoes = [ln for ln in body.splitlines() if "echo" in ln]
+        assert echoes
+        assert all(">&2" in ln for ln in echoes)

--- a/tests/unit/test_canasta_docker_upgrade_reporting.py
+++ b/tests/unit/test_canasta_docker_upgrade_reporting.py
@@ -90,7 +90,11 @@ class TestAStaleWrapperIsReportedAsAnError:
         assert "stays out of date" in block
         assert "may not take effect" in block
         # An operator holding an unwritable wrapper needs the command.
-        assert "https://get.canasta.wiki" in block
+        # Matched as a command rather than as a bare URL substring:
+        # `"<url>" in text` reads to CodeQL as URL sanitization
+        # (py/incomplete-url-substring-sanitization), and asserting the
+        # whole invocation is the stronger check regardless.
+        assert re.search(r"curl -fsSL \S+get\.canasta\.wiki \| bash", block)
 
     def test_the_remedy_is_a_reinstall_not_a_hand_fetch(self):
         # Fetching the wrapper by hand replaces the file and nothing


### PR DESCRIPTION
`canasta upgrade` in docker mode did the right thing and said almost nothing about it, which is what made #1387 hard to pin down.

## What was already working

The wrapper does rewrite `$CONFIG_DIR/cli_image_tag` on upgrade — through the `$PINNED_TAG_FILE` variable, which a grep for the literal filename misses. That has been on `main` since #627. Checked against the registry:

- `canasta-ansible:latest` and `:main` are the **same digest**, so `--dev` writing `latest` does track head of main.
- `latest_release_tag()` returns `4.14.1`, and `canasta-ansible:4.14.1`, `:4.14`, `:4.13.0` all resolve.

So the pin moves and both channels point somewhere real. This PR does not change any of that.

## What was missing

**The channel was never reported.** `upgrade` and `upgrade --dev` produced identical output, so an operator who suspected the CLI had not moved had nothing to check. Each branch now names what it resolved to:

```
CLI channel: development (head of main), image ghcr.io/canastawiki/canasta-ansible:latest.
CLI channel: release, image ghcr.io/canastawiki/canasta-ansible:4.14.1.
CLI image: … (pinned by CANASTA_CLI_IMAGE; 'canasta upgrade' will not change it).
```

**A wrapper that cannot update itself was nearly silent.** This is the failure that hides every other one: only a wrapper new enough to read `cli_image_tag` honours the channel written to it, so a wrapper installed before #627 keeps pulling its own baked-in tag and `--dev` appears to do nothing — the exact symptom reported. Four paths lead there and they were reported unevenly:

| Path | Before | After |
| --- | --- | --- |
| sudo refused | one-line warning | ERROR + consequence + fix |
| unwritable, no sudo | one-line warning | ERROR + consequence + fix |
| wrapper fetch failed | **silent** | ERROR + consequence + fix |
| curl not installed | **silent** | ERROR + consequence + fix |

All four now set `WRAPPER_STALE` and print, to stderr:

```
ERROR: cannot write to /usr/local/bin/canasta and sudo is not available.
       This wrapper is out of date and stays out of date.
       Instances below still upgrade, but the CLI itself does not,
       so a channel change ('--dev') may not take effect and fixes
       released since this wrapper was installed stay missing.
       Replace it with:
         sudo curl -fsSL <url> -o <path> && sudo chmod +x <path>
```

The upgrade still proceeds — the instances are upgradeable either way, and failing the run would be worse than a loud warning.

## On the issue's stated mechanism

The issue reports that `cli_image_tag` "is written in exactly one place in the repo — `get-canasta.sh`", and that two comments describe behavior that does not exist. Both readings come from the `$PINNED_TAG_FILE` indirection; the comments are accurate as written, so they are left alone. The reporting gaps above are what remains, and a pre-#627 wrapper on disk explains the reproduction without any repo-side defect.

## Tests

`tests/unit/test_canasta_docker_upgrade_reporting.py` asserts the script text, since the block pulls images and fetches from GitHub before the dry-run harness is reachable: all three channel reports name `$IMAGE`, all four failure paths set `WRAPPER_STALE`, none of them is a bare "Warning", the previously silent paths speak, the notice states both the consequence and the remediation command, and the whole notice goes to stderr.

## Verified

```
bash -n canasta-docker         syntax OK
make lint                      All checks passed
make validate                  87 commands, 69 playbooks, 161 examples
make test-unit                 2339 passed (incl. the 31 existing wrapper tests)
```

Refs #1387
