### PR TITLE
Fix the whitespace findings, and make ruff.toml authoritative

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,7 @@ test: test-unit
 
 lint: venv
 	$(YAMLLINT) --strict meta/ roles/ playbooks/ inventory/ canasta.yml
-	# Stage 1 of #1409: the full pyflakes set. F811/F821 caught a test
-	# class shadowing 27 tests and a helper calling an unimported
-	# module. --preview because several of these only fire there —
-	# F401 alone was already missing findings without it.
-	$(RUFF) check --select F --preview .
+	$(RUFF) check .
 	$(PYTHON) scripts/validate_definitions.py
 
 # --- Documentation -----------------------------------------------------------

--- a/canasta.py
+++ b/canasta.py
@@ -64,7 +64,7 @@ def _ca_bundle_override(environ, verify_paths, path_exists, certifi_where):
         return None
     cafile = verify_paths.cafile
     capath = verify_paths.capath
-    if ( cafile and path_exists( cafile ) ) or ( capath and path_exists( capath ) ):
+    if (cafile and path_exists(cafile)) or (capath and path_exists(capath)):
         return None
     return certifi_where()
 

--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -1710,7 +1710,6 @@ def _resolve_ssh_target(host):
     return ("%s@%s" % (user, target)) if user else target
 
 
-
 def _read_remote_or_local_file(path, host):
     """Read a file from localhost or a remote host. Returns content or
     None on error."""

--- a/direct_commands/gitops.py
+++ b/direct_commands/gitops.py
@@ -536,6 +536,7 @@ def cmd_gitops_status(args):
         print(_parse_gitops_status(stdout, inst_id))
     return 0
 
+
 def _gitops_diff_script(path, stat=False, ssh_key=None):
     # For each of the three boundaries we emit two sections: a
     # --name-only list (for the file count and the restart/update

--- a/direct_commands/info.py
+++ b/direct_commands/info.py
@@ -177,6 +177,7 @@ def cmd_list(args):
     _helpers._print_table(details)
     return 0
 
+
 def _describe_unread_version(inst_id, inst, path, orchestrator, host):
     """Why the running version could not be read.
 
@@ -395,6 +396,7 @@ def cmd_version(args):
         print("Instance '%s': %s" % (iid, image))
     return 0
 
+
 def _resolve_status_instance(args):
     """Pick the instance the user wants status for: --id wins, otherwise
     detect it from the working directory, walking up parent dirs so it
@@ -428,6 +430,7 @@ def _kubectl_section(host, ns, cmd_args, label):
     if not out.strip():
         return (label, "(none)")
     return (label, out.rstrip())
+
 
 @register("status")
 def cmd_status(args):

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,7 +1,23 @@
-# Focused lint gate: catch unused imports (F401) across the Python code.
-# Other rule families are intentionally left off for now to keep the gate
-# narrow and low-noise; expand deliberately if desired.
+# Lint gate for the Python code. Kept here rather than as `--select` flags
+# in the Makefile so an editor or pre-commit hook running bare `ruff check`
+# sees exactly what CI does. A flag in the Makefile silently overrides this
+# file, which is how the two came to disagree.
+#
+# Widened in stages under #1409. Stage 1: the full pyflakes set, after
+# F401 alone passed while two unused imports went unreported, a test class
+# shadowed another (hiding 2 tests, one of them failing), and a helper
+# called an unimported module. Stage 2: whitespace and blank lines — the
+# class that let three stray blank lines through a rebase unnoticed.
 extend-exclude = [".claude"]
 
+# Several selected rules only fire under preview, including two of the
+# F401 findings the narrower gate was missing.
+preview = true
+
 [lint]
-select = ["F401"]
+# F      pyflakes in full — undefined names, redefinitions, unused imports
+# E1/E2  indentation and whitespace
+# E3     blank lines
+# W2/W3  trailing whitespace, blank line at end of file
+# W6     deprecated constructs
+select = ["F", "E1", "E2", "E3", "W2", "W3", "W6"]

--- a/scripts/wiki_publish.py
+++ b/scripts/wiki_publish.py
@@ -111,6 +111,7 @@ def _group_subcommands(group_name):
             return list(nested[parts[1]])
     return []
 
+
 CMD_GROUPS = [
     ("System", ["install", "doctor", "host", "storage", "argocd", "uninstall"]),
     ("Instance management", [

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -37,6 +37,7 @@ class SkipTest(Exception):
     """Raised when a test's prerequisites are not met."""
     pass
 
+
 # Atomic-ish port counter (single-threaded, no need for locks)
 _port_counter = int(os.environ.get("CANASTA_TEST_PORT_BASE", "10080"))
 

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -231,7 +231,6 @@ class TestResolveCommandName:
         assert name == "gitops_fix_submodules"
 
 
-
 class TestGlobalFlags:
     def test_verbose_before_command(self):
         """--verbose before command should be parsed by the global parser."""

--- a/tests/unit/test_crowdsec.py
+++ b/tests/unit/test_crowdsec.py
@@ -1649,5 +1649,3 @@ class TestBouncerEnrollForceGuard:
         when = " ".join(str(self._enroll_task().get("when", "")).split())
         assert "_crowdsec_existing" in when
         assert "_crowdsec_have_key" in when
-
-

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -188,6 +188,7 @@ class TestReadWikis:
         wikis = direct_commands._read_wikis(str(tmp_path / "nodir"), "localhost")
         assert wikis == []
 
+
 class TestBuildUrls:
     def test_url_with_https_protocol(self):
         urls = direct_commands._helpers._wiki_probe_urls("https://example-wiki.com")
@@ -2971,6 +2972,7 @@ class TestCmdGitopsStatusK8s:
         )
         # Remote host: both the git status and the Argo CD kubectl run
         # over SSH against the host's kubeconfig, not the laptop's.
+
         def fake_ssh(host, cmd):
             if "kubectl get application" in cmd:
                 return (0, json.dumps(app))
@@ -4431,6 +4433,7 @@ class TestDockerHostPropagation:
 
         def fake_run(cmd, **kw):
             captured["argv"] = cmd
+
             class R:
                 returncode = 0
                 stdout = ""
@@ -4462,6 +4465,7 @@ class TestDockerHostPropagation:
 
         def fake_run(cmd, **kw):
             captured["argv"] = cmd
+
             class R:
                 returncode = 0
                 stdout = ""
@@ -4539,6 +4543,7 @@ class TestDockerHostPropagation:
 
         def fake_run(cmd, **kw):
             captured["env"] = kw.get("env")
+
             class R:
                 returncode = 0
                 stdout = "abc123\n"
@@ -4573,6 +4578,7 @@ class TestDockerHostPropagation:
 
         def fake_run(cmd, **kw):
             captured["env"] = kw.get("env")
+
             class R:
                 returncode = 0
                 stdout = "abc123\n"
@@ -4811,6 +4817,7 @@ class TestRemoteK8sStreamAndExec:
                             raising=False)
         # _stream_in_container drives the argv through an inner _run();
         # patch subprocess.Popen to capture without spawning.
+
         class FakeProc:
             returncode = 0
 

--- a/tests/unit/test_doctor_origin_tls.py
+++ b/tests/unit/test_doctor_origin_tls.py
@@ -207,6 +207,7 @@ class TestOriginTlsGate:
         doctor._origin_tls_lines(self._inst(orchestrator="kubernetes"))
         assert "127.0.0.1:'443'" in seen["script"]
 
+
 # Real issuer string from a Let's Encrypt staging certificate.
 LE_STAGING = ("C=US, O=(STAGING) Let's Encrypt, "
               "CN=(STAGING) Artificial Amaranth YE1")

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -817,6 +817,7 @@ class TestResolvePasswordHelper:
         # Walk every task (including those in `block:`) and make sure
         # at least one set_fact targets `_resolved_password` — the
         # contract the call sites depend on.
+
         def walk(items):
             for t in items or []:
                 if not isinstance(t, dict):

--- a/tests/unit/test_trusted_proxies.py
+++ b/tests/unit/test_trusted_proxies.py
@@ -70,7 +70,6 @@ def _render_proxy(mode, header, dynamic, cidrs=None, strict=False):
     )
 
 
-
 def _render_proxy_with(**ctx):
     """Cloudflare mode plus whatever the caller overrides."""
     base = dict(

--- a/tests/unit/test_upgrade_detects_legacy_runtime.py
+++ b/tests/unit/test_upgrade_detects_legacy_runtime.py
@@ -53,7 +53,6 @@ def _named(path, needle):
          if needle.lower() in str(t.get("name", "")).lower()), None)
 
 
-
 CONFIRM = "Confirm the recorded runtime against the instance's host"
 
 
@@ -144,6 +143,7 @@ class TestTheProbeAsksTheHost:
         task = _named(DETECT, "Record the detected runtime")
         assert task["delegate_to"] == "canasta_controller"
         assert task["vars"]["ansible_connection"] == "local"
+
 
 class TestAPodmanSocketIsNotAskedAboutDocker:
     def test_the_socket_is_noted_before_probing(self):


### PR DESCRIPTION
Stage 2 of #1409, rebased onto `main` now that #1410 has merged.

## The whitespace fixes

All 29 findings were auto-fixable, so the Python side is `ruff check --select E1,E2,E3,W2,W3,W6 --preview --fix` with no hand edits.

| Rule | Count |
| --- | --- |
| E306 blank-lines-before-nested-definition | 7 |
| E302 blank-lines-top-level | 6 |
| E201/E202 whitespace in brackets | 8 |
| E303 too-many-blank-lines | 4 |
| E305 blank-lines-after-function-or-class | 3 |
| W391 too-many-newlines-at-end-of-file | 1 |

`git diff -w` is not a sufficient check for this: it ignores whitespace *within* a line but still reports blank lines as added or removed, so it cannot tell this change from one that adds code. Verified by normalising instead:

```
blank lines added:   16
blank lines removed:  6
non-blank added:      1
non-blank removed:    1
whitespace-only: True
```

The one non-blank change is the E201/E202 fix:

```diff
-    if ( cafile and path_exists( cafile ) ) or ( capath and path_exists( capath ) ):
+    if (cafile and path_exists(cafile)) or (capath and path_exists(capath)):
```

## And a correction to stage 1

#1410 widened the rules with a `--select` flag in the Makefile. That flag **overrides** `ruff.toml`, so `main` currently has the two disagreeing — the Makefile asks for the full pyflakes set while `ruff.toml` still says `select = ["F401"]`. Anyone running bare `ruff check` in an editor gets the file's answer, not CI's, which is the exact problem #1409 set out to fix.

This moves the selection into `ruff.toml` and reduces the Makefile to `$(RUFF) check .`.

I should also flag that I was wrong twice in #1409 and carried it into #1410's commit message:

- I wrote that there was no `ruff.toml`. There is one, and its comment says the narrow gate was deliberate — "expand deliberately if desired". This series is that deliberate expansion, but the framing in the issue was wrong.
- The shadowed test class hid **2** tests, not 27. Measured by collection: `test_crowdsec.py` goes 130 → 132. Both corrected on #1409; the stale figure is removed from the comment here.

## Verified

```
make lint        All checks passed  (now bare `ruff check .`)
make validate    87 commands, 69 playbooks, 161 examples
make test-unit   2397 passed
```

Stage 3 (`E501`) follows, and needs a `line-length` decision — the distribution argues for a ceiling rather than the house style. Details there.

Refs #1409
