### PR TITLE
ci(podman): enable the rootless socket so the lane covers the path real hosts take

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -269,9 +269,13 @@ jobs:
           [engine.runtimes]
           crun = ["/usr/local/bin/crun"]
           EOF
-          # Rootless Podman prerequisites
-          sudo loginctl enable-linger "$(id -un)"
-          sudo sysctl -w net.ipv4.ip_unprivileged_port_start=80
+          # Subordinate id ranges are a property of the runner image, not
+          # something Canasta configures — the static bundle brings no
+          # useradd hook to write them. Lingering, the unprivileged port
+          # floor and the socket are deliberately NOT set here: they are
+          # the three rootless prerequisites `canasta install podman`
+          # exists to configure, and setting them by hand would mean this
+          # lane never tests that it does. See #1432.
           grep -q "^$(id -un):" /etc/subuid 2>/dev/null || \
             echo "$(id -un):100000:65536" | sudo tee -a /etc/subuid
           grep -q "^$(id -un):" /etc/subgid 2>/dev/null || \
@@ -335,14 +339,6 @@ jobs:
             exit 1
           fi
 
-      - name: Smoke test podman
-        run: |
-          podman --version
-          podman-compose --version
-          podman info >/dev/null
-          podman run --rm docker.io/library/alpine:latest true
-          echo "Podman ${{ matrix.podman_version }} smoke test passed"
-
       - name: Install Python dependencies
         run: |
           python -m venv .venv
@@ -361,30 +357,56 @@ jobs:
           git config --global user.name "CI"
           git config --global user.email "ci@canasta.wiki"
 
-      # Configure the rootless prerequisites the way an operator does,
-      # rather than by hand, so this lane exercises the install path and
-      # ends up in the state a real Podman host is in. The socket is the
-      # point: without it the CLI never detects a Podman socket, falls
-      # through to "Docker absent, use Podman" instead, and the whole
-      # lane silently tests a route no installed host takes. See #1432.
+      # The rootless prerequisites — lingering, the unprivileged port
+      # floor, and the socket — are configured the way an operator
+      # configures them, so the lane both exercises the install path and
+      # ends up in the state a real Podman host is in.
+      #
+      # The socket is the point. Without it the CLI detects no Podman
+      # socket, falls through to "Docker absent, use Podman" instead, and
+      # the lane silently tests a route no installed host takes. See #1432.
       - name: Configure rootless prerequisites via canasta install podman
         run: ./canasta-native install podman
 
-      # `install podman` warns rather than fails when it cannot enable
-      # the socket, which is exactly how this gap stayed invisible. Assert
-      # it here so a silent regression fails the lane instead of quietly
-      # restoring the blind spot.
-      - name: Assert the rootless Podman socket is live
+      # Every one of those three steps warns rather than fails when it
+      # cannot be applied, which is exactly how this gap stayed invisible.
+      # Assert the results so a silent regression fails the lane instead
+      # of quietly restoring the blind spot.
+      - name: Assert the rootless prerequisites are in place
         run: |
+          fail=0
           sock="/run/user/$(id -u)/podman/podman.sock"
           if [ ! -S "$sock" ]; then
             echo "No socket at $sock — 'canasta install podman' did not enable" \
                  "podman.socket, so this lane cannot reach the socket-detection" \
                  "path it exists to cover." >&2
             systemctl --user status podman.socket --no-pager 2>&1 | head -20 >&2 || true
-            exit 1
+            fail=1
           fi
-          echo "rootless Podman socket: $sock"
+          if [ "$(loginctl show-user "$(id -un)" -p Linger --value)" != "yes" ]; then
+            echo "Lingering is off — systemd would reap the containers when" \
+                 "the session ends." >&2
+            fail=1
+          fi
+          floor="$(cat /proc/sys/net/ipv4/ip_unprivileged_port_start)"
+          if [ "$floor" -gt 80 ]; then
+            echo "Unprivileged port floor is $floor — rootless Caddy cannot" \
+                 "bind 80/443." >&2
+            fail=1
+          fi
+          [ "$fail" -eq 0 ] || exit 1
+          echo "socket=$sock linger=yes port_floor=$floor"
+
+      # After `canasta install podman`, so this confirms the environment
+      # that command produced actually runs containers — /run/user/<uid>
+      # does not exist until lingering is enabled.
+      - name: Smoke test podman
+        run: |
+          podman --version
+          podman-compose --version
+          podman info >/dev/null
+          podman run --rm docker.io/library/alpine:latest true
+          echo "Podman ${{ matrix.podman_version }} smoke test passed"
 
       - name: Run Podman tests
         run: >-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -361,10 +361,36 @@ jobs:
           git config --global user.name "CI"
           git config --global user.email "ci@canasta.wiki"
 
+      # Configure the rootless prerequisites the way an operator does,
+      # rather than by hand, so this lane exercises the install path and
+      # ends up in the state a real Podman host is in. The socket is the
+      # point: without it the CLI never detects a Podman socket, falls
+      # through to "Docker absent, use Podman" instead, and the whole
+      # lane silently tests a route no installed host takes. See #1432.
+      - name: Configure rootless prerequisites via canasta install podman
+        run: ./canasta-native install podman
+
+      # `install podman` warns rather than fails when it cannot enable
+      # the socket, which is exactly how this gap stayed invisible. Assert
+      # it here so a silent regression fails the lane instead of quietly
+      # restoring the blind spot.
+      - name: Assert the rootless Podman socket is live
+        run: |
+          sock="/run/user/$(id -u)/podman/podman.sock"
+          if [ ! -S "$sock" ]; then
+            echo "No socket at $sock — 'canasta install podman' did not enable" \
+                 "podman.socket, so this lane cannot reach the socket-detection" \
+                 "path it exists to cover." >&2
+            systemctl --user status podman.socket --no-pager 2>&1 | head -20 >&2 || true
+            exit 1
+          fi
+          echo "rootless Podman socket: $sock"
+
       - name: Run Podman tests
         run: >-
           .venv/bin/python tests/integration/run_tests.py
           lifecycle upgrade upgrade-rebuilds-buildable rebuild doctor
+          podman-socket-runtime
         timeout-minutes: 35
 
   integration-features:

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -308,6 +308,64 @@ def read_env(path):
 
 # --- Tests ---
 
+def test_podman_socket_runtime(inst):
+    """A rootless Podman socket must be what decides the runtime.
+
+    There are two ways to arrive at Podman, and only one of them is what
+    an installed host does. With no socket and Docker unreachable, the
+    pre-flight falls through to "Docker absent, Podman present" and
+    switches the runtime there. With a socket, it decides from the socket
+    before probing anything.
+
+    A lane that only ever takes the first route says nothing about the
+    second, which is the one `canasta install podman` produces and every
+    real rootless host takes. That is where #1424 broke `create` outright
+    while this suite stayed green on every push to main.
+
+    Skips where there is no socket, so Docker lanes are unaffected.
+    """
+    sock = "/run/user/%d/podman/podman.sock" % os.getuid()
+    if not os.path.exists(sock):
+        raise SkipTest("no rootless Podman socket at %s" % sock)
+
+    print("Creating instance with a Podman socket present...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir,
+        "-e", inst.env_file,
+    )
+
+    with open(os.path.join(inst.config_dir, "conf.json")) as f:
+        record = (json.load(f).get("Instances") or {})[inst.id]
+
+    # The socket has to be what got recorded. Reaching Podman by the
+    # fallback leaves dockerHost unset, so this is what tells the two
+    # routes apart.
+    assert record.get("dockerHost") == "unix://%s" % sock, (
+        "create did not record the detected Podman socket; it likely "
+        "reached Podman by the Docker-absent fallback instead. "
+        "dockerHost=%r" % record.get("dockerHost")
+    )
+    assert "podman" in (record.get("composeCommand") or ""), (
+        "composeCommand=%r" % record.get("composeCommand")
+    )
+    assert record.get("inspectCommand") == "podman", (
+        "inspectCommand=%r" % record.get("inspectCommand")
+    )
+
+    print("Waiting for wiki...")
+    wait_for_wiki(inst.http_port)
+
+    # The containers must actually be Podman's, not just labelled so.
+    running = subprocess.run(
+        ["podman", "ps", "--format", "{{.Names}}"],
+        capture_output=True, text=True,
+    ).stdout
+    assert any(inst.id in line for line in running.splitlines()), (
+        "no Podman containers for %s; podman ps:\n%s" % (inst.id, running)
+    )
+
+
 def test_lifecycle(inst):
     """Create -> verify -> stop -> start -> verify -> delete."""
     print("Creating instance...")
@@ -3863,6 +3921,7 @@ ALL_TESTS = {
     "k8s-crowdsec": test_k8s_crowdsec,
     "k8s-backup": test_k8s_backup,
     "lifecycle": test_lifecycle,
+    "podman-socket-runtime": test_podman_socket_runtime,
     "import": test_import_export,
     "upgrade": test_upgrade,
     "upgrade-rebuilds-buildable": test_upgrade_rebuilds_buildable,


### PR DESCRIPTION
Fixes #1432.

The Podman lane masked Docker and never enabled `podman.socket`, so the CLI found no socket, fell through to "Docker absent, Podman present", and switched the runtime there. That is not the route an installed host takes — `canasta install podman` enables the socket, and the pre-flight then decides from it before probing anything.

So the lane tested a configuration our own installer does not produce, and could not reach the one it does. #1424 broke `canasta create` on **every** rootless-Podman host, and this suite stayed green across every push to main while it was broken. It was found by hand.

## What changed

**`canasta install podman` now owns the rootless prerequisites.** The lane previously set lingering and the unprivileged port floor by hand, which meant it never tested that the install command sets them. Both are removed. `subuid`/`subgid` stay — those are a property of the runner image (the static bundle brings no useradd hook), not something Canasta configures.

**The results are asserted.** All three prerequisites warn rather than fail when they cannot be applied — precisely how this gap stayed invisible — so lingering, the port floor and the socket are each checked, and the lane fails loudly if any is missing.

**The smoke test moved after the install.** `/run/user/<uid>` does not exist until lingering is enabled, so running podman before that point would test an environment the install has not produced yet.

**New test `podman-socket-runtime`** asserts the socket is what *decided* the runtime, not merely that Podman was reached:

```python
assert record.get("dockerHost") == "unix://%s" % sock
assert "podman" in (record.get("composeCommand") or "")
assert record.get("inspectCommand") == "podman"
```

Reaching Podman by the fallback leaves `dockerHost` unset, which is what tells the two routes apart. A lifecycle test passes either way and cannot distinguish them — so enabling the socket without this assertion would still let a socket-detection regression through. It skips where there is no socket, so Docker lanes are unaffected.

## Verification

Dispatched on this branch (`workflow_dispatch` runs the full matrix rather than push's single leg): https://github.com/CanastaWiki/Canasta-CLI/actions/runs/30763950492

The install command configured a runner that started with none of the prerequisites:

```
Enabling lingering and lowering unprivileged port floor...
Podman already available. Rootless prerequisites were configured.
socket=/run/user/1001/podman/podman.sock linger=yes port_floor=80
```

Since the manual `loginctl enable-linger` and `sysctl` lines are gone, nothing else could have set those.

Leg `5.3.2 / 1.3.0` finished:

```
PASSED: podman-socket-runtime
=== Results: 6 passed, 0 failed, 0 skipped ===
```

`0 skipped` is the load-bearing part — the test skips itself when no socket is present, so a skip would have meant the lane still was not reaching the socket path.

The remaining legs (4.9.5, 5.8.4, and the podman-compose 1.6.0 variant) were still running when this was opened.

## Note on a risk that did not materialize

`install podman` gates its rootless block on `podman info --format {{.Host.Security.Rootless}}` returning `true`, and `podman info` might have needed the `/run/user/<uid>` that lingering itself creates — the old lane set lingering first, possibly for that reason. It did not: the block ran and configured all three. Worth knowing, since it means the command works on a host that has never had a user session set up.

`make test-unit` (2457), `make validate`, `make lint` and `actionlint` all green.
