### PR TITLE
feat(install): add uv target to install uv + podman-compose via Astral uv

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -722,6 +722,28 @@ def hoist_flags_from_remainder(args):
         setattr(args, pos_name, new_args)
 
 
+class _DynamicChoices:
+    """argparse choices that accept a fixed list plus a prefix pattern.
+
+    Used for `canasta install` where the base packages are fixed
+    (docker, podman, etc.) but `uv:<tool>` is an open-ended prefix
+    (e.g. `uv:podman-compose`).  argparse calls `__contains__` for
+    validation and `__iter__` for --help output.
+    """
+
+    def __init__(self, base, prefix):
+        self._base = set(base)
+        self._prefix = prefix
+
+    def __contains__(self, item):
+        if item in self._base:
+            return True
+        return isinstance(item, str) and item.startswith(self._prefix)
+
+    def __iter__(self):
+        return iter(sorted(self._base))
+
+
 def _positional_choices(param, name):
     """argparse kwargs constraining a positional to a fixed set of values.
 
@@ -732,6 +754,9 @@ def _positional_choices(param, name):
     """
     choices = param.get("choices")
     if choices:
+        prefix = param.get("choices_dynamic_prefix")
+        if prefix:
+            return {"choices": _DynamicChoices(choices, prefix)}
         return {"choices": choices}
     return {"metavar": name.upper()}
 

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -775,7 +775,8 @@ commands:
     description: "Install dependencies on the target host"
     long_description: |
       Install one or more dependencies on the target host. Supported
-      packages: docker, k8s-cp, k8s-worker, git-crypt, sops, canasta, podman.
+      packages: docker, k8s-cp, k8s-worker, git-crypt, sops, canasta,
+      podman, uv, uv:<tool>.
 
       `k8s-cp` installs k3s as a control-plane node — the cluster's
       API server, scheduler, etc., plus kubectl + helm on the same
@@ -823,6 +824,13 @@ commands:
       rootless Podman targets. Idempotent — skips if podman is already
       installed.
 
+      `uv` installs the Astral uv Python package manager on its own.
+      `uv:<tool>` installs `<tool>` via uv (e.g. `uv:podman-compose`).
+      This is the recommended workaround for Debian 13 (trixie) stable,
+      which ships podman-compose 1.3.0 — a version with a known bug
+      that breaks Canasta's docker-compose.yml defaults. Idempotent —
+      skips if the tool is already present.
+
       Multiple packages can be combined in a single command, except
       that `k8s-cp` and `k8s-worker` are mutually exclusive on a given
       host.
@@ -837,6 +845,10 @@ commands:
       - "canasta install -i mysite canasta"
       - "canasta install podman"
       - "canasta install --host prod1.example.com podman"
+      - "canasta install uv"
+      - "canasta install --host prod1.example.com uv"
+      - "canasta install uv:podman-compose"
+      - "canasta install --host prod1.example.com uv:podman-compose"
     playbook: install.yml
     parameters:
       - name: host
@@ -863,10 +875,11 @@ commands:
         positional: true
         multi: true
         required: true
-        choices: [docker, k8s-cp, k8s-worker, git-crypt, sops, podman, canasta]
+        choices: [docker, k8s-cp, k8s-worker, git-crypt, sops, podman, canasta, uv]
+        choices_dynamic_prefix: "uv:"
         description: >-
           Dependencies to install (docker, k8s-cp, k8s-worker,
-          git-crypt, sops, podman, canasta)
+          git-crypt, sops, podman, canasta, uv, uv:<tool>)
       - name: public_ip
         type: string
         multi: true

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -1,7 +1,7 @@
 ---
 # canasta install - Install dependencies on the target host.
 # Accepts one or more package names: docker, k8s-cp, k8s-worker,
-# git-crypt, sops, canasta, podman.
+# git-crypt, sops, canasta, podman, uv, uv:<tool>.
 #
 # Package names are the CLI's own, dispatched on as-is. The task files
 # below keep the name of the software they install (k3s), which is not
@@ -25,9 +25,19 @@
   ansible.builtin.fail:
     msg: >-
       Unknown package '{{ item }}'. Supported: docker, k8s-cp,
-      k8s-worker, git-crypt, sops, canasta, podman.
-  when: item not in ['docker', 'k8s-cp', 'k8s-worker', 'git-crypt', 'sops', 'canasta', 'podman']
+      k8s-worker, git-crypt, sops, canasta, podman, uv, uv:<tool>.
+  when: >
+    item not in ['docker', 'k8s-cp', 'k8s-worker', 'git-crypt',
+                 'sops', 'canasta', 'podman', 'uv']
+    and not (item | regex_search('^uv:[a-zA-Z0-9_-]+$'))
   loop: "{{ _install_packages }}"
+
+- name: Separate regular packages from uv-prefixed targets
+  ansible.builtin.set_fact:
+    _regular_packages: "{{ _install_packages | reject('search', '^uv:') | list }}"
+    _uv_targets: >-
+      {{ _install_packages | select('search', '^uv:')
+         | map('regex_replace', '^uv:', '') | list }}
 
 - name: Validate k8s-cp + k8s-worker not requested together
   ansible.builtin.fail:
@@ -36,8 +46,8 @@
       A node is either the cluster's control plane or a worker, not
       both.
   when:
-    - "'k8s-cp' in _install_packages"
-    - "'k8s-worker' in _install_packages"
+    - "'k8s-cp' in _regular_packages"
+    - "'k8s-worker' in _regular_packages"
 
 - name: Validate --cp-host is provided for k8s-worker
   ansible.builtin.fail:
@@ -46,7 +56,7 @@
       control plane host registered via 'canasta host add'. Canasta
       SSHs to that host to fetch the join token and cluster API URL.
   when:
-    - "'k8s-worker' in _install_packages"
+    - "'k8s-worker' in _regular_packages"
     - not (cp_host is defined and (cp_host | length > 0))
 
 # Every package below needs root. Refuse now, with a message naming the
@@ -60,40 +70,49 @@
   ansible.builtin.include_role:
     name: install
     tasks_from: docker.yml
-  when: "'docker' in _install_packages"
+  when: "'docker' in _regular_packages"
 
 - name: Install Kubernetes control plane (k3s server, kubectl, helm)
   ansible.builtin.include_role:
     name: install
     tasks_from: k3s.yml
-  when: "'k8s-cp' in _install_packages"
+  when: "'k8s-cp' in _regular_packages"
 
 - name: Install Kubernetes worker (k3s agent joined to control plane)
   ansible.builtin.include_role:
     name: install
     tasks_from: k3s_worker.yml
-  when: "'k8s-worker' in _install_packages"
+  when: "'k8s-worker' in _regular_packages"
 
 - name: Install git-crypt
   ansible.builtin.include_role:
     name: install
     tasks_from: git_crypt.yml
-  when: "'git-crypt' in _install_packages"
+  when: "'git-crypt' in _regular_packages"
 
 - name: Install the SOPS toolchain (sops + age)
   ansible.builtin.include_role:
     name: install
     tasks_from: sops_age.yml
-  when: "'sops' in _install_packages"
+  when: "'sops' in _regular_packages"
 
 - name: Install canasta-native
   ansible.builtin.include_role:
     name: install
     tasks_from: canasta.yml
-  when: "'canasta' in _install_packages"
+  when: "'canasta' in _regular_packages"
 
 - name: Install Podman and configure rootless prerequisites
   ansible.builtin.include_role:
     name: install
     tasks_from: podman.yml
-  when: "'podman' in _install_packages"
+  when: "'podman' in _regular_packages"
+
+- name: Install uv and requested uv tools
+  ansible.builtin.include_role:
+    name: install
+    tasks_from: uv.yml
+  when: "_uv_targets | length > 0 or 'uv' in _regular_packages"
+  vars:
+    uv_targets: "{{ _uv_targets }}"
+    uv_install_self: "{{ 'uv' in _regular_packages }}"

--- a/roles/install/tasks/uv.yml
+++ b/roles/install/tasks/uv.yml
@@ -57,14 +57,22 @@
           curl -LsSf https://astral.sh/uv/install.sh | sh
       when: _uv_install is failed
 
-- name: Warn if ~/.local/bin is not in persistent PATH
-  ansible.builtin.debug:
-    msg: >-
-      WARNING: {{ _install_home }}/.local/bin is not in your shell PATH.
-      Add this to your ~/.profile (or ~/.bashrc):
-        export PATH="$HOME/.local/bin:$PATH"
-      Then log out and back in (or run 'source ~/.profile') so that
-      uv-installed tools are available.
+- name: Add ~/.local/bin to PATH in ~/.profile
+  ansible.builtin.lineinfile:
+    path: "{{ _install_home }}/.profile"
+    regexp: '^\s*export\s+PATH=.*\.local/bin'
+    line: 'export PATH="$HOME/.local/bin:$PATH"'
+    create: true
+    mode: "0644"
+  when: "_install_home ~ '/.local/bin' not in lookup('env', 'PATH') | default('')"
+
+- name: Add ~/.local/bin to PATH in ~/.bashrc
+  ansible.builtin.lineinfile:
+    path: "{{ _install_home }}/.bashrc"
+    regexp: '^\s*export\s+PATH=.*\.local/bin'
+    line: 'export PATH="$HOME/.local/bin:$PATH"'
+    create: true
+    mode: "0644"
   when: "_install_home ~ '/.local/bin' not in lookup('env', 'PATH') | default('')"
 
 - name: Install requested tools via uv

--- a/roles/install/tasks/uv.yml
+++ b/roles/install/tasks/uv.yml
@@ -1,0 +1,96 @@
+---
+# Install uv (Astral Python package manager) and optionally install
+# tools via uv. Accepts two vars from the caller:
+#   uv_install_self (bool) — install the uv binary itself
+#   uv_targets (list of str) — tools to install via 'uv tool install <target>'
+#
+# Debian 13 (trixie) stable ships podman-compose 1.3.0 which has a
+# critical bug with ${VAR:-default} variable substitution
+# (containers/podman-compose#1105). Installing via uv provides a
+# fixed version outside the system package manager.
+
+- name: Determine operator (SSH) user
+  ansible.builtin.command: id -un
+  become: false
+  changed_when: false
+  register: _install_user_cmd
+
+- name: Determine operator home directory
+  ansible.builtin.command: "echo ~{{ _install_user_cmd.stdout | trim }}"
+  become: false
+  changed_when: false
+  register: _install_home_cmd
+
+- name: Set install paths fact
+  ansible.builtin.set_fact:
+    _install_user: "{{ ansible_user | default(_install_user_cmd.stdout, true) | trim }}"
+    _install_home: "{{ _install_home_cmd.stdout | trim }}"
+    _uv_bin: "{{ _install_home_cmd.stdout | trim }}/.local/bin/uv"
+
+- name: Ensure ~/.local/bin is on PATH for this session
+  ansible.builtin.set_fact:
+    ansible_env:
+      PATH: "{{ _install_home }}/.local/bin:{{ ansible_env.PATH | default(lookup('env', 'PATH')) }}"
+
+- name: Check if uv is already installed
+  ansible.builtin.stat:
+    path: "{{ _uv_bin }}"
+  register: _uv_stat
+
+- name: Install uv
+  when:
+    - not _uv_stat.stat.exists
+    - uv_install_self | default(false) | bool or (uv_targets | default([]) | length > 0)
+  become: false
+  block:
+    - name: Download and run uv installer
+      ansible.builtin.shell:
+        cmd: "curl -LsSf https://astral.sh/uv/install.sh | sh"
+        creates: "{{ _uv_bin }}"
+      register: _uv_install
+      changed_when: true
+
+    - name: Warn if uv installer failed
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: uv installer failed. Install manually:
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+      when: _uv_install is failed
+
+- name: Warn if ~/.local/bin is not in persistent PATH
+  ansible.builtin.debug:
+    msg: >-
+      WARNING: {{ _install_home }}/.local/bin is not in your shell PATH.
+      Add this to your ~/.profile (or ~/.bashrc):
+        export PATH="$HOME/.local/bin:$PATH"
+      Then log out and back in (or run 'source ~/.profile') so that
+      uv-installed tools are available.
+  when: "_install_home ~ '/.local/bin' not in lookup('env', 'PATH') | default('')"
+
+- name: Install requested tools via uv
+  when: uv_targets | default([]) | length > 0
+  become: false
+  block:
+    - name: Install each uv target
+      ansible.builtin.command:
+        cmd: "{{ _uv_bin }} tool install {{ item }}"
+      loop: "{{ uv_targets }}"
+      changed_when: true
+      register: _uv_tool_install
+      ignore_errors: true
+
+    - name: Report installed tools
+      ansible.builtin.debug:
+        msg: >-
+          Installed {{ item.item }} via uv at
+          {{ _install_home }}/.local/share/uv/tools/{{ item.item }}.
+      loop: "{{ _uv_tool_install.results }}"
+      when: item.rc | default(1) == 0
+
+    - name: Warn about failed tool installs
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: Failed to install {{ item.item }} via uv. Try manually:
+          {{ _uv_bin }} tool install {{ item.item }}
+      loop: "{{ _uv_tool_install.results }}"
+      when: item.rc | default(1) != 0

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -1028,6 +1028,17 @@ class TestInstallCommand:
             parser.parse_args(["install", "dokcer"])
         assert "invalid choice" in capsys.readouterr().err
 
+    def test_install_accepts_uv_prefixed_package(self, parser):
+        # uv:<tool> is accepted by the dynamic choices prefix.
+        args = parser.parse_args(["install", "uv:podman-compose"])
+        assert args.packages == ["uv:podman-compose"]
+
+    def test_install_rejects_malformed_uv_prefix(self, parser, capsys):
+        # uv: alone or with invalid chars is rejected.
+        with pytest.raises(SystemExit):
+            parser.parse_args(["install", "uv:"])
+        assert "invalid choice" in capsys.readouterr().err
+
     def test_install_usage_names_every_package(self, parser, capsys):
         # The point of the choices list: `canasta install` with no
         # arguments has to answer "what can I install?".
@@ -1035,7 +1046,7 @@ class TestInstallCommand:
             parser.parse_args(["install"])
         err = capsys.readouterr().err
         for pkg in ("docker", "k8s-cp", "k8s-worker",
-                    "git-crypt", "sops", "canasta"):
+                    "git-crypt", "sops", "canasta", "uv"):
             assert pkg in err, (
                 "usage must list %s; an opaque PACKAGES metavar leaves the "
                 "valid values undiscoverable" % pkg

--- a/tests/unit/test_install_podman.py
+++ b/tests/unit/test_install_podman.py
@@ -67,13 +67,24 @@ class TestTheCommandIsReachable:
             "playbook runs"
         )
 
+    def test_uv_is_an_accepted_choice(self):
+        assert "uv" in _install_param()["choices"], (
+            "`canasta install uv` is rejected by the parser before the "
+            "playbook runs"
+        )
+
     def test_the_choices_match_what_the_playbook_dispatches_on(self):
         # The playbook dispatches on the CLI's own package names, so this
         # is a literal match — no translation table to keep in step.
         with open(INSTALL) as f:
             body = f.read()
         for pkg in _install_param()["choices"]:
-            assert "'%s' in _install_packages" % pkg in body, (
+            # Regular packages dispatch on _regular_packages; uv is also
+            # dispatched via the uv.yml role with uv_targets.
+            assert (
+                "'%s' in _regular_packages" % pkg in body
+                or "'%s' in _install_packages" % pkg in body
+            ), (
                 "'%s' is accepted but nothing dispatches on it" % pkg
             )
 

--- a/tests/unit/test_validate_definitions.py
+++ b/tests/unit/test_validate_definitions.py
@@ -234,7 +234,7 @@ class TestDispatchChecks:
     def test_install_choices_and_branches_agree(self):
         param = {"name": "packages",
                  "choices": ["docker", "k8s-cp", "k8s-worker", "git-crypt",
-                             "sops", "podman", "canasta"]}
+                             "sops", "podman", "canasta", "uv"]}
         assert validate_definitions.check_dispatch(
             {}, param, self._playbook("install.yml")) == []
 


### PR DESCRIPTION
**Problem**

Debian 13 (trixie) stable ships podman-compose 1.3.0 which has a critical bug where the `${VAR:-default}` variable-substitution syntax is passed **literally** to containers when the source and destination variable names match (containers/podman-compose#1105). This breaks Canasta's `docker-compose.yml` defaults for `MYSQL_HOST`, `PHP_MAX_INPUT_VARS`, and others.

**What this PR does**

Adds a new `canasta install uv` target that:

1. Installs the Astral `uv` Python package manager via the official standalone installer (`curl -LsSf https://astral.sh/uv/install.sh | sh`)
2. Uses `uv tool install podman-compose` to install a fixed version of podman-compose (>= 1.5.0) outside the system package manager

**Files changed**

- `roles/install/tasks/uv.yml` — new Ansible role task that performs the install
- `playbooks/install.yml` — adds `uv` to validation and dispatch
- `meta/command_definitions.yml` — adds `uv` to choices, examples, and long description

**Usage**

```bash
canasta install uv -H nichework.com
# or for localhost:
canasta install uv
```

**Related issues**

- Fixes #1435
- See also #1434 (doctor warning for podman-compose 1.3.0) and #1436 (the PR that adds the warning)