### PR TITLE
Heal a missing MYSQL_PASSWORD only when no database can be locked out

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -396,6 +396,24 @@ def _run_compose(inst_id, inst, action_args, include_sidecars=False):
     return _retry_on_ssh_reset(_attempt)
 
 
+def _missing_db_password(inst):
+    """True when .env has no usable MYSQL_PASSWORD.
+
+    db exits immediately without it, and healing needs to know whether a
+    database volume already exists before deciding whether generating a
+    replacement is safe. That check lives in the Ansible path
+    (orchestrator/tasks/heal_mysql_password.yml) rather than being
+    duplicated here, so this only has to detect the condition.
+    """
+    env = _read_env_file(inst.get("path", ""), inst.get("host") or "localhost")
+    if not env:
+        # Unreadable or absent .env is a different problem, and treating
+        # it as this one would swallow the compose failure the caller is
+        # about to report. A real instance's .env has many keys.
+        return False
+    return not (env.get("MYSQL_PASSWORD") or "").strip()
+
+
 # Profiles that Canasta derives from CANASTA_ENABLE_* feature flags.
 # (profile_name, flag_name, default_when_flag_unset)
 # Matches roles/orchestrator/tasks/sync_compose_profiles.yml.

--- a/direct_commands/lifecycle.py
+++ b/direct_commands/lifecycle.py
@@ -34,6 +34,14 @@ def cmd_start(args):
     _helpers._sync_compose_profiles(inst)
     rc = _helpers._run_compose(inst_id, inst, ["up", "-d"])
     if rc != 0:
+        if _helpers._missing_db_password(inst):
+            # db exits immediately without it. Whether generating a
+            # replacement is safe depends on there being no database to
+            # lock out, which the Ansible path decides — hand the broken
+            # case over rather than duplicating that judgement here.
+            # Checked only on failure: on a remote instance reading .env
+            # is an SSH round trip.
+            return _helpers.FALLBACK
         _helpers._dump_compose_failure(inst)
         return rc
     return _helpers._wait_web_ready(inst_id, inst)

--- a/roles/orchestrator/tasks/heal_mysql_password.yml
+++ b/roles/orchestrator/tasks/heal_mysql_password.yml
@@ -1,0 +1,82 @@
+---
+# Restore a missing MYSQL_PASSWORD in .env — but only when doing so
+# cannot lock the operator out of their own database.
+#
+# docker-compose.yml passes it to two services:
+#   db  -> MYSQL_ROOT_PASSWORD=${MYSQL_PASSWORD}
+#   web -> MYSQL_PASSWORD=${MYSQL_PASSWORD}
+#
+# MariaDB reads MARIADB_ROOT_PASSWORD only when it initialises an empty
+# data directory. On a volume that already holds a database the stored
+# password wins and the variable is ignored — so inventing a new one
+# there leaves the DB on its old password while web is handed the new
+# one. That turns a loud failure (db exits with a clear message) into a
+# quiet one: db healthy, wiki unable to authenticate. The real password
+# is unrecoverable at that point; it existed only in the lost .env and
+# as a hash inside the volume.
+#
+# So: generate when there is no database to lock out, and refuse
+# otherwise, naming the ways back.
+#
+# Input: instance_path, inspect_command
+
+- name: Read MYSQL_PASSWORD from .env
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read
+    key: MYSQL_PASSWORD
+  register: _heal_mysql_pw
+  no_log: true  # registers the password
+
+- name: Heal the missing database password
+  when: (_heal_mysql_pw.value | default('') | trim) == ''
+  block:
+    # Compose names it <project>_mysql-data-volume, and the project is the
+    # instance directory's basename lowercased — the same derivation the
+    # container label filters use.
+    - name: Look for an existing database volume
+      ansible.builtin.command:
+        argv:
+          - "{{ inspect_command | default('docker') }}"
+          - volume
+          - inspect
+          - "{{ instance_path | basename | lower }}_mysql-data-volume"
+      register: _heal_db_volume
+      changed_when: false
+      failed_when: false
+
+    # Refuse rather than guess. A wrong password here is worse than the
+    # failure it replaces, because the DB comes up healthy and only
+    # MediaWiki notices.
+    - name: Fail when a database already exists
+      ansible.builtin.fail:
+        msg: >-
+          MYSQL_PASSWORD is missing from {{ instance_path }}/.env, and this
+          instance already has a database volume
+          ({{ instance_path | basename | lower }}_mysql-data-volume).
+          Generating a new password would not reach that database —
+          MariaDB only applies the root password when it first initialises
+          — so the wiki would be handed credentials the database does not
+          accept. Restore the value instead: 'canasta backup restore'
+          brings back .env from a snapshot, or copy MYSQL_PASSWORD from
+          another copy of the file. If the database was never actually
+          initialised, remove the empty volume and start again.
+      when: _heal_db_volume.rc == 0
+
+    - name: Generate a database password
+      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/generate_password.yml"
+
+    - name: Write the generated password to .env
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: set
+        key: MYSQL_PASSWORD
+        value: "{{ _generated_password }}"
+      no_log: true  # holds the password
+
+    - name: Report the healed password
+      ansible.builtin.debug:
+        msg: >-
+          MYSQL_PASSWORD was missing from .env and no database volume
+          existed yet, so a new password was generated and saved. The
+          database will initialise with it.

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -71,6 +71,12 @@
              | join(' ') }}
       when: compose_command is search('podman')
 
+    # Before anything starts: db exits immediately when MYSQL_PASSWORD is
+    # absent from .env, and the message it prints names MariaDB variables
+    # the operator never set.
+    - name: Heal a missing database password
+      ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/heal_mysql_password.yml"
+
     - name: Check if already running
       ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/check_running.yml"
 

--- a/tests/unit/test_heal_mysql_password.py
+++ b/tests/unit/test_heal_mysql_password.py
@@ -1,0 +1,122 @@
+"""A missing MYSQL_PASSWORD is only safe to replace when nothing uses it.
+
+docker-compose.yml hands the value to two services:
+
+    db  -> MYSQL_ROOT_PASSWORD=${MYSQL_PASSWORD}
+    web -> MYSQL_PASSWORD=${MYSQL_PASSWORD}
+
+MariaDB applies MARIADB_ROOT_PASSWORD only when it initialises an empty
+data directory. On a volume that already holds a database the stored
+password wins and the variable is ignored, so a freshly generated one
+reaches web but not db: the container comes up healthy and only
+MediaWiki notices it cannot authenticate. That is strictly worse than
+the failure it would replace, which at least says what is wrong.
+
+The real password is unrecoverable at that point — it lived in the lost
+.env and as a hash inside the volume.
+"""
+
+import os
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+HEAL = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "heal_mysql_password.yml")
+START = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "start.yml")
+COMPOSE = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "files", "compose",
+    "docker-compose.yml")
+
+
+def _tasks():
+    with open(HEAL) as f:
+        return yaml.safe_load(f)
+
+
+def _named(name):
+    for t in _tasks():
+        if t.get("name") == name:
+            return t
+        for inner in t.get("block") or []:
+            if inner.get("name") == name:
+                return inner
+    raise AssertionError("task not found: %s" % name)
+
+
+class TestItRefusesWhenADatabaseExists:
+    def test_an_existing_volume_is_fatal(self):
+        task = _named("Fail when a database already exists")
+        assert "ansible.builtin.fail" in task
+        assert "_heal_db_volume.rc == 0" in str(task["when"]), (
+            "the refusal must key on the volume being found"
+        )
+
+    def test_the_message_says_why_generating_would_not_help(self):
+        msg = _named("Fail when a database already exists")[
+            "ansible.builtin.fail"]["msg"]
+        assert "only applies the root password when it first initialises" in msg
+
+    def test_the_message_names_a_way_back(self):
+        # The operator cannot recover the password by thinking harder; it
+        # exists only in a backup or another copy of .env.
+        msg = _named("Fail when a database already exists")[
+            "ansible.builtin.fail"]["msg"]
+        assert "canasta backup restore" in msg
+
+    def test_the_refusal_precedes_the_generation(self):
+        block = next(t for t in _tasks()
+                     if t.get("name") == "Heal the missing database password")
+        names = [x.get("name") for x in block["block"]]
+        assert (names.index("Fail when a database already exists")
+                < names.index("Generate a database password"))
+
+
+class TestItHealsWhenThereIsNothingToLoseAccessTo:
+    def test_it_generates_and_writes(self):
+        gen = _named("Generate a database password")
+        assert gen["ansible.builtin.include_tasks"].endswith(
+            "generate_password.yml")
+        write = _named("Write the generated password to .env")
+        env = write["canasta_env"]
+        assert env["key"] == "MYSQL_PASSWORD"
+        assert env["state"] == "set"
+
+    def test_it_does_not_log_the_password(self):
+        for name in ("Read MYSQL_PASSWORD from .env",
+                     "Write the generated password to .env"):
+            assert _named(name)["no_log"] is True
+
+    def test_it_only_acts_when_the_value_is_absent(self):
+        block = next(t for t in _tasks()
+                     if t.get("name") == "Heal the missing database password")
+        assert "_heal_mysql_pw" in str(block["when"])
+
+
+class TestItRunsBeforeAnythingStarts:
+    def test_start_includes_it(self):
+        with open(START) as f:
+            play = next(p for p in yaml.safe_load(f)
+                        if "Docker Compose" in str(p.get("name", "")))
+        names = [t.get("name") for t in play["block"]]
+        assert "Heal a missing database password" in names
+
+    def test_it_precedes_the_containers_coming_up(self):
+        with open(START) as f:
+            play = next(p for p in yaml.safe_load(f)
+                        if "Docker Compose" in str(p.get("name", "")))
+        names = [t.get("name") for t in play["block"]]
+        assert (names.index("Heal a missing database password")
+                < names.index("Start containers"))
+
+
+class TestThePremiseStillHolds:
+    def test_compose_still_feeds_the_value_to_both_services(self):
+        # If either consumer stops using MYSQL_PASSWORD, the reasoning
+        # above needs revisiting rather than the tests being deleted.
+        with open(COMPOSE) as f:
+            text = f.read()
+        assert "MYSQL_ROOT_PASSWORD=${MYSQL_PASSWORD}" in text
+        assert "MYSQL_PASSWORD=${MYSQL_PASSWORD}" in text


### PR DESCRIPTION
Implements the self-heal, with the safety condition worked out in the issue discussion.

## Why it is conditional

`docker-compose.yml` feeds `MYSQL_PASSWORD` to two services:

```yaml
db:  MYSQL_ROOT_PASSWORD=${MYSQL_PASSWORD}
web: MYSQL_PASSWORD=${MYSQL_PASSWORD}
```

MariaDB applies `MARIADB_ROOT_PASSWORD` only when it **initialises an empty data directory**. On a volume that already holds a database, the stored password wins and the variable is ignored.

So generating a replacement splits sharply:

| Database volume | Outcome |
| --- | --- |
| absent | db initialises with the new password, web connects with it — fixed |
| **present** | db keeps its old password and ignores the new one; web is handed the new one and **cannot authenticate** |

The second row is the reported case: a lost or corrupted `.env` implies the instance already existed, so the volume is populated. Healing there would replace a loud failure — db exits with a clear message — with a quiet one: db healthy, wiki broken, and nothing pointing at the cause. The password is also unrecoverable at that point, existing only in the lost `.env` and as a hash inside the volume.

## What it does

`roles/orchestrator/tasks/heal_mysql_password.yml`, included from the Compose start path before anything comes up:

1. Read `MYSQL_PASSWORD`. Present and non-empty — nothing to do.
2. Look for `<project>_mysql-data-volume`.
3. **Found** — fail, saying why generating would not help and naming the ways back: `canasta backup restore` (snapshots do capture `.env`; confirmed in a restore round-trip), another copy of the file, or removing the volume if the database was never really initialised.
4. **Not found** — generate via the same `generate_password.yml` create uses, write it, and say so.

## Where the check lives

One copy, in the Ansible path. The Python fast path returns `FALLBACK` for the broken case rather than repeating the judgement.

Two details that took a correction each:

- **It fires only after `up -d` has failed.** Checking upfront costs an SSH round trip on every remote `canasta start`, which defeats the fast path for a condition that is nearly never true.
- **An unreadable `.env` is not treated as a missing key.** `_read_env_file` returns `{}` for both, and conflating them meant a genuine compose failure — a port conflict, say — would route to Ansible and lose its diagnostic dump. `test_start_does_not_wait_when_up_failed` caught that.

## Tests

`tests/unit/test_heal_mysql_password.py` — the refusal keys on the volume being found and precedes generation; its message explains why generating would not help and names a way back; the password is never logged; the heal runs before `Start containers`.

One test asserts the *premise* rather than the code: that `docker-compose.yml` still feeds `MYSQL_PASSWORD` to both services. If either consumer changes, the reasoning above needs revisiting rather than the tests being adjusted to fit.

## Verified

```
make lint        yamllint + ruff + ansible-lint + validate, all clean
                 ansible-lint: 0 failures in 348 files, profile "production"
make test-unit   2423 passed
```

Fixes #1418
