### PR TITLE
Lint the shell, workflows and Dockerfiles, and stop CI drifting from make

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -15,6 +15,18 @@
 # Everything under playbooks/ is a task file included from canasta.yml,
 # not a play. Without this, ansible-lint parses each as a playbook and
 # reports every task keyword as "not a valid attribute for a Play".
+# Declared so linting does not require the collections installed.
+# requirements.yml pins kubernetes.core for runtime; installing it just to
+# lint would put the Galaxy CDN in the path of this gate, and the jobs that
+# do install it need a four-attempt retry loop for exactly that reason.
+# The rules enabled below do not inspect module options, so a mock is
+# enough to resolve the names.
+mock_modules:
+  - kubernetes.core.helm
+  - kubernetes.core.helm_repository
+  - kubernetes.core.k8s
+  - kubernetes.core.k8s_info
+
 kinds:
   - tasks: "playbooks/*.yml"
 
@@ -40,6 +52,11 @@ enable_list:
   - risky-file-permissions
 
 skip_list:
+  # Paired with mock_modules above: a mock carries no argspec, so this
+  # rule reports every parameter of a kubernetes.core task as
+  # unsupported — 39 of them. Validating options against a mock is
+  # meaningless, and none of the enabled rules depend on it.
+  - args
   # add_host in canasta.yml is inherently a once-per-run action; the rule
   # only matters under `strategy: free`, which this repo does not use.
   - run-once

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -410,11 +410,11 @@ jobs:
           LEG: ${{ matrix.leg }}
         run: |
           case "$LEG" in
-            "config & farms") tests="extension-skin wiki-farm config-side-effects" ;;
-            "backup & ops")   tests="backup backup-advanced sitemap maintenance" ;;
+            "config & farms") tests=(extension-skin wiki-farm config-side-effects) ;;
+            "backup & ops")   tests=(backup backup-advanced sitemap maintenance) ;;
             *) echo "unknown feature leg: $LEG" >&2; exit 1 ;;
           esac
-          .venv/bin/python tests/integration/run_tests.py $tests
+          .venv/bin/python tests/integration/run_tests.py "${tests[@]}"
         timeout-minutes: 20
 
   integration-gitops:
@@ -431,7 +431,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y git-crypt
           sudo groupadd -f www-data
-          sudo usermod -aG www-data $(whoami)
+          sudo usermod -aG www-data "$(whoami)"
           python -m venv .venv
           .venv/bin/pip install -r requirements.txt
           .venv/bin/pip install kubernetes
@@ -726,13 +726,25 @@ jobs:
           .venv/bin/pip install -r requirements.txt
           .venv/bin/pip install yamllint
 
-      - name: YAML lint
-        run: >-
-          .venv/bin/yamllint --strict -c .yamllint.yml
-          meta/ roles/ playbooks/ inventory/ canasta.yml
+      # One target, so CI and a local `make lint` cannot disagree. They
+      # had: this job still passed `--select F401`, which overrides
+      # ruff.toml and silently ran a weaker check than the Makefile, and
+      # it never ran ansible-lint at all.
+      - name: Lint (yamllint, ruff, ansible-lint, definitions)
+        run: make lint
 
-      - name: Python unused-import check
-        run: .venv/bin/ruff check --select F401 .
+      - name: Shell lint
+        uses: docker://koalaman/shellcheck:stable
+        with:
+          args: --severity=info canasta-docker canasta-native get-canasta.sh
 
-      - name: Validate definitions
-        run: .venv/bin/python scripts/validate_definitions.py
+      - name: Workflow lint
+        uses: docker://rhysd/actionlint:latest
+        with:
+          args: -color=false
+
+      - name: Dockerfile lint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          recursive: true
+          config: hadolint.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ inventory/hosts.yml
 # Version metadata captured at install time (Makefile: build-info)
 BUILD_COMMIT
 BUILD_DATE
+
+# ansible-lint writes its collection/module cache here.
+.ansible/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM python:3.12-slim
 
+# Several RUN steps below pipe a download straight into tar or bash.
+# Without pipefail a failed or truncated download still leaves the
+# pipeline exiting 0 — the Helm step in particular would pipe nothing
+# into bash and the image would build "successfully" with no helm in it.
+# python:3.12-slim is Debian-based, so bash is present.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
@@ -12,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Docker CLI (not daemon - we use host's Docker via socket)
 RUN curl -fsSL --retry 3 --retry-delay 5 \
-        https://download.docker.com/linux/static/stable/$(uname -m)/docker-27.5.1.tgz \
+        "https://download.docker.com/linux/static/stable/$(uname -m)/docker-27.5.1.tgz" \
     | tar xz --strip-components=1 -C /usr/local/bin docker/docker
 
 # Install Docker Compose plugin (uses uname -m for arch: x86_64/aarch64)

--- a/canasta-native
+++ b/canasta-native
@@ -19,7 +19,8 @@ SCRIPT_DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
 # Record this wrapper's absolute path so downstream tooling (e.g. the
 # crontab entry written by 'backup schedule set') can re-invoke the CLI
 # with a fully-qualified path, independent of cron's minimal PATH.
-export CANASTA_CLI_BIN="${SCRIPT_DIR}/$(basename "$SOURCE")"
+CANASTA_CLI_BIN="${SCRIPT_DIR}/$(basename "$SOURCE")"
+export CANASTA_CLI_BIN
 
 if [[ -x "${SCRIPT_DIR}/.venv/bin/python" ]]; then
     exec "${SCRIPT_DIR}/.venv/bin/python" "${SCRIPT_DIR}/canasta.py" "$@"

--- a/get-canasta.sh
+++ b/get-canasta.sh
@@ -250,7 +250,6 @@ announce_upgrade() {
 
 detect_platform() {
     OS="$(uname -s)"
-    ARCH="$(uname -m)"
 
     IS_WSL=false
     if [[ -f /proc/version ]] && grep -qi microsoft /proc/version 2>/dev/null; then

--- a/hadolint.yaml
+++ b/hadolint.yaml
@@ -1,0 +1,14 @@
+---
+# Fail on warnings, not just errors: the findings worth having here
+# (pipes without pipefail, bad chown/copy) are warnings.
+failure-threshold: warning
+format: tty
+no-color: true
+
+ignored:
+  # Pin versions in apt-get install. The only Dockerfiles here that
+  # install packages are throwaway integration-test images built from
+  # ubuntu:24.04 on demand; pinned versions would rot out of the archive
+  # within weeks and break CI for no safety gained. The shipped images
+  # (images/caddy) pin by digest-bearing base tag instead.
+  - DL3008

--- a/tests/integration/remote/Dockerfile
+++ b/tests/integration/remote/Dockerfile
@@ -2,6 +2,11 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# The Docker keyring RUN below pipes curl into gpg. Without pipefail a
+# failed download still leaves gpg exiting 0 on empty input, and the build
+# continues with a keyring that cannot verify anything.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Install SSH server, Python 3, sudo, cron (for backup schedule tests),
 # and prerequisites for Docker CLI
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Adds the three static checks from the survey in #1409, and fixes what they found.

I expected this to be pure CI wiring — all three were near-silent when I measured them for the issues. Two things turned out otherwise.

## The shipped CLI image can build without Helm

`Dockerfile` installs Helm by piping a download into `bash`:

```dockerfile
RUN curl -fsSL --retry 3 --retry-delay 5 \
        https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \
    | bash
```

A pipeline reports its **last** command's status. Without `pipefail`, a failed or truncated download pipes nothing into `bash`, `bash` exits 0, and the image builds successfully **with no helm in it**. The same file pipes another download into `tar`, and the integration-test image pipes `curl` into `gpg --dearmor`, where a failed download leaves a keyring that verifies nothing.

All three now set `SHELL ["/bin/bash", "-o", "pipefail", "-c"]`. This is the same class as the twelve Ansible tasks fixed in #1416 — it just lives in Dockerfiles.

## CI had drifted from `make lint`

The Lint job ran its own list of commands, and that list was stale:

```yaml
- name: Python unused-import check
  run: .venv/bin/ruff check --select F401 .
```

`--select` on the command line **overrides `ruff.toml`**, so CI was running a weaker check than `make lint` — and `ruff.toml`'s own header warns about precisely that override being how the two came to disagree. The job also never ran ansible-lint, added to `make lint` in #1416.

The job now runs `make lint`. One target, so they cannot diverge again.

## Everything else the tools found

| Finding | Fix |
| --- | --- |
| `SC2155` — `export VAR="$(cmd)"` masks a failing `basename` | declare, then export |
| `SC2034` — `ARCH` assigned once, never read (its sibling `OS` is used twice) | removed |
| `SC2046` — unquoted `$(whoami)` in a workflow | quoted |
| `SC2046` — unquoted `$(uname -m)` inside a URL | quoted |
| `SC2086` — unquoted `$tests` | **made an array**, not quoted — the splitting is deliberate there, so quoting would pass one argument instead of four |

## hadolint config

`hadolint.yaml` follows CanastaBase's convention, with two deliberate differences:

- `failure-threshold: warning` rather than `error`, because the findings worth having here are warnings.
- `DL4006` is **fixed rather than ignored**, unlike CanastaBase's config — it is the `pipefail` rule above, and this PR exists partly because of what it caught.

`DL3008` (pin apt versions) is ignored with the reason recorded: the only Dockerfiles that `apt-get install` are throwaway integration-test images built from `ubuntu:24.04` on demand, and pinned versions would rot out of the archive within weeks for no safety gained.

## Verified

```
shellcheck --severity=info   clean across canasta-docker, canasta-native, get-canasta.sh
actionlint                   clean across all 5 workflows
hadolint                     clean across all 4 Dockerfiles
make lint                    yamllint + ruff + ansible-lint + validate, all clean
make test-unit               2413 passed
```

Fixes #1414
Fixes #1415
