### PR TITLE
Run ansible-lint, and make shell pipelines fail loudly

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,54 @@
+---
+# Narrow by design, in the spirit of ruff.toml. The default rule set
+# reports 1191 findings on this repo, 908 of them `no-role-prefix` — a
+# variable-naming convention whose adoption would mean renaming hundreds
+# of variables across every role for no behavioral change, and 128
+# `command-instead-of-module`, where shelling out to docker/kubectl/git is
+# the deliberate design (that is what exec.yml exists for).
+#
+# What is enabled here is the subset about correctness rather than style.
+# Widen it deliberately, the way #1409 widened ruff, rather than by
+# turning the default set on.
+#
+# See #1413.
+
+# Everything under playbooks/ is a task file included from canasta.yml,
+# not a play. Without this, ansible-lint parses each as a playbook and
+# reports every task keyword as "not a valid attribute for a Play".
+kinds:
+  - tasks: "playbooks/*.yml"
+
+exclude_paths:
+  - .claude/
+  - .venv/
+  - tests/integration/
+
+# risky-shell-pipe        a pipeline reports its LAST command's status, so a
+#                         failing command mid-pipe passes silently unless
+#                         pipefail is set. This hid a restore that could
+#                         report success having imported nothing.
+# no-changed-when         a command task that always reports "changed" makes
+#                         --check and idempotency claims meaningless.
+# risky-file-permissions  a file created without an explicit mode inherits
+#                         whatever umask is in play.
+# ignore-errors           deliberately NOT enabled yet: 24 sites, each needing
+#                         a judgment call about which failure is tolerable.
+#                         Tracked in #1413.
+enable_list:
+  - risky-shell-pipe
+  - no-changed-when
+  - risky-file-permissions
+
+skip_list:
+  # add_host in canasta.yml is inherently a once-per-run action; the rule
+  # only matters under `strategy: free`, which this repo does not use.
+  - run-once
+  - no-role-prefix
+  - command-instead-of-module
+  - command-instead-of-shell
+  - no-handler
+  - name
+  - ignore-errors
+  - jinja
+  - var-naming
+  - yaml

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -33,7 +33,7 @@ exclude_paths:
 #                         whatever umask is in play.
 # ignore-errors           deliberately NOT enabled yet: 24 sites, each needing
 #                         a judgment call about which failure is tolerable.
-#                         Tracked in #1413.
+#                         Tracked in #1417; add it here once they are done.
 enable_list:
   - risky-shell-pipe
   - no-changed-when

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PIP := $(VENV)/bin/pip
 PYTEST := $(VENV)/bin/pytest
 YAMLLINT := $(VENV)/bin/yamllint
 RUFF := $(VENV)/bin/ruff
+ANSIBLE_LINT := $(VENV)/bin/ansible-lint
 
 # --- Setup -------------------------------------------------------------------
 
@@ -34,6 +35,7 @@ test: test-unit
 lint: venv
 	$(YAMLLINT) --strict meta/ roles/ playbooks/ inventory/ canasta.yml
 	$(RUFF) check .
+	$(ANSIBLE_LINT) --offline roles/ playbooks/ canasta.yml
 	$(PYTHON) scripts/validate_definitions.py
 
 # --- Documentation -----------------------------------------------------------

--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -39,6 +39,7 @@
         - instance_path is defined
         - not (keep_config | default(false) | bool)
         - (orchestrator | default('compose')) == 'compose'
+      changed_when: true
       ignore_errors: true  # Best-effort cleanup on failure
 
     - name: Clean up on failure (uninstall Helm release)
@@ -47,6 +48,7 @@
       when:
         - not (keep_config | default(false) | bool)
         - (orchestrator | default('compose')) in ['kubernetes', 'k8s']
+      changed_when: true
       ignore_errors: true  # Best-effort cleanup on failure
 
     - name: Clean up on failure (delete K8s namespace)
@@ -55,6 +57,7 @@
       when:
         - not (keep_config | default(false) | bool)
         - (orchestrator | default('compose')) in ['kubernetes', 'k8s']
+      changed_when: true
       ignore_errors: true  # Best-effort cleanup on failure
 
     # Rootless Podman maps the container's root to a subuid, so files the
@@ -105,6 +108,7 @@
         - instance_path is defined
         - not (keep_config | default(false) | bool)
         - instance_dir_was_created | default(false) | bool
+      changed_when: true
       ignore_errors: true  # Best-effort cleanup on failure
 
     - name: Deregister instance on failure

--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -412,13 +412,17 @@
   when: _restore_db_files is succeeded and _restore_db_files.stdout | trim | length > 0
   ansible.builtin.shell:
     cmd: >-
+      set -o pipefail;
       kubectl exec -n {{ _k8s_namespace }} restic-restore --
       cat /currentsnapshot/config/backup/{{ item }} |
       kubectl exec -i -n {{ _k8s_namespace }} {{ _k8s_pod_name }} --
       bash -c 'mariadb -h "${MYSQL_HOST:-db}" -u "${MYSQL_USER:-root}" -p"$MYSQL_PASSWORD"'
+  args:
+    executable: /bin/bash
   loop: >-
     {{ _restore_db_files.stdout_lines | default([])
        | select('match', '^db_.*\.sql$') | list }}
+  changed_when: true
   no_log: true
 
 # Restore the canasta-managed K8s Secrets if the snapshot includes
@@ -476,9 +480,12 @@
   when: _restore_secrets_filename != ''
   ansible.builtin.shell:
     cmd: >-
+      set -o pipefail;
       kubectl exec -n {{ _k8s_namespace }} restic-restore --
       cat /currentsnapshot/config/backup/{{ _restore_secrets_filename }} |
       kubectl apply -n {{ _k8s_namespace }} -f -
+  args:
+    executable: /bin/bash
   changed_when: true
   no_log: true
 

--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -98,7 +98,7 @@
     msg: "Creating instance directories..."
 
 - name: Ensure directories exist
-  include_tasks: noisy_create_dir.yml
+  ansible.builtin.include_tasks: noisy_create_dir.yml
   loop:
     - { dir: extensions }
     - { dir: skins }

--- a/roles/devmode/tasks/enable.yml
+++ b/roles/devmode/tasks/enable.yml
@@ -81,8 +81,14 @@
 
     - name: Extract code from container
       ansible.builtin.shell:
-        cmd: "{{ inspect_command }} exec canasta-dev-extract tar -cf - -C /var/www/mediawiki/w . | tar -xf - -C mediawiki-code/"
+        cmd: >-
+          set -o pipefail;
+          {{ inspect_command }} exec canasta-dev-extract
+          tar -cf - -C /var/www/mediawiki/w . |
+          tar -xf - -C mediawiki-code/
         chdir: "{{ instance_path }}"
+      args:
+        executable: /bin/bash
       changed_when: true
 
     - name: Remove temporary container

--- a/roles/gitops/tasks/_detect_gitcrypt_lock.yml
+++ b/roles/gitops/tasks/_detect_gitcrypt_lock.yml
@@ -11,7 +11,7 @@
 
 - name: Read hosts.yaml git-crypt header
   ansible.builtin.shell:
-    cmd: "head -c 10 hosts/hosts.yaml 2>/dev/null | od -An -tx1 | tr -d ' \\n'"
+    cmd: "set -o pipefail; head -c 10 hosts/hosts.yaml 2>/dev/null | od -An -tx1 | tr -d ' \\n'"
   args:
     chdir: "{{ instance_path }}"
     executable: /bin/bash

--- a/roles/gitops/tasks/_heal_dangling_submodules.yml
+++ b/roles/gitops/tasks/_heal_dangling_submodules.yml
@@ -13,8 +13,10 @@
 
 - name: List submodule gitlinks in the index
   ansible.builtin.shell:
-    cmd: "git ls-files --stage | awk '$1 == \"160000\" {print $4}'"
+    cmd: "set -o pipefail; git ls-files --stage | awk '$1 == \"160000\" {print $4}'"
     chdir: "{{ instance_path }}"
+  args:
+    executable: /bin/bash
   register: _heal_gitlinks
   changed_when: false
 

--- a/roles/gitops/tasks/_recover_orphan_gitlinks.yml
+++ b/roles/gitops/tasks/_recover_orphan_gitlinks.yml
@@ -14,8 +14,10 @@
 
 - name: List staged/committed gitlinks in the index
   ansible.builtin.shell:
-    cmd: "git ls-files --stage | awk '$1 == \"160000\" {print $4}'"
+    cmd: "set -o pipefail; git ls-files --stage | awk '$1 == \"160000\" {print $4}'"
     chdir: "{{ instance_path }}"
+  args:
+    executable: /bin/bash
   register: _rog_gitlinks
   changed_when: false
 

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -160,6 +160,7 @@
           ssh-keygen -t ed25519
           -f {{ _ssh_key_path }}
           -N ''
+      changed_when: true
           -C 'canasta-{{ instance_id }}'
       when: not (_existing_is_ssh_key | bool)
 

--- a/roles/orchestrator/tasks/backup_schedule_apply.yml
+++ b/roles/orchestrator/tasks/backup_schedule_apply.yml
@@ -147,6 +147,7 @@
   ansible.builtin.blockinfile:
     path: "{{ _host_crontab_file }}"
     create: true
+    mode: "0600"
     marker: "# {mark} canasta-backup-{{ instance_id }}"
     block: "{{ cron_expression }} {{ _cron_cmd }}"
   when: _sched_use_file

--- a/roles/orchestrator/tasks/create_preflight.yml
+++ b/roles/orchestrator/tasks/create_preflight.yml
@@ -119,8 +119,11 @@
         - name: Read lingering and the unprivileged port floor
           ansible.builtin.shell:
             cmd: |
+              set -o pipefail
               printf '%s\n' "$(loginctl show-user "$(id -un)" --property=Linger 2>/dev/null | cut -d= -f2)"
               printf '%s\n' "$(cat /proc/sys/net/ipv4/ip_unprivileged_port_start 2>/dev/null)"
+          args:
+            executable: /bin/bash
           register: _rootless_facts
           changed_when: false
           failed_when: false
@@ -213,6 +216,7 @@
     - name: Probe for userspace listener on the HTTP port
       ansible.builtin.shell:
         cmd: |
+          set -o pipefail
           if command -v ss >/dev/null 2>&1; then
             ss -tlnH "sport = :{{ _preflight_http_port }}"
           elif command -v lsof >/dev/null 2>&1; then
@@ -220,6 +224,8 @@
           else
             echo "CANASTA_PORT_PROBE_UNAVAILABLE"
           fi
+      args:
+        executable: /bin/bash
       register: _port80_listener
       changed_when: false
       failed_when: false
@@ -227,6 +233,7 @@
     - name: Probe for userspace listener on the HTTPS port
       ansible.builtin.shell:
         cmd: |
+          set -o pipefail
           if command -v ss >/dev/null 2>&1; then
             ss -tlnH "sport = :{{ _preflight_https_port }}"
           elif command -v lsof >/dev/null 2>&1; then
@@ -234,6 +241,8 @@
           else
             echo "CANASTA_PORT_PROBE_UNAVAILABLE"
           fi
+      args:
+        executable: /bin/bash
       register: _port443_listener
       changed_when: false
       failed_when: false
@@ -333,8 +342,8 @@
     - name: Probe podman version for host-gateway support
       ansible.builtin.shell:
         cmd: |
-          {% raw %}set -o pipefail
-          command -v podman >/dev/null 2>&1 || exit 0
+          set -o pipefail
+          {% raw %}command -v podman >/dev/null 2>&1 || exit 0
           ver=$(podman --version 2>/dev/null | awk '{print $3}')
           [ -n "$ver" ] || exit 0
           # Emit the bridge gateway only when podman is older than 4.4.0.
@@ -343,6 +352,8 @@
               podman network inspect podman \
                   --format '{{range .Subnets}}{{.Gateway}}{{end}}' 2>/dev/null
           fi{% endraw %}
+      args:
+        executable: /bin/bash
       register: _host_gateway_probe
       changed_when: false
       failed_when: false
@@ -378,6 +389,8 @@
         cmd: >-
           set -o pipefail && df --output=avail {{ _docker_root_dir | quote }}
           2>/dev/null | tail -1
+      args:
+        executable: /bin/bash
       register: _docker_storage_avail
       changed_when: false
       failed_when: false

--- a/roles/orchestrator/tasks/restore_instance.yml
+++ b/roles/orchestrator/tasks/restore_instance.yml
@@ -320,7 +320,7 @@
     # than fail the whole restore, which already succeeded.
     - name: Check git-crypt lock state
       ansible.builtin.shell:
-        cmd: "head -c 10 hosts/hosts.yaml 2>/dev/null | od -An -tx1 | tr -d ' \\n'"
+        cmd: "set -o pipefail; head -c 10 hosts/hosts.yaml 2>/dev/null | od -An -tx1 | tr -d ' \\n'"
       args:
         chdir: "{{ instance_path }}"
         executable: /bin/bash

--- a/roles/upgrade/tasks/migrations/extract_secret_key.yml
+++ b/roles/upgrade/tasks/migrations/extract_secret_key.yml
@@ -12,9 +12,12 @@
     - name: Search for wgSecretKey in PHP files
       ansible.builtin.shell:
         cmd: >-
+          set -o pipefail;
           grep -roEh '\$wgSecretKey\s*=\s*["'"'"'][a-fA-F0-9]+["'"'"']' config/ 2>/dev/null |
           head -1 | grep -oE '[a-fA-F0-9]{32,}' || true
         chdir: "{{ instance_path }}"
+      args:
+        executable: /bin/bash
       register: _sk_grep
       changed_when: false
       no_log: true  # holds the wiki's session-signing secret


### PR DESCRIPTION
`ansible-lint==26.6.0` is pinned in `requirements.txt` and installs into `.venv` on every setup. Nothing ever ran it. Ansible is the largest surface in the repo — 293 task and playbook files against 217 Python files — and the only check it had was `yamllint --strict`, which validates YAML, not Ansible.

## The rule set

The default reports 1191 findings, which is why turning it on wholesale was never attractive:

| Rule | Count | Enabled |
| --- | --- | --- |
| `no-role-prefix` | 908 | no — renaming hundreds of variables for no behavioral change |
| `command-instead-of-module` | 128 | no — shelling out to docker/kubectl/git is the design; `exec.yml` is the abstraction |
| **`risky-shell-pipe`** | 12 | **yes** |
| `ignore-errors` | 24 | not yet — 24 judgment calls, left in #1413 |
| `no-changed-when` | 5 | **yes** |
| `risky-file-permissions` | 1 | **yes** |

`.ansible-lint` records the skipped families and why, so the question does not have to be rediscovered.

## What `risky-shell-pipe` was hiding

A pipeline's exit status is its **last** command's. Without `pipefail`, `foo | bar` reports `bar`'s result and a failing `foo` passes silently. The worst instance is the Kubernetes DB import:

```yaml
kubectl exec ... cat /currentsnapshot/config/backup/{{ item }} |
kubectl exec -i ... bash -c 'mariadb ...'
```

If the `cat` fails — missing file, pod gone — `mariadb` reads empty input and exits 0. **The restore reports success having imported nothing.** Several of the other eleven are in gitops recovery paths, where the same silence applies.

## `executable: /bin/bash` is not optional here

`pipefail` is not in POSIX until Issue 8, and dash only implemented it in 0.5.12. Debian 13 has 0.5.12 and accepts it — verified on a live host, `set -o pipefail; false | true` gives rc=1 — but Ubuntu 22.04 ships 0.5.11, where the option itself errors. Ansible's `shell` defaults to `/bin/sh`, so every fixed task sets the executable explicitly.

One pre-existing `pipefail` task had the same gap and would have failed on those targets, silently: it carries `failed_when: false`.

## The `kinds` mapping

Everything under `playbooks/` is a task file included from `canasta.yml`, not a play. ansible-lint assumed otherwise and reported 71 `syntax-check` errors of the form "'ansible.builtin.set_fact' is not a valid attribute for a Play" — which were **masking three real `no-changed-when` findings** in `create.yml`'s rescue block. Those are now fixed too.

## Result

```
Passed: 0 failure(s), 0 warning(s) in 347 files processed of 358 encountered.
Last profile that met the validation criteria was 'production'.
```

## Verified

```
make lint                 yamllint + ruff + ansible-lint + validate_definitions, all clean
make validate             87 commands, 69 playbooks, 161 examples
make test-unit            2397 passed
ansible-playbook --syntax-check   ok
```

Every changed task was re-parsed with PyYAML and its `cmd` rendered as the shell would receive it, to confirm the folded-scalar cases got `set -o pipefail;` with the separator and the literal-block cases got their own line.

## Follow-ups

`ignore-errors` (24 sites) stays open on #1413 — each needs a decision about which failure is tolerable, and the codebase already has the better pattern in `run_backup.yml`, which tolerates only "already exists".

Sibling issues from the same survey: #1414 (shellcheck) and #1415 (actionlint, hadolint).

Fixes #1413
