### PR TITLE
Reload Caddy on reconcile so config edits reach the running server

### DIFF
--- a/roles/instance_lifecycle/tasks/reconcile.yml
+++ b/roles/instance_lifecycle/tasks/reconcile.yml
@@ -56,6 +56,16 @@
     name: orchestrator
     tasks_from: start.yml
 
+# The converge above cannot deliver Caddy config: both the Caddyfile and
+# Caddyfile.site are bind-mounted files, so their contents are invisible to
+# compose's change detection and the container is left running the config it
+# started with. Reload after the converge, so a Caddy that start.yml had to
+# bring up is already listening.
+- name: Apply Caddy config to the running server
+  ansible.builtin.include_role:
+    name: orchestrator
+    tasks_from: reload_caddy.yml
+
 - name: Report reconciled
   ansible.builtin.debug:
     msg: >-

--- a/roles/orchestrator/tasks/reload_caddy.yml
+++ b/roles/orchestrator/tasks/reload_caddy.yml
@@ -1,0 +1,48 @@
+---
+# Make a regenerated Caddyfile (or a hand-edited Caddyfile.site) reach the
+# running Caddy without bouncing the instance.
+#
+# Compose bind-mounts both files, so `docker compose up -d` sees no change to
+# the service definition and never recreates the container — the new config
+# would otherwise sit on disk unread. Kubernetes needs nothing here: the caddy
+# deployment carries a checksum/caddy-config annotation, so a ConfigMap change
+# already rolls the pod on helm upgrade.
+#
+# `caddy reload` is atomic: an invalid config is rejected and the previously
+# loaded one keeps serving, so no separate validate pass is needed.
+# Input: instance_path, instance_id, instance_orchestrator
+
+- name: Get running services for the Caddy reload
+  ansible.builtin.include_tasks: list_running_services.yml
+
+# Reloading a Caddy that isn't up would fail on a stopped or partially
+# converged instance; the next start loads the file from disk anyway.
+#
+# split() takes no argument on purpose: this is a folded scalar, so YAML hands
+# Jinja a literal backslash-n rather than a newline, and split('\n') would
+# match nothing and never find the service. Bare split() breaks on whitespace.
+- name: Determine whether Caddy can be reloaded
+  ansible.builtin.set_fact:
+    _reload_caddy: >-
+      {{ (instance_orchestrator | default('compose') == 'compose')
+         and 'caddy' in (_running_services | default('') | trim).split() }}
+
+- name: Reload Caddy
+  block:
+    - name: Apply the regenerated config to the running Caddy
+      ansible.builtin.include_tasks: exec.yml
+      vars:
+        exec_service: caddy
+        exec_command: caddy reload --config /etc/caddy/Caddyfile
+      when: _reload_caddy | bool
+  # Caddy's own adapter error (with the offending file and line) is already
+  # printed by the failed exec above, so this adds only what it can't say:
+  # that nothing broke.
+  rescue:
+    - name: Report the rejected config
+      ansible.builtin.fail:
+        msg: >-
+          Caddy rejected the configuration reported above and is still serving
+          the previously loaded one, so the site is unaffected. Fix
+          config/Caddyfile.site in the instance directory and run the command
+          again.

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -94,6 +94,10 @@
       failed_when: false
       when: not (_container_running | default(false) | bool)
 
+    # The three failure guards below default rc: `Start containers` is skipped
+    # on an already-running instance, and a skipped result is a dict with no
+    # rc at all, so a bare `_start_result.rc` raises instead of evaluating.
+    #
     # When docker compose up fails (typically an unhealthy container),
     # capture per-service logs and state before we bail out. The caller
     # usually rolls back (docker compose down) on failure, which wipes
@@ -107,7 +111,7 @@
       register: _start_ps
       changed_when: false
       failed_when: false
-      when: _start_result.rc != 0
+      when: _start_result.rc | default(0) != 0
 
     - name: Capture compose logs on failure
       ansible.builtin.command:
@@ -116,7 +120,7 @@
       register: _start_logs
       changed_when: false
       failed_when: false
-      when: _start_result.rc != 0
+      when: _start_result.rc | default(0) != 0
 
     # Ansible's default callback swallows stderr/stdout for failed
     # command modules under the compact "[ERROR]: Task failed: ..."
@@ -134,7 +138,7 @@
           {{ _start_ps.stdout | default('(not captured)') }}
           --- docker compose logs (last 200) ---
           {{ _start_logs.stdout | default('(not captured)') }}
-      when: _start_result.rc != 0
+      when: _start_result.rc | default(0) != 0
 
     # Wait for the web container to finish booting before returning.
     # /run-all.sh in the canasta image runs `composer update`

--- a/tests/unit/test_reconcile_caddy_reload.py
+++ b/tests/unit/test_reconcile_caddy_reload.py
@@ -1,0 +1,167 @@
+"""Structural guards for the Caddy reload on `canasta reconcile`.
+
+Compose bind-mounts config/Caddyfile and config/Caddyfile.site, so `docker
+compose up -d` never recreates the container on a content change and a
+regenerated Caddyfile is left unread. reconcile must therefore reload Caddy
+explicitly, after the converge and only when Caddy is actually running.
+Kubernetes rolls the caddy pod off the ConfigMap checksum annotation and must
+not be reloaded this way.
+"""
+
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+RECONCILE = os.path.join(
+    REPO_ROOT, "roles", "instance_lifecycle", "tasks", "reconcile.yml"
+)
+RELOAD_CADDY = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "tasks", "reload_caddy.yml"
+)
+CADDY_DEPLOYMENT = os.path.join(
+    REPO_ROOT, "roles", "orchestrator", "files", "helm", "canasta",
+    "templates", "deployment-caddy.yaml",
+)
+
+
+def _load(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _tasks_from(task):
+    inc = task.get("ansible.builtin.include_role") or task.get("include_role")
+    return inc.get("tasks_from", "") if isinstance(inc, dict) else ""
+
+
+def _includes(task):
+    inc = (task.get("ansible.builtin.include_tasks")
+           or task.get("include_tasks") or "")
+    return inc if isinstance(inc, str) else str(inc)
+
+
+def _walk(tasks):
+    """Yield every task, descending into block/rescue/always."""
+    for task in tasks or []:
+        yield task
+        for key in ("block", "rescue", "always"):
+            yield from _walk(task.get(key))
+
+
+class TestReconcileReloadsCaddy:
+    def test_reconcile_reloads_caddy(self):
+        froms = [_tasks_from(t) for t in _load(RECONCILE)]
+        assert "reload_caddy.yml" in froms, (
+            "reconcile must reload Caddy; a bind-mounted Caddyfile change is "
+            "invisible to `docker compose up -d`, so the regenerated config "
+            "would never reach the running server"
+        )
+
+    def test_reload_comes_after_the_converge(self):
+        froms = [_tasks_from(t) for t in _load(RECONCILE)]
+        assert froms.index("reload_caddy.yml") > froms.index("start.yml"), (
+            "reload must follow start.yml so a Caddy the converge had to "
+            "bring up is already listening"
+        )
+
+    def test_reload_comes_after_config_regeneration(self):
+        froms = [_tasks_from(t) for t in _load(RECONCILE)]
+        assert froms.index("reload_caddy.yml") > froms.index(
+            "update_config.yml"
+        ), "reload must follow the Caddyfile regeneration it delivers"
+
+    def test_reconcile_is_still_non_disruptive(self):
+        froms = [_tasks_from(t) for t in _load(RECONCILE)]
+        assert "stop.yml" not in froms, (
+            "the reload must not have introduced a stop — reconcile stays the "
+            "non-disruptive converge"
+        )
+
+
+class TestReloadCaddyTask:
+    def test_reloads_the_caddy_service(self):
+        execs = [
+            t for t in _walk(_load(RELOAD_CADDY))
+            if _includes(t).endswith("exec.yml")
+        ]
+        assert execs, "reload_caddy must exec through the exec.yml abstraction"
+        variables = execs[0].get("vars", {})
+        assert variables.get("exec_service") == "caddy", (
+            "the reload must target the caddy service, not the default (web)"
+        )
+        assert "caddy reload" in variables.get("exec_command", ""), (
+            "must issue `caddy reload`"
+        )
+
+    def test_reload_is_gated_on_caddy_running(self):
+        execs = [
+            t for t in _walk(_load(RELOAD_CADDY))
+            if _includes(t).endswith("exec.yml")
+        ]
+        assert "_reload_caddy" in str(execs[0].get("when", "")), (
+            "reloading a Caddy that isn't up would fail on a stopped or "
+            "partially converged instance"
+        )
+
+    def test_gate_requires_compose_and_a_running_caddy(self):
+        gate = next(
+            (t for t in _walk(_load(RELOAD_CADDY))
+             if "_reload_caddy" in (t.get("ansible.builtin.set_fact") or {})),
+            None,
+        )
+        assert gate is not None, "reload_caddy must compute a _reload_caddy gate"
+        expr = gate["ansible.builtin.set_fact"]["_reload_caddy"]
+        assert "compose" in expr, (
+            "K8s rolls the caddy pod off the ConfigMap checksum annotation; "
+            "it must not be reloaded through the Compose path"
+        )
+        assert "caddy" in expr and "_running_services" in expr, (
+            "the gate must check that caddy is among the running services"
+        )
+
+    def test_lists_running_services_before_gating(self):
+        tasks = _load(RELOAD_CADDY)
+        listed = next(
+            i for i, t in enumerate(tasks)
+            if _includes(t).endswith("list_running_services.yml")
+        )
+        gated = next(
+            i for i, t in enumerate(tasks)
+            if "_reload_caddy" in (t.get("ansible.builtin.set_fact") or {})
+        )
+        assert listed < gated, (
+            "_running_services must be populated before the gate reads it"
+        )
+
+    def test_rejected_config_fails_with_a_reassuring_message(self):
+        rescues = [
+            t for task in _load(RELOAD_CADDY)
+            for t in _walk(task.get("rescue"))
+            if "ansible.builtin.fail" in t
+        ]
+        assert rescues, (
+            "a rejected config must be rescued into a clear failure, not a "
+            "raw shell error"
+        )
+        msg = rescues[0]["ansible.builtin.fail"]["msg"]
+        assert "Caddyfile.site" in msg, "must point at the file to fix"
+        assert "previously loaded" in msg, (
+            "must say the old config is still serving — `caddy reload` is "
+            "atomic, so the site is not down"
+        )
+
+
+class TestKubernetesStillRollsOnChecksum:
+    """The reload is Compose-only because K8s already handles it. If that
+    annotation ever goes away, K8s loses config delivery silently."""
+
+    def test_caddy_deployment_has_a_config_checksum_annotation(self):
+        with open(CADDY_DEPLOYMENT) as f:
+            body = f.read()
+        assert "checksum/caddy-config" in body, (
+            "the caddy deployment must keep its config checksum annotation — "
+            "it is what rolls the pod on a ConfigMap change, and the reason "
+            "reload_caddy.yml is Compose-only"
+        )

--- a/tests/unit/test_start_skip_guards.py
+++ b/tests/unit/test_start_skip_guards.py
@@ -1,0 +1,65 @@
+"""Guard against register-on-skip in start.yml's failure diagnostics.
+
+`Start containers` is skipped when the instance is already running, and a
+skipped task registers a dict with no `rc` key at all. The three failure
+guards that read `_start_result.rc` must therefore default it, or every
+`canasta start` / `canasta reconcile` against a running instance dies with
+"object of type 'dict' has no attribute 'rc'" before reaching its own work.
+"""
+
+import os
+
+import yaml
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+START = os.path.join(REPO_ROOT, "roles", "orchestrator", "tasks", "start.yml")
+
+
+def _walk(tasks):
+    for task in tasks or []:
+        yield task
+        for key in ("block", "rescue", "always"):
+            yield from _walk(task.get(key))
+
+
+def _all_tasks():
+    with open(START) as f:
+        return list(_walk(yaml.safe_load(f)))
+
+
+class TestStartResultGuards:
+    def test_start_containers_is_conditional(self):
+        """The premise: the registering task can be skipped."""
+        task = next(
+            t for t in _all_tasks() if t.get("name") == "Start containers"
+        )
+        assert task.get("register") == "_start_result"
+        assert "_container_running" in str(task.get("when", "")), (
+            "start is skipped on an already-running instance — that is what "
+            "makes the guards below load-bearing"
+        )
+
+    def test_every_rc_conditional_defaults(self):
+        bare = [
+            t.get("name")
+            for t in _all_tasks()
+            if "_start_result.rc" in str(t.get("when", ""))
+            and "_start_result.rc | default" not in str(t.get("when", ""))
+        ]
+        assert not bare, (
+            "these tasks read _start_result.rc without a default and will "
+            f"raise when the start was skipped: {bare}"
+        )
+
+    def test_the_guards_still_exist(self):
+        """The diagnostics stay; only their conditional was wrong."""
+        guarded = [
+            t.get("name")
+            for t in _all_tasks()
+            if "_start_result.rc" in str(t.get("when", ""))
+        ]
+        assert len(guarded) == 3, (
+            "expected the ps capture, the logs capture, and the explicit "
+            f"fail to remain gated on rc; found {guarded}"
+        )


### PR DESCRIPTION
Makes `canasta reconcile` actually deliver Caddy configuration to a running instance. Two defects had to be fixed to get there; each is a separate commit closing its own issue.

Fixes #1440
Fixes #1441

## 1. reconcile died on any running instance (#1441)

`Start containers` in `roles/orchestrator/tasks/start.yml` is skipped when the instance is already up, and a skipped task registers a dict with no `rc` key. The three failure-diagnostic guards reading `_start_result.rc` then raised instead of evaluating:

```
Error: Task failed: Error while evaluating conditional: object of type 'dict' has no attribute 'rc'
```

`canasta start` has a `direct_commands` fast path and never reaches the file, which is why this went unnoticed. `canasta reconcile` has no fast path, so its normal case — converging a running instance — always failed.

Fixed by defaulting the rc in all three guards, matching the idiom already used elsewhere in the same file (`_start_web_podman_ready.rc | default(0)`). The diagnostics are unchanged; only the conditional was wrong.

## 2. reconcile rendered Caddy config that was never read (#1440)

`reconcile` regenerates the Caddyfile and converges with `docker compose up -d`. But `config/Caddyfile` and `config/Caddyfile.site` are bind-mounted files — compose hashes the service definition, not file contents — so the container is never recreated and keeps serving the config it started with. Nothing else issued a reload. The regenerated file sat on disk unread, with no error, while the command reference advertises `reconcile` as the way to apply local config edits without a full restart.

Adds `roles/orchestrator/tasks/reload_caddy.yml`, called after the converge.

- **Compose only.** On Kubernetes the caddy deployment's `checksum/caddy-config` annotation already rolls the pod on `helm upgrade`. A test pins that annotation, since its removal would silently break config delivery on that path.
- **Gated on caddy running**, so a stopped or partially converged instance is left alone.
- **No separate validate pass.** `caddy reload` is atomic: an invalid config is rejected with the offending file and line while the previously loaded one keeps serving. A validate pass would be a redundant round-trip. The rejection is rescued into a message stating the site is unaffected.

## Verification

Tested against a running Compose instance using an observable `header` directive in `Caddyfile.site`:

| | result |
|---|---|
| reconcile before the fix | directive **not served** — reproduced |
| reconcile after the fix | **served** |
| removing the directive | propagates too |
| invalid config | fails with Caddy's exact `Caddyfile.site:13` error; site still returns **HTTP 200** on the previous config |
| caddy container `StartedAt` | **unchanged** throughout — in-place reload, no downtime |

`Caddyfile.site` was restored byte-identical afterward.

For #1441, forced through the Ansible path against a running instance: `exit=2` before, `exit=0` after.

`make test-unit` (2470), `make validate`, and `make lint` (yamllint, ruff, ansible-lint at the production profile) all pass.

## Note for reviewers

The running-service gate uses argument-less `split()` on purpose. In a folded YAML scalar, `split('\n')` receives a literal backslash-n rather than a newline, matches nothing, and silently evaluates false — which is exactly how the first version of this failed. There's a comment on the line so it doesn't get "simplified" back.

The same idiom appears in `roles/maintenance/tasks/exec.yml`, where it is cosmetic (it only formats a service list for display) but likely prints all services on one line. Left alone here as out of scope.
