### PR TITLE
fix(create): stop the runtime probes overwriting each other's result

### DIFF
--- a/roles/orchestrator/tasks/create_preflight.yml
+++ b/roles/orchestrator/tasks/create_preflight.yml
@@ -59,7 +59,7 @@
         - name: Probe podman info (compose_command is podman-based)
           ansible.builtin.command:
             cmd: podman info
-          register: _docker_check
+          register: _podman_only_probe
           changed_when: false
           failed_when: false
 
@@ -72,14 +72,14 @@
         - name: Probe docker info
           ansible.builtin.command:
             cmd: docker info
-          register: _docker_check
+          register: _docker_probe
           changed_when: false
           failed_when: false
 
         - name: Probe podman info (fallback)
           ansible.builtin.command:
             cmd: podman info
-          register: _podman_check
+          register: _podman_fallback_probe
           changed_when: false
           failed_when: false
 
@@ -88,8 +88,24 @@
             compose_command: podman-compose
             inspect_command: podman
           when:
-            - _docker_check.rc | default(1) != 0
-            - _podman_check.rc | default(1) == 0
+            - _docker_probe.rc | default(1) != 0
+            - _podman_fallback_probe.rc | default(1) == 0
+
+    # Exactly one of the two blocks above runs, and a skipped task still
+    # registers — with a result that carries no `rc` and no `stdout`. So
+    # the probes cannot share a register name, and nothing downstream may
+    # read one of them directly: collapse them here into the single
+    # result that answered. Docker comes before the Podman fallback so a
+    # host running both is described by the runtime it will actually use.
+    - name: Record the runtime probe that answered
+      ansible.builtin.set_fact:
+        _runtime_check: >-
+          {{ [_podman_only_probe | default({}),
+              _docker_probe | default({}),
+              _podman_fallback_probe | default({})]
+             | selectattr('rc', 'defined')
+             | selectattr('rc', 'equalto', 0)
+             | list | first | default({}) }}
 
     - name: Fail if container runtime not available
       ansible.builtin.fail:
@@ -97,9 +113,7 @@
           No container runtime is available on this host.
           Docker and Podman are both absent or unreachable.
           Run 'canasta doctor' to check all dependencies.
-      when: >-
-        (_docker_check.rc | default(1) != 0)
-        and (_podman_check.rc | default(1) != 0)
+      when: _runtime_check.rc is not defined
 
     # Rootless Podman has two prerequisites that are invisible until the
     # instance silently fails: systemd reaps the containers when the
@@ -377,7 +391,7 @@
     - name: Resolve container storage root
       ansible.builtin.set_fact:
         _docker_root_dir: >-
-          {{ (_docker_check.stdout | default('')
+          {{ (_runtime_check.stdout | default('')
              | regex_findall('(?:Docker Root Dir|graphRoot):\s*(.+)') | first | default('')) | trim }}
 
     # `df --output=avail` is GNU coreutils only (BusyBox/BSD lack it);

--- a/tests/unit/test_create_preflight_podman_socket.py
+++ b/tests/unit/test_create_preflight_podman_socket.py
@@ -93,11 +93,82 @@ class TestItRunsBeforeTheProbes:
         )
 
     def test_the_podman_branch_still_probes_the_runtime(self):
-        # Selecting podman early must land in the branch that registers
-        # _docker_check, or 'Fail if container runtime not available'
-        # fires on a perfectly good Podman host.
         task = _named("Check container runtime is available")
         assert "podman" in task["when"]
         inner = task["block"][0]
         assert inner["ansible.builtin.command"]["cmd"] == "podman info"
-        assert inner["register"] == "_docker_check"
+
+
+class TestTheProbesDoNotClobberEachOther:
+    """Two conditional probes sharing one register name is a live failure.
+
+    Exactly one of the two probe blocks runs; the other is skipped. A
+    skipped task still registers, and the result it stores has no `rc`
+    and no `stdout`. So when both blocks registered `_docker_check`, the
+    skipped one overwrote the successful one, `rc` fell back to the
+    `default(1)`, and `create` aborted with "No container runtime is
+    available" on a host where `podman info` had just succeeded.
+
+    The same clobbering emptied the `docker info` output that the disk
+    check parses its storage root from, silently skipping it.
+    """
+
+    def _registers(self):
+        """Every register name in the preflight, with its task name."""
+        found = []
+
+        def walk(tasks):
+            for t in tasks or []:
+                if "register" in t:
+                    found.append((t["register"], t.get("name")))
+                for key in ("block", "rescue", "always"):
+                    walk(t.get(key))
+
+        walk(_block_tasks())
+        return found
+
+    def test_no_register_name_is_used_twice(self):
+        names = [r for r, _ in self._registers()]
+        dupes = {n for n in names if names.count(n) > 1}
+        assert not dupes, (
+            "these registers are set by more than one task, so whichever "
+            "task is skipped will overwrite the other's result: %s"
+            % sorted(dupes)
+        )
+
+    def test_each_probe_registers_distinctly(self):
+        by_task = dict((n, r) for r, n in self._registers())
+        assert by_task["Probe podman info (compose_command is podman-based)"] \
+            != by_task["Probe docker info"]
+        assert by_task["Probe docker info"] \
+            != by_task["Probe podman info (fallback)"]
+
+    def test_the_failure_check_reads_the_collapsed_result(self):
+        # Reading any single probe register here is what broke: the one
+        # that answered may not be the one this task can see.
+        task = _named("Fail if container runtime not available")
+        assert "_runtime_check" in str(task["when"])
+        for probe in ("_podman_only_probe", "_docker_probe",
+                      "_podman_fallback_probe"):
+            assert probe not in str(task["when"])
+
+    def test_the_collapsed_result_keeps_only_a_probe_that_succeeded(self):
+        expr = _named("Record the runtime probe that answered")[
+            "ansible.builtin.set_fact"]["_runtime_check"]
+        assert "selectattr('rc', 'defined')" in expr, (
+            "a skipped probe has no rc and must be filtered out"
+        )
+        assert "selectattr('rc', 'equalto', 0)" in expr
+
+    def test_docker_outranks_the_podman_fallback(self):
+        # On a host running both, the recorded storage root must describe
+        # the runtime create will actually use.
+        expr = _named("Record the runtime probe that answered")[
+            "ansible.builtin.set_fact"]["_runtime_check"]
+        assert expr.index("_docker_probe") < expr.index(
+            "_podman_fallback_probe")
+
+    def test_the_storage_root_reads_the_collapsed_result(self):
+        expr = _named("Resolve container storage root")[
+            "ansible.builtin.set_fact"]["_docker_root_dir"]
+        assert "_runtime_check.stdout" in expr


### PR DESCRIPTION
Fixes #1424.

`canasta create` aborted with "No container runtime is available on this host" on any host where the rootless Podman socket is auto-detected — while `canasta doctor` reported Docker, Podman and the socket all healthy. Found by hands-on testing of the 4.15.0 release candidate.

## What was wrong

Two mutually exclusive probe blocks in `create_preflight.yml` registered the same variable, `_docker_check`. Exactly one block runs; the other is skipped — and **a skipped task still registers**, storing a result with no `rc` and no `stdout`. The skipped task therefore overwrote the successful probe's result, `_docker_check.rc | default(1)` fell back to `1`, and the availability check concluded nothing was installed:

```
TASK [orchestrator : Probe podman info (compose_command is podman-based)] ***
ok: [localhost]
TASK [orchestrator : Probe docker info] ***
skipping: [localhost]
TASK [orchestrator : Probe podman info (fallback)] ***
skipping: [localhost]
TASK [orchestrator : Fail if container runtime not available] ***
fatal: [localhost]: FAILED! => "No container runtime is available on this host."
```

The shared register predates this release and was harmless then: on a fresh `create`, `compose_command` never named Podman, so the first block always skipped and the second always ran. Deciding the runtime from the socket (#1399) sets `compose_command: podman-compose` *before* the probes, which flips which block runs — turning a latent bug into a guaranteed failure on the primary Podman path.

A second, quieter effect: `Resolve container storage root` parses `_docker_check.stdout` for the disk-space preflight. The same clobbering left it empty, silently no-opping that check.

## The fix

Each probe gets its own register, and a single `set_fact` collapses them into the one result that answered. Both the availability check and the storage-root parse read that instead of any individual probe. Docker is ordered ahead of the Podman fallback so a host running both is described by the runtime create will actually use.

## Tests

`tests/unit/test_create_preflight_podman_socket.py` asserted the shared register name as though it were the mechanism that made Podman hosts work:

```python
assert inner["register"] == "_docker_check"
```

It encoded the wrong model of Ansible's skip semantics and passed against broken behavior. Replaced with coverage of the collapse, the ordering, and both consumers — plus a guard that no two tasks anywhere in the preflight share a register name, since the general form of this bug can recur elsewhere in the file.

## Verification

Reproduced the failure on a host with rootless Podman active, applied the fix, and re-ran the same command. `create` completed, and the registry recorded the runtime correctly:

```json
"dockerHost":      "unix:///run/user/1000/podman/podman.sock",
"composeCommand":  "podman-compose",
"inspectCommand":  "podman"
```

All four containers came up under Podman (`docker ps` empty), the readiness gate waited for db then web, and the wiki served HTTP 200.

`make test-unit` (2432 passed), `make validate`, `make lint` all green.
