### PR TITLE
fix: set inspect_command from dockerHost and preserve fields in registry state:present

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -1533,6 +1533,7 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
                 docker_host = inst.get("dockerHost") or ""
                 if "podman" in docker_host:
                     extra_vars["compose_command"] = "podman-compose"
+                    extra_vars["inspect_command"] = "podman"
             except (OSError, IOError, KeyError):
                 pass
 

--- a/roles/common/library/canasta_registry.py
+++ b/roles/common/library/canasta_registry.py
@@ -288,6 +288,13 @@ def run_module():
         })
 
         if inst_id in instances:
+            # Preserve fields the caller did not supply so a caller that
+            # only sets compose_command does not silently erase a prior
+            # inspect_command (and vice versa).
+            for key in ("composeCommand", "inspectCommand", "dockerHost",
+                        "buildFrom", "buildArgs", "registry", "kindCluster"):
+                if key not in new_instance and key in instances[inst_id]:
+                    new_instance[key] = instances[inst_id][key]
             if instances[inst_id] != new_instance:
                 changed = True
                 instances[inst_id] = new_instance

--- a/roles/common/library/canasta_registry.py
+++ b/roles/common/library/canasta_registry.py
@@ -175,6 +175,31 @@ def instance_to_dict(instance):
     return result
 
 
+# Fields instance_to_dict writes unconditionally. Everything else it
+# emits is optional, and `state: present` rebuilds the record from its
+# parameters — so any optional field the caller did not supply would
+# vanish, silently erasing either a runtime fact some other code path
+# discovered (composeCommand, inspectCommand, dockerHost) or an operator
+# setting (devMode).
+#
+# Derived from instance_to_dict rather than listed by hand: a field added
+# there is preserved without anyone having to remember this, which is the
+# failure mode that produced the erase in the first place.
+_ALWAYS_WRITTEN = ("id", "path", "orchestrator")
+
+
+def preserved_on_present():
+    """Optional registry fields, taken from instance_to_dict itself."""
+    probe = instance_to_dict({
+        "id": "probe", "path": "/probe", "orchestrator": "compose",
+        "host": "probe", "devMode": True, "managedCluster": True,
+        "registry": "probe", "kindCluster": "probe", "buildFrom": "/probe",
+        "buildArgs": {"probe": "1"}, "dockerHost": "probe",
+        "composeCommand": "probe", "inspectCommand": "probe",
+    })
+    return tuple(k for k in probe if k not in _ALWAYS_WRITTEN)
+
+
 def run_module():
     module_args = dict(
         state=dict(type="str", default="query",
@@ -288,11 +313,10 @@ def run_module():
         })
 
         if inst_id in instances:
-            # Preserve fields the caller did not supply so a caller that
-            # only sets compose_command does not silently erase a prior
-            # inspect_command (and vice versa).
-            for key in ("composeCommand", "inspectCommand", "dockerHost",
-                        "buildFrom", "buildArgs", "registry", "kindCluster"):
+            # Preserve every optional field the caller did not supply, so
+            # a caller that sets only compose_command does not erase a
+            # prior inspect_command (and vice versa).
+            for key in preserved_on_present():
                 if key not in new_instance and key in instances[inst_id]:
                     new_instance[key] = instances[inst_id][key]
             if instances[inst_id] != new_instance:

--- a/tests/unit/test_registry_partial_update.py
+++ b/tests/unit/test_registry_partial_update.py
@@ -153,8 +153,16 @@ class TestUpdateRefusesWhatItCannotMerge:
         assert _read_back(tmp_dir) == before
 
 
-class TestPresentStillReplaces:
-    """create owns the whole record and relies on this."""
+class TestPresentKeepsWhatItWasNotGiven:
+    """`present` rebuilds the record, but must not erase by omission.
+
+    create supplies the whole record, so `present` replacing it is right.
+    What is not right is dropping an optional field the caller left
+    unset: composeCommand and inspectCommand are discovered at runtime by
+    detect_runtime, dockerHost by the socket probe, devMode by
+    `devmode enable`. A caller that supplies one and not the other would
+    otherwise erase the rest.
+    """
 
     def test_it_preserves_fields_it_was_not_given(self, tmp_dir):
         _seed(tmp_dir)
@@ -194,3 +202,41 @@ class TestEveryStoredFieldCanBeUpdated:
         stored = set(canasta_registry.instance_to_dict(FULL))
         updatable = {key for key, _param in canasta_registry.UPDATABLE_FIELDS}
         assert stored - updatable == {"id", "path"}
+
+
+class TestThePreserveListCannotGoStale:
+    """A field added to instance_to_dict must be preserved automatically.
+
+    An earlier version listed the preserved keys by hand and covered
+    seven of the ten optional fields — host, devMode and managedCluster
+    were still erasable by exactly the mechanism the list existed to
+    prevent. Deriving the list removes the chance to forget; these tests
+    keep it derived.
+    """
+
+    def test_every_optional_field_is_preserved(self):
+        emitted = canasta_registry.instance_to_dict({
+            "id": "x", "path": "/x", "orchestrator": "compose",
+            "host": "h", "devMode": True, "managedCluster": True,
+            "registry": "r", "kindCluster": "k", "buildFrom": "/b",
+            "buildArgs": {"a": "1"}, "dockerHost": "d",
+            "composeCommand": "c", "inspectCommand": "i",
+        })
+        optional = {k for k in emitted if k not in ("id", "path",
+                                                    "orchestrator")}
+        assert optional == set(canasta_registry.preserved_on_present()), (
+            "instance_to_dict emits a field that state=present would drop "
+            "when the caller omits it"
+        )
+
+    def test_the_three_always_written_are_not_in_the_list(self):
+        # They are rebuilt from required parameters every time, so
+        # preserving them would be meaningless at best.
+        assert not (set(canasta_registry.preserved_on_present())
+                    & {"id", "path", "orchestrator"})
+
+    def test_it_covers_the_fields_the_hand_list_missed(self):
+        preserved = set(canasta_registry.preserved_on_present())
+        for field in ("host", "devMode", "managedCluster"):
+            assert field in preserved, (
+                "%s was erasable under the hand-maintained list" % field)

--- a/tests/unit/test_registry_partial_update.py
+++ b/tests/unit/test_registry_partial_update.py
@@ -156,13 +156,15 @@ class TestUpdateRefusesWhatItCannotMerge:
 class TestPresentStillReplaces:
     """create owns the whole record and relies on this."""
 
-    def test_it_drops_fields_it_was_not_given(self, tmp_dir):
+    def test_it_preserves_fields_it_was_not_given(self, tmp_dir):
         _seed(tmp_dir)
         _, failed, _ = run_module_with_params(canasta_registry, _params(
             state="present", id="demo", path="/srv/canasta/demo",
             orchestrator="compose", config_dir=tmp_dir))
         assert not failed
-        assert "composeCommand" not in _read_back(tmp_dir)
+        entry = _read_back(tmp_dir)
+        assert entry["composeCommand"] == "podman-compose"
+        assert entry["inspectCommand"] == "podman"
 
     def test_the_orchestrator_default_survived_losing_its_argspec_default(
             self, tmp_dir):


### PR DESCRIPTION
Fixes #1419
Fixes #1420

### Changes

- **canasta.py**: when inferring compose_command from dockerHost containing 'podman', also set inspect_command to 'podman' so Ansible tasks like check_running.yml use the correct runtime binary
- **canasta_registry.py**: state:present now preserves existing fields that the caller did not supply, preventing a partial write from silently erasing composeCommand or inspectCommand from the registry
- **test_registry_partial_update.py**: updated test to reflect the new preserve-semantics of state:present