### PR TITLE
fix(docker): let 'canasta install' target a remote host from docker mode

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -24,30 +24,6 @@ set -euo pipefail
 CANASTA_CLI_BIN="$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")"
 export CANASTA_CLI_BIN
 
-# `canasta install` provisions software ON THE HOST — k3s as a systemd
-# unit, the docker engine package, etc. That work can't run inside the
-# canasta-ansible container, which has no systemd and no privilege over
-# the host package manager. Reject these commands early with a clear
-# pointer to the supported alternatives, instead of failing later with
-# a cryptic "Can not find systemd" from the k3s installer.
-if [[ "${1:-}" == "install" ]]; then
-    cat >&2 <<'INSTALL_GUARD_EOF'
-Error: 'canasta install' is not supported in canasta-docker mode.
-
-These commands install system packages on the host (k3s as a systemd
-unit, docker engine, etc.) which can't run from inside a container.
-
-Either:
-  - Use canasta-native:
-      curl -fsSL https://get.canasta.wiki | bash -s -- --native
-  - Or install the dependency manually on the host (e.g.
-      curl -sfL https://get.k3s.io | sh -
-    for k3s) and use canasta-docker for the rest of the workflow
-    (create, start, backup, restore, etc.).
-INSTALL_GUARD_EOF
-    exit 1
-fi
-
 # CANASTA_CLI_IMAGE is the post-rename name; CANASTA_ANSIBLE_IMAGE
 # remains a backwards-compatible fallback for users who already
 # set the old name in their environment. When either is set the user has
@@ -69,6 +45,104 @@ fi
 
 # Ensure config directory exists
 mkdir -p "$CONFIG_DIR"
+
+# `canasta install` provisions software ON THE HOST — k3s as a systemd
+# unit, the docker engine package, etc. That work can't run inside the
+# canasta-ansible container, which has no systemd and no privilege over
+# the host package manager. A LOCAL install is impossible here and is
+# rejected up front with a pointer to the supported alternatives.
+#
+# A REMOTE install is fine: the playbook runs over SSH on the target
+# (-H/--host, or -i/--id, which the CLI resolves to the instance's
+# registered host), where systemd and root exist. The wrapper only needs
+# to tell the two apart, so it resolves the target and passes the
+# command through to the container unchanged.
+INSTALL_TARGET_HOST=""
+INSTALL_INSTANCE=""
+if [[ "${1:-}" == "install" ]]; then
+    _install_argv=("$@")
+    _install_pos=1
+    while [[ $_install_pos -lt ${#_install_argv[@]} ]]; do
+        case "${_install_argv[$_install_pos]}" in
+            -H|--host)
+                _install_pos=$((_install_pos + 1))
+                if [[ $_install_pos -lt ${#_install_argv[@]} ]]; then
+                    INSTALL_TARGET_HOST="${_install_argv[$_install_pos]}"
+                fi
+                _install_pos=$((_install_pos + 1))
+                ;;
+            -H=*|--host=*)
+                INSTALL_TARGET_HOST="${_install_argv[$_install_pos]#*=}"
+                _install_pos=$((_install_pos + 1))
+                ;;
+            -i|--id)
+                _install_pos=$((_install_pos + 1))
+                if [[ $_install_pos -lt ${#_install_argv[@]} ]]; then
+                    INSTALL_INSTANCE="${_install_argv[$_install_pos]}"
+                fi
+                _install_pos=$((_install_pos + 1))
+                ;;
+            -i=*|--id=*)
+                INSTALL_INSTANCE="${_install_argv[$_install_pos]#*=}"
+                _install_pos=$((_install_pos + 1))
+                ;;
+            *)
+                _install_pos=$((_install_pos + 1))
+                ;;
+        esac
+    done
+
+    # Resolve a bare -i/--id to its registered host so the wrapper can
+    # tell a remote install (pass through) from a local one (reject).
+    if [[ -n "$INSTALL_INSTANCE" && -z "$INSTALL_TARGET_HOST" ]]; then
+        if [[ -f "$CONFIG_DIR/conf.json" ]] && command -v python3 &>/dev/null; then
+            INSTALL_TARGET_HOST="$(python3 -c "
+import json, sys
+try:
+    with open('$CONFIG_DIR/conf.json') as f:
+        data = json.load(f)
+    inst = data.get('Instances', {}).get('$INSTALL_INSTANCE', {})
+    print(inst.get('host', ''))
+except Exception:
+    pass
+" 2>/dev/null || true)"
+        elif [[ -f "$CONFIG_DIR/conf.json" ]]; then
+            INSTALL_TARGET_HOST="$(grep -A15 "\"$INSTALL_INSTANCE\"" "$CONFIG_DIR/conf.json" 2>/dev/null \
+                | grep '"host"' | head -1 \
+                | sed 's/.*"host"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' \
+                || true)"
+        fi
+    fi
+
+    if [[ -z "$INSTALL_TARGET_HOST" \
+        || "$INSTALL_TARGET_HOST" == "localhost" \
+        || "$INSTALL_TARGET_HOST" == "127.0.0.1" ]]; then
+        if [[ -z "$INSTALL_TARGET_HOST" && -n "$INSTALL_INSTANCE" ]]; then
+            echo "Error: instance '$INSTALL_INSTANCE' is not registered, so there is no" >&2
+            echo "host to install on. Register it with 'canasta create' or 'canasta host add'." >&2
+        else
+            cat >&2 <<'INSTALL_GUARD_EOF'
+Error: 'canasta install' is not supported in canasta-docker mode.
+
+These commands install system packages on the host (k3s as a systemd
+unit, docker engine, etc.) which can't run from inside a container.
+
+Either:
+  - Use canasta-native:
+      curl -fsSL https://get.canasta.wiki | bash -s -- --native
+  - Or install the dependency manually on the host (e.g.
+      curl -sfL https://get.k3s.io | sh -
+    for k3s) and use canasta-docker for the rest of the workflow
+    (create, start, backup, restore, etc.).
+
+Or install on a remote host with:
+      canasta install <package> -i <instance-id>
+which runs the install over SSH on the host where the instance lives.
+INSTALL_GUARD_EOF
+        fi
+        exit 1
+    fi
+fi
 
 # Select the canasta-ansible image. The channel (release vs dev) is pinned
 # by 'canasta upgrade' in $CONFIG_DIR/cli_image_tag and applies to every

--- a/canasta.py
+++ b/canasta.py
@@ -1865,7 +1865,12 @@ def main():
     # Pre-flight: the Docker-mode CLI cannot drive a Podman instance that
     # is local to this controller. Refuse before either path starts, so
     # the operator gets the reason instead of a mid-operation rc=127.
-    check_docker_mode_can_reach_runtime(args)
+    # `install` is exempt: it never drives an instance's compose stack —
+    # in Docker mode the wrapper only lets it through when it targets a
+    # remote host (booting canasta-native there to run the install), so
+    # a local Podman instance is irrelevant to it.
+    if command_name != "install":
+        check_docker_mode_can_reach_runtime(args)
 
     # Interactive exec: bypass Ansible for TTY support.
     if command_name == "maintenance_exec":

--- a/tests/unit/test_canasta_docker.py
+++ b/tests/unit/test_canasta_docker.py
@@ -10,6 +10,7 @@ real unix sockets uses short paths under /tmp rather than pytest's
 tmp_path fixture (which lives under /private/var/folders/...).
 """
 
+import json
 import os
 import shutil
 import socket
@@ -669,3 +670,111 @@ class TestRestoreAndGitopsCrontabMediation:
         # create doesn't touch the crontab; no mediation needed.
         argv, _ = run_dry(["backup", "create", "-i", "x"])
         assert_no_env_key(argv, "CANASTA_HOST_CRONTAB")
+
+
+class TestInstallDockerMode:
+    """`canasta install` under the docker wrapper.
+
+    A local install (no target, or a target resolving to the controller
+    itself) is rejected up front: the canasta-ansible container has no
+    systemd and no host package manager. A remote install (-H/--host, or
+    -i/--id naming an instance registered on a non-controller host) is
+    passed through unchanged — the CLI resolves -i to the instance's
+    registered host and the install playbook runs over SSH on the
+    target, where systemd and root exist.
+    """
+
+    def _conf(self, config_dir, instances):
+        """Seed conf.json with the given instances."""
+        path = os.path.join(config_dir, "conf.json")
+        with open(path, "w") as f:
+            json.dump({"Instances": instances}, f)
+
+    def _config_dir(self):
+        config_dir = tempfile.mkdtemp(prefix="cd-", dir="/tmp")
+        _run_dry_tmpdirs.append(config_dir)
+        return config_dir
+
+    def _run(self, args, env=None):
+        """Invoke the wrapper in dry-run mode WITHOUT asserting success
+        (used by the refusal cases, which must exit 1)."""
+        base_env = os.environ.copy()
+        base_env["CANASTA_DOCKER_DRY_RUN"] = "1"
+        if env:
+            base_env.update(env)
+        return subprocess.run(
+            [WRAPPER] + list(args),
+            env=base_env,
+            cwd="/tmp",
+            capture_output=True,
+            text=True,
+        )
+
+    def test_remote_instance_via_i_passes_through(self):
+        config_dir = self._config_dir()
+        self._conf(config_dir, {"nichework": {
+            "id": "nichework", "path": "/srv/nichework",
+            "host": "nichework.com", "orchestrator": "compose"}})
+        argv, _ = run_dry(
+            ["install", "uv:podman-compose", "-i", "nichework"],
+            env={"CANASTA_CONFIG_DIR": config_dir},
+        )
+        assert user_args(argv) == ["install", "uv:podman-compose",
+                                   "-i", "nichework"]
+
+    def test_remote_host_via_H_passes_through(self):
+        argv, _ = run_dry(["install", "podman", "-H", "prod1.example.com"])
+        assert user_args(argv) == ["install", "podman",
+                                   "-H", "prod1.example.com"]
+
+    def test_extra_flags_survive_pass_through(self):
+        argv, _ = run_dry(["install", "k8s-cp", "--public-ip", "203.0.113.10",
+                           "-H", "node2"])
+        assert user_args(argv) == [
+            "install", "k8s-cp", "--public-ip", "203.0.113.10", "-H", "node2",
+        ]
+
+    def test_double_dash_forms_of_target_are_handled(self):
+        config_dir = self._config_dir()
+        self._conf(config_dir, {"nichework": {
+            "id": "nichework", "path": "/srv/nichework",
+            "host": "nichework.com", "orchestrator": "compose"}})
+        argv, _ = run_dry(
+            ["install", "docker", "--id=nichework"],
+            env={"CANASTA_CONFIG_DIR": config_dir},
+        )
+        assert user_args(argv) == ["install", "docker", "--id=nichework"]
+
+    def test_a_local_install_is_refused(self):
+        result = self._run(["install", "docker"])
+        assert result.returncode == 1
+        assert "not supported in canasta-docker mode" in result.stderr
+
+    def test_install_by_i_for_an_unregistered_instance_is_refused(self):
+        config_dir = self._config_dir()
+        self._conf(config_dir, {})
+        result = self._run(["install", "sops", "-i", "nosuch"],
+                           env={"CANASTA_CONFIG_DIR": config_dir})
+        assert result.returncode == 1
+        assert "'nosuch' is not registered" in result.stderr
+
+    def test_install_by_i_for_a_local_instance_is_refused(self):
+        # A registered instance whose host is the controller itself can't
+        # be reached from inside the container either.
+        config_dir = self._config_dir()
+        self._conf(config_dir, {"local1": {
+            "id": "local1", "path": "/srv/local1",
+            "host": "localhost", "orchestrator": "compose"}})
+        result = self._run(["install", "podman", "-i", "local1"],
+                           env={"CANASTA_CONFIG_DIR": config_dir})
+        assert result.returncode == 1
+        assert "not supported in canasta-docker mode" in result.stderr
+
+    def test_install_by_H_for_localhost_is_refused(self):
+        result = self._run(["install", "podman", "-H", "localhost"])
+        assert result.returncode == 1
+        assert "not supported in canasta-docker mode" in result.stderr
+
+    def test_non_install_commands_are_unaffected(self):
+        argv, _ = run_dry(["version"])
+        assert "install" not in user_args(argv)


### PR DESCRIPTION
## Summary

`canasta install` was unusable from canasta-docker: the wrapper rejected **every** invocation with `Error: 'canasta install' is not supported in canasta-docker mode` (#535), even when the command named a remote target via `-i <instance>` or `-H <host>`.

The rejection is correct for a **local** install — inside the container there's no systemd and no host package manager — but for a **remote** target the install playbook already runs over SSH on the target with root, exactly like every other remote `-H` command in docker mode. This PR lets remote-targeted installs through.

## Behavior

```
$ canasta install uv:podman-compose -i nichework          # now: runs over SSH on nichework.com
$ canasta install podman -H prod1.example.com            # now: runs over SSH on prod1.example.com
$ canasta install docker                                 # still refused (no target)
$ canasta install docker -i local-instance               # still refused (target resolves to localhost)
$ canasta install sops -i unknown                        # refused with 'instance not registered'
```

### canasta-docker

Resolve the install target from `-H`/`--host` or, for a bare `-i`/`--id`, from the instance's registered host in the registry. When the target is missing or is the controller itself (localhost/127.0.0.1), keep the existing rejection — with an added hint for the `-i` case and a pointer at the now-working remote form. A remote target passes the command through to the container unchanged; the CLI resolves `-i` to the host and the playbook runs over SSH.

### canasta.py

Exempt `install` from the docker-mode Podman guard (`check_docker_mode_can_reach_runtime`). Install never drives an instance's compose stack, and in docker mode the wrapper only lets it through when it targets a remote host — so a local Podman instance registered in the registry is irrelevant and must not block a `-H` install.

## Testing

- `tests/unit/test_canasta_docker.py`: new `TestInstallDockerMode` covers pass-through for `-i`/`-H`/long-form targets, preservation of extra flags (`--public-ip`), and the retained refusals (no target, unknown instance, localhost instance, `-H localhost`).
- Full unit suite: 2464 passed, 2 skipped.

Closes #1438.