### PR TITLE
fix(start): check for a missing MYSQL_PASSWORD before starting, not after

### DIFF
--- a/direct_commands/_helpers.py
+++ b/direct_commands/_helpers.py
@@ -396,16 +396,21 @@ def _run_compose(inst_id, inst, action_args, include_sidecars=False):
     return _retry_on_ssh_reset(_attempt)
 
 
-def _missing_db_password(inst):
+def _missing_db_password(inst, env=None):
     """True when .env has no usable MYSQL_PASSWORD.
 
-    db exits immediately without it, and healing needs to know whether a
-    database volume already exists before deciding whether generating a
-    replacement is safe. That check lives in the Ansible path
-    (orchestrator/tasks/heal_mysql_password.yml) rather than being
-    duplicated here, so this only has to detect the condition.
+    Healing needs to know whether a database volume already exists before
+    deciding whether generating a replacement is safe. That check lives
+    in the Ansible path (orchestrator/tasks/heal_mysql_password.yml)
+    rather than being duplicated here, so this only has to detect the
+    condition.
+
+    Pass ``env`` when the caller has already read .env, to avoid a second
+    read; omit it to read here.
     """
-    env = _read_env_file(inst.get("path", ""), inst.get("host") or "localhost")
+    if env is None:
+        env = _read_env_file(
+            inst.get("path", ""), inst.get("host") or "localhost")
     if not env:
         # Unreadable or absent .env is a different problem, and treating
         # it as this one would swallow the compose failure the caller is
@@ -482,12 +487,16 @@ def _sync_compose_profiles(inst):
     COMPOSE_PROFILES gets reconciled before compose is invoked. Mirrors
     roles/orchestrator/tasks/sync_compose_profiles.yml — canasta config
     set has its own copy that fires on the relevant keys.
+
+    Returns the parsed .env (empty when there is none) so a caller that
+    needs another key from it does not pay for a second read — on a
+    remote instance that is a second SSH round trip.
     """
     host = inst.get("host") or "localhost"
     path = inst.get("path", "")
     content = _read_env_content(path, host)
     if not content:
-        return  # No .env to sync
+        return {}  # No .env to sync
 
     entries = _parse_env_entries(content)
     env = {k: v for k, v, c in entries if not c and k}
@@ -520,7 +529,7 @@ def _sync_compose_profiles(inst):
     image_changed = image_managed and current_caddy_image != desired_caddy_image
 
     if not profiles_changed and not image_changed:
-        return  # No change needed
+        return env  # No change needed
 
     # Rewrite only the keys that changed, keeping every other line verbatim so
     # quoting (and any inline '#' inside quotes) on unrelated keys survives.
@@ -559,6 +568,8 @@ def _sync_compose_profiles(inst):
                 inst.get("id"), inst,
                 profile_flags + ["rm", "-sf"] + stale_services,
             )
+
+    return env
 
 
 def _dump_compose_failure(inst, include_sidecars=False):

--- a/direct_commands/lifecycle.py
+++ b/direct_commands/lifecycle.py
@@ -31,17 +31,19 @@ def cmd_start(args):
     if _helpers._check_running_compose(path, host, docker_host, compose_cmd):
         print("Instance '%s' is already running." % inst_id)
         return 0
-    _helpers._sync_compose_profiles(inst)
+    env = _helpers._sync_compose_profiles(inst)
+    # Before 'up', not after a failure: MariaDB ignores the root-password
+    # variable once its volume holds a database, so compose comes up
+    # clean and only MediaWiki notices it cannot authenticate. Starting
+    # first would leave a wiki serving 500s and report success. Whether
+    # generating a replacement is safe depends on there being no database
+    # to lock out, which the Ansible path decides — hand the broken case
+    # over rather than duplicating that judgement here. The .env read is
+    # free: _sync_compose_profiles just parsed it.
+    if _helpers._missing_db_password(inst, env):
+        return _helpers.FALLBACK
     rc = _helpers._run_compose(inst_id, inst, ["up", "-d"])
     if rc != 0:
-        if _helpers._missing_db_password(inst):
-            # db exits immediately without it. Whether generating a
-            # replacement is safe depends on there being no database to
-            # lock out, which the Ansible path decides — hand the broken
-            # case over rather than duplicating that judgement here.
-            # Checked only on failure: on a remote instance reading .env
-            # is an SSH round trip.
-            return _helpers.FALLBACK
         _helpers._dump_compose_failure(inst)
         return rc
     return _helpers._wait_web_ready(inst_id, inst)

--- a/tests/unit/test_start_checks_db_password_before_up.py
+++ b/tests/unit/test_start_checks_db_password_before_up.py
@@ -1,0 +1,144 @@
+"""A missing MYSQL_PASSWORD has to be caught before the containers start.
+
+The heal in orchestrator/tasks/heal_mysql_password.yml only runs on the
+Ansible path, and cmd_start reached it by returning FALLBACK when
+`compose up` failed. That premise was wrong: MariaDB applies the root
+password only when it initialises an empty data directory, so on an
+instance whose volume already holds a database, compose comes up clean
+with the variable empty. Every container reports healthy and only
+MediaWiki notices it cannot authenticate.
+
+Observed end to end: `canasta start` printed the containers, ran the
+readiness gate, exited 0 — and the wiki served HTTP 500 "Cannot access
+the database". The heal never ran, because `up` never failed.
+
+So the check runs before `up`. The read costs nothing: cmd_start already
+calls _sync_compose_profiles, which parses .env one line earlier and now
+hands it back.
+"""
+
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+
+import direct_commands  # noqa: E402
+import direct_commands._helpers  # noqa: E402
+
+
+def _args():
+    return type("Args", (), {"id": "test"})()
+
+
+def _common(monkeypatch, calls, env):
+    monkeypatch.setattr(subprocess, "call",
+                        lambda cmd, **kw: calls.append(cmd) or 0)
+    monkeypatch.setattr(direct_commands._helpers, "_resolve_instance",
+                        lambda args: ("test", {"path": "/srv/test",
+                                               "orchestrator": "compose"}))
+    monkeypatch.setattr(direct_commands._helpers, "_compose_file_args",
+                        lambda *a, **kw: ["-f", "docker-compose.yml"])
+    monkeypatch.setattr(direct_commands._helpers, "_check_running_compose",
+                        lambda *a, **kw: False)
+    monkeypatch.setattr(direct_commands._helpers, "_sync_compose_profiles",
+                        lambda inst: env)
+    monkeypatch.setattr(direct_commands._helpers, "_wait_web_ready",
+                        lambda i, inst: 0)
+
+
+class TestTheCheckRunsBeforeAnythingStarts:
+    def test_a_missing_password_hands_over_without_starting(self, monkeypatch):
+        calls = []
+        _common(monkeypatch, calls, {"MYSQL_PASSWORD": "", "OTHER": "x"})
+
+        assert direct_commands.cmd_start(_args()) == direct_commands._helpers.FALLBACK
+        assert calls == [], (
+            "compose started the stack before the password was checked; the "
+            "wiki comes up unable to authenticate and start reports success"
+        )
+
+    def test_an_absent_key_counts_as_missing(self, monkeypatch):
+        calls = []
+        _common(monkeypatch, calls, {"OTHER": "x"})
+
+        assert direct_commands.cmd_start(_args()) == direct_commands._helpers.FALLBACK
+        assert calls == []
+
+    def test_whitespace_only_counts_as_missing(self, monkeypatch):
+        calls = []
+        _common(monkeypatch, calls, {"MYSQL_PASSWORD": "   ", "OTHER": "x"})
+
+        assert direct_commands.cmd_start(_args()) == direct_commands._helpers.FALLBACK
+        assert calls == []
+
+
+class TestAHealthyInstanceIsUnaffected:
+    def test_a_present_password_starts_normally(self, monkeypatch):
+        calls = []
+        _common(monkeypatch, calls, {"MYSQL_PASSWORD": "s3cret", "OTHER": "x"})
+
+        assert direct_commands.cmd_start(_args()) == 0
+        assert calls, "a healthy instance was not started"
+        assert calls[0][-2:] == ["up", "-d"]
+
+    def test_an_unreadable_env_is_not_treated_as_this_problem(self, monkeypatch):
+        # An empty parse means no .env or an unreadable one — a different
+        # fault. Claiming it as a missing password would send every such
+        # instance down the heal path instead of reporting what is wrong.
+        calls = []
+        _common(monkeypatch, calls, {})
+
+        assert direct_commands.cmd_start(_args()) == 0
+        assert calls, "an unreadable .env was misread as a missing password"
+
+
+class TestTheEnvIsReadOnlyOnce:
+    def test_a_supplied_env_is_not_re_read(self, monkeypatch):
+        reads = []
+        monkeypatch.setattr(direct_commands._helpers, "_read_env_file",
+                            lambda p, h: reads.append(p) or {})
+
+        assert direct_commands._helpers._missing_db_password(
+            {"path": "/srv/test"}, {"MYSQL_PASSWORD": "", "OTHER": "x"}) is True
+        assert reads == [], (
+            "a second .env read is a second SSH round trip on a remote "
+            "instance, on every start"
+        )
+
+    def test_it_still_reads_when_no_env_is_supplied(self, monkeypatch):
+        reads = []
+        monkeypatch.setattr(
+            direct_commands._helpers, "_read_env_file",
+            lambda p, h: reads.append(p) or {"MYSQL_PASSWORD": "", "K": "v"})
+
+        assert direct_commands._helpers._missing_db_password(
+            {"path": "/srv/test"}) is True
+        assert reads == ["/srv/test"]
+
+
+class TestSyncComposeProfilesHandsBackWhatItParsed:
+    def _inst(self, tmp_path):
+        return {"path": str(tmp_path), "host": "localhost"}
+
+    def test_it_returns_the_parsed_env_when_nothing_changed(self, tmp_path):
+        (tmp_path / ".env").write_text(
+            "COMPOSE_PROFILES=varnish\nMYSQL_PASSWORD=s3cret\n")
+        env = direct_commands._sync_compose_profiles(self._inst(tmp_path))
+        assert env["MYSQL_PASSWORD"] == "s3cret"
+
+    def test_it_returns_the_parsed_env_when_it_rewrote_profiles(self, tmp_path):
+        (tmp_path / ".env").write_text(
+            "CANASTA_ENABLE_ELASTICSEARCH=true\nCOMPOSE_PROFILES=\n"
+            "MYSQL_PASSWORD=s3cret\n")
+        env = direct_commands._sync_compose_profiles(self._inst(tmp_path))
+        assert "COMPOSE_PROFILES=elasticsearch" in (
+            tmp_path / ".env").read_text()
+        assert env["MYSQL_PASSWORD"] == "s3cret"
+
+    def test_no_env_file_yields_an_empty_mapping(self, tmp_path):
+        # Falsy, so the caller treats it as "nothing to judge on" rather
+        # than as a missing password.
+        assert direct_commands._sync_compose_profiles(
+            self._inst(tmp_path)) == {}


### PR DESCRIPTION
Fixes #1426.

The MYSQL_PASSWORD heal added in #1423 never ran on the default `canasta start` path. Found while e2e-testing the 4.15.0 release candidate.

## What was wrong

`cmd_start` checked `_missing_db_password` only when `compose up` returned non-zero:

```python
rc = _helpers._run_compose(inst_id, inst, ["up", "-d"])
if rc != 0:
    if _helpers._missing_db_password(inst):
        return _helpers.FALLBACK
```

The comment justified this with "db exits immediately without it". It does not. MariaDB applies `MARIADB_ROOT_PASSWORD` only when it initialises an **empty** data directory; on a volume that already holds a database the stored password wins and the empty variable is ignored. So `db` comes up healthy, `up` returns 0, and the branch is never entered.

The condition the heal exists to catch is precisely the condition under which `up` succeeds — the check could only ever fire when `up` failed for some *other* reason and the password happened to also be missing.

Observed end to end, with `MYSQL_PASSWORD` deleted from `.env`:

```
Starting containers...
pod1_db_1
pod1_web_1
pod1_caddy_1
pod1_varnish_1
Waiting for web to become ready...
=== EXIT 0 ===
```

and the wiki serving:

```
HTTP 500
<title>MediaWiki</title>
Cannot access the database
```

Forcing the Ansible path showed the guard itself was correct and merely unreachable.

## The fix

Move the check ahead of `up`. The cost the old comment cited — an SSH round trip to read `.env` on a remote instance — does not apply: `cmd_start` already calls `_sync_compose_profiles`, which reads and parses `.env` one line earlier, on every start, remote included. It now returns that mapping, and `_missing_db_password` takes an optional pre-read env, so the check adds no I/O.

An empty mapping still means "no `.env`, or unreadable" rather than "missing password", so that separate fault keeps reporting itself instead of being routed to the heal.

## Verification

On the host that produced the 500 above, with the password still missing:

```
$ canasta start -i pod1
Starting containers...
Error: MYSQL_PASSWORD is missing from .../pod1/.env, and this instance already
has a database volume (pod1_mysql-data-volume). Generating a new password would
not reach that database — MariaDB only applies the root password when it first
initialises — so the wiki would be handed credentials the database does not
accept. Restore the value instead: 'canasta backup restore' brings back .env
from a snapshot, or copy MYSQL_PASSWORD from another copy of the file. ...
=== EXIT 2 ===
```

Restoring `.env` and starting again returned the wiki to HTTP 200.

## Coverage

The tests that came with #1423 asserted the Ansible task's structure — the refusal, its ordering, its message — but nothing asserted the fast path could reach it, which is why a dead check looked covered. The new tests drive `cmd_start` directly and assert compose is never invoked when the key is missing, that a healthy instance is unaffected, that an unreadable `.env` is not misread as this fault, and that the env is read only once.

`make test-unit` (2442 passed), `make validate`, `make lint` all green.
