### PR TITLE
Port the 4.15.0 fixes to main

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -11,6 +11,7 @@ import shlex
 import ssl
 import subprocess
 import sys
+import time
 import urllib.parse
 import urllib.request
 
@@ -584,6 +585,153 @@ def _dump_compose_failure(inst, include_sidecars=False):
             )
         print("--- %s ---" % label, file=sys.stderr)
         print(output.strip() if output else "(empty)", file=sys.stderr)
+
+
+# Readiness gate after `up -d`. Mirrors roles/orchestrator/tasks/start.yml:
+# 60 x 10s = 10 min, comfortably above the CanastaBase healthcheck's 5 min
+# --start-period plus a slow first-time composer install. The Podman fallback
+# probe's 30 x 10s matches the --start-period alone.
+_WEB_HEALTH_RETRIES = 60
+_WEB_HEALTH_DELAY = 10
+_WEB_PROBE_RETRIES = 30
+_WEB_PROBE_DELAY = 10
+
+
+def _runtime_capture(inst, argv, timeout=30):
+    """Run a native runtime (docker/podman) command for an instance, on the
+    controller or over ssh. Returns (rc, stdout)."""
+    host = inst.get("host") or "localhost"
+    docker_host = inst.get("dockerHost")
+    if _is_localhost(host):
+        try:
+            result = subprocess.run(
+                argv, capture_output=True, text=True, timeout=timeout,
+                env=_docker_env(docker_host),
+            )
+            return result.returncode, result.stdout
+        except (subprocess.TimeoutExpired, OSError):
+            return 1, ""
+    cmd = " ".join(_shell_quote(a) for a in argv)
+    if docker_host:
+        cmd = "DOCKER_HOST=%s %s" % (_shell_quote(docker_host), cmd)
+    return _ssh_run(host, cmd)
+
+
+def _web_container_id(inst):
+    """The running web container's id, or "" when the stack is not up.
+
+    `ps` without -a lists only running containers. A daemon-level call, so
+    the project label — not cwd — is what keeps it from matching another
+    instance's web container.
+    """
+    runtime = _resolve_inspect_cmd(inst)
+    rc, out = _runtime_capture(inst, [
+        runtime, "ps",
+        "--filter", "label=com.docker.compose.project=%s"
+                    % _compose_project(inst.get("path", "")),
+        "--filter", "label=com.docker.compose.service=web",
+        "--format", "{{.ID}}",
+    ])
+    if rc != 0:
+        return ""
+    return out.strip().split("\n")[0].strip()
+
+
+def _web_health_status(inst, cid):
+    """The web container's health status, or "" when it reports none.
+
+    Runtimes disagree on what "no health data" looks like: Podman 4.9.3
+    reports a non-nil .State.Health whose Status is empty, older Podman omits
+    .State.Health entirely, and Docker reports a real status. So the probe
+    renders the status itself rather than testing the struct for presence —
+    an empty render means "nothing to wait on" on every runtime.
+    """
+    rc, out = _runtime_capture(inst, [
+        _resolve_inspect_cmd(inst), "inspect", "-f",
+        "{{if .State.Health}}{{.State.Health.Status}}{{end}}", cid,
+    ])
+    return out.strip() if rc == 0 else ""
+
+
+def _wait_web_ready(inst_id, inst):
+    """Block until the instance's web container is ready. Returns an exit code.
+
+    /run-all.sh in the canasta image runs `composer update` synchronously
+    before starting apache, so a `canasta maintenance` (or any other
+    `compose exec web php …`) issued the moment `up -d` returns races composer
+    and crashes on a half-written vendor/. The image's HEALTHCHECK probes
+    /server-status, which answers only once composer AND apache have finished
+    — so "healthy" is the right gate. An image that declares no healthcheck
+    defines its own readiness contract and is not waited on.
+    """
+    cid = _web_container_id(inst)
+    if not cid:
+        print(
+            "Error: started the containers, but no running 'web' container is "
+            "present for instance '%s'. The instance is not up — check "
+            "'canasta list' and the container logs on the host. On rootless "
+            "Podman this is usually lingering: without 'sudo loginctl "
+            "enable-linger <user>', systemd stops the containers as soon as "
+            "the session that started them ends." % inst_id,
+            file=sys.stderr,
+        )
+        return 1
+
+    status = _web_health_status(inst, cid)
+    if status:
+        for attempt in range(_WEB_HEALTH_RETRIES):
+            if status == "healthy":
+                return 0
+            if attempt == 0:
+                print("Waiting for web to become ready...")
+            time.sleep(_WEB_HEALTH_DELAY)
+            status = _web_health_status(inst, cid)
+        print(
+            "Error: the 'web' container for instance '%s' did not report "
+            "healthy within %d minutes; its last status was '%s'. The image's "
+            "healthcheck probes /server-status, which answers only once "
+            "composer and apache have both finished — so this usually means "
+            "composer is still running, or failed. Check the container logs."
+            % (inst_id, _WEB_HEALTH_RETRIES * _WEB_HEALTH_DELAY // 60,
+               status or "(none)"),
+            file=sys.stderr,
+        )
+        return 1
+
+    runtime = _resolve_inspect_cmd(inst)
+    if "podman" not in runtime:
+        return 0
+
+    # Podman renders an empty status for the stock image — the published
+    # image is OCI-format and podman ignores Healthcheck in an OCI config,
+    # and podman runs healthchecks from systemd transient timers that compose
+    # never creates. So ask the container the question the healthcheck would
+    # ask, which depends on nothing but `exec`. 127.0.0.1, not localhost:
+    # localhost resolves to ::1 first under rootless podman, and CanastaBase
+    # before 1.3.19 served /server-status only to 127.0.0.1.
+    #
+    # Best-effort on purpose: a custom image that never serves /server-status
+    # must not turn a missing signal into a failed start.
+    print("Waiting for web to become ready...")
+    for attempt in range(_WEB_PROBE_RETRIES):
+        rc, _out = _runtime_capture(inst, [
+            runtime, "exec", cid,
+            "wget", "-q", "--method=HEAD", "127.0.0.1/server-status",
+        ])
+        if rc == 0:
+            return 0
+        if attempt < _WEB_PROBE_RETRIES - 1:
+            time.sleep(_WEB_PROBE_DELAY)
+    print(
+        "web did not answer /server-status within %d minutes, so the "
+        "readiness gate is being skipped. A custom image that does not serve "
+        "/server-status is expected here. On the stock image this means web "
+        "is still starting, and a command that runs php in the container may "
+        "race composer."
+        % (_WEB_PROBE_RETRIES * _WEB_PROBE_DELAY // 60),
+        file=sys.stderr,
+    )
+    return 0
 
 
 def _k8s_namespace(instance_id):

--- a/direct_commands/doctor.py
+++ b/direct_commands/doctor.py
@@ -318,31 +318,15 @@ _SERVICE_PROFILE = {
 _SERVICE_PROFILE["db"] = "internal-db"
 
 
-_PROXIED_REQUEST_HEADERS = ("Cf-Connecting-Ip", "Cdn-Loop", "X-Forwarded-For")
-
-
-def _looks_proxied(cdn_evidence):
-    """True when the sampled access log says something is proxying in front.
-
-    cdn_evidence is (sampled, hits). A majority rather than a single hit: any
-    client can forge X-Forwarded-For, but a proxy sets these on everything it
-    forwards.
-    """
-    if not cdn_evidence:
-        return False
-    sampled, hits = cdn_evidence
-    return sampled > 0 and hits * 2 > sampled
-
-
 def _consistency_warnings(env, current_profiles, running_services, uses_cirrus,
-                          template_literals=None, cdn_evidence=None):
+                          template_literals=None):
     """Pure: warnings about config/runtime drift for a Compose instance.
 
     - COMPOSE_PROFILES that disagrees with what sync would derive from the
       flags + DB mode.
     - A container running under a profile that isn't active (unmanaged — a
       stop/start won't restore it).
-    - CrowdSec enabled behind a proxy with no CADDY_TRUSTED_PROXIES.
+    - CrowdSec enabled with no CADDY_TRUSTED_PROXIES.
     - CirrusSearch configured in settings while Elasticsearch is disabled.
     - any env.template literal that differs from .env (the durable gitops
       source and the live config have diverged; a pull would reset .env to it).
@@ -378,21 +362,17 @@ def _consistency_warnings(env, current_profiles, running_services, uses_cirrus,
             "unmanaged Elasticsearch; set CANASTA_ENABLE_ELASTICSEARCH=true")
 
     crowdsec_on = env.get("CANASTA_ENABLE_CROWDSEC", "").strip().lower() == "true"
-    if (crowdsec_on and not env.get("CADDY_TRUSTED_PROXIES", "").strip()
-            and _looks_proxied(cdn_evidence)):
-        sampled, hits = cdn_evidence
+    if crowdsec_on and not env.get("CADDY_TRUSTED_PROXIES", "").strip():
         warns.append(
-            "CrowdSec is enabled and %d of the last %d Caddy access-log "
-            "entries carry proxy headers (%s), but CADDY_TRUSTED_PROXIES is "
-            "unset — CrowdSec sees only the proxy's addresses, so its "
-            "scenarios cannot identify a real client and any ban it issues "
-            "lands on a shared edge node and blocks every visitor behind it. "
-            "Set it to the provider in front of this instance: 'canasta "
-            "config set CADDY_TRUSTED_PROXIES=cloudflare' (or imperva, or a "
-            "comma-separated CIDR list for any other proxy). Leave it unset "
-            "if Caddy really is the edge — trusting the header "
-            "unconditionally would let any client forge its own source IP"
-            % (hits, sampled, ", ".join(_PROXIED_REQUEST_HEADERS)))
+            "CrowdSec is enabled, but CADDY_TRUSTED_PROXIES is not set. If "
+            "this instance runs behind a proxy such as Cloudflare or Imperva, "
+            "set it — otherwise CrowdSec sees only the proxy's addresses, so "
+            "its scenarios cannot identify a real client and any ban it "
+            "issues lands on a shared edge node and blocks every visitor "
+            "behind it: 'canasta config set CADDY_TRUSTED_PROXIES=cloudflare' "
+            "(or imperva, or a comma-separated CIDR list for any other "
+            "proxy). Leave it unset if Caddy is the edge — trusting the "
+            "header then would let any client forge its own source IP")
 
     drifted = sorted(
         k for k, tv in (template_literals or {}).items()
@@ -411,17 +391,11 @@ def _consistency_warnings(env, current_profiles, running_services, uses_cirrus,
     return warns
 
 
-# Read through the caddy container: the access log lives in a named volume.
-_ACCESS_LOG_SAMPLE = 200
-
-
 def _gather_runtime(path, host, inst=None):
-    """(running_services, uses_cirrus, env_template_literals, cdn_evidence) for
-    an instance, localhost or remote. env_template_literals maps each KEY to the
-    literal value pinned in env.template, excluding placeholder (KEY={{...}})
-    lines and comments; empty when not gitops / no env.template. cdn_evidence is
-    (sampled, hits) over the tail of the Caddy access log, (0, 0) when it can't
-    be read."""
+    """(running_services, uses_cirrus, env_template_literals) for an instance,
+    localhost or remote. env_template_literals maps each KEY to the literal
+    value pinned in env.template, excluding placeholder (KEY={{...}}) lines and
+    comments; empty when not gitops / no env.template."""
     d = _helpers._SENTINEL
     qpath = _helpers._shell_quote(path)
     compose_cmd = _helpers._resolve_compose_cmd(inst or {"path": path})
@@ -434,18 +408,8 @@ def _gather_runtime(path, host, inst=None):
         "&& echo USES_CIRRUS || echo NO_CIRRUS; "
         "echo '%(d)s'; "
         "grep -E '^[A-Za-z_][A-Za-z0-9_]*=' %(p)s/env.template 2>/dev/null "
-        "| grep -v '={{'; "
-        "echo '%(d)s'; "
-        "_al=$(%(c)s exec -T caddy tail -n %(n)d /var/log/caddy/access.log "
-        "2>/dev/null); "
-        "printf '%%s %%s\\n' "
-        "\"$(printf '%%s' \"$_al\" | grep -c . )\" "
-        "\"$(printf '%%s' \"$_al\" | grep -Ec '%(h)s')\""
-    ) % {
-        "p": qpath, "d": d, "c": compose_str,
-        "n": _ACCESS_LOG_SAMPLE,
-        "h": "|".join(_PROXIED_REQUEST_HEADERS),
-    }
+        "| grep -v '={{'"
+    ) % {"p": qpath, "d": d, "c": compose_str}
     if _helpers._is_localhost(host):
         try:
             out = subprocess.run(
@@ -453,11 +417,11 @@ def _gather_runtime(path, host, inst=None):
                 capture_output=True, text=True, timeout=30,
             ).stdout
         except (subprocess.TimeoutExpired, OSError):
-            return [], False, {}, (0, 0)
+            return [], False, {}
     else:
         rc, out = _helpers._ssh_run(host, script)
         if rc != 0 and not out.strip():
-            return [], False, {}, (0, 0)
+            return [], False, {}
     parts = out.split(d + "\n")
     head = parts[0].strip() if parts else ""
     running = [s for s in head.split("\n") if s.strip()]
@@ -473,15 +437,7 @@ def _gather_runtime(path, host, inst=None):
             if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
                 val = val[1:-1]
             template_literals[key.strip()] = val
-    cdn_evidence = (0, 0)
-    if len(parts) > 3:
-        fields = parts[3].strip().split()
-        if len(fields) == 2:
-            try:
-                cdn_evidence = (int(fields[0]), int(fields[1]))
-            except ValueError:
-                pass
-    return running, uses_cirrus, template_literals, cdn_evidence
+    return running, uses_cirrus, template_literals
 
 
 def _instance_consistency_lines(inst):
@@ -505,10 +461,9 @@ def _instance_consistency_lines(inst):
         p.strip() for p in env.get("COMPOSE_PROFILES", "").split(",")
         if p.strip()
     ]
-    running, uses_cirrus, template_literals, cdn_evidence = _gather_runtime(
-        path, host, inst)
+    running, uses_cirrus, template_literals = _gather_runtime(path, host, inst)
     warns = _consistency_warnings(
-        env, current, running, uses_cirrus, template_literals, cdn_evidence)
+        env, current, running, uses_cirrus, template_literals)
     lines = ["", "Instance consistency (%s):" % inst.get("id", "?")]
     if warns:
         lines += ["  WARN: %s" % w for w in warns]

--- a/direct_commands/lifecycle.py
+++ b/direct_commands/lifecycle.py
@@ -35,7 +35,8 @@ def cmd_start(args):
     rc = _helpers._run_compose(inst_id, inst, ["up", "-d"])
     if rc != 0:
         _helpers._dump_compose_failure(inst)
-    return rc
+        return rc
+    return _helpers._wait_web_ready(inst_id, inst)
 
 
 @register("stop")
@@ -84,7 +85,9 @@ def cmd_restart(args):
     rc = _helpers._run_compose(inst_id, inst, ["up", "-d"])
     if rc != 0:
         _helpers._dump_compose_failure(inst)
-    return rc
+        return rc
+    return _helpers._wait_web_ready(inst_id, inst)
+
 
 _SCALE_SUPPORTED_COMPONENTS = ("web",)
 

--- a/direct_commands/rebuild.py
+++ b/direct_commands/rebuild.py
@@ -152,4 +152,5 @@ def cmd_rebuild(args):
         inst_id, inst, ["up", "-d"], include_sidecars=has_sidecars)
     if rc != 0:
         _helpers._dump_compose_failure(inst, include_sidecars=has_sidecars)
-    return rc
+        return rc
+    return _helpers._wait_web_ready(inst_id, inst)

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -501,6 +501,10 @@ commands:
       automatically. Use `canasta devmode enable` or `canasta devmode
       disable` to toggle development mode; use `canasta config set
       <FLAG>=true|false` to adjust the optional components.
+
+      The command returns once the web container reports healthy, so a
+      command run immediately afterward does not race the image's
+      startup. An image that declares no healthcheck is not waited on.
     examples:
       - "canasta start"
     playbook: start.yml
@@ -532,7 +536,8 @@ commands:
       Docker containers. Any pending configuration migrations are
       applied during the restart. Use `canasta devmode enable` or
       `canasta devmode disable` to change the development mode
-      setting.
+      setting. The command returns once the web container reports
+      healthy.
     examples:
       - "canasta restart"
     playbook: restart.yml
@@ -578,7 +583,8 @@ commands:
       Rebuild every service that has a `build:` directive in the
       merged compose config (docker-compose.override.yml or
       docker-compose.dev.yml) and restart the instance to pick up
-      the rebuilt image.
+      the rebuilt image. The command returns once the web container
+      reports healthy.
 
       Use this after editing a custom Dockerfile, or after changing
       the base CANASTA_IMAGE when you want to refresh a layered

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -709,7 +709,7 @@ commands:
       When an instance is resolved (from -i, or from the current
       directory), also checks that instance: config and runtime
       agreement, whether local config edits have been applied, whether
-      CrowdSec is enabled behind a proxy with no CADDY_TRUSTED_PROXIES,
+      CrowdSec is enabled with no CADDY_TRUSTED_PROXIES set,
       and the certificate the origin is actually serving (expired, or
       silently reissued by Caddy's internal CA after ACME failed).
     examples:

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1578,6 +1578,8 @@ class TestLifecycleCommands:
             direct_commands._helpers, "_sync_compose_profiles", lambda inst: None)
         monkeypatch.setattr(
             direct_commands._helpers, "_run_compose", lambda *a, **kw: 0)
+        monkeypatch.setattr(
+            direct_commands._helpers, "_wait_web_ready", lambda i, inst: 0)
         args = type("Args", (), {"id": "scsite"})()
         assert direct_commands.cmd_start(args) == 0
 
@@ -1598,6 +1600,8 @@ class TestLifecycleCommands:
         monkeypatch.setattr(direct_commands._helpers, "_compose_file_args",
             lambda *a, **kw: ["-f", "docker-compose.yml"],
         )
+        monkeypatch.setattr(direct_commands._helpers, "_wait_web_ready",
+            lambda i, inst: 0)
 
         args = type("Args", (), {"id": "test"})()
         rc = direct_commands.cmd_start(args)
@@ -1649,6 +1653,9 @@ class TestLifecycleCommands:
             lambda *a, **kw: ["-f", "docker-compose.yml"],
         )
 
+        monkeypatch.setattr(direct_commands._helpers, "_wait_web_ready",
+            lambda i, inst: 0)
+
         args = type("Args", (), {"id": "test"})()
         rc = direct_commands.cmd_restart(args)
         assert rc == 0
@@ -1693,10 +1700,12 @@ class TestLifecycleCommands:
             lambda inst: events.append("sync"))
         monkeypatch.setattr(direct_commands._helpers, "_run_compose",
             lambda inst_id, inst, action: events.append(action[0]) or 0)
+        monkeypatch.setattr(direct_commands._helpers, "_wait_web_ready",
+            lambda i, inst: events.append("wait") or 0)
         args = type("Args", (), {"id": "test"})()
         rc = direct_commands.cmd_restart(args)
         assert rc == 0
-        assert events == ["sync", "down", "up"]
+        assert events == ["sync", "down", "up", "wait"]
 
     def test_stop_syncs_profiles_before_down(self, monkeypatch):
         # Standalone stop reconciles too, so `down` tears down the full
@@ -1739,6 +1748,8 @@ class TestLifecycleCommands:
         monkeypatch.setattr(direct_commands._helpers, "_compose_file_args",
             lambda *a, **kw: ["-f", "docker-compose.yml"],
         )
+        monkeypatch.setattr(direct_commands._helpers, "_wait_web_ready",
+            lambda i, inst: 0)
 
         args = type("Args", (), {"id": "test"})()
         rc = direct_commands.cmd_start(args)

--- a/tests/unit/test_doctor_consistency.py
+++ b/tests/unit/test_doctor_consistency.py
@@ -20,6 +20,7 @@ class TestConsistencyWarnings:
         env = {
             "CANASTA_ENABLE_ELASTICSEARCH": "true",
             "CANASTA_ENABLE_CROWDSEC": "true",
+            "CADDY_TRUSTED_PROXIES": "cloudflare",
             "COMPOSE_PROFILES": "internal-db,varnish,crowdsec,elasticsearch",
         }
         profiles = ["internal-db", "varnish", "crowdsec", "elasticsearch"]
@@ -32,6 +33,7 @@ class TestConsistencyWarnings:
         env = {
             "CANASTA_ENABLE_ELASTICSEARCH": "false",
             "CANASTA_ENABLE_CROWDSEC": "true",
+            "CADDY_TRUSTED_PROXIES": "cloudflare",
             "COMPOSE_PROFILES": "varnish,crowdsec",
         }
         profiles = ["varnish", "crowdsec"]
@@ -54,6 +56,7 @@ class TestConsistencyWarnings:
         env = {
             "USE_EXTERNAL_DB": "true",
             "CANASTA_ENABLE_CROWDSEC": "true",
+            "CADDY_TRUSTED_PROXIES": "cloudflare",
             "COMPOSE_PROFILES": "varnish,crowdsec",
         }
         out = _w(env, ["varnish", "crowdsec"], ["web", "varnish", "crowdsec"], False)
@@ -125,7 +128,7 @@ class TestGatherRuntime:
 
         monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
         monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _R())
-        running, cirrus, lits, cdn = doctor._gather_runtime("/srv/x", "localhost")
+        running, cirrus, lits = doctor._gather_runtime("/srv/x", "localhost")
         assert running == ["web", "varnish", "db"]
         assert cirrus is True
         assert lits["CANASTA_IMAGE"] == "ghcr.io/canastawiki/canasta:3.5.1"
@@ -140,7 +143,7 @@ class TestGatherRuntime:
 
         monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
         monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _R())
-        running, cirrus, lits, cdn = doctor._gather_runtime("/srv/x", "localhost")
+        running, cirrus, lits = doctor._gather_runtime("/srv/x", "localhost")
         assert running == ["web"]
         assert cirrus is False
         assert lits == {}
@@ -161,7 +164,7 @@ class TestInstanceConsistencyLines:
                                "COMPOSE_PROFILES=varnish\n")
         monkeypatch.setattr(
             doctor, "_gather_runtime",
-            lambda path, host, inst=None: (["web", "varnish", "db"], True, {}, (0, 0)))
+            lambda path, host, inst=None: (["web", "varnish", "db"], True, {}))
         lines = doctor._instance_consistency_lines(inst)
         assert lines[1] == "Instance consistency (site):"
         body = " ".join(lines)
@@ -176,11 +179,12 @@ class TestInstanceConsistencyLines:
         monkeypatch.setattr(
             doctor._helpers, "_read_env_content",
             lambda path, host: "CANASTA_ENABLE_CROWDSEC=true\n"
+                               "CADDY_TRUSTED_PROXIES=cloudflare\n"
                                "COMPOSE_PROFILES=internal-db,varnish,crowdsec\n")
         monkeypatch.setattr(
             doctor, "_gather_runtime",
             lambda path, host, inst=None: (
-                ["web", "varnish", "crowdsec", "db"], False, {}, (0, 0)))
+                ["web", "varnish", "crowdsec", "db"], False, {}))
         lines = doctor._instance_consistency_lines(inst)
         assert any("OK (" in line for line in lines)
 
@@ -196,8 +200,7 @@ class TestInstanceConsistencyLines:
             doctor, "_gather_runtime",
             lambda path, host, inst=None: (["web", "varnish", "db"], False,
                                 {"CANASTA_IMAGE":
-                                 "ghcr.io/canastawiki/canasta:3.5.1"},
-                                (0, 0)))
+                                 "ghcr.io/canastawiki/canasta:3.5.1"}))
         body = " ".join(doctor._instance_consistency_lines(inst))
         assert "env.template disagrees with .env" in body
         assert "3.5.1" in body and "3.5.12" in body
@@ -216,14 +219,14 @@ class TestInstanceConsistencyLines:
         monkeypatch.setattr(
             doctor, "_gather_runtime",
             lambda path, host, inst=None: (
-                ["web", "db"], False, {"HTTP_PORT": "80"}, (0, 0)))
+                ["web", "db"], False, {"HTTP_PORT": "80"}))
         body = " ".join(doctor._instance_consistency_lines(inst))
         assert "env.template disagrees with .env" in body
         assert "canasta reconcile" in body
         assert "names its own fix" in body
 
 
-class TestCrowdSecBehindCdn:
+class TestCrowdSecTrustedProxies:
     ENV = {
         "CANASTA_ENABLE_CROWDSEC": "true",
         "COMPOSE_PROFILES": "internal-db,varnish,crowdsec",
@@ -231,75 +234,28 @@ class TestCrowdSecBehindCdn:
     PROFILES = ["internal-db", "varnish", "crowdsec"]
     RUNNING = ["web", "caddy", "varnish", "crowdsec", "db"]
 
-    def _warns(self, env=None, cdn_evidence=None):
+    def _warns(self, env=None):
         return doctor._consistency_warnings(
-            env or dict(self.ENV), self.PROFILES, self.RUNNING, False,
-            None, cdn_evidence)
+            env or dict(self.ENV), self.PROFILES, self.RUNNING, False, None)
 
-    def test_warns_when_proxied_and_unset(self):
-        out = self._warns(cdn_evidence=(200, 200))
+    def test_warns_when_crowdsec_is_on_and_trusted_proxies_is_unset(self):
+        out = self._warns()
         assert len(out) == 1
-        assert "CADDY_TRUSTED_PROXIES is unset" in out[0]
-        assert "200 of the last 200" in out[0]
+        assert "CADDY_TRUSTED_PROXIES is not set" in out[0]
+        assert "Cloudflare or Imperva" in out[0]
         assert "canasta config set CADDY_TRUSTED_PROXIES=cloudflare" in out[0]
 
     def test_quiet_when_trusted_proxies_is_set(self):
-        env = dict(self.ENV, CADDY_TRUSTED_PROXIES="cloudflare")
-        assert self._warns(env, cdn_evidence=(200, 200)) == []
+        assert self._warns(dict(self.ENV, CADDY_TRUSTED_PROXIES="cloudflare")) == []
+        assert self._warns(dict(self.ENV, CADDY_TRUSTED_PROXIES="10.0.0.0/8")) == []
 
-    def test_quiet_on_a_direct_edge_facing_instance(self):
-        assert self._warns(cdn_evidence=(200, 0)) == []
+    def test_a_blank_value_still_warns(self):
+        assert self._warns(dict(self.ENV, CADDY_TRUSTED_PROXIES="   ")) != []
 
     def test_quiet_when_crowdsec_is_disabled(self):
         env = {"CANASTA_ENABLE_CROWDSEC": "false",
                "COMPOSE_PROFILES": "internal-db,varnish"}
         out = doctor._consistency_warnings(
             env, ["internal-db", "varnish"], ["web", "caddy", "varnish", "db"],
-            False, None, (200, 200))
+            False, None)
         assert out == []
-
-    def test_a_forged_header_on_one_request_is_not_enough(self):
-        assert self._warns(cdn_evidence=(200, 1)) == []
-        assert self._warns(cdn_evidence=(200, 100)) == []   # exactly half
-        assert self._warns(cdn_evidence=(200, 101)) != []   # a majority
-
-    def test_quiet_when_the_access_log_is_unreadable(self):
-        assert self._warns(cdn_evidence=(0, 0)) == []
-        assert self._warns(cdn_evidence=None) == []
-
-
-class TestGatherRuntimeCdnEvidence:
-    def test_parses_the_sampled_counts(self, monkeypatch):
-        d = doctor._helpers._SENTINEL
-        out = "web\n%s\nNO_CIRRUS\n%s\n\n%s\n200 187\n" % (d, d, d)
-
-        class _R:
-            stdout = out
-
-        monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
-        monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _R())
-        assert doctor._gather_runtime("/srv/x", "localhost")[3] == (200, 187)
-
-    def test_missing_or_malformed_counts_are_no_evidence(self, monkeypatch):
-        d = doctor._helpers._SENTINEL
-
-        class _R:
-            stdout = "web\n%s\nNO_CIRRUS\n%s\n\n%s\nnope\n" % (d, d, d)
-
-        monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
-        monkeypatch.setattr(doctor.subprocess, "run", lambda *a, **k: _R())
-        assert doctor._gather_runtime("/srv/x", "localhost")[3] == (0, 0)
-
-    def test_samples_the_caddy_access_log(self, monkeypatch):
-        seen = {}
-
-        class _R:
-            stdout = ""
-
-        monkeypatch.setattr(doctor._helpers, "_is_localhost", lambda h: True)
-        monkeypatch.setattr(
-            doctor.subprocess, "run",
-            lambda *a, **k: (seen.update(script=a[0][2]) or _R()))
-        doctor._gather_runtime("/srv/x", "localhost")
-        assert "exec -T caddy tail -n 200 /var/log/caddy/access.log" in seen["script"]
-        assert "Cf-Connecting-Ip|Cdn-Loop|X-Forwarded-For" in seen["script"]

--- a/tests/unit/test_rebuild.py
+++ b/tests/unit/test_rebuild.py
@@ -84,6 +84,9 @@ class TestRebuildBuildAndRestart:
         monkeypatch.setattr(direct_commands._helpers, "_sync_compose_profiles",
             lambda inst: None,
         )
+        monkeypatch.setattr(direct_commands._helpers, "_wait_web_ready",
+            lambda i, inst: 0,
+        )
 
         rc = direct_commands.cmd_rebuild(_args())
         assert rc == 0
@@ -145,6 +148,44 @@ class TestRebuildBuildAndRestart:
         assert "--no-restart" in out
         assert "canasta restart" in out
 
+    def test_waits_for_web_after_the_restart(self, monkeypatch):
+        # A rebuild replaces the image, so the restart it drives is the case
+        # where composer runs longest — returning before web is ready is
+        # exactly when a follow-up command races it.
+        _patch_compose_inst(monkeypatch)
+        monkeypatch.setattr(direct_commands.rebuild, "_list_buildable_services",
+            lambda inst, include_sidecars=False: ["web"],
+        )
+        events = []
+        monkeypatch.setattr(direct_commands._helpers, "_run_compose",
+            lambda inst_id, inst, action, include_sidecars=False:
+                events.append(action[0]) or 0,
+        )
+        monkeypatch.setattr(direct_commands._helpers, "_sync_compose_profiles",
+            lambda inst: None,
+        )
+        monkeypatch.setattr(direct_commands._helpers, "_wait_web_ready",
+            lambda i, inst: events.append("wait") or 1,
+        )
+        assert direct_commands.cmd_rebuild(_args()) == 1
+        assert events == ["build", "down", "up", "wait"]
+
+    def test_no_restart_does_not_wait(self, monkeypatch):
+        _patch_compose_inst(monkeypatch)
+        monkeypatch.setattr(direct_commands.rebuild, "_list_buildable_services",
+            lambda inst, include_sidecars=False: ["web"],
+        )
+        events = []
+        monkeypatch.setattr(direct_commands._helpers, "_run_compose",
+            lambda inst_id, inst, action, include_sidecars=False:
+                events.append(action[0]) or 0,
+        )
+        monkeypatch.setattr(direct_commands._helpers, "_wait_web_ready",
+            lambda i, inst: events.append("wait") or 0,
+        )
+        assert direct_commands.cmd_rebuild(_args(no_restart=True)) == 0
+        assert events == ["build"]
+
     def test_build_failure_skips_restart_and_returns_code(self, monkeypatch):
         _patch_compose_inst(monkeypatch)
         monkeypatch.setattr(direct_commands.rebuild, "_list_buildable_services",
@@ -201,6 +242,8 @@ class TestRebuildSidecars:
             direct_commands._helpers, "_run_compose", fake_run_compose)
         monkeypatch.setattr(
             direct_commands._helpers, "_sync_compose_profiles", lambda inst: None)
+        monkeypatch.setattr(
+            direct_commands._helpers, "_wait_web_ready", lambda i, inst: 0)
         rc = direct_commands.cmd_rebuild(_args())
         return rc, listed, calls
 

--- a/tests/unit/test_start_readiness_gate.py
+++ b/tests/unit/test_start_readiness_gate.py
@@ -1,0 +1,195 @@
+"""Tests for the Compose fast path's readiness gate.
+
+`canasta start` used to return the moment `docker compose up -d` exited, while
+the Ansible path waited for the web container to report healthy. Anything that
+runs php in the container right after start — `canasta maintenance`,
+install.php — then raced the image's synchronous `composer update` and crashed
+on a half-written vendor/. These tests pin the fast path to the same contract
+as roles/orchestrator/tasks/start.yml.
+"""
+
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+sys.path.insert(0, REPO_ROOT)
+
+import direct_commands  # noqa: E402
+from direct_commands import _helpers  # noqa: E402
+
+
+DOCKER = {"path": "/srv/test", "orchestrator": "compose"}
+PODMAN = {"path": "/srv/test", "orchestrator": "compose",
+          "composeCommand": "podman-compose", "inspectCommand": "podman"}
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    """Record the waits instead of taking them."""
+    slept = []
+    monkeypatch.setattr(_helpers.time, "sleep", lambda s: slept.append(s))
+    return slept
+
+
+def _runtime(monkeypatch, responses):
+    """Stub _runtime_capture with a queue of (rc, stdout) per call, replaying
+    the last entry once exhausted. Returns the list of argv seen."""
+    seen = []
+    queue = list(responses)
+
+    def fake(inst, argv, timeout=30):
+        seen.append(argv)
+        return queue.pop(0) if len(queue) > 1 else queue[0]
+
+    monkeypatch.setattr(_helpers, "_runtime_capture", fake)
+    return seen
+
+
+class TestWaitWebReady:
+    def test_returns_immediately_when_already_healthy(self, monkeypatch,
+                                                      no_sleep):
+        _runtime(monkeypatch, [(0, "abc123\n"), (0, "healthy\n")])
+        assert _helpers._wait_web_ready("test", dict(DOCKER)) == 0
+        assert no_sleep == []
+
+    def test_waits_while_starting_then_passes(self, monkeypatch, no_sleep):
+        _runtime(monkeypatch, [
+            (0, "abc123\n"),
+            (0, "starting\n"),
+            (0, "starting\n"),
+            (0, "healthy\n"),
+        ])
+        assert _helpers._wait_web_ready("test", dict(DOCKER)) == 0
+        assert no_sleep == [_helpers._WEB_HEALTH_DELAY] * 2
+
+    def test_fails_and_names_the_last_status_on_timeout(self, monkeypatch,
+                                                        no_sleep, capsys):
+        _runtime(monkeypatch, [(0, "abc123\n"), (0, "starting\n")])
+        assert _helpers._wait_web_ready("test", dict(DOCKER)) == 1
+        err = capsys.readouterr().err
+        assert "did not report healthy" in err
+        assert "'starting'" in err
+        assert len(no_sleep) == _helpers._WEB_HEALTH_RETRIES
+
+    def test_no_healthcheck_on_docker_is_not_waited_on(self, monkeypatch,
+                                                       no_sleep):
+        # A custom image that declares no HEALTHCHECK defines its own
+        # readiness contract; waiting on a signal it never emits would hang.
+        _runtime(monkeypatch, [(0, "abc123\n"), (0, "\n")])
+        assert _helpers._wait_web_ready("test", dict(DOCKER)) == 0
+        assert no_sleep == []
+
+    def test_fails_when_no_web_container_is_running(self, monkeypatch, capsys):
+        # `up -d` exiting 0 does not prove the stack is up: with rootless
+        # podman and no lingering, systemd kills the containers as the ssh
+        # session ends. Without this the gate would just be skipped.
+        _runtime(monkeypatch, [(0, "\n")])
+        assert _helpers._wait_web_ready("test", dict(DOCKER)) == 1
+        err = capsys.readouterr().err
+        assert "no running 'web' container" in err
+        assert "enable-linger" in err
+
+    def test_probes_server_status_on_podman(self, monkeypatch, no_sleep):
+        # Podman renders an empty health status for the stock (OCI) image, so
+        # ask the container the question the healthcheck would ask.
+        seen = _runtime(monkeypatch, [
+            (0, "abc123\n"),
+            (0, "\n"),
+            (1, ""),
+            (0, ""),
+        ])
+        assert _helpers._wait_web_ready("test", dict(PODMAN)) == 0
+        probe = seen[-1]
+        assert probe[:3] == ["podman", "exec", "abc123"]
+        assert "127.0.0.1/server-status" in probe
+
+    def test_podman_probe_is_best_effort(self, monkeypatch, no_sleep, capsys):
+        # An image that never serves /server-status must not turn a missing
+        # signal into a failed start.
+        _runtime(monkeypatch, [(0, "abc123\n"), (0, "\n"), (1, "")])
+        assert _helpers._wait_web_ready("test", dict(PODMAN)) == 0
+        assert "did not answer /server-status" in capsys.readouterr().err
+
+    def test_container_lookup_is_scoped_to_the_instance_project(
+            self, monkeypatch, no_sleep):
+        seen = _runtime(monkeypatch, [(0, "abc123\n"), (0, "healthy\n")])
+        _helpers._wait_web_ready("test", dict(DOCKER))
+        ps = seen[0]
+        assert "label=com.docker.compose.project=test" in ps
+        assert "label=com.docker.compose.service=web" in ps
+
+
+class TestRuntimeCapture:
+    def test_remote_probe_goes_over_ssh(self, monkeypatch):
+        calls = []
+
+        def fake_ssh(host, cmd):
+            calls.append((host, cmd))
+            return 0, "healthy\n"
+
+        monkeypatch.setattr(_helpers, "_ssh_run", fake_ssh)
+        rc, out = _helpers._runtime_capture(
+            dict(DOCKER, host="admin@remote"), ["docker", "ps"])
+        assert (rc, out.strip()) == (0, "healthy")
+        assert calls[0][0] == "admin@remote"
+        assert "docker" in calls[0][1]
+
+    def test_remote_probe_carries_the_instances_docker_host(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            _helpers, "_ssh_run",
+            lambda host, cmd: (calls.append(cmd), (0, ""))[1])
+        _helpers._runtime_capture(
+            dict(DOCKER, host="admin@remote",
+                 dockerHost="unix:///run/user/1000/docker.sock"),
+            ["docker", "ps"])
+        assert calls[0].startswith("DOCKER_HOST=")
+
+
+class TestLifecycleGating:
+    """start/restart return the gate's verdict, and only after a clean `up`."""
+
+    def _inst(self, monkeypatch, events):
+        monkeypatch.setattr(
+            _helpers, "_resolve_instance", lambda args: ("test", dict(DOCKER)))
+        monkeypatch.setattr(_helpers, "_sync_compose_profiles",
+                            lambda inst: None)
+        monkeypatch.setattr(
+            _helpers, "_run_compose",
+            lambda inst_id, inst, action: events.append(action[0]) or 0)
+        return type("Args", (), {"id": "test"})()
+
+    def test_start_returns_the_gates_failure(self, monkeypatch):
+        events = []
+        args = self._inst(monkeypatch, events)
+        monkeypatch.setattr(_helpers, "_wait_web_ready",
+                            lambda i, inst: events.append("wait") or 1)
+        assert direct_commands.cmd_start(args) == 1
+        assert events == ["up", "wait"]
+
+    def test_start_does_not_wait_when_up_failed(self, monkeypatch):
+        events = []
+        monkeypatch.setattr(
+            _helpers, "_resolve_instance", lambda args: ("test", dict(DOCKER)))
+        monkeypatch.setattr(_helpers, "_sync_compose_profiles",
+                            lambda inst: None)
+        monkeypatch.setattr(_helpers, "_run_compose",
+                            lambda inst_id, inst, action: 1)
+        monkeypatch.setattr(_helpers, "_dump_compose_failure",
+                            lambda inst, **kw: events.append("dump"))
+        monkeypatch.setattr(_helpers, "_wait_web_ready",
+                            lambda i, inst: events.append("wait") or 0)
+        args = type("Args", (), {"id": "test"})()
+        assert direct_commands.cmd_start(args) == 1
+        assert events == ["dump"]
+
+    def test_restart_waits_too(self, monkeypatch):
+        # The Ansible restart path includes start.yml, gate and all.
+        events = []
+        args = self._inst(monkeypatch, events)
+        monkeypatch.setattr(_helpers, "_wait_web_ready",
+                            lambda i, inst: events.append("wait") or 0)
+        assert direct_commands.cmd_restart(args) == 0
+        assert events == ["down", "up", "wait"]


### PR DESCRIPTION
#1383 and #1386 were opened against `release/4.15.0` rather than `main`, so the fixes for #1381 and #1382 exist only on the release branch. `main` has been missing both since they merged.

That matters now rather than at release time: work is in flight against `main` that rewrites `cmd_start` — the same function #1386 changed — with no way to see #1386 exists. A change developed against today's `main` can regress a fix that has already shipped in the release.

## What this carries

Both commits, cherry-picked with their original messages and authorship:

| Commit | Fixes | Effect |
| --- | --- | --- |
| `#1383` | #1381 | `doctor` warns on CrowdSec without `CADDY_TRUSTED_PROXIES` instead of inferring a proxy from access-log headers a scanner can forge |
| `#1386` | #1382 | `canasta start` waits for web to be ready on the Compose fast path |

## What it deliberately leaves out

The `RELEASE_NOTES.md` hunk from each. Both edited the 4.15.0 entry, which does not exist on `main` — that line belongs to the release commit. `RELEASE_NOTES.md` here is byte-identical to `main`.

## Effect on the release PR

This is the shape the release was meant to have. Once #1379 is rebased onto `main`, its two fix commits become empty and drop out, leaving it carrying only release mechanics — `VERSION`, `CANASTA_VERSION`, and the release note — which is what the 3.5.19/4.14.0 precedent does and what #1379's own body already claims.

No cherry-pick markers, no conflicts carried over; the only resolution was dropping the release-note hunk.

## Verified

```
make lint        All checks passed
make validate    87 commands, 69 playbooks, 161 examples
make test-unit   2363 passed
```

The count rises from 2339 because the ported commits bring `tests/unit/test_start_readiness_gate.py` and `tests/unit/test_rebuild.py` with them.

Refs #1381, #1382
