### PR TITLE
fix(docker): refuse a local Podman instance instead of failing partway

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -929,15 +929,17 @@ def check_create_precondition(args):
 def _runs_under_podman(instance):
     """True when this instance's compose calls need Podman tooling.
 
-    Any of the three can say so: an explicit podman compose_command, a
-    podman inspect_command, or a dockerHost pointing at Podman's socket
-    — the last because a legacy record with neither command set has its
-    runtime inferred from the socket.
+    Asks the same resolver the compose calls go through rather than
+    testing the registry fields directly. Those fields are a precedence
+    chain — an explicit composeCommand wins over .env, which wins over
+    inspectCommand, which wins over the dockerHost socket — so reading
+    them as a set disagrees with reality at both ends: an instance
+    recorded as `docker compose` against a Podman socket really does run
+    `docker compose` (which the container has), and one whose only
+    statement is `compose_command` in .env really does need
+    podman-compose.
     """
-    return any(
-        "podman" in (instance.get(key) or "")
-        for key in ("composeCommand", "inspectCommand", "dockerHost")
-    )
+    return "podman" in " ".join(_resolve_compose_cmd(instance))
 
 
 def check_docker_mode_can_reach_runtime(args):

--- a/canasta.py
+++ b/canasta.py
@@ -926,6 +926,89 @@ def check_create_precondition(args):
     sys.exit(EXIT_ALREADY_EXISTS)
 
 
+def _runs_under_podman(instance):
+    """True when this instance's compose calls need Podman tooling.
+
+    Any of the three can say so: an explicit podman compose_command, a
+    podman inspect_command, or a dockerHost pointing at Podman's socket
+    — the last because a legacy record with neither command set has its
+    runtime inferred from the socket.
+    """
+    return any(
+        "podman" in (instance.get(key) or "")
+        for key in ("composeCommand", "inspectCommand", "dockerHost")
+    )
+
+
+def check_docker_mode_can_reach_runtime(args):
+    """Refuse a Podman instance that is local to a Docker-mode controller.
+
+    In Docker mode the CLI runs inside the canasta-ansible container,
+    which ships docker and `docker compose` but no podman-compose. For a
+    *remote* instance that does not matter — compose runs on the target
+    over SSH, where podman-compose lives. For an instance local to the
+    controller the compose call runs in the container and dies partway
+    through with a bare `rc=127`, after stack files have already been
+    rewritten.
+
+    Installing podman-compose on the host does not help: the command
+    runs inside the container, and only the socket, the registry, $HOME
+    and the working directory are mounted — not host binaries. So the
+    honest answer is to refuse up front and name the native CLI.
+    """
+    if os.environ.get("CANASTA_RUN_MODE") != "docker":
+        return
+    conf_file = get_config_file_path()
+    if not os.path.isfile(conf_file):
+        return
+    instances = canasta_config.read_config(
+        get_config_dir()).get("Instances", {})
+
+    # Scope to the instance the command names; commands that take no
+    # target (upgrade) act on every registered instance, so check them
+    # all rather than letting one bad record fail the run halfway.
+    inst_id = getattr(args, "id", None)
+    if inst_id:
+        candidates = {inst_id: instances[inst_id]} if inst_id in instances else {}
+    else:
+        inst_path = getattr(args, "path", None)
+        if inst_path:
+            target = os.path.abspath(inst_path)
+            candidates = {
+                k: v for k, v in instances.items()
+                if os.path.abspath(v.get("path", "")) == target
+            }
+        else:
+            candidates = instances
+
+    blocked = sorted(
+        k for k, v in candidates.items()
+        if v.get("orchestrator", "compose") == "compose"
+        and v.get("host") in ("localhost", "", None)
+        and _runs_under_podman(v)
+    )
+    if not blocked:
+        return
+
+    print(
+        "Error: %s runs under Podman on this controller, which the "
+        "Docker-mode CLI cannot manage.\n"
+        "The CLI runs inside a container that has no podman-compose, and "
+        "installing one on the host does not reach it.\n"
+        "Install the native CLI to manage %s:\n"
+        "  curl -fsSL https://get.canasta.wiki | bash -s -- --native\n"
+        "Instances on remote hosts are unaffected — their compose "
+        "commands run on the target."
+        % (
+            "instance '%s'" % blocked[0] if len(blocked) == 1
+            else "instances %s" % ", ".join("'%s'" % b for b in blocked),
+            "it" if len(blocked) == 1 else "them",
+        ),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
 def _redirect_stdin_from_file(path):
     """Point fd 0 at `path` so the about-to-be-exec'd command reads it as
     stdin. Used by `maintenance exec --stdin-file`. No-op when path is unset.
@@ -1776,6 +1859,11 @@ def main():
     # as a backstop).
     if command_name == "create":
         check_create_precondition(args)
+
+    # Pre-flight: the Docker-mode CLI cannot drive a Podman instance that
+    # is local to this controller. Refuse before either path starts, so
+    # the operator gets the reason instead of a mid-operation rc=127.
+    check_docker_mode_can_reach_runtime(args)
 
     # Interactive exec: bypass Ansible for TTY support.
     if command_name == "maintenance_exec":

--- a/tests/unit/test_docker_mode_podman_guard.py
+++ b/tests/unit/test_docker_mode_podman_guard.py
@@ -112,6 +112,17 @@ class TestItRefusesALocalPodmanInstance:
         registry({"leg": legacy})
         assert _refuses(_args(id="leg")) == 1
 
+    def test_a_compose_command_stated_only_in_env_is_caught(self, registry,
+                                                            tmp_path):
+        # The registry says nothing about the runtime, but .env does, and
+        # the resolver reads it for local instances. Testing the registry
+        # fields alone would let this through to fail at runtime.
+        (tmp_path / ".env").write_text("compose_command=podman-compose\n")
+        inst = {"id": "envy", "path": str(tmp_path), "host": "localhost",
+                "orchestrator": "compose"}
+        registry({"envy": inst})
+        assert _refuses(_args(id="envy")) == 1
+
 
 class TestItDoesNotRefuseAnythingElse:
     def _ok(self, args):
@@ -125,6 +136,17 @@ class TestItDoesNotRefuseAnythingElse:
     def test_a_local_docker_instance_is_allowed(self, registry):
         registry({"doc1": DOCKER_LOCAL})
         self._ok(_args(id="doc1"))
+
+    def test_docker_compose_against_a_podman_socket_is_allowed(self, registry):
+        # The #1390 mis-recording shape, and also how canasta-docker on a
+        # Podman-only host legitimately works: the wrapper mounts the
+        # Podman socket at /var/run/docker.sock and `docker compose` --
+        # which the container has -- drives it. An explicit composeCommand
+        # outranks the socket, so this must not be blocked.
+        inst = dict(DOCKER_LOCAL, id="mixed",
+                    dockerHost="unix:///run/user/1000/podman/podman.sock")
+        registry({"mixed": inst})
+        self._ok(_args(id="mixed"))
 
     def test_native_mode_is_never_blocked(self, registry):
         # Native mode runs podman-compose from the host, where it exists.

--- a/tests/unit/test_docker_mode_podman_guard.py
+++ b/tests/unit/test_docker_mode_podman_guard.py
@@ -1,0 +1,154 @@
+"""Docker mode cannot drive a Podman instance local to the controller.
+
+The CLI runs inside the canasta-ansible container, which ships docker
+and `docker compose` but no podman-compose. Without a guard, an upgrade
+gets as far as rewriting the stack files and then dies:
+
+    Writing Compose stack files...
+    Pulling Canasta container images...
+    Error: pull Compose images failed (rc=127): /bin/sh: 1: podman-compose: not found
+
+Remote instances are deliberately *not* blocked: their compose commands
+run on the target over SSH, where podman-compose exists. That path was
+verified working end to end (status and restart) against a remote
+Podman instance, so blocking it would break the topology that matters
+most for Podman.
+
+Installing podman-compose on the host does not change any of this — the
+command runs inside the container, and only the socket, the registry,
+$HOME and the working directory are mounted, not host binaries.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+
+import canasta  # noqa: E402
+
+PODMAN_LOCAL = {
+    "id": "pod1", "path": "/srv/pod1", "orchestrator": "compose",
+    "host": "localhost",
+    "dockerHost": "unix:///run/user/1000/podman/podman.sock",
+    "composeCommand": "podman-compose", "inspectCommand": "podman",
+}
+DOCKER_LOCAL = {
+    "id": "doc1", "path": "/srv/doc1", "orchestrator": "compose",
+    "host": "localhost", "dockerHost": "unix:///var/run/docker.sock",
+    "composeCommand": "docker compose", "inspectCommand": "docker",
+}
+PODMAN_REMOTE = dict(PODMAN_LOCAL, id="rem1", path="/srv/rem1",
+                     host="cicalese@example.com")
+
+
+def _args(**kw):
+    kw.setdefault("id", None)
+    kw.setdefault("path", None)
+    return type("Args", (), kw)()
+
+
+@pytest.fixture
+def registry(monkeypatch, tmp_path):
+    """Point the guard at a registry we control, in docker mode."""
+    def _install(instances, mode="docker"):
+        conf = tmp_path / "conf.json"
+        conf.write_text("{}")
+        monkeypatch.setenv("CANASTA_RUN_MODE", mode)
+        monkeypatch.setattr(canasta, "get_config_file_path", lambda: str(conf))
+        monkeypatch.setattr(canasta, "get_config_dir", lambda: str(tmp_path))
+        monkeypatch.setattr(canasta.canasta_config, "read_config",
+                            lambda d: {"Instances": instances})
+    return _install
+
+
+def _refuses(args):
+    with pytest.raises(SystemExit) as e:
+        canasta.check_docker_mode_can_reach_runtime(args)
+    return e.value.code
+
+
+class TestItRefusesALocalPodmanInstance:
+    def test_named_instance_is_refused(self, registry):
+        registry({"pod1": PODMAN_LOCAL})
+        assert _refuses(_args(id="pod1")) == 1
+
+    def test_the_message_says_why_and_what_to_do(self, registry, capsys):
+        registry({"pod1": PODMAN_LOCAL})
+        _refuses(_args(id="pod1"))
+        err = capsys.readouterr().err
+        assert "pod1" in err
+        assert "podman-compose" in err
+        assert "get.canasta.wiki" in err
+        assert "--native" in err
+
+    def test_it_says_installing_on_the_host_will_not_help(self, registry,
+                                                          capsys):
+        # Otherwise the obvious next move is `brew install podman-compose`,
+        # which cannot reach inside the container.
+        registry({"pod1": PODMAN_LOCAL})
+        _refuses(_args(id="pod1"))
+        assert "does not reach it" in capsys.readouterr().err
+
+    def test_an_untargeted_command_checks_every_instance(self, registry):
+        # `upgrade` takes no -i and acts on all of them, so one bad record
+        # must stop it before it half-finishes the others.
+        registry({"doc1": DOCKER_LOCAL, "pod1": PODMAN_LOCAL})
+        assert _refuses(_args()) == 1
+
+    def test_it_matches_by_path_too(self, registry):
+        registry({"pod1": PODMAN_LOCAL})
+        assert _refuses(_args(path="/srv/pod1")) == 1
+
+    def test_a_legacy_record_with_only_a_podman_socket_is_caught(self,
+                                                                registry):
+        # Neither command recorded; the runtime is inferred from the
+        # socket, so the compose call still needs podman-compose.
+        legacy = {"id": "leg", "path": "/srv/leg", "orchestrator": "compose",
+                  "host": "localhost",
+                  "dockerHost": "unix:///run/user/1000/podman/podman.sock"}
+        registry({"leg": legacy})
+        assert _refuses(_args(id="leg")) == 1
+
+
+class TestItDoesNotRefuseAnythingElse:
+    def _ok(self, args):
+        assert canasta.check_docker_mode_can_reach_runtime(args) is None
+
+    def test_a_remote_podman_instance_is_allowed(self, registry):
+        # Verified working end to end; compose runs on the target.
+        registry({"rem1": PODMAN_REMOTE})
+        self._ok(_args(id="rem1"))
+
+    def test_a_local_docker_instance_is_allowed(self, registry):
+        registry({"doc1": DOCKER_LOCAL})
+        self._ok(_args(id="doc1"))
+
+    def test_native_mode_is_never_blocked(self, registry):
+        # Native mode runs podman-compose from the host, where it exists.
+        registry({"pod1": PODMAN_LOCAL}, mode="native")
+        self._ok(_args(id="pod1"))
+
+    def test_a_kubernetes_instance_is_not_compose_and_is_allowed(self,
+                                                                 registry):
+        k8s = dict(PODMAN_LOCAL, id="k1", orchestrator="kubernetes")
+        registry({"k1": k8s})
+        self._ok(_args(id="k1"))
+
+    def test_targeting_a_docker_instance_ignores_an_unrelated_podman_one(
+            self, registry):
+        # Scoped commands must not be blocked by a record they never touch.
+        registry({"doc1": DOCKER_LOCAL, "pod1": PODMAN_LOCAL})
+        self._ok(_args(id="doc1"))
+
+    def test_an_unknown_id_is_left_to_the_normal_error_path(self, registry):
+        registry({"pod1": PODMAN_LOCAL})
+        self._ok(_args(id="nosuch"))
+
+    def test_no_registry_is_not_an_error(self, monkeypatch):
+        monkeypatch.setenv("CANASTA_RUN_MODE", "docker")
+        monkeypatch.setattr(canasta, "get_config_file_path",
+                            lambda: "/nonexistent/conf.json")
+        self._ok(_args(id="pod1"))


### PR DESCRIPTION
Refs #1428.

In Docker mode the CLI runs inside the `canasta-ansible` container, which ships `docker` and `docker compose` but no `podman-compose`. For an instance **local to the controller** the compose call runs in that container, so the operation got as far as rewriting the stack files and then died:

```
Writing Compose stack files...
Pulling Canasta container images...
Error: pull Compose images failed (rc=127): /bin/sh: 1: podman-compose: not found
```

This refuses up front instead, before either the fast path or Ansible starts.

## What is and is not blocked

Blocked only when all three hold: the instance is Compose, it is local to this controller (`host` unset or `localhost`), and it looks Podman-backed.

**Remote instances are deliberately not blocked.** Their compose commands run on the target over SSH, where `podman-compose` exists. I verified that topology end to end against a remote Podman instance — `status` returning the full container table, and `restart` (down + up) with the wiki back at HTTP 200 afterwards. That is the topology that matters most for Podman, so there is a test asserting it stays allowed.

"Podman-backed" is decided by asking `_resolve_compose_cmd` — the same resolver the compose calls go through — rather than by inspecting the registry fields.

That matters, because those fields are a **precedence chain** (`composeCommand` > `.env` > `inspectCommand` > `dockerHost`), not a set. An earlier revision of this branch tested them as a set and was wrong in both directions:

- It **blocked a working configuration**: `composeCommand: "docker compose"` with a Podman `dockerHost` resolves to `docker compose`, which the container has. That is the #1390 mis-recording shape, and also how the wrapper legitimately runs on a Podman-only host — it mounts the Podman socket at `/var/run/docker.sock` and `docker compose` drives it.
- It **missed a broken one**: an instance whose only statement of runtime is `compose_command` in `.env`, which the resolver reads for local instances.

Deferring to the resolver means the guard and the compose call cannot disagree. Both cases have regression tests.

Scoping follows the command. `-i`/`-p` check just that instance; a command that takes no target — `upgrade`, which cannot be scoped — checks every registered instance, so one bad record stops the run instead of half-finishing the others.

## The message

```
Error: instance 'podlocal' runs under Podman on this controller, which the Docker-mode CLI cannot manage.
The CLI runs inside a container that has no podman-compose, and installing one on the host does not reach it.
Install the native CLI to manage it:
  curl -fsSL https://get.canasta.wiki | bash -s -- --native
Instances on remote hosts are unaffected — their compose commands run on the target.
```

The second line is there because the obvious next move is otherwise to install `podman-compose` on the host, which cannot work: the command runs inside the container, and only the socket, the registry, `$HOME` and the working directory are mounted — not host binaries.

## Verification

Built an image from this branch and ran the wrapper against a crafted registry:

| case | result |
|---|---|
| local Podman instance | refused, message above, exit 1 |
| local Docker instance | passes through, normal status output |
| remote Podman instance (real, on a test host) | passes through, full container table |

`make test-unit` (2457 passed), `make validate`, `make lint` all green.

## Not covered here

The wrapper cannot find the Podman socket on macOS (`podman machine` paths are absent from its discovery chain) — filed separately as #1429, since it is about starting the container at all rather than about `podman-compose`, and it needs a macOS host with Podman to confirm.
