### PR TITLE
docs(installer): describe --dev and --prefix as the parser treats them

### DIFF
--- a/get-canasta.sh
+++ b/get-canasta.sh
@@ -9,17 +9,20 @@
 # Usage:
 #   curl -fsSL https://get.canasta.wiki | bash
 #   curl -fsSL https://get.canasta.wiki | bash -s -- --native
-#   curl -fsSL https://get.canasta.wiki | bash -s -- --docker
-#   curl -fsSL https://get.canasta.wiki | bash -s -- --dev
+#   curl -fsSL https://get.canasta.wiki | bash -s -- --docker --dev
+#   curl -fsSL https://get.canasta.wiki | bash -s -- --native --prefix /opt/canasta
 #
 # Documentation: https://canasta.wiki/wiki/Help:Installation
 #
 # Flags:
 #   --native    Install canasta-native (requires Python 3.10+, git)
 #   --docker    Install canasta-docker (requires Docker only, default)
-#   --dev       Track the development branch (head of main) instead of
-#               the latest released version
-#   --prefix    Installation prefix (default: /opt/canasta-ansible for native)
+#   --dev       Track the development branch (head of main) instead of the
+#               latest released version. Independent of the mode: combine it
+#               with --native or --docker.
+#   --prefix    Directory to install canasta-native into. Native mode only;
+#               docker mode ignores it. Defaults to /opt/canasta-ansible on
+#               Linux and ~/canasta-ansible on macOS.
 #
 # Linux native installs create a 'canasta' system group. Add users with:
 #   sudo usermod -aG canasta $USER

--- a/tests/unit/test_get_canasta_flag_docs.py
+++ b/tests/unit/test_get_canasta_flag_docs.py
@@ -1,0 +1,105 @@
+"""The installer's documented flags must match what it parses.
+
+The header block listed --dev as a fourth peer of --native/--docker:
+
+    curl -fsSL https://get.canasta.wiki | bash -s -- --docker
+    curl -fsSL https://get.canasta.wiki | bash -s -- --dev
+
+reading as though --dev were an alternative mode. It is not: parse_args
+keeps MODE and DEV in separate variables, so --docker --dev is the
+combination an operator on the dev channel actually wants. The -h output
+had it right all along.
+
+--prefix was described as "Installation prefix (default:
+/opt/canasta-ansible for native)", which understated two things:
+install_docker_mode never reads PREFIX, so docker mode ignores the flag
+outright, and the default differs by platform.
+"""
+
+import os
+import re
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+INSTALLER = os.path.join(REPO_ROOT, "get-canasta.sh")
+
+
+def _script():
+    with open(INSTALLER) as f:
+        return f.read()
+
+
+def _header():
+    """The leading comment block, up to the first non-comment line."""
+    lines = []
+    for line in _script().splitlines()[1:]:
+        if line.startswith("#"):
+            lines.append(line)
+        elif line.strip() == "":
+            continue
+        else:
+            break
+    return "\n".join(lines)
+
+
+def _documented_flags():
+    block = _header().split("# Flags:", 1)[1]
+    return set(re.findall(r"^#\s+(--[a-z-]+)", block, re.M))
+
+
+def _parsed_flags():
+    body = re.search(r"parse_args\(\) \{.*?\n\}", _script(), re.S).group(0)
+    flags = set(re.findall(r"^\s+(--[a-z-]+)\)", body, re.M))
+    flags |= set(re.findall(r"^\s+(--[a-z-]+)=\*\)", body, re.M))
+    return {f for f in flags if f not in ("--help",)}
+
+
+class TestTheDocsMatchTheParser:
+    def test_every_parsed_flag_is_documented(self):
+        assert _parsed_flags() - _documented_flags() == set()
+
+    def test_every_documented_flag_is_parsed(self):
+        assert _documented_flags() - _parsed_flags() == set()
+
+
+class TestDevIsNotAMode:
+    def test_dev_is_documented_as_independent_of_the_mode(self):
+        block = _header().split("# Flags:", 1)[1]
+        dev = block.split("--dev", 1)[1].split("--prefix")[0]
+        assert "combine" in dev.lower() or "independent" in dev.lower(), (
+            "--dev reads as an alternative to --native/--docker rather "
+            "than something you combine with one"
+        )
+
+    def test_an_example_combines_dev_with_a_mode(self):
+        usage = _header().split("# Usage:", 1)[1].split("# Documentation")[0]
+        combined = [ln for ln in usage.splitlines()
+                    if "--dev" in ln and ("--docker" in ln or "--native" in ln)]
+        assert combined, (
+            "no usage example shows --dev alongside a mode, so the list "
+            "reads as four mutually exclusive invocations"
+        )
+
+    def test_the_help_output_groups_them_correctly(self):
+        # This was already right; keep it that way.
+        assert "[--native|--docker] [--dev]" in _script()
+
+
+class TestPrefixIsNativeOnly:
+    def test_docker_mode_does_not_read_prefix(self):
+        body = re.search(
+            r"install_docker_mode\(\) \{.*?\n\}", _script(), re.S).group(0)
+        assert "PREFIX" not in body
+
+    def test_the_docs_say_native_only(self):
+        block = _header().split("--prefix", 1)[1]
+        assert "ative mode only" in block or "native only" in block.lower()
+
+    def test_both_platform_defaults_are_named(self):
+        block = _header().split("--prefix", 1)[1]
+        assert "/opt/canasta-ansible" in block
+        assert "canasta-ansible" in block and "macOS" in block
+
+    def test_the_documented_defaults_are_the_real_ones(self):
+        script = _script()
+        assert 'PREFIX:-/opt/canasta-ansible' in script
+        assert 'PREFIX:-${HOME}/canasta-ansible' in script


### PR DESCRIPTION
`get-canasta.sh`'s header described its flags in a way the parser does not match.

## `--dev` read as a mode

The usage block listed it as a fourth peer of `--native` and `--docker`, so the four lines read as mutually exclusive invocations. `parse_args` keeps them separate:

```bash
--native) MODE="native" ;;
--docker) MODE="docker" ;;
--dev)    DEV=true ;;
```

so `--docker --dev` is valid — and it is what an operator on the dev channel actually wants — but no example showed it. The `-h` output already had it right (`[--native|--docker] [--dev] [--prefix PATH]`); only the header misled.

## `--prefix` understated its scope

It is **native-only**: `install_docker_mode()` never reads `PREFIX`, so the flag is silently ignored in docker mode. The old "for native" qualifier read as a note about the default rather than a restriction on the flag. The default is also platform-dependent — `/opt/canasta-ansible` on Linux, `~/canasta-ansible` on macOS — and only the first was named. And the value is a directory path, which "installation prefix" does not quite say.

## After

```
# Usage:
#   curl -fsSL https://get.canasta.wiki | bash
#   curl -fsSL https://get.canasta.wiki | bash -s -- --native
#   curl -fsSL https://get.canasta.wiki | bash -s -- --docker --dev
#   curl -fsSL https://get.canasta.wiki | bash -s -- --native --prefix /opt/canasta
#
# Flags:
#   --native    Install canasta-native (requires Python 3.10+, git)
#   --docker    Install canasta-docker (requires Docker only, default)
#   --dev       Track the development branch (head of main) instead of the
#               latest released version. Independent of the mode: combine it
#               with --native or --docker.
#   --prefix    Directory to install canasta-native into. Native mode only;
#               docker mode ignores it. Defaults to /opt/canasta-ansible on
#               Linux and ~/canasta-ansible on macOS.
```

Comment-only; no behavior change.

## Tests

`tests/unit/test_get_canasta_flag_docs.py` extracts the flag names from the header and from `parse_args` and asserts the two sets are equal in both directions, so a flag added to one and not the other fails. It also pins the specific claims: `--dev` is described as combinable, at least one usage example shows it alongside a mode, `install_docker_mode` contains no `PREFIX`, both platform defaults are named, and the documented default strings are the ones the script actually uses.

## Not included

`--prefix` in docker mode is accepted and ignored without comment. Warning would be kinder, but that is a behavior change rather than a documentation fix — noted in #1406 for a separate decision.

## Verified

```
bash -n get-canasta.sh   syntax OK
make lint                All checks passed
make test-unit           2373 passed
```

Fixes #1406
