### PR TITLE
Clarify that per-wiki settings live in <wiki-id> subdirectories

### DIFF
--- a/instance_template/config/settings/wikis/README
+++ b/instance_template/config/settings/wikis/README
@@ -1,12 +1,23 @@
 # Per-Wiki Settings Directory
 
-This directory contains PHP configuration files specific to this wiki.
-Files are loaded automatically in lexicographic order, AFTER global settings.
+Per-wiki settings live in subdirectories named after the wiki ID:
+
+    config/settings/wikis/<wiki-id>/
+
+Each wiki's directory is loaded automatically in lexicographic order, AFTER
+global settings. For example, settings for the wiki with ID `docs` go in:
+
+    config/settings/wikis/docs/
+
+The parent `config/settings/wikis/` directory itself contains no PHP files —
+it only holds the per-wiki subdirectories (and this README). Files placed
+directly in `config/settings/wikis/` are NOT loaded. Each wiki's directory is
+created automatically when the wiki is created.
 
 ## Load Order
 
-All .php files in this directory are loaded automatically in lexicographic order.
-You can optionally use numeric prefixes to control load order:
+All .php files in a wiki's directory are loaded automatically in lexicographic
+order. You can optionally use numeric prefixes to control load order:
 
     10-first.php   # Loaded first (within this wiki's directory)
     50-logo.php    # Loaded in the middle
@@ -14,8 +25,8 @@ You can optionally use numeric prefixes to control load order:
 
 But plain names work fine:
 
-    Logo.php
-    Permissions.php
+    config/settings/wikis/docs/Logo.php
+    config/settings/wikis/docs/Permissions.php
 
 ## What to Configure Here
 
@@ -57,6 +68,8 @@ config/settings/global/README for the full convention (Docker Compose only).
 
 ## Notes
 
-- All .php files in this directory are loaded automatically
+- All .php files in a wiki's directory are loaded automatically
 - Per-wiki settings override global settings with the same variable
 - Files without the .php extension (like this README) are ignored
+- Files placed directly in config/settings/wikis/ (not in a <wiki-id>
+  subdirectory) are NOT loaded


### PR DESCRIPTION
## Summary

The README at `instance_template/config/settings/wikis/README` is misleading. It opens with:

> This directory contains PHP configuration files specific to this wiki.

but per-wiki settings do not live directly in `config/settings/wikis/` — they live in **wiki-ID subdirectories** under it, i.e. `config/settings/wikis/<wiki-id>/`. In a fresh instance `config/settings/wikis/` contains only the README itself.

The correct location is already stated consistently elsewhere:

- `instance_template/config/settings/global/DefaultSettings.php:7` — "Per-wiki overrides can be placed in config/settings/wikis/<wiki-id>/."
- `instance_template/config/settings/global/README:40-42` — "For wiki-specific settings, add files to: config/settings/wikis/<wiki_id>/"
- `roles/create/tasks/_settings_files.yml` creates `config/settings/wikis/{{ item }}` per wiki ID and copies `--wiki-settings` to `config/settings/wikis/{{ wiki }}/Settings.php`.

## Why it matters

A user following the opening line may drop a `.php` file directly into `config/settings/wikis/` and expect it to be loaded for their wiki. The README's "Load Order" and "What to Configure Here" sections also describe "this directory" generically without ever naming the `<wiki-id>` subdirectory, so nothing corrects the initial impression.

## Suggested fix

Rewrite `instance_template/config/settings/wikis/README` to lead with the subdirectory structure, mirroring the global README's cross-reference, e.g.:

> Per-wiki settings live in subdirectories named after the wiki ID:
>
>     config/settings/wikis/<wiki-id>/
>
> Each wiki's directory is loaded automatically in lexicographic order, AFTER global settings.

Then keep the existing load-order / what-to-configure / host-local-overrides content, updated to refer to "the wiki's directory" and an example like `config/settings/wikis/docs/Logo.php` rather than a bare filename.

Also update the "Notes" section so it doesn't imply files in the parent `config/settings/wikis/` directory are loaded.